### PR TITLE
Fix pending access after identity linkage

### DIFF
--- a/apps/api/src/auth/resolve-access-rbac-context.ts
+++ b/apps/api/src/auth/resolve-access-rbac-context.ts
@@ -99,6 +99,16 @@ export async function resolveAccessRbacContext(
       };
     }
 
+    if (latestRequest?.status === "pending") {
+      return {
+        email: linkedIdentity.user.email,
+        requestId: latestRequest.id,
+        status: "pending",
+        subject: identity.subject,
+        userId: linkedIdentity.user.id
+      };
+    }
+
     return {
       email: linkedIdentity.user.email,
       reason: "access_request_required",


### PR DESCRIPTION
## Summary
- keep linked identities in the pending state when a pending access request exists
- return the live request id and user id for linked pending callers

## Validation
- bun run typecheck:api
- direct resolver script for linked pending users

Closes #234