### PR TITLE
Fix portal auth-gating state redirects

### DIFF
--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -9,9 +9,11 @@ type PortalAccessStatus = "approved" | "denied" | "pending" | "unauthenticated";
 
 type PortalRouteAccessContext = {
   pathname: string;
+  search?: string;
   reason?:
     | "access_request_required"
     | "identity_recovery_required"
+    | "insufficient_role"
     | "rejected_or_withdrawn"
     | "unknown_identity";
   roles: string[];
@@ -113,36 +115,47 @@ function preserveLocalPortalState(targetPath: string, location = window.location
   return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
 }
 
-function resolveRedirectTarget(redirectTarget: RouteRedirectTarget) {
-  if (redirectTarget === "portal_home") {
-    return preserveLocalPortalState("/");
+function readRouteDeniedReason(
+  search = window.location.search
+): PortalRouteAccessContext["reason"] | undefined {
+  const reason = new URLSearchParams(search).get("reason");
+
+  if (
+    reason === "access_request_required" ||
+    reason === "identity_recovery_required" ||
+    reason === "insufficient_role" ||
+    reason === "rejected_or_withdrawn" ||
+    reason === "unknown_identity"
+  ) {
+    return reason;
   }
 
-  if (redirectTarget === "portal_pending") {
-    return preserveLocalPortalState("/pending");
-  }
-
-  if (redirectTarget === "portal_denied") {
-    return preserveLocalPortalState("/denied");
-  }
-
-  return buildPublicUrl("/");
+  return undefined;
 }
 
-function getLoopSafeFallbackTarget(context: PortalRouteAccessContext) {
+function isCurrentRedirectTarget(
+  targetPath: string,
+  context: PortalRouteAccessContext
+) {
+  const targetUrl = new URL(targetPath, window.location.origin);
+  return (
+    targetUrl.pathname === context.pathname &&
+    targetUrl.search === (context.search ?? "")
+  );
+}
+
+function resolveCanonicalStateTarget(context: PortalRouteAccessContext) {
   if (context.status === "pending") {
     return preserveLocalPortalState("/pending");
   }
 
-  if (context.status === "approved") {
-    return preserveLocalPortalState("/");
-  }
-
   if (context.status === "denied") {
-    return preserveLocalPortalState("/denied");
+    return context.reason === "access_request_required"
+      ? preserveLocalPortalState("/access-request")
+      : preserveLocalPortalState("/denied");
   }
 
-  return buildPublicUrl("/");
+  return null;
 }
 
 export function findMatchedPortalRoute(pathname: string) {
@@ -151,17 +164,47 @@ export function findMatchedPortalRoute(pathname: string) {
 
 export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
   const matchedRoute = findPortalRoute(context.pathname);
+  const routeDeniedReason = readRouteDeniedReason(context.search);
+
+  if (context.status === "approved" && matchedRoute?.id === "portal.pending") {
+    return preserveLocalPortalState("/");
+  }
+
+  if (context.status === "approved" && matchedRoute?.id === "portal.access-request") {
+    return preserveLocalPortalState("/");
+  }
+
+  if (context.status === "approved" && matchedRoute?.id === "portal.denied") {
+    return routeDeniedReason === "insufficient_role"
+      ? null
+      : preserveLocalPortalState("/");
+  }
+
+  const canonicalStateTarget = resolveCanonicalStateTarget(context);
+
+  if (canonicalStateTarget && !isCurrentRedirectTarget(canonicalStateTarget, context)) {
+    return canonicalStateTarget;
+  }
 
   if (!matchedRoute || canAccessRoute(matchedRoute, context)) {
     return null;
   }
 
-  const redirectTarget = resolveRedirectTarget(matchedRoute.redirectIfDenied);
-  const redirectPathname = new URL(redirectTarget, window.location.origin).pathname;
-
-  if (redirectPathname === context.pathname) {
-    return getLoopSafeFallbackTarget(context);
+  if (context.status === "approved") {
+    return preserveLocalPortalState("/denied?reason=insufficient_role");
   }
 
-  return redirectTarget;
+  if (context.status === "pending") {
+    return preserveLocalPortalState("/pending");
+  }
+
+  if (context.status === "denied") {
+    return context.reason === "access_request_required"
+      ? preserveLocalPortalState("/access-request")
+      : preserveLocalPortalState("/denied");
+  }
+
+  return matchedRoute.redirectIfDenied === "public_home"
+    ? buildPublicUrl("/")
+    : preserveLocalPortalState("/");
 }

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -41,6 +41,12 @@ type PortalMeResponse = {
   };
 };
 
+function readRouteDeniedReason(search = window.location.search) {
+  const reason = new URLSearchParams(search).get("reason");
+
+  return reason === "insufficient_role" ? reason : null;
+}
+
 function readLocalAccessOverride(): PortalAccessState | null {
   if (!isLocalHostname(window.location.hostname)) {
     return null;
@@ -88,6 +94,7 @@ export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const currentRelativeUrl = useMemo(() => getCurrentRelativeUrl(), []);
+  const routeDeniedReason = readRouteDeniedReason();
   const routeRedirectTarget = useMemo(() => {
     if (
       state.status === "loading" ||
@@ -99,11 +106,15 @@ export function PortalBootstrap() {
 
     return resolvePortalRouteRedirect({
       pathname: window.location.pathname,
-      reason: state.status === "denied" ? state.reason : undefined,
+      reason:
+        state.status === "denied"
+          ? state.reason
+          : routeDeniedReason ?? undefined,
       roles: state.status === "approved" ? state.roles : [],
+      search: window.location.search,
       status: state.status
     });
-  }, [state]);
+  }, [routeDeniedReason, state]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -323,6 +334,21 @@ export function PortalBootstrap() {
               }
             : undefined
         }
+      />
+    );
+  }
+
+  if (
+    state.status === "approved" &&
+    window.location.pathname === "/denied" &&
+    routeDeniedReason === "insufficient_role"
+  ) {
+    return (
+      <PortalStatusCard
+        eyebrow="Portal"
+        title="Permission denied"
+        body={`Signed in${state.email ? ` as ${state.email}` : ""}, but your current portal role does not allow this area.`}
+        action={{ href: buildPortalUrl("/"), label: "Return to portal home" }}
       />
     );
   }


### PR DESCRIPTION
## Summary
- canonicalize portal auth-gating routes so pending users land on `/pending` and access-request users land on `/access-request`
- keep rejected and withdrawn users on `/denied` while making approved insufficient-role users land on a stable permission-denied screen
- stop approved users from bouncing through `/denied` back to `/` when they hit a higher-role route

## Issues
Closes #129
Closes #132
Closes #133

## QA
- Playwright local override check: pending root -> `/pending`
- Playwright local override check: access-request-required root -> `/access-request`
- Playwright local override check: rejected root -> `/denied`
- Playwright local override check: helper hitting `/launch` -> `/denied?reason=insufficient_role`
- Playwright local override check: approved user direct `/denied` without insufficient-role reason -> `/`
- Playwright local override check: denied user direct `/denied` with access-request reason -> `/access-request`