### PR TITLE
fix(api): allow provider auth hosts to finalize sessions

### DIFF
--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -14,6 +14,8 @@ function normalizeOrigin(value: string) {
 function readAllowedCorsOrigins() {
   const baselineOrigins = [
     "https://auth.paretoproof.com",
+    "https://github.auth.paretoproof.com",
+    "https://google.auth.paretoproof.com",
     "https://portal.paretoproof.com"
   ];
   const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS?.split(",")


### PR DESCRIPTION
## Summary
- allow provider-specific auth hosts in the API CORS baseline
- unblock the GitHub and Google auth handoff into /portal/session/finalize
- fix the live follow-up found after merging #307

Closes #308