### PR TITLE
Add portal admin access-request decision UI

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -332,7 +332,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
                 <p className="portal-request-meta">
                   Created {new Date(requestItem.createdAt).toLocaleString()}
                   {requestItem.reviewedAt
-                    ? ` Â· Reviewed ${new Date(requestItem.reviewedAt).toLocaleString()}`
+                    ? ` · Reviewed ${new Date(requestItem.reviewedAt).toLocaleString()}`
                     : ""}
                 </p>
 

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -8,6 +8,7 @@ import {
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import { findMatchedPortalRoute } from "../lib/portal-route-access";
+import { PortalAccessRequestPanel } from "./portal-access-request-panel";
 import { PortalProfilePanel } from "./portal-profile-panel";
 
 type PortalShellProps = {
@@ -162,7 +163,9 @@ export function PortalShell({ email, roles }: PortalShellProps) {
         </section>
 
         <section className="portal-grid">
-          {activeSection?.id === "profile" ? (
+          {activeSection?.id === "access_requests" ? (
+            <PortalAccessRequestPanel email={email} />
+          ) : activeSection?.id === "profile" ? (
             <PortalProfilePanel email={email} />
           ) : (
             <>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -338,6 +338,10 @@ p {
   grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
 }
 
+.portal-grid-stack {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .portal-identity-list {
   display: grid;
   gap: 0.9rem;
@@ -351,6 +355,39 @@ p {
   padding: 1rem 1.1rem;
   border-radius: 1rem;
   background: rgba(0, 0, 0, 0.03);
+}
+
+.portal-request-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.portal-request-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.portal-request-header,
+.portal-request-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.portal-request-actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.portal-request-meta,
+.portal-request-rationale {
+  margin-bottom: 0;
+}
+
+.portal-request-meta {
+  color: #5d5140;
+  font-size: 0.94rem;
 }
 
 .portal-action-card {
@@ -423,5 +460,10 @@ p {
 
   .portal-grid-profile {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portal-request-header {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- add the admin access-request queue panel with a local development fallback for iterative UI work
- wire the access-request queue into the authenticated admin shell
- validate approve/reject persistence locally through the portal surface

Closes #222