### PR TITLE
Prevent rejected users from reopening access requests

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -308,6 +308,14 @@ export function registerPortalRoutes(
             where: eq(accessRequests.email, accessEmail)
           });
 
+          if (
+            existingRequest &&
+            (existingRequest.status === "rejected" ||
+              existingRequest.status === "withdrawn")
+          ) {
+            throw new PortalAccessRequestConflictError("access_request_reentry_not_allowed");
+          }
+
           if (existingRequest?.status === "pending") {
             const [updatedRequest] = await tx
               .update(accessRequests)

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -9,6 +9,7 @@ type PortalAccessStatus = "approved" | "denied" | "pending" | "unauthenticated";
 
 type PortalRouteAccessContext = {
   pathname: string;
+  reason?: "access_request_required" | "rejected_or_withdrawn" | "unknown_identity";
   roles: string[];
   status: PortalAccessStatus;
 };
@@ -50,6 +51,12 @@ function canAccessRoute(
 ) {
   if (route.access === "portal_authenticated") {
     return context.status !== "unauthenticated";
+  }
+
+  if (route.access === "access_request_required_only") {
+    return (
+      context.status === "denied" && context.reason === "access_request_required"
+    );
   }
 
   if (route.access === "pending_only") {

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -90,6 +90,7 @@ export function PortalBootstrap() {
 
     return resolvePortalRouteRedirect({
       pathname: window.location.pathname,
+      reason: state.status === "denied" ? state.reason : undefined,
       roles: state.status === "approved" ? state.roles : [],
       status: state.status
     });
@@ -247,7 +248,10 @@ export function PortalBootstrap() {
   }
 
   if (state.status === "denied") {
-    if (window.location.pathname === "/access-request") {
+    if (
+      state.reason === "access_request_required" &&
+      window.location.pathname === "/access-request"
+    ) {
       return (
         <AccessRequestScreen
           email={state.email}

--- a/packages/shared/src/contracts/route-access.ts
+++ b/packages/shared/src/contracts/route-access.ts
@@ -38,13 +38,13 @@ export const appRouteAccessMatrix = [
     summary: "Authenticated portal landing page after Cloudflare Access."
   },
   {
-    access: "portal_authenticated",
+    access: "access_request_required_only",
     host: "portal.paretoproof.com",
     id: "portal.access-request",
     path: "/access-request",
-    redirectIfDenied: "public_home",
+    redirectIfDenied: "portal_denied",
     surface: "portal",
-    summary: "Contributor request and approval-state summary."
+    summary: "Contributor request screen for authenticated identities that have never been reviewed."
   },
   {
     access: "approved_helper_or_higher",

--- a/packages/shared/src/types/route-access.ts
+++ b/packages/shared/src/types/route-access.ts
@@ -3,6 +3,7 @@ export type AppSurface = "public_site" | "portal";
 export type RouteAccessLevel =
   | "public"
   | "portal_authenticated"
+  | "access_request_required_only"
   | "pending_only"
   | "denied_only"
   | "approved_helper_or_higher"


### PR DESCRIPTION
## Summary
- restrict the /access-request portal route to identities that truly need a first-time request
- stop denied users from seeing the request screen just by deep-linking into it
- reject backend re-entry when the latest request was already rejected or withdrawn

Closes #252