### PR TITLE
Redesign public, auth, and portal web surfaces

### DIFF
--- a/apps/web/src/components/app-icon.tsx
+++ b/apps/web/src/components/app-icon.tsx
@@ -1,0 +1,141 @@
+export type AppIconName =
+  | "compass"
+  | "spark"
+  | "shield"
+  | "grid"
+  | "user"
+  | "flask"
+  | "play"
+  | "server"
+  | "key"
+  | "users"
+  | "github"
+  | "google"
+  | "check"
+  | "arrow-right"
+  | "panel-left"
+  | "panel-right";
+
+export function AppIcon({ name }: { name: AppIconName }) {
+  switch (name) {
+    case "compass":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="8" />
+          <path d="M10 14l2-4 4-2-2 4-4 2z" />
+        </svg>
+      );
+    case "spark":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 3l1.8 4.7L19 9.5l-4.2 2.4L13 17l-1.8-5.1L7 9.5l5.2-1.8L12 3z" />
+        </svg>
+      );
+    case "shield":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 3l7 3v5c0 4.2-2.7 7.4-7 10-4.3-2.6-7-5.8-7-10V6l7-3z" />
+        </svg>
+      );
+    case "grid":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="6" height="6" rx="1" />
+          <rect x="14" y="4" width="6" height="6" rx="1" />
+          <rect x="4" y="14" width="6" height="6" rx="1" />
+          <rect x="14" y="14" width="6" height="6" rx="1" />
+        </svg>
+      );
+    case "user":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="12" cy="8" r="4" />
+          <path d="M5 20c1.8-3.4 4.2-5 7-5s5.2 1.6 7 5" />
+        </svg>
+      );
+    case "flask":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M10 3h4" />
+          <path d="M11 3v5l-5 8a3 3 0 0 0 2.6 4.5h6.8A3 3 0 0 0 18 16l-5-8V3" />
+          <path d="M9 14h6" />
+        </svg>
+      );
+    case "play":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M8 6l10 6-10 6V6z" />
+        </svg>
+      );
+    case "server":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="4" y="5" width="16" height="5" rx="1.5" />
+          <rect x="4" y="14" width="16" height="5" rx="1.5" />
+          <path d="M8 7.5h.01M8 16.5h.01" />
+        </svg>
+      );
+    case "key":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="8" cy="12" r="4" />
+          <path d="M12 12h8M17 12v3M20 12v2" />
+        </svg>
+      );
+    case "users":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="9" cy="9" r="3" />
+          <circle cx="17" cy="10" r="2.5" />
+          <path d="M4.5 19c1.3-2.7 3.2-4 5.7-4s4.4 1.3 5.7 4" />
+          <path d="M15.2 18c.6-1.3 1.7-2 3.2-2 1.2 0 2.3.5 3.1 1.6" />
+        </svg>
+      );
+    case "github":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 3a8.8 8.8 0 0 0-2.8 17.2c.4.1.6-.2.6-.5v-1.8c-2.4.5-3-.6-3.2-1.2-.1-.4-.6-1.2-1-1.5-.3-.2-.7-.8 0-.8.7 0 1.2.6 1.4.9.8 1.3 2 1 2.5.8.1-.6.3-1 .6-1.3-2.1-.2-4.4-1-4.4-4.7 0-1 .4-1.9 1-2.5-.1-.2-.5-1.2.1-2.5 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 4.9 0c1.9-1.3 2.7-1 2.7-1 .6 1.3.2 2.3.1 2.5.6.6 1 1.4 1 2.5 0 3.7-2.3 4.5-4.4 4.7.3.3.7.8.7 1.7v2.5c0 .3.2.6.6.5A8.8 8.8 0 0 0 12 3z" />
+        </svg>
+      );
+    case "google":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M20 12.2c0-.6-.1-1.1-.2-1.7H12v3.2h4.5a3.9 3.9 0 0 1-1.7 2.5v2.1h2.8c1.7-1.6 2.4-3.8 2.4-6.1z" />
+          <path d="M12 20.2c2.2 0 4.1-.7 5.4-2l-2.8-2.1c-.8.5-1.7.8-2.6.8-2 0-3.8-1.4-4.4-3.3H4.7V16A8.2 8.2 0 0 0 12 20.2z" />
+          <path d="M7.6 13.6a5 5 0 0 1 0-3.2V8H4.7a8.2 8.2 0 0 0 0 8l2.9-2.4z" />
+          <path d="M12 7.2c1.2 0 2.3.4 3.1 1.2l2.3-2.3A8.1 8.1 0 0 0 4.7 8l2.9 2.4c.6-1.9 2.4-3.2 4.4-3.2z" />
+        </svg>
+      );
+    case "check":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M5 13l4 4L19 7" />
+        </svg>
+      );
+    case "arrow-right":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M5 12h14" />
+          <path d="M13 7l6 5-6 5" />
+        </svg>
+      );
+    case "panel-left":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="16" height="16" rx="2" />
+          <path d="M10 4v16" />
+          <path d="M15 12l-3-3" />
+          <path d="M15 12l-3 3" />
+        </svg>
+      );
+    case "panel-right":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <rect x="4" y="4" width="16" height="16" rx="2" />
+          <path d="M14 4v16" />
+          <path d="M9 12l3-3" />
+          <path d="M9 12l3 3" />
+        </svg>
+      );
+  }
+}

