### PR TITLE
Fix portal API cross-origin browser access

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,3 +7,4 @@ APP_SESSION_SECRET=replace-with-a-long-random-secret
 CF_ACCESS_TEAM_DOMAIN=paretoproof.cloudflareaccess.com
 CF_ACCESS_PORTAL_AUD=replace-with-portal-cloudflare-access-audience
 CF_ACCESS_INTERNAL_AUD=replace-with-internal-cloudflare-access-audience
+CORS_ALLOWED_ORIGINS=https://paretoproof.com,https://auth.paretoproof.com,https://portal.paretoproof.com

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@fastify/cors": "^11.1.0",
     "@paretoproof/shared": "workspace:*",
     "drizzle-orm": "latest",
     "fastify": "latest",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ const port = Number(process.env.PORT ?? 3000);
 const host = process.env.HOST ?? "0.0.0.0";
 
 const start = async () => {
-  const app = buildServer();
+  const app = await buildServer();
 
   try {
     await app.listen({ host, port });

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -1,3 +1,4 @@
+import cors from "@fastify/cors";
 import Fastify from "fastify";
 import { createAccessGuard } from "../auth/require-access.js";
 import { createDbClient } from "../db/client.js";
@@ -5,12 +6,59 @@ import { registerAdminRoutes } from "../routes/admin.js";
 import { registerHealthRoute } from "../routes/health.js";
 import { registerPortalRoutes } from "../routes/portal.js";
 
-export function buildServer() {
+function normalizeOrigin(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+function readAllowedCorsOrigins() {
+  const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS?.split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (configuredOrigins?.length) {
+    return configuredOrigins.map(normalizeOrigin);
+  }
+
+  return [
+    "https://paretoproof.com",
+    "https://auth.paretoproof.com",
+    "https://portal.paretoproof.com"
+  ];
+}
+
+function isAllowedLocalOrigin(origin: string) {
+  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin);
+}
+
+export async function buildServer() {
   const app = Fastify({
     logger: true
   });
   const db = createDbClient();
   const requireAccess = createAccessGuard(db);
+  const allowedOrigins = readAllowedCorsOrigins();
+
+  await app.register(cors, {
+    credentials: true,
+    origin(origin, callback) {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      const normalizedOrigin = normalizeOrigin(origin);
+
+      if (
+        allowedOrigins.includes(normalizedOrigin) ||
+        isAllowedLocalOrigin(normalizedOrigin)
+      ) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error("origin_not_allowed"), false);
+    }
+  });
 
   registerHealthRoute(app);
   registerPortalRoutes(app, db, requireAccess);

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
     "apps/api": {
       "name": "@paretoproof/api",
       "dependencies": {
+        "@fastify/cors": "^11.1.0",
         "@paretoproof/shared": "workspace:*",
         "drizzle-orm": "latest",
         "fastify": "latest",
@@ -176,6 +177,8 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/cors": ["@fastify/cors@11.2.0", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw=="],
 
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
@@ -394,6 +397,8 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastify": ["fastify@5.8.2", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg=="],
+
+    "fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 


### PR DESCRIPTION
## Summary
- add credentialed CORS handling for the live portal/browser origin set
- allow local Vite origins for development without widening production access
- make API startup await plugin registration before listening

Closes #250