### PR TITLE
Fix worker image frozen Bun install

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -3,6 +3,8 @@ FROM oven/bun:1.3.10 AS build
 WORKDIR /app
 
 COPY package.json bun.lock tsconfig.base.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
 COPY apps/worker/package.json apps/worker/tsconfig.json ./apps/worker/
 COPY packages/shared/package.json packages/shared/tsconfig.json ./packages/shared/
 


### PR DESCRIPTION
## Summary
- fix the worker image Docker build so frozen Bun installs see the full workspace manifest set
- stop the GHCR publish workflow on `main` from failing on lockfile drift inside Docker
- clean up issue #316 so it describes the actual build failure and carries normal labels

## Issues
Closes #316

## QA
- not run locally (fix derived directly from failing Actions run 22934522183 and the worker Dockerfile workspace manifest mismatch)