### PR TITLE
Fix unsafe auth redirect handling

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,11 @@
 import { AuthEntry } from "./routes/auth-entry";
 import { PortalBootstrap } from "./routes/portal-bootstrap";
 import { PublicSite } from "./routes/public-site";
-import { resolveWebSurface } from "./lib/surface";
+import { readPortalRedirectTarget, resolveWebSurface } from "./lib/surface";
 
 export default function App() {
   const surface = resolveWebSurface();
-  const redirectPath =
-    new URLSearchParams(window.location.search).get("redirect") ?? "/";
+  const redirectPath = readPortalRedirectTarget();
 
   if (surface === "auth") {
     return <AuthEntry redirectPath={redirectPath} />;

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -69,6 +69,11 @@ function sanitizePortalTargetPath(targetPath: string) {
   }
 }
 
+export function readPortalRedirectTarget(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  return sanitizePortalTargetPath(params.get("redirect") ?? "/");
+}
+
 function buildLocalSurfaceUrl(
   surface: Exclude<WebSurface, "public">,
   targetPath: string,


### PR DESCRIPTION
## Summary
- reject absolute and protocol-relative redirect targets before auth handoff
- normalize redirect targets at the app boundary before rendering the auth surface
- preserve valid portal-relative paths while preventing auth.paretoproof.com from acting as a redirect trampoline

## Validation
- bun run typecheck:web
- bun run build:web
- local Playwright verification for safe and unsafe redirect targets

Closes #214