### PR TITLE
Allow provider auth hosts in API CORS

### DIFF
--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -14,6 +14,8 @@ function normalizeOrigin(value: string) {
 function readAllowedCorsOrigins() {
   const baselineOrigins = [
     "https://auth.paretoproof.com",
+    "https://github.auth.paretoproof.com",
+    "https://google.auth.paretoproof.com",
     "https://portal.paretoproof.com"
   ];
   const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS?.split(",")


### PR DESCRIPTION
## Summary
- allow `github.auth.paretoproof.com` and `google.auth.paretoproof.com` in the API credentialed CORS baseline
- keep the existing repo-managed origin allowlist model instead of requiring a live env override for provider finalize POSTs

## Issues
Closes #308

## QA
- not run (code change is limited to the static allowed-origin baseline in the API server bootstrap)