### PR TITLE
Make the web env example local-safe by default

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://api.paretoproof.com
+VITE_API_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- point the web env example at http://localhost:3000 instead of the production API host
- keep local frontend development aligned with the documented local-first workflow
- leave the production API hostname documented in the deployment and operations baselines instead of in the local template

Closes #195