### PR TITLE
Add worker image GHCR publish workflow

### DIFF
--- a/.github/workflows/publish-worker-image.yml
+++ b/.github/workflows/publish-worker-image.yml
@@ -1,0 +1,62 @@
+name: Publish Worker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/worker/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "bun.lock"
+      - "tsconfig.base.json"
+      - ".github/workflows/publish-worker-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  WORKER_IMAGE: ghcr.io/${{ github.repository_owner }}/paretoproof-worker
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: worker-image-publish
+      cancel-in-progress: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.WORKER_IMAGE }}
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and publish worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to build and publish the worker image to GHCR
- trigger on `main` pushes that affect worker/shared build inputs, plus manual dispatch
- publish repo-managed `main` and `sha-*` tags without introducing a fuller release-tag policy ahead of issue #104

## Issues
Closes #89

## QA
- not run (workflow-only change)