### PR TITLE
Keep auth completion and retry flows inside ParetoProof surfaces

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -8,7 +8,7 @@ import {
   type PortalAccessRequestSummary
 } from "@paretoproof/shared";
 import { and, desc, eq, isNull } from "drizzle-orm";
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import {
   accessRequests,
   auditEvents,
@@ -133,6 +133,18 @@ function buildPortalAuthStartUrl(options: {
   return authUrl.toString();
 }
 
+function buildPortalAuthRetryUrl(redirectPath: string) {
+  const authUrl = new URL("https://auth.paretoproof.com");
+
+  if (redirectPath !== "/") {
+    authUrl.searchParams.set("redirect", redirectPath);
+  }
+
+  authUrl.searchParams.set("handoff", "retry");
+
+  return authUrl.toString();
+}
+
 function toPortalProfile(options: {
   currentSubject: string;
   fallbackEmail: string | null;
@@ -186,6 +198,112 @@ export function registerPortalRoutes(
   db: ReturnTypeOfCreateDbClient,
   requireAccess: ReturnTypeOfCreateAccessGuard
 ) {
+  const handlePortalSessionCompletion = async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => {
+    const cookieHeader =
+      typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+    const identity = request.accessIdentity;
+    const parsedBody =
+      typeof request.body === "object" && request.body !== null
+        ? (request.body as { redirect?: string })
+        : undefined;
+    const redirectPath = sanitizePortalRedirectPath(
+      parsedBody?.redirect ??
+        (request.query as { redirect?: string } | undefined)?.redirect ??
+        null
+    );
+    const portalUrl = new URL(redirectPath, "https://portal.paretoproof.com");
+    const linkIntent = verifyAccessLinkIntent(cookieHeader);
+    const providerHint = verifyAccessProviderHint(cookieHeader);
+
+    if (identity && linkIntent) {
+      const linkStatus = await db.transaction(async (tx) => {
+        const intentRow = await tx.query.identityLinkIntents.findFirst({
+          where: eq(identityLinkIntents.id, linkIntent.intentId)
+        });
+
+        if (!intentRow || intentRow.usedAt || intentRow.expiresAt.getTime() <= Date.now()) {
+          return "invalid";
+        }
+
+        const existingSubjectOwner = await tx.query.userIdentities.findFirst({
+          where: eq(userIdentities.providerSubject, identity.subject)
+        });
+
+        if (existingSubjectOwner && existingSubjectOwner.userId !== intentRow.userId) {
+          return "conflict";
+        }
+
+        if (providerHint !== intentRow.targetProvider) {
+          return "provider_mismatch";
+        }
+
+        const now = new Date();
+
+        if (!existingSubjectOwner) {
+          await tx.insert(userIdentities).values({
+            provider: intentRow.targetProvider,
+            providerEmail: normalizeOptionalEmail(identity.email),
+            providerSubject: identity.subject,
+            userId: intentRow.userId
+          });
+        } else {
+          await tx
+            .update(userIdentities)
+            .set({
+              lastSeenAt: now,
+              providerEmail: normalizeOptionalEmail(identity.email)
+            })
+            .where(eq(userIdentities.id, existingSubjectOwner.id));
+        }
+
+        await tx
+          .update(identityLinkIntents)
+          .set({
+            usedAt: now
+          })
+          .where(eq(identityLinkIntents.id, intentRow.id));
+
+        await tx.insert(auditEvents).values({
+          actorKind: "portal_user",
+          actorUserId: intentRow.userId,
+          eventId: "user_identity.linked",
+          payload: {
+            identityProvider: intentRow.targetProvider,
+            identitySubject: identity.subject,
+            targetUserId: intentRow.userId
+          },
+          severity: "critical",
+          subjectKind: "user_identity",
+          targetUserId: intentRow.userId
+        });
+
+        return "linked";
+      });
+
+      portalUrl.searchParams.set("link", linkStatus);
+    }
+
+    const responseCookies = [clearSignedAccessCookie("PortalLinkIntent")];
+
+    if (identity && providerHint) {
+      responseCookies.unshift(
+        buildSignedAccessCookie(
+          "PortalAccessProvider",
+          `${providerHint}|${identity.subject}`,
+          { maxAgeSeconds: 24 * 60 * 60 }
+        )
+      );
+    } else {
+      responseCookies.unshift(clearSignedAccessCookie("PortalAccessProvider"));
+    }
+
+    reply.header("set-cookie", responseCookies);
+    reply.redirect(portalUrl.toString());
+  };
+
   app.get(
     "/portal/me",
     {
@@ -199,113 +317,28 @@ export function registerPortalRoutes(
     }
   );
 
+  app.get("/portal/session/complete", async (request, reply) => {
+    const redirectPath = sanitizePortalRedirectPath(
+      (request.query as { redirect?: string } | undefined)?.redirect ?? null
+    );
+
+    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
+  });
+
   app.post(
     "/portal/session/complete",
     {
       preHandler: requireAccess("authenticated_access_identity")
     },
-    async (request, reply) => {
-      const cookieHeader =
-        typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
-      const identity = request.accessIdentity;
-      const parsedBody =
-        typeof request.body === "object" && request.body !== null
-          ? (request.body as { redirect?: string })
-          : undefined;
-      const redirectPath = sanitizePortalRedirectPath(
-        parsedBody?.redirect ??
-            (request.query as { redirect?: string } | undefined)?.redirect ??
-            null
-      );
-      const portalUrl = new URL(redirectPath, "https://portal.paretoproof.com");
-      const linkIntent = verifyAccessLinkIntent(cookieHeader);
-      const providerHint = verifyAccessProviderHint(cookieHeader);
+    handlePortalSessionCompletion
+  );
 
-      if (identity && linkIntent) {
-        const linkStatus = await db.transaction(async (tx) => {
-          const intentRow = await tx.query.identityLinkIntents.findFirst({
-            where: eq(identityLinkIntents.id, linkIntent.intentId)
-          });
-
-          if (!intentRow || intentRow.usedAt || intentRow.expiresAt.getTime() <= Date.now()) {
-            return "invalid";
-          }
-
-          const existingSubjectOwner = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.providerSubject, identity.subject)
-          });
-
-          if (existingSubjectOwner && existingSubjectOwner.userId !== intentRow.userId) {
-            return "conflict";
-          }
-
-          if (providerHint !== intentRow.targetProvider) {
-            return "provider_mismatch";
-          }
-
-          const now = new Date();
-
-          if (!existingSubjectOwner) {
-            await tx.insert(userIdentities).values({
-              provider: intentRow.targetProvider,
-              providerEmail: normalizeOptionalEmail(identity.email),
-              providerSubject: identity.subject,
-              userId: intentRow.userId
-            });
-          } else {
-            await tx
-              .update(userIdentities)
-              .set({
-                lastSeenAt: now,
-                providerEmail: normalizeOptionalEmail(identity.email)
-              })
-              .where(eq(userIdentities.id, existingSubjectOwner.id));
-          }
-
-          await tx
-            .update(identityLinkIntents)
-            .set({
-              usedAt: now
-            })
-            .where(eq(identityLinkIntents.id, intentRow.id));
-
-          await tx.insert(auditEvents).values({
-            actorKind: "portal_user",
-            actorUserId: intentRow.userId,
-            eventId: "user_identity.linked",
-            payload: {
-              identityProvider: intentRow.targetProvider,
-              identitySubject: identity.subject,
-              targetUserId: intentRow.userId
-            },
-            severity: "critical",
-            subjectKind: "user_identity",
-            targetUserId: intentRow.userId
-          });
-
-          return "linked";
-        });
-
-        portalUrl.searchParams.set("link", linkStatus);
-      }
-
-      const responseCookies = [clearSignedAccessCookie("PortalLinkIntent")];
-
-      if (identity && providerHint) {
-        responseCookies.unshift(
-          buildSignedAccessCookie(
-            "PortalAccessProvider",
-            `${providerHint}|${identity.subject}`,
-            { maxAgeSeconds: 24 * 60 * 60 }
-          )
-        );
-      } else {
-        responseCookies.unshift(clearSignedAccessCookie("PortalAccessProvider"));
-      }
-
-      reply.header("set-cookie", responseCookies);
-      reply.redirect(portalUrl.toString());
-    }
+  app.post(
+    "/portal/session/finalize",
+    {
+      preHandler: requireAccess("authenticated_access_identity")
+    },
+    handlePortalSessionCompletion
   );
 
   app.get(

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -186,6 +186,17 @@ export function buildApiSessionCompleteUrl(targetPath = "/") {
   return completionUrl.toString();
 }
 
+export function buildApiSessionFinalizeUrl(targetPath = "/") {
+  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
+  const completionUrl = new URL("/portal/session/finalize", "https://api.paretoproof.com");
+
+  if (normalizedTargetPath !== "/") {
+    completionUrl.searchParams.set("redirect", normalizedTargetPath);
+  }
+
+  return completionUrl.toString();
+}
+
 export function resolveAccessProviderHost(hostname = window.location.hostname): AccessProvider | null {
   if (hostname === "github.auth.paretoproof.com") {
     return "github";

--- a/apps/web/src/routes/access-completion.tsx
+++ b/apps/web/src/routes/access-completion.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { AppIcon } from "../components/app-icon";
-import { buildApiSessionCompleteUrl } from "../lib/surface";
+import { buildApiSessionFinalizeUrl } from "../lib/surface";
 
 type AccessCompletionProps = {
   provider: "github" | "google";
@@ -12,7 +12,7 @@ export function AccessCompletion({ provider, redirectPath }: AccessCompletionPro
     const form = document.createElement("form");
 
     form.method = "POST";
-    form.action = buildApiSessionCompleteUrl(redirectPath);
+    form.action = buildApiSessionFinalizeUrl(redirectPath);
     form.style.display = "none";
     document.body.append(form);
     form.submit();

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,5 +1,12 @@
+import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
-import { buildAccessStartUrl, buildPublicUrl, isLocalHostname } from "../lib/surface";
+import { getApiBaseUrl } from "../lib/api-base-url";
+import {
+  buildAccessStartUrl,
+  buildPortalUrl,
+  buildPublicUrl,
+  isLocalHostname
+} from "../lib/surface";
 
 type AuthEntryProps = {
   redirectPath: string;
@@ -15,6 +22,50 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const githubStartUrl = buildAccessStartUrl("github", redirectPath);
   const googleStartUrl = buildAccessStartUrl("google", redirectPath);
   const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
+  const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
+  const portalUrl = useMemo(() => buildPortalUrl(redirectPath), [redirectPath]);
+  const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);
+  const handoffMode = new URLSearchParams(window.location.search).get("handoff");
+  const showRetryNotice = handoffMode === "retry";
+
+  useEffect(() => {
+    if (isLocal) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    async function resolveExistingSession() {
+      try {
+        const response = await fetch(`${apiBaseUrl}/portal/me`, {
+          credentials: "include",
+          headers: {
+            Accept: "application/json"
+          },
+          signal: controller.signal
+        });
+
+        if (response.ok) {
+          window.location.replace(portalUrl);
+          return;
+        }
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+      }
+
+      if (!controller.signal.aborted) {
+        setIsCheckingSession(false);
+      }
+    }
+
+    void resolveExistingSession();
+
+    return () => {
+      controller.abort();
+    };
+  }, [apiBaseUrl, isLocal, portalUrl]);
 
   return (
     <main className="auth-shell">
@@ -31,6 +82,17 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
             Provider choice, account linking, and contributor approval belong in one
             deliberate handoff instead of a stack of awkward intermediary screens.
           </p>
+          {showRetryNotice ? (
+            <p className="auth-panel-copy">
+              The secure API handoff URL only works after sign-in. Restart from this auth
+              entry and already-authenticated browsers will be sent straight to the portal.
+            </p>
+          ) : null}
+          {isCheckingSession ? (
+            <p className="auth-panel-copy">
+              Checking whether this browser already has a valid portal session.
+            </p>
+          ) : null}
         </div>
 
         <div className="auth-provider-layout">

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -18,11 +18,20 @@ export const apiEndpointCatalog = [
     purpose: "Return the caller's resolved identity, role summary, and approval state."
   },
   {
+    access: "anonymous",
+    audience: "public",
+    id: "portal.session.retry",
+    method: "GET",
+    path: "/portal/session/complete",
+    purpose:
+      "Restart the branded auth entry when a browser lands on the raw session-completion URL directly."
+  },
+  {
     access: "authenticated_access_identity",
     audience: "portal",
     id: "portal.session.complete",
     method: "POST",
-    path: "/portal/session/complete",
+    path: "/portal/session/finalize",
     purpose:
       "Finish the Cloudflare Access login handoff on the API audience and return the browser to the static portal host."
   },


### PR DESCRIPTION
## Summary
- add a public browser-safe retry entry for `GET /portal/session/complete`
- move the Access-protected session-finalization POST to `/portal/session/finalize`
- auto-forward already-authenticated browsers from `auth.paretoproof.com` into the portal
- preserve the branded auth surface when the API handoff URL is visited directly

## Testing
- live verification planned after merge and deploy because this change depends on the Cloudflare Access path configuration

Closes #306