--- a/apps/web/src/routes/access-completion.tsx
+++ b/apps/web/src/routes/access-completion.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { AppIcon } from "../components/app-icon";
 import { buildApiSessionCompleteUrl } from "../lib/surface";
 
 type AccessCompletionProps = {
@@ -26,7 +27,12 @@ export function AccessCompletion({ provider, redirectPath }: AccessCompletionPro
   return (
     <main className="auth-shell auth-shell-compact">
       <section className="auth-inline-status">
-        <p className="eyebrow">ParetoProof Portal</p>
+        <p className="eyebrow">
+          <span className="inline-icon" aria-hidden="true">
+            <AppIcon name="shield" />
+          </span>
+          ParetoProof Portal
+        </p>
         <h1>Completing {providerLabel} sign in</h1>
         <p>
           Your Cloudflare Access session is active. Finishing the portal handoff now.

--- a/apps/web/src/routes/access-request-screen.tsx
+++ b/apps/web/src/routes/access-request-screen.tsx
@@ -5,6 +5,7 @@ import {
   type PortalAccessRequestInput
 } from "@paretoproof/shared";
 import { useState } from "react";
+import { AppIcon } from "../components/app-icon";
 
 type AccessRequestScreenProps =
   | {
@@ -78,8 +79,13 @@ export function AccessRequestScreen({
 
   return (
     <main className="auth-shell">
-      <section className="auth-card">
-        <p className="eyebrow">Portal access</p>
+      <section className="auth-card auth-card-polished auth-status-card">
+        <p className="eyebrow">
+          <span className="inline-icon" aria-hidden="true">
+            <AppIcon name="key" />
+          </span>
+          Portal access
+        </p>
         <h1>
           {mode === "identity_recovery"
             ? "Recover approved access"

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,8 +1,15 @@
+import { AppIcon } from "../components/app-icon";
 import { buildAccessStartUrl, buildPublicUrl, isLocalHostname } from "../lib/surface";
 
 type AuthEntryProps = {
   redirectPath: string;
 };
+
+const authChecks = [
+  "Provider identity should resolve into one ParetoProof account, not duplicate users.",
+  "Approval state needs to be surfaced before the portal handoff looks broken.",
+  "Recovery should explain what changed instead of dumping users into Access noise."
+];
 
 export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const githubStartUrl = buildAccessStartUrl("github", redirectPath);
@@ -13,41 +20,75 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
     <main className="auth-shell">
       <section className="auth-card auth-card-polished">
         <div className="auth-card-intro">
-          <p className="eyebrow">ParetoProof Portal</p>
-          <h1>Sign in to the contributor workspace.</h1>
+          <p className="eyebrow">
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="shield" />
+            </span>
+            ParetoProof portal
+          </p>
+          <h1>Use one clean entry, then route users into the right identity state.</h1>
           <p className="auth-lead">
-            Access stays behind Cloudflare Access. Use a trusted provider to
-            continue into the portal and let the backend decide your approval
-            level.
+            Provider choice, account linking, and contributor approval belong in one
+            deliberate handoff instead of a stack of awkward intermediary screens.
           </p>
         </div>
 
-        <div className="auth-provider-list">
-          <a className="auth-provider-button" href={githubStartUrl}>
-            <span className="auth-provider-mark" aria-hidden="true">
-              GH
-            </span>
-            <span>
-              <strong>Continue with GitHub</strong>
-              <small>Use your GitHub identity for portal access.</small>
-            </span>
-          </a>
-          <a className="auth-provider-button" href={googleStartUrl}>
-            <span className="auth-provider-mark" aria-hidden="true">
-              GO
-            </span>
-            <span>
-              <strong>Continue with Google</strong>
-              <small>Use your Google account for the same portal flow.</small>
-            </span>
-          </a>
+        <div className="auth-provider-layout">
+          <section className="auth-provider-panel">
+            <p className="section-tag">Sign in</p>
+            <h2>Choose a trusted provider</h2>
+            <p className="auth-panel-copy">
+              GitHub and Google stay first-class without changing the overall shell.
+            </p>
+            <div className="auth-provider-list">
+              <a className="auth-provider-button" href={githubStartUrl}>
+                <span className="auth-provider-mark" aria-hidden="true">
+                  <AppIcon name="github" />
+                </span>
+                <span>
+                  <strong>Continue with GitHub</strong>
+                  <small>Primary contributor sign-in for repository-linked work.</small>
+                </span>
+                <span className="auth-provider-arrow" aria-hidden="true">
+                  <AppIcon name="arrow-right" />
+                </span>
+              </a>
+              <a className="auth-provider-button" href={googleStartUrl}>
+                <span className="auth-provider-mark" aria-hidden="true">
+                  <AppIcon name="google" />
+                </span>
+                <span>
+                  <strong>Continue with Google</strong>
+                  <small>Fallback for approved contributors who operate outside GitHub.</small>
+                </span>
+                <span className="auth-provider-arrow" aria-hidden="true">
+                  <AppIcon name="arrow-right" />
+                </span>
+              </a>
+            </div>
+          </section>
+
+          <aside className="auth-provider-panel auth-provider-panel-notes">
+            <p className="section-tag">Guardrails</p>
+            <h2>What the flow has to explain</h2>
+            <ul className="auth-check-list">
+              {authChecks.map((item) => (
+                <li key={item}>
+                  <span className="auth-check-mark" aria-hidden="true">
+                    <AppIcon name="check" />
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </aside>
         </div>
 
         <div className="auth-card-footer">
           <p>
             {isLocal
-              ? "Local development bypasses Cloudflare Access and opens a fully approved portal session."
-              : "If you have not been approved yet, sign in first and submit an access request from inside the portal."}
+              ? "Local development can jump straight into an approved portal session so the UI can be tested without Cloudflare Access in the loop."
+              : "If you are not approved yet, sign in first and submit your contributor request from inside the portal."}
           </p>
           <a className="button button-secondary" href={buildPublicUrl("/")}>
             Back to paretoproof.com

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -1,5 +1,6 @@
 import type { PortalAccessRequestInput } from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
+import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import { resolvePortalRouteRedirect } from "../lib/portal-route-access";
 import { AccessRequestScreen } from "./access-request-screen";
@@ -355,8 +356,13 @@ type PortalStatusCardProps = {
 function PortalStatusCard({ action, body, eyebrow, title }: PortalStatusCardProps) {
   return (
     <main className="auth-shell">
-      <section className="auth-card">
-        <p className="eyebrow">{eyebrow}</p>
+      <section className="auth-card auth-card-polished auth-status-card">
+        <p className="eyebrow">
+          <span className="inline-icon" aria-hidden="true">
+            <AppIcon name="shield" />
+          </span>
+          {eyebrow}
+        </p>
         <h1>{title}</h1>
         <p>{body}</p>
         {action ? (

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -8,6 +8,7 @@ import {
   type PortalSectionDefinition
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
+import { AppIcon, type AppIconName } from "../components/app-icon";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { findMatchedPortalRoute } from "../lib/portal-route-access";
 import { buildPortalUrl } from "../lib/surface";
@@ -24,31 +25,96 @@ const portalRoutePathById = new Map(
 );
 
 const portalRoleOrder: PortalRole[] = ["admin", "collaborator", "helper"];
-const portalSectionCode: Record<PortalSectionDefinition["id"], string> = {
-  access_requests: "AQ",
-  launch: "LN",
-  overview: "OV",
-  profile: "PF",
-  runs: "RN",
-  users: "US",
-  workers: "WK"
+const portalSectionIconById: Record<PortalSectionDefinition["id"], AppIconName> = {
+  access_requests: "key",
+  launch: "play",
+  overview: "grid",
+  profile: "user",
+  runs: "flask",
+  users: "users",
+  workers: "server"
 };
+
+const overviewMetrics = [
+  {
+    label: "Approval state",
+    note: "role-linked and current",
+    value: "approved"
+  },
+  {
+    label: "API health",
+    note: "Railway to Neon responding",
+    value: "green"
+  },
+  {
+    label: "Recent runs",
+    note: "2 pending review, 1 blocked",
+    value: "08"
+  },
+  {
+    label: "Identity links",
+    note: "GitHub and Google attached",
+    value: "02"
+  }
+];
+
+const overviewRuns = [
+  {
+    branch: "main",
+    id: "PP-318",
+    model: "gpt-oss",
+    state: "passed",
+    target: "mathlib4 / simplification"
+  },
+  {
+    branch: "auth-fix",
+    id: "PP-319",
+    model: "claude",
+    state: "running",
+    target: "proof search / induction"
+  },
+  {
+    branch: "railway-host",
+    id: "PP-320",
+    model: "gemini",
+    state: "blocked",
+    target: "worker smoke / queue handoff"
+  }
+];
+
+const overviewTimeline = [
+  {
+    detail: "Tom linked GitHub and entered the contributor portal without the Access handoff breaking.",
+    meta: "11:24 UTC",
+    title: "Access request approved"
+  },
+  {
+    detail: "A stale Google-only identity needs relink confirmation before approval is restored.",
+    meta: "09:10 UTC",
+    title: "Recovery check required"
+  },
+  {
+    detail: "Railway health and Neon connectivity both reported green after the last deploy.",
+    meta: "07:42 UTC",
+    title: "API host validation"
+  }
+];
 
 const portalSectionBodyCopy: Record<PortalSectionDefinition["id"], string> = {
   access_requests:
-    "This queue will hold contributor requests, approval notes, and the next decision actions for admins.",
+    "The approval queue, stale identity recovery, and decision notes need to stay calm and readable under real admin load.",
   launch:
-    "This launch view will become the benchmark entrypoint for collaborators and admins once the backend run flow is wired through.",
+    "Launch should become a checklist-driven control surface once benchmark execution is wired through the backend.",
   overview:
-    "This overview will surface benchmark health, recent activity, and the most important contributor actions first.",
+    "The default view should show benchmark posture, approval state, and recent operational movement in one scan.",
   profile:
-    "This profile view holds the signed-in contributor details the MVP already supports and the currently linked Access identities.",
+    "Profile is where contributors confirm linked identities, edit the small supported fields, and recover broken auth state.",
   runs:
-    "This section will list benchmark runs, queue status, and the route into deeper run detail pages.",
+    "Runs should read like an audit log with dense but legible state instead of decorative tiles.",
   users:
-    "This surface will become the role and contributor directory once the admin management workflows are implemented.",
+    "This surface will grow into contributor and role management without forcing a shell redesign.",
   workers:
-    "This worker view will show queue posture, fleet health, and the execution surfaces that sit behind the control plane."
+    "Worker posture belongs in the same serious shell even before orchestration is fully live."
 };
 
 function coercePortalRoles(rawRoles: string[]): PortalRole[] {
@@ -121,14 +187,17 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       >
         <div className="portal-sidebar-header">
           <div className="portal-brand-block">
-            <p className="eyebrow">Portal</p>
+            <span className="portal-brand-mark" aria-hidden="true">
+              <AppIcon name="spark" />
+            </span>
             {!navigationCollapsed ? (
-              <>
+              <div>
+                <p className="eyebrow">Portal</p>
                 <h1>ParetoProof</h1>
                 <p className="portal-brand-copy">
                   Formal benchmark operations and contributor tooling.
                 </p>
-              </>
+              </div>
             ) : null}
           </div>
           <button
@@ -139,7 +208,12 @@ export function PortalShell({ email, roles }: PortalShellProps) {
             }}
             type="button"
           >
-            {navigationCollapsed ? ">>" : "<<"}
+            <span className="sidebar-toggle-icon" aria-hidden="true">
+              <AppIcon name={navigationCollapsed ? "panel-right" : "panel-left"} />
+            </span>
+            <span className="sr-only">
+              {navigationCollapsed ? "Expand navigation" : "Collapse navigation"}
+            </span>
           </button>
         </div>
 
@@ -156,7 +230,9 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                 key={section.id}
                 title={section.navLabel}
               >
-                <span className="portal-nav-link-initial">{portalSectionCode[section.id]}</span>
+                <span className="portal-nav-link-icon" aria-hidden="true">
+                  <AppIcon name={portalSectionIconById[section.id]} />
+                </span>
                 {!navigationCollapsed ? (
                   <span className="portal-nav-copy">
                     <span className="portal-nav-label">{section.navLabel}</span>
@@ -181,17 +257,21 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       <section className="portal-main">
         <header className="portal-topbar">
           <div>
-            <p className="eyebrow">Authenticated portal</p>
+            <p className="eyebrow">
+              <span className="inline-icon" aria-hidden="true">
+                <AppIcon name="grid" />
+              </span>
+              Authenticated portal
+            </p>
             <h1>{activeSection?.navLabel ?? "Portal"}</h1>
             <p className="portal-topbar-copy">
-              {activeSection?.description ??
-                "Contributor and benchmark control surface."}
+              {activeSection?.description ?? "Contributor and benchmark control surface."}
             </p>
           </div>
           <div className="portal-identity">
             <span className="role-chip">{email ?? "Signed in"}</span>
             {approvedRoles.map((role) => (
-              <span className="role-chip" key={role}>
+              <span className="role-chip role-chip-muted" key={role}>
                 {role}
               </span>
             ))}
@@ -202,47 +282,48 @@ export function PortalShell({ email, roles }: PortalShellProps) {
           <p className="portal-status-copy">
             {activeSection ? portalSectionBodyCopy[activeSection.id] : ""}
           </p>
-          <span className="role-chip role-chip-muted">
+          <span className="role-chip role-chip-tonal">
             {approvedRoles.join(" · ") || "authenticated"}
           </span>
         </section>
 
-        <section className="portal-content">
-          {activeSection?.id === "access_requests" ? (
-            <PortalAccessRequestPanel email={email} />
-          ) : activeSection?.id === "profile" ? (
-            <PortalProfilePanel email={email} />
-          ) : (
-            <section className="portal-workspace-grid">
-              <article className="portal-panel portal-surface-main">
-                <p className="eyebrow">Current section</p>
-                <h2>{activeSection?.navLabel ?? "Portal section"}</h2>
-                <p>{activeSection?.summary}</p>
+        {activeSection?.id === "overview" ? (
+          <>
+            <section className="portal-metric-strip" aria-label="Portal metrics">
+              {overviewMetrics.map((metric) => (
+                <article className="portal-metric-cell" key={metric.label}>
+                  <span>{metric.label}</span>
+                  <strong>{metric.value}</strong>
+                  <small>{metric.note}</small>
+                </article>
+              ))}
+            </section>
+
+            <section className="portal-overview-grid">
+              <article className="portal-panel portal-panel-emphasis">
+                <p className="section-tag">Control plane overview</p>
+                <h2>One stable canvas for auth, approvals, and benchmark posture.</h2>
+                <p>
+                  The shell should read like an operational workspace. Navigation stays
+                  structural on the left, the content pane carries the dense information,
+                  and the visual hierarchy comes from seams and typography rather than
+                  oversized rounded cards.
+                </p>
                 {activeFreshnessPolicy ? (
                   <PortalFreshnessCard lastUpdatedAt={null} routeId={activeRouteId} />
                 ) : null}
                 <div className="portal-section-notes">
-                  <p className="portal-panel-muted">
-                    This surface is structurally ready and can be filled in as backend
-                    features land.
-                  </p>
                   <ul className="portal-note-list">
-                    <li>
-                      Navigation and route access already reflect the approved role model.
-                    </li>
-                    <li>
-                      Live data can replace these placeholders without redesigning the shell.
-                    </li>
-                    <li>
-                      The left workspace rail stays stable while each section grows
-                      independently.
-                    </li>
+                    <li>Keep recent runs, approval posture, and launch state visible in one pass.</li>
+                    <li>Use symbols and labels in the rail instead of two-letter abbreviations.</li>
+                    <li>Reserve strong color for state, not for every container.</li>
                   </ul>
                 </div>
               </article>
+
               <aside className="portal-panel portal-surface-rail">
-                <p className="eyebrow">Available actions</p>
-                <h2>Role-aware controls</h2>
+                <p className="section-tag">Role-aware controls</p>
+                <h2>Next actions</h2>
                 <div className="portal-action-list">
                   {overviewActions.map((action) => (
                     <PortalActionRow action={action} key={action.id} />
@@ -250,8 +331,96 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                 </div>
               </aside>
             </section>
-          )}
-        </section>
+
+            <section className="portal-overview-grid portal-overview-grid-secondary">
+              <article className="portal-panel portal-panel-table">
+                <div className="portal-panel-header">
+                  <div>
+                    <p className="section-tag">Run queue</p>
+                    <h2>Recent benchmark activity</h2>
+                  </div>
+                  <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+                    View all runs
+                  </a>
+                </div>
+
+                <div className="portal-table-shell" role="table" aria-label="Recent runs">
+                  <div className="portal-table-head" role="row">
+                    <span>Run</span>
+                    <span>Model</span>
+                    <span>Target</span>
+                    <span>Branch</span>
+                    <span>Status</span>
+                  </div>
+                  {overviewRuns.map((row) => (
+                    <div className="portal-table-row" key={row.id} role="row">
+                      <span>{row.id}</span>
+                      <span>{row.model}</span>
+                      <span>{row.target}</span>
+                      <span>{row.branch}</span>
+                      <span className={`portal-state-badge portal-state-${row.state}`}>
+                        {row.state}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </article>
+
+              <aside className="portal-panel">
+                <p className="section-tag">Approvals</p>
+                <h2>Identity and review timeline</h2>
+                <div className="portal-timeline">
+                  {overviewTimeline.map((item) => (
+                    <article className="portal-timeline-item" key={item.title}>
+                      <strong>{item.title}</strong>
+                      <p>{item.detail}</p>
+                      <small>{item.meta}</small>
+                    </article>
+                  ))}
+                </div>
+              </aside>
+            </section>
+          </>
+        ) : (
+          <section className="portal-content">
+            {activeSection?.id === "access_requests" ? (
+              <PortalAccessRequestPanel email={email} />
+            ) : activeSection?.id === "profile" ? (
+              <PortalProfilePanel email={email} />
+            ) : (
+              <section className="portal-workspace-grid">
+                <article className="portal-panel portal-surface-main">
+                  <p className="section-tag">Current section</p>
+                  <h2>{activeSection?.navLabel ?? "Portal section"}</h2>
+                  <p>{activeSection?.summary}</p>
+                  {activeFreshnessPolicy ? (
+                    <PortalFreshnessCard lastUpdatedAt={null} routeId={activeRouteId} />
+                  ) : null}
+                  <div className="portal-section-notes">
+                    <p className="portal-panel-muted">
+                      This surface is structurally ready and can be filled in as backend
+                      features land.
+                    </p>
+                    <ul className="portal-note-list">
+                      <li>Navigation and route access already reflect the approved role model.</li>
+                      <li>Live data can replace the placeholder content without another shell rewrite.</li>
+                      <li>The rail stays fixed while each deeper workflow grows independently.</li>
+                    </ul>
+                  </div>
+                </article>
+                <aside className="portal-panel portal-surface-rail">
+                  <p className="section-tag">Available actions</p>
+                  <h2>Role-aware controls</h2>
+                  <div className="portal-action-list">
+                    {overviewActions.map((action) => (
+                      <PortalActionRow action={action} key={action.id} />
+                    ))}
+                  </div>
+                </aside>
+              </section>
+            )}
+          </section>
+        )}
       </section>
     </main>
   );

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -1,36 +1,110 @@
+import { AppIcon } from "../components/app-icon";
 import { buildAuthUrl } from "../lib/surface";
+
+const publicSignals = [
+  {
+    detail: "versioned harness inputs, environment metadata, and comparable outputs",
+    label: "Reproducible runs",
+    value: "22"
+  },
+  {
+    detail: "researchers, mathematicians, and admins see distinct surfaces",
+    label: "Approval model",
+    value: "role aware"
+  },
+  {
+    detail: "API control plane separated from heavier Lean and model execution",
+    label: "Execution split",
+    value: "API / workers"
+  }
+];
+
+const publicBands = [
+  {
+    body:
+      "ParetoProof tracks what actually ran, under which identities, and with which execution contracts instead of publishing one-off benchmark claims.",
+    eyebrow: "Benchmark ledger",
+    title: "Evidence before hype"
+  },
+  {
+    body:
+      "Contributor approval, identity linking, and recovery are product surfaces. They do not live in a side spreadsheet bolted onto auth.",
+    eyebrow: "Access model",
+    title: "Operational trust"
+  },
+  {
+    body:
+      "Cloudflare owns entry, Railway owns the control plane, Neon owns structured state, and workers stay separate from the public backend.",
+    eyebrow: "Hosting posture",
+    title: "Control-plane split"
+  }
+];
 
 export function PublicSite() {
   return (
     <main className="site-shell">
       <header className="site-header">
-        <div>
-          <p className="eyebrow">ParetoProof</p>
-          <p className="site-tagline">Formal benchmark infrastructure for theorem proving systems.</p>
+        <div className="site-brand">
+          <span className="site-brand-mark" aria-hidden="true">
+            <AppIcon name="spark" />
+          </span>
+          <div>
+            <p className="eyebrow">ParetoProof</p>
+            <p className="site-tagline">
+              Formal benchmark infrastructure for mathematical reasoning systems.
+            </p>
+          </div>
         </div>
         <a className="button button-secondary" href={buildAuthUrl("/")}>
-          Log in
+          Contributor sign in
         </a>
       </header>
 
-      <section className="hero-card">
-        <div className="hero-copy">
-          <p className="eyebrow">Public Site</p>
-          <h1>Measure real progress on formal mathematical reasoning.</h1>
-          <p>
-            ParetoProof is building a benchmark platform for Lean-based theorem
-            proving systems, with reproducible runs, audited access control, and
-            a private portal for contributors.
+      <section className="site-hero">
+        <div className="site-hero-copy">
+          <p className="eyebrow">
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="compass" />
+            </span>
+            Formal math evaluation
+          </p>
+          <h1>Measure frontier reasoning with reproducible proof workflows.</h1>
+          <p className="site-lead">
+            ParetoProof exists to answer what frontier systems can actually do on formal
+            mathematical tasks without hiding the auth, approval, or execution conditions
+            that make the result trustworthy.
           </p>
           <div className="hero-actions">
             <a className="button" href={buildAuthUrl("/")}>
               Enter the portal
             </a>
             <a className="button button-secondary" href="/benchmarks">
-              View benchmark overview
+              Read the benchmark model
             </a>
           </div>
         </div>
+
+        <aside className="site-signal-column" aria-label="Project signals">
+          {publicSignals.map((signal) => (
+            <article className="site-signal-row" key={signal.label}>
+              <span className="site-signal-value">{signal.value}</span>
+              <div>
+                <h2>{signal.label}</h2>
+                <p>{signal.detail}</p>
+              </div>
+            </article>
+          ))}
+        </aside>
+      </section>
+
+      <section className="site-band-grid" aria-label="Project summary">
+        {publicBands.map((band) => (
+          <article className="site-band" key={band.title}>
+            <p className="section-tag">{band.eyebrow}</p>
+            <h2>{band.title}</h2>
+            <p>{band.body}</p>
+          </article>
+        ))}
       </section>
     </main>
   );

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1,34 +1,47 @@
 :root {
   color-scheme: light;
-  font-family: "Segoe UI Variable", "Segoe UI", sans-serif;
-  color: #0f1d46;
-  background:
-    radial-gradient(circle at top left, rgba(20, 52, 164, 0.12), transparent 26%),
-    linear-gradient(180deg, #f5f8ff 0%, #eef3ff 55%, #e8efff 100%);
-  --blue-strong: #1434a4;
-  --blue-soft: #2f56cc;
-  --blue-faint: rgba(20, 52, 164, 0.08);
-  --panel: rgba(255, 255, 255, 0.94);
-  --panel-soft: rgba(247, 250, 255, 0.94);
-  --border: rgba(20, 52, 164, 0.12);
-  --border-strong: rgba(20, 52, 164, 0.2);
-  --text-muted: #5f719f;
-  --text-soft: #263866;
-  --danger: #d24747;
-  --warning: #b57709;
-  --shadow: 0 24px 55px rgba(20, 52, 164, 0.1);
+  font-family: "Aptos", "Segoe UI Variable", "Segoe UI", sans-serif;
+  --bg: #eef3f9;
+  --bg-strong: #dde6f2;
+  --paper: rgba(255, 255, 255, 0.88);
+  --paper-strong: #f9fbff;
+  --ink: #10203d;
+  --ink-soft: #546a8a;
+  --line: rgba(16, 42, 103, 0.13);
+  --line-strong: rgba(16, 42, 103, 0.22);
+  --navy: #112a67;
+  --navy-strong: #0b1d49;
+  --blue: #2563eb;
+  --mint: #0e8b73;
+  --amber: #b97514;
+  --rose: #a8475e;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top left, rgba(20, 52, 164, 0.12), transparent 26%),
-    linear-gradient(180deg, #f5f8ff 0%, #eef3ff 55%, #e8efff 100%);
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.1), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(17, 42, 103, 0.11), transparent 28%),
+    linear-gradient(180deg, #f7f9fc 0%, #eef3f9 100%);
+  color: var(--ink);
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }
 
 a {
@@ -36,127 +49,320 @@ a {
   text-decoration: none;
 }
 
-button,
-a.button {
+button {
   cursor: pointer;
 }
 
+svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+h1,
+h2,
+p,
+ul {
+  margin: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.eyebrow,
+.section-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--blue);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.section-tag {
+  letter-spacing: 0.14em;
+}
+
+.inline-icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.button,
+a.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 2.9rem;
+  padding: 0.8rem 1.15rem;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #173b92 0%, var(--navy) 100%);
+  color: #fff;
+  font-weight: 700;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    transform 160ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+}
+
+.button-secondary,
+a.button-secondary {
+  background: rgba(255, 255, 255, 0.66);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  border-color: var(--line-strong);
+}
+
 .site-shell,
-.auth-shell,
-.portal-shell-preview,
-.portal-shell {
-  min-height: 100vh;
-  padding: 2rem;
+.auth-shell {
+  width: min(1480px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 28px 0;
 }
 
 .site-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
+  display: grid;
+  gap: 24px;
+}
+
+.site-header,
+.site-hero,
+.site-band-grid,
+.auth-card,
+.auth-inline-status,
+.portal-main {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(249, 251, 255, 0.96));
 }
 
 .site-header {
+  padding: 20px 24px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 16px;
 }
 
-.site-tagline {
-  margin: 0.35rem 0 0;
-  max-width: 32rem;
-  color: var(--text-muted);
-}
-
-.hero-card,
-.auth-card,
-.portal-preview-card {
-  width: min(100%, 70rem);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(244, 248, 255, 0.96));
-  box-shadow: var(--shadow);
-}
-
-.hero-card {
-  flex: 1;
+.site-brand {
   display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.site-brand-mark {
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
   align-items: center;
-  padding: clamp(2rem, 5vw, 4rem);
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(17, 42, 103, 0.06);
+  color: var(--navy);
 }
 
-.hero-copy {
-  max-width: 40rem;
+.site-tagline,
+.site-lead,
+.site-band p,
+.site-signal-row p,
+.auth-lead,
+.auth-panel-copy,
+.auth-card-footer p,
+.portal-topbar-copy,
+.portal-status-copy,
+.portal-panel p,
+.portal-panel-muted,
+.portal-action-copy,
+.portal-request-meta,
+.portal-request-rationale,
+.portal-timeline-item p,
+.portal-nav-summary,
+.portal-brand-copy,
+.form-error,
+.auth-inline-status p:last-child {
+  color: var(--ink-soft);
+  line-height: 1.6;
 }
 
-.hero-copy p:last-child {
-  margin-bottom: 0;
+.site-hero {
+  padding: 32px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.92fr);
+  gap: 28px;
+  align-items: start;
 }
 
-.hero-actions {
+.site-hero-copy,
+.auth-card-intro {
+  display: grid;
+  gap: 18px;
+}
+
+.site-hero-copy h1,
+.auth-card h1,
+.auth-inline-status h1,
+.portal-topbar h1 {
+  font-size: clamp(2.6rem, 4vw, 4.6rem);
+  line-height: 0.94;
+  letter-spacing: -0.05em;
+}
+
+.site-lead,
+.auth-lead {
+  font-size: 1.05rem;
+  max-width: 48rem;
+}
+
+.hero-actions,
+.portal-link-actions,
+.portal-request-actions,
+.portal-identity {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
+  gap: 12px;
 }
 
-.auth-shell,
-.portal-shell-preview {
+.site-signal-column {
+  border-left: 1px solid var(--line);
+  padding-left: 24px;
   display: grid;
-  place-items: center;
 }
 
-.auth-shell-compact {
-  padding: 1.5rem;
+.site-signal-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: start;
+  padding: 18px 0;
+}
+
+.site-signal-row + .site-signal-row,
+.auth-provider-button + .auth-provider-button,
+.portal-action-card + .portal-action-card,
+.portal-timeline-item + .portal-timeline-item,
+.portal-identity-row + .portal-identity-row,
+.portal-table-row + .portal-table-row {
+  border-top: 1px solid var(--line);
+}
+
+.site-signal-row h2,
+.site-band h2,
+.auth-provider-panel h2,
+.portal-panel h2,
+.portal-main h2,
+.auth-inline-status h2 {
+  font-size: 1.35rem;
+  letter-spacing: -0.03em;
+}
+
+.site-signal-value {
+  min-width: 6rem;
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--navy);
+}
+
+.site-band-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.site-band {
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.site-band + .site-band {
+  border-left: 1px solid var(--line);
+}
+
+.auth-shell {
+  min-height: 100vh;
+  display: grid;
+  align-items: center;
 }
 
 .auth-card,
-.portal-preview-card {
-  padding: clamp(2rem, 4vw, 3rem);
+.auth-inline-status {
+  width: min(1040px, 100%);
+  margin: 0 auto;
+  padding: 28px;
+}
+
+.auth-card {
+  display: grid;
+  gap: 24px;
 }
 
 .auth-card-polished {
-  width: min(100%, 62rem);
-  border-radius: 1.25rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 247, 255, 0.98));
-  box-shadow:
-    0 24px 80px rgba(20, 52, 164, 0.12),
-    inset 0 0 0 1px rgba(20, 52, 164, 0.08);
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.09), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 251, 255, 0.98));
 }
 
-.auth-card-intro {
-  max-width: 38rem;
+.auth-provider-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(251, 252, 255, 0.84);
 }
 
-.auth-lead {
-  color: #41536f;
+.auth-provider-panel {
+  padding: 22px;
+  display: grid;
+  gap: 14px;
+}
+
+.auth-provider-panel-notes {
+  border-left: 1px solid var(--line);
 }
 
 .auth-provider-list {
   display: grid;
-  gap: 0.85rem;
-  margin: 2rem 0 1.5rem;
 }
 
 .auth-provider-button {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 1rem;
+  grid-template-columns: 42px minmax(0, 1fr) 20px;
+  gap: 14px;
   align-items: center;
-  padding: 1rem 1.1rem;
-  border: 1px solid rgba(20, 52, 164, 0.12);
-  border-radius: 1rem;
-  background: #ffffff;
-  box-shadow: 0 12px 36px rgba(20, 52, 164, 0.08);
-  transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+  padding: 16px 0;
 }
 
-.auth-provider-button:hover,
-.auth-provider-button:focus-visible {
-  border-color: rgba(20, 52, 164, 0.26);
-  box-shadow: 0 18px 42px rgba(20, 52, 164, 0.14);
-  transform: translateY(-1px);
+.auth-provider-button:hover .auth-provider-arrow,
+.auth-provider-button:focus-visible .auth-provider-arrow {
+  color: var(--navy);
 }
 
 .auth-provider-button strong,
@@ -165,472 +371,401 @@ a.button {
 }
 
 .auth-provider-button small {
-  margin-top: 0.2rem;
-  color: #5f6f87;
-  font-size: 0.92rem;
+  margin-top: 4px;
+  color: var(--ink-soft);
 }
 
-.auth-provider-mark {
+.auth-provider-mark,
+.auth-check-mark,
+.portal-nav-link-icon,
+.portal-brand-mark,
+.sidebar-toggle-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.9rem;
-  height: 2.9rem;
-  border-radius: 0.85rem;
-  background: #1434a4;
-  color: #ffffff;
-  font-size: 1rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: rgba(17, 42, 103, 0.06);
+  color: var(--navy);
+}
+
+.auth-provider-mark,
+.portal-brand-mark {
+  width: 42px;
+  height: 42px;
+}
+
+.auth-provider-arrow {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  color: var(--ink-soft);
+  transition: color 160ms ease;
+}
+
+.auth-check-list,
+.portal-note-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.auth-check-list li {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.auth-check-mark {
+  width: 32px;
+  height: 32px;
 }
 
 .auth-card-footer {
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid rgba(20, 52, 164, 0.08);
+  gap: 16px;
 }
 
-.auth-card-footer p {
-  margin: 0;
-  max-width: 38rem;
-  color: #5f6f87;
+.auth-shell-compact .auth-inline-status {
+  width: min(720px, 100%);
 }
 
-.auth-inline-status {
-  width: min(100%, 34rem);
-  padding: 2rem 2.25rem;
-  border: 1px solid rgba(20, 52, 164, 0.14);
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 18px 48px rgba(20, 52, 164, 0.12);
-}
-
-.auth-inline-status p:last-child {
-  margin-bottom: 0;
-  color: var(--text-muted);
+.auth-status-card {
+  width: min(840px, 100%);
 }
 
 .auth-form {
   display: grid;
-  gap: 1rem;
-  margin-top: 1.5rem;
+  gap: 14px;
+  margin-top: 8px;
 }
 
 .auth-field {
   display: grid;
-  gap: 0.45rem;
+  gap: 6px;
   font-weight: 600;
 }
 
-.auth-field select,
+.auth-input,
 .auth-field input,
+.auth-field select,
 .auth-field textarea {
   width: 100%;
-  padding: 0.85rem 0.95rem;
-  border: 1px solid var(--border);
-  border-radius: 0.7rem;
-  background: rgba(255, 255, 255, 0.96);
-  color: #142145;
-  font: inherit;
+  padding: 0.9rem 0.95rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--ink);
 }
 
-.auth-field select:focus,
+.auth-input:focus,
 .auth-field input:focus,
+.auth-field select:focus,
 .auth-field textarea:focus {
-  outline: 1px solid var(--blue-soft);
-  border-color: rgba(88, 130, 255, 0.65);
+  outline: 2px solid rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.42);
 }
 
-.auth-field textarea {
-  min-height: 7rem;
-  resize: vertical;
-}
-
-.auth-input:disabled {
-  opacity: 0.72;
+.auth-input:disabled,
+.auth-field input:disabled,
+.auth-field select:disabled,
+.auth-field textarea:disabled,
+.button:disabled {
+  opacity: 0.7;
   cursor: not-allowed;
 }
 
+.auth-field textarea {
+  min-height: 7.5rem;
+  resize: vertical;
+}
+
 .form-error {
-  margin-bottom: 0;
-  color: var(--danger);
-  font-weight: 600;
-}
-
-.eyebrow {
-  margin: 0 0 0.75rem;
-  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--blue-soft);
-}
-
-h1 {
-  margin: 0 0 1rem;
-  font-size: clamp(2rem, 5vw, 4rem);
-  line-height: 0.95;
-}
-
-p {
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  line-height: 1.6;
-  color: var(--text-soft);
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.75rem;
-  padding: 0.8rem 1.1rem;
-  border: 1px solid transparent;
-  border-radius: 0.7rem;
-  background: linear-gradient(180deg, #2d56da 0%, var(--blue-strong) 100%);
-  color: #ffffff;
-  font-weight: 600;
-}
-
-.button-secondary {
-  background: rgba(255, 255, 255, 0.86);
-  color: var(--blue-strong);
-  border-color: var(--border);
-  box-shadow: none;
-}
-
-.role-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 0.7rem;
-  background: rgba(20, 52, 164, 0.08);
-  color: var(--blue-strong);
-  font-size: 0.92rem;
-  font-weight: 600;
-}
-
-.role-chip-muted {
-  background: rgba(20, 52, 164, 0.04);
-  color: var(--text-muted);
+  color: var(--rose);
 }
 
 .portal-shell {
+  min-height: 100vh;
+  padding: 18px;
   display: grid;
-  grid-template-columns: minmax(15rem, 17rem) minmax(0, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 18px;
 }
 
 .portal-sidebar {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: linear-gradient(180deg, var(--navy) 0%, var(--navy-strong) 100%);
+  color: #fff;
+  padding: 24px 18px;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  min-width: 0;
-  position: sticky;
-  top: 1.5rem;
-  align-self: start;
-  min-height: calc(100vh - 3rem);
-  padding: 1rem;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: linear-gradient(180deg, rgba(20, 52, 164, 0.96), rgba(12, 36, 120, 0.98));
-  box-shadow: var(--shadow);
-  color: #f7fbff;
-}
-
-.portal-sidebar-collapsed {
-  padding-inline: 0.65rem;
+  gap: 24px;
 }
 
 .portal-sidebar-header,
-.portal-topbar {
+.portal-topbar,
+.portal-panel-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 16px;
 }
 
-.portal-sidebar-header h1,
-.portal-topbar h1,
-.portal-panel h2 {
-  font-size: clamp(1.4rem, 3vw, 2.4rem);
+.portal-brand-block {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.portal-brand-mark {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.portal-sidebar .eyebrow {
+  color: rgba(186, 206, 255, 0.84);
+}
+
+.portal-sidebar h1 {
+  font-size: 1.55rem;
+  letter-spacing: -0.04em;
+}
+
+.portal-brand-copy,
+.portal-sidebar-footer-label,
+.portal-sidebar-footer-value,
+.portal-nav-summary {
+  color: rgba(218, 227, 250, 0.76);
 }
 
 .sidebar-toggle {
-  min-width: 2.65rem;
-  min-height: 2.65rem;
-  padding: 0.55rem 0.65rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.7rem;
-  background: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
-  font: inherit;
-  font-weight: 700;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  padding: 0;
+}
+
+.sidebar-toggle-icon {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  border: 0;
+  color: inherit;
 }
 
 .portal-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  display: grid;
+  gap: 4px;
 }
 
 .portal-nav-link {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr);
-  align-items: start;
-  gap: 0.9rem;
-  padding: 0.8rem 0.85rem;
-  border: 1px solid transparent;
-  border-radius: 0.85rem;
-  color: #f3f7ff;
-  transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 12px 10px;
+  border-left: 2px solid transparent;
+  border-radius: 12px;
+  transition: background-color 160ms ease, border-color 160ms ease;
 }
 
 .portal-nav-link:hover,
 .portal-nav-link:focus-visible {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .portal-nav-link-active {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.24);
-}
-
-.portal-nav-link-initial {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.55rem;
   background: rgba(255, 255, 255, 0.08);
-  font-size: 0.82rem;
+  border-left-color: rgba(130, 173, 255, 0.95);
+}
+
+.portal-nav-link-icon {
+  width: 34px;
+  height: 34px;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.portal-nav-label,
+.portal-sidebar-footer-value {
+  display: block;
   font-weight: 700;
 }
 
-.portal-nav-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
+.portal-sidebar-footer {
+  margin-top: auto;
+  padding-top: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-.portal-nav-label {
-  font-weight: 700;
+.portal-sidebar-collapsed {
+  padding-inline: 12px;
 }
 
-.portal-nav-summary,
-.portal-panel-muted {
-  color: var(--text-muted);
+.portal-sidebar-collapsed .portal-brand-block {
+  grid-template-columns: 1fr;
+  justify-items: center;
 }
 
-.portal-sidebar .portal-nav-summary,
-.portal-sidebar .portal-panel-muted {
-  color: rgba(247, 250, 255, 0.66);
+.portal-sidebar-collapsed .portal-brand-block > div,
+.portal-sidebar-collapsed .portal-nav-copy,
+.portal-sidebar-collapsed .portal-sidebar-footer {
+  display: none;
 }
 
 .portal-sidebar-collapsed .portal-nav-link {
   grid-template-columns: 1fr;
   justify-items: center;
-}
-
-.portal-sidebar-collapsed .portal-nav-copy,
-.portal-sidebar-collapsed .portal-sidebar-header h1,
-.portal-sidebar-collapsed .portal-sidebar-header p:not(.eyebrow) {
-  display: none;
-}
-
-.portal-sidebar-collapsed .portal-sidebar-header {
-  align-items: center;
+  padding-inline: 8px;
 }
 
 .portal-main {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  padding: 26px;
+  display: grid;
+  gap: 18px;
   min-width: 0;
+  align-content: start;
 }
 
-.portal-identity {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.6rem;
+.portal-topbar h1 {
+  font-size: clamp(2.2rem, 4vw, 3.8rem);
 }
 
-.portal-brand-copy,
-.portal-topbar-copy,
-.portal-status-copy,
-.portal-sidebar-footer-label,
-.portal-sidebar-footer-value {
-  margin-bottom: 0;
-}
-
-.portal-sidebar-footer {
-  margin-top: auto;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.16);
-}
-
-.portal-sidebar-footer-label {
-  color: rgba(247, 250, 255, 0.66);
-  font-size: 0.84rem;
-}
-
-.portal-sidebar-footer-value {
-  color: #ffffff;
-  font-weight: 600;
-}
-
-.portal-topbar {
-  align-items: flex-end;
-}
-
-.portal-topbar-copy {
-  max-width: 46rem;
-  color: var(--text-muted);
+.portal-status-strip,
+.portal-metric-strip,
+.portal-panel,
+.portal-table-shell {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.74);
 }
 
 .portal-status-strip {
+  padding: 16px 18px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.95rem 1.2rem;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.72);
+  gap: 16px;
 }
 
-.portal-status-copy {
-  color: var(--text-muted);
+.role-chip,
+.portal-action-badge,
+.portal-state-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.42rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.66);
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--ink);
 }
 
-.portal-content {
-  min-width: 0;
+.role-chip-muted,
+.role-chip-tonal {
+  background: rgba(17, 42, 103, 0.06);
+  color: var(--navy);
 }
 
+.portal-metric-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.portal-metric-cell {
+  padding: 18px 20px;
+  display: grid;
+  gap: 6px;
+}
+
+.portal-metric-cell + .portal-metric-cell {
+  border-left: 1px solid var(--line);
+}
+
+.portal-metric-cell span,
+.portal-metric-cell small,
+.portal-table-head,
+.portal-table-row span:not(.portal-state-badge) {
+  color: var(--ink-soft);
+}
+
+.portal-metric-cell strong {
+  font-size: 1.6rem;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+}
+
+.portal-overview-grid,
+.portal-workspace-grid,
+.portal-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.portal-overview-grid,
 .portal-workspace-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.95fr);
-  gap: 1rem;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.92fr);
 }
 
-.portal-panel {
-  padding: 1.15rem 1.2rem;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: var(--panel);
-}
-
-.portal-panel h2 {
-  margin-top: 0;
-}
-
-.portal-panel-hero {
-  min-height: 11rem;
-}
-
-.portal-action-list {
-  display: grid;
-  gap: 0;
-  margin-top: 0.35rem;
-  border-top: 1px solid var(--border);
-}
-
+.portal-overview-grid-secondary,
 .portal-grid-profile {
-  grid-template-columns: minmax(0, 1.2fr) minmax(18rem, 0.8fr);
+  grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.92fr);
 }
 
 .portal-grid-stack {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.portal-identity-list {
+.portal-panel {
+  padding: 22px;
   display: grid;
-  gap: 0;
+  gap: 16px;
 }
 
-.portal-identity-row,
-.portal-identity-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.95rem 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.portal-request-list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.portal-request-card {
-  display: grid;
-  gap: 1rem;
-}
-
-.portal-request-header,
-.portal-request-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.portal-request-actions {
-  justify-content: flex-start;
-  flex-wrap: wrap;
-}
-
-.portal-request-meta,
-.portal-request-rationale {
-  margin-bottom: 0;
-}
-
-.portal-request-meta {
-  color: #5d5140;
-  font-size: 0.94rem;
-}
-
-.portal-action-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.95rem 0;
-  border-bottom: 1px solid var(--border);
+.portal-panel-emphasis {
+  background:
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.08), transparent 34%),
+    rgba(255, 255, 255, 0.8);
 }
 
 .portal-freshness-card {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  margin: 1rem 0 0;
-  padding: 1rem;
-  border: 1px solid var(--border);
-  border-radius: 0.9rem;
-  background: var(--panel-soft);
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .portal-freshness-card h3 {
-  margin: 0 0 0.45rem;
   font-size: 1rem;
+  letter-spacing: -0.02em;
 }
 
 .portal-freshness-actions {
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  gap: 0.65rem;
+  gap: 12px;
 }
 
 .portal-freshness-badge {
@@ -638,126 +773,259 @@ p {
 }
 
 .portal-freshness-fresh {
-  background: rgba(14, 142, 72, 0.12);
-  border-color: rgba(14, 142, 72, 0.22);
-  color: #15673c;
+  color: var(--mint);
+  border-color: rgba(14, 139, 115, 0.2);
+  background: rgba(14, 139, 115, 0.08);
 }
 
 .portal-freshness-manual,
 .portal-freshness-planned {
-  background: rgba(20, 52, 164, 0.08);
-  border-color: rgba(20, 52, 164, 0.2);
-  color: var(--blue-strong);
+  color: var(--navy);
+  border-color: rgba(17, 42, 103, 0.16);
+  background: rgba(17, 42, 103, 0.06);
 }
 
 .portal-freshness-stale {
-  background: rgba(181, 119, 9, 0.12);
-  border-color: rgba(181, 119, 9, 0.24);
-  color: var(--warning);
-}
-
-.portal-action-disabled {
-  opacity: 0.72;
-}
-
-.portal-action-title {
-  margin-bottom: 0.25rem;
-  font-weight: 700;
-}
-
-.portal-action-copy,
-.portal-action-hint {
-  margin-bottom: 0;
-}
-
-.portal-action-hint {
-  color: var(--blue-soft);
-  font-size: 0.92rem;
-}
-
-.portal-action-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2rem;
-  padding: 0.35rem 0.7rem;
-  border: 1px solid var(--border-strong);
-  border-radius: 999px;
-  background: rgba(20, 52, 164, 0.08);
-  color: var(--blue-strong);
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.portal-surface-main {
-  min-height: 16rem;
+  color: var(--amber);
+  border-color: rgba(185, 117, 20, 0.2);
+  background: rgba(185, 117, 20, 0.1);
 }
 
 .portal-section-notes {
-  margin-top: 1.35rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
 }
 
-.portal-note-list {
-  margin: 0;
-  padding-left: 1.1rem;
-  color: var(--text-muted);
+.portal-note-list li {
+  position: relative;
+  padding-left: 16px;
+  color: var(--ink-soft);
 }
 
-.portal-note-list li + li {
-  margin-top: 0.45rem;
+.portal-note-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.65em;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--blue);
 }
 
-.portal-grid {
+.portal-action-list,
+.portal-timeline,
+.portal-request-list,
+.portal-identity-list {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
 }
 
-.portal-link-actions {
+.portal-action-card,
+.portal-identity-row,
+.portal-timeline-item {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin: 1rem 0 0.85rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 0;
 }
 
-@media (max-width: 720px) {
-  .site-header {
+.portal-action-card:first-child,
+.portal-identity-row:first-child,
+.portal-timeline-item:first-child {
+  padding-top: 0;
+}
+
+.portal-action-card:last-child,
+.portal-identity-row:last-child,
+.portal-timeline-item:last-child {
+  padding-bottom: 0;
+}
+
+.portal-action-title {
+  margin-bottom: 4px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.portal-action-hint {
+  margin-top: 6px;
+  color: var(--blue);
+}
+
+.portal-table-shell {
+  overflow: hidden;
+}
+
+.portal-table-head,
+.portal-table-row {
+  display: grid;
+  grid-template-columns: 0.9fr 0.8fr 1.6fr 0.9fr 0.7fr;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 16px;
+}
+
+.portal-table-head {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.portal-table-row span:first-child {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.portal-state-badge {
+  justify-self: start;
+}
+
+.portal-state-passed {
+  color: var(--mint);
+  border-color: rgba(14, 139, 115, 0.2);
+  background: rgba(14, 139, 115, 0.08);
+}
+
+.portal-state-running {
+  color: var(--blue);
+  border-color: rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.portal-state-blocked {
+  color: var(--amber);
+  border-color: rgba(185, 117, 20, 0.2);
+  background: rgba(185, 117, 20, 0.1);
+}
+
+.portal-timeline-item {
+  display: grid;
+  gap: 6px;
+}
+
+.portal-timeline-item small {
+  color: var(--rose);
+  font-weight: 700;
+}
+
+.portal-request-card {
+  gap: 14px;
+}
+
+.portal-request-list {
+  gap: 16px;
+}
+
+.portal-request-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.portal-request-rationale {
+  padding-left: 14px;
+  border-left: 2px solid rgba(37, 99, 235, 0.14);
+}
+
+@media (max-width: 1220px) {
+  .site-hero,
+  .auth-provider-layout,
+  .portal-overview-grid,
+  .portal-overview-grid-secondary,
+  .portal-workspace-grid,
+  .portal-grid-profile,
+  .portal-topbar,
+  .portal-status-strip,
+  .auth-card-footer {
+    grid-template-columns: 1fr;
     flex-direction: column;
   }
 
+  .portal-metric-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-metric-cell:nth-child(3),
+  .portal-metric-cell:nth-child(4) {
+    border-top: 1px solid var(--line);
+  }
+
+  .portal-metric-cell:nth-child(3) {
+    border-left: 0;
+  }
+
+  .auth-provider-panel-notes {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .site-signal-column {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+    padding-left: 0;
+    padding-top: 12px;
+  }
+}
+
+@media (max-width: 900px) {
   .site-shell,
-  .auth-shell,
-  .portal-shell-preview,
-  .portal-shell {
-    padding: 1rem;
+  .auth-shell {
+    width: min(100%, calc(100% - 24px));
+    padding: 12px 0;
+  }
+
+  .site-header,
+  .site-hero,
+  .auth-card,
+  .auth-inline-status,
+  .portal-main {
+    padding: 18px;
+  }
+
+  .site-band-grid,
+  .portal-shell,
+  .portal-grid,
+  .portal-nav,
+  .portal-metric-strip {
+    grid-template-columns: 1fr;
   }
 
   .portal-shell {
-    grid-template-columns: minmax(0, 1fr);
+    padding: 10px;
   }
 
   .portal-sidebar {
-    position: static;
+    border-radius: 18px;
     min-height: auto;
   }
 
-  .portal-grid {
-    grid-template-columns: minmax(0, 1fr);
+  .site-band + .site-band {
+    border-left: 0;
+    border-top: 1px solid var(--line);
   }
 
-  .portal-grid-profile {
-    grid-template-columns: minmax(0, 1fr);
+  .portal-main {
+    border-radius: 18px;
   }
 
-  .portal-workspace-grid {
-    grid-template-columns: minmax(0, 1fr);
+  .portal-metric-cell + .portal-metric-cell {
+    border-left: 0;
+    border-top: 1px solid var(--line);
   }
 
-  .portal-request-header {
-    align-items: flex-start;
-    flex-direction: column;
+  .portal-table-head,
+  .portal-table-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-table-head span:nth-child(3),
+  .portal-table-head span:nth-child(4),
+  .portal-table-row span:nth-child(3),
+  .portal-table-row span:nth-child(4) {
+    display: none;
   }
 
   .portal-freshness-card,
@@ -765,15 +1033,32 @@ p {
     align-items: flex-start;
     flex-direction: column;
   }
+}
 
-  .auth-card-footer {
-    align-items: flex-start;
+@media (max-width: 640px) {
+  .site-header,
+  .hero-actions,
+  .portal-identity,
+  .portal-request-header,
+  .portal-request-actions,
+  .portal-action-card {
+    align-items: stretch;
     flex-direction: column;
   }
 
-  .portal-topbar,
-  .portal-status-strip {
-    align-items: flex-start;
-    flex-direction: column;
+  .button,
+  a.button {
+    width: 100%;
+  }
+
+  .site-hero-copy h1,
+  .auth-card h1,
+  .auth-inline-status h1,
+  .portal-topbar h1 {
+    font-size: clamp(2rem, 10vw, 3rem);
+  }
+
+  .portal-sidebar-collapsed .portal-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- redesign the real routed public site, auth entry, and portal shell instead of a fake demo surface
- replace two-letter provider and nav blocks with shared SVG symbols and a tighter visual system
- remove the puffy card-heavy treatment in favor of flatter panels, structural rail navigation, and denser portal overview layouts

## Validation
- `bun run build:web`
- `bun run typecheck:web`
- visual QA in local Vite at `http://127.0.0.1:4173` for public, auth, portal overview, profile, and access-request states
- visual comparison pass against live `https://paretoproof.com` and `https://auth.paretoproof.com`

## Notes
- Closes #305
- this resolves the broken merge-marker state that was preventing the web app from rendering on this machine
- local machine bootstrap completed for this work: Bun, Playwright Chromium, and Windows UI automation fallbacks
