### PR TITLE
fix(auth): split finalize entry from finalize submission

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -335,6 +335,14 @@ export function registerPortalRoutes(
     reply.redirect(buildPortalAuthRetryUrl(redirectPath));
   });
 
+  app.get("/portal/session/finalize", async (request, reply) => {
+    const redirectPath = sanitizePortalRedirectPath(
+      (request.query as { redirect?: string } | undefined)?.redirect ?? null
+    );
+
+    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
+  });
+
   app.post(
     "/portal/session/complete",
     {
@@ -344,7 +352,7 @@ export function registerPortalRoutes(
   );
 
   app.post(
-    "/portal/session/finalize",
+    "/portal/session/finalize/submit",
     {
       preHandler: requireAccess("authenticated_access_identity")
     },

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -188,7 +188,7 @@ export function buildApiSessionCompleteUrl(targetPath = "/") {
 
 export function buildApiSessionFinalizeUrl(targetPath = "/") {
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
-  const completionUrl = new URL("/portal/session/finalize", "https://api.paretoproof.com");
+  const completionUrl = new URL("/portal/session/finalize/submit", "https://api.paretoproof.com");
 
   if (normalizedTargetPath !== "/") {
     completionUrl.searchParams.set("redirect", normalizedTargetPath);

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -31,7 +31,7 @@ export const apiEndpointCatalog = [
     audience: "portal",
     id: "portal.session.complete",
     method: "POST",
-    path: "/portal/session/finalize",
+    path: "/portal/session/finalize/submit",
     purpose:
       "Finish the Cloudflare Access login handoff on the API audience and return the browser to the static portal host."
   },


### PR DESCRIPTION
## Summary
- keep /portal/session/finalize as a public retry redirect entry
- move the protected finalize POST onto /portal/session/finalize/submit
- let Cloudflare bypass the visible finalize URL without breaking the actual protected finalize submission

Closes #319