### PR TITLE
Fix Pages deploy for auth surface rollout

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
           command: >-
-            --cwd=apps/web
             pages deploy dist
             --project-name=paretoproof-web
             --branch=main


### PR DESCRIPTION
## Summary
- switch the Cloudflare Wrangler action to run from apps/web using its workingDirectory input
- keep the existing Pages deploy command intact so the auth host Functions are bundled from the correct project root

## Verification
- reviewed the failed production deploy log from run 22869038376
- confirmed the fix matches the action invocation model instead of passing an unsupported --cwd flag to Wrangler