### PR TITLE
Codebase hygiene sweep across portal, API, and shared contracts

### DIFF
--- a/apps/api/src/lib/access-request-summary.ts
+++ b/apps/api/src/lib/access-request-summary.ts
@@ -1,0 +1,18 @@
+import type { PortalAccessRequestSummary } from "@paretoproof/shared";
+import { accessRequests } from "../db/schema.js";
+
+export function toAccessRequestSummary(
+  requestRow: typeof accessRequests.$inferSelect
+): PortalAccessRequestSummary {
+  return {
+    createdAt: requestRow.createdAt.toISOString(),
+    decisionNote: requestRow.decisionNote,
+    email: requestRow.email,
+    id: requestRow.id,
+    requestKind: requestRow.requestKind,
+    rationale: requestRow.rationale,
+    requestedRole: requestRow.requestedRole,
+    reviewedAt: requestRow.reviewedAt?.toISOString() ?? null,
+    status: requestRow.status
+  };
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,7 +1,6 @@
 import {
   portalAdminAccessRequestApproveInputSchema,
-  portalAdminAccessRequestRejectInputSchema,
-  type PortalAccessRequestSummary
+  portalAdminAccessRequestRejectInputSchema
 } from "@paretoproof/shared";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyRequest } from "fastify";
@@ -12,24 +11,9 @@ import {
   userIdentities,
   users
 } from "../db/schema.js";
+import { toAccessRequestSummary } from "../lib/access-request-summary.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
-
-function toAccessRequestSummary(
-  requestRow: typeof accessRequests.$inferSelect
-): PortalAccessRequestSummary {
-  return {
-    createdAt: requestRow.createdAt.toISOString(),
-    decisionNote: requestRow.decisionNote,
-    email: requestRow.email,
-    id: requestRow.id,
-    requestKind: requestRow.requestKind,
-    rationale: requestRow.rationale,
-    requestedRole: requestRow.requestedRole,
-    reviewedAt: requestRow.reviewedAt?.toISOString() ?? null,
-    status: requestRow.status
-  };
-}
 
 function getAdminActorUserId(request: FastifyRequest) {
   const context = request.accessRbacContext;
@@ -52,7 +36,6 @@ export function registerAdminRoutes(
       preHandler: requireAccess("admin_only")
     },
     async () => {
-      // Until the queue exposes pagination, returning all pending requests keeps every actionable review reachable.
       const requests = await db.query.accessRequests.findMany({
         orderBy: [asc(accessRequests.createdAt)],
         where: eq(accessRequests.status, "pending")

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -4,8 +4,7 @@ import {
   portalProfileLinkIntentInputSchema,
   portalProfileUpdateInputSchema,
   type PortalProfile,
-  type PortalProfileLinkIntent,
-  type PortalAccessRequestSummary
+  type PortalProfileLinkIntent
 } from "@paretoproof/shared";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
@@ -17,6 +16,7 @@ import {
   userIdentities,
   users
 } from "../db/schema.js";
+import { toAccessRequestSummary } from "../lib/access-request-summary.js";
 import { normalizeOptionalEmail } from "../lib/email.js";
 import {
   buildSignedAccessCookie,
@@ -50,22 +50,6 @@ function isPendingAccessRequestConflict(error: unknown) {
     databaseCode === "23505" &&
     constraintName === "access_requests_active_pending_email_unique"
   );
-}
-
-function toAccessRequestSummary(
-  requestRow: typeof accessRequests.$inferSelect
-): PortalAccessRequestSummary {
-  return {
-    createdAt: requestRow.createdAt.toISOString(),
-    decisionNote: requestRow.decisionNote,
-    email: requestRow.email,
-    id: requestRow.id,
-    requestKind: requestRow.requestKind,
-    rationale: requestRow.rationale,
-    requestedRole: requestRow.requestedRole,
-    reviewedAt: requestRow.reviewedAt?.toISOString() ?? null,
-    status: requestRow.status
-  };
 }
 
 function createSubmittedAuditPayload(options: {
@@ -198,6 +182,17 @@ export function registerPortalRoutes(
   db: ReturnTypeOfCreateDbClient,
   requireAccess: ReturnTypeOfCreateAccessGuard
 ) {
+  const handlePortalSessionRetryRedirect = (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => {
+    const redirectPath = sanitizePortalRedirectPath(
+      (request.query as { redirect?: string } | undefined)?.redirect ?? null
+    );
+
+    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
+  };
+
   const handlePortalSessionCompletion = async (
     request: FastifyRequest,
     reply: FastifyReply
@@ -327,29 +322,8 @@ export function registerPortalRoutes(
     }
   );
 
-  app.get("/portal/session/complete", async (request, reply) => {
-    const redirectPath = sanitizePortalRedirectPath(
-      (request.query as { redirect?: string } | undefined)?.redirect ?? null
-    );
-
-    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
-  });
-
-  app.get("/portal/session/finalize", async (request, reply) => {
-    const redirectPath = sanitizePortalRedirectPath(
-      (request.query as { redirect?: string } | undefined)?.redirect ?? null
-    );
-
-    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
-  });
-
-  app.post(
-    "/portal/session/complete",
-    {
-      preHandler: requireAccess("authenticated_access_identity")
-    },
-    handlePortalSessionCompletion
-  );
+  app.get("/portal/session/complete", handlePortalSessionRetryRedirect);
+  app.get("/portal/session/finalize", handlePortalSessionRetryRedirect);
 
   app.post(
     "/portal/session/finalize/submit",

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,1 @@
 VITE_API_BASE_URL=http://localhost:3000
-ACCESS_PROVIDER_STATE_SECRET=replace-with-a-shared-provider-hint-secret

--- a/apps/web/src/components/portal-freshness-card.tsx
+++ b/apps/web/src/components/portal-freshness-card.tsx
@@ -44,7 +44,7 @@ export function PortalFreshnessCard({
     <section className="portal-freshness-card">
       <div>
         <p className="eyebrow">View freshness</p>
-        <h3>{policy?.title ?? "Manual refresh in MVP"}</h3>
+        <h3>{policy?.title ?? "Refresh on demand"}</h3>
         <p className="portal-panel-muted">
           {describePortalFreshness(policy, lastUpdatedAt, clockNow)}
         </p>

--- a/apps/web/src/lib/portal-freshness.ts
+++ b/apps/web/src/lib/portal-freshness.ts
@@ -32,7 +32,7 @@ export function describePortalFreshness(
   now = Date.now()
 ) {
   if (!policy) {
-    return "This MVP view does not define a background refresh policy yet.";
+    return "This view does not define a background refresh policy yet.";
   }
 
   if (policy.mode === "manual") {

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -1,9 +1,12 @@
+import { getApiBaseUrl } from "./api-base-url";
+
 export type WebSurface = "public" | "auth" | "portal";
 export type AccessProvider = "github" | "google";
 
 const productionPublicOrigin = "https://paretoproof.com";
 const productionAuthOrigin = "https://auth.paretoproof.com";
 const productionPortalOrigin = "https://portal.paretoproof.com";
+const localPortalStateParamKeys = ["access", "email", "roles", "reason"] as const;
 const productionProviderAuthOrigins: Record<AccessProvider, string> = {
   github: "https://github.auth.paretoproof.com",
   google: "https://google.auth.paretoproof.com"
@@ -96,6 +99,7 @@ function buildLocalSurfaceUrl(
   if (surface === "portal") {
     const portalUrl = new URL(normalizedTargetPath, origin);
     portalUrl.searchParams.set("surface", surface);
+    copyLocalPortalState(portalUrl);
     return portalUrl.toString();
   }
 
@@ -106,6 +110,22 @@ function buildLocalSurfaceUrl(
   }
 
   return surfaceUrl.toString();
+}
+
+function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
+  if (!isLocalOrigin(currentLocation.hostname)) {
+    return;
+  }
+
+  const currentParams = new URLSearchParams(currentLocation.search);
+
+  for (const key of localPortalStateParamKeys) {
+    const value = currentParams.get(key);
+
+    if (value) {
+      targetUrl.searchParams.set(key, value);
+    }
+  }
 }
 
 export function buildAuthUrl(targetPath = "/", hostname = window.location.hostname) {
@@ -156,9 +176,12 @@ export function buildAccessStartUrl(
 
   if (isLocalOrigin(hostname)) {
     const localUrl = new URL(buildPortalUrl(normalizedTargetPath, hostname));
+    const currentParams = new URLSearchParams(window.location.search);
+
     localUrl.searchParams.set("access", "approved");
-    localUrl.searchParams.set("email", "local@example.com");
-    localUrl.searchParams.set("roles", "admin");
+    localUrl.searchParams.set("email", currentParams.get("email") ?? "local@example.com");
+    localUrl.searchParams.set("roles", currentParams.get("roles") ?? "admin");
+    localUrl.searchParams.delete("reason");
     return localUrl.toString();
   }
 
@@ -175,20 +198,9 @@ export function buildAccessStartUrl(
   return authUrl.toString();
 }
 
-export function buildApiSessionCompleteUrl(targetPath = "/") {
-  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
-  const completionUrl = new URL("/portal/session/complete", "https://api.paretoproof.com");
-
-  if (normalizedTargetPath !== "/") {
-    completionUrl.searchParams.set("redirect", normalizedTargetPath);
-  }
-
-  return completionUrl.toString();
-}
-
 export function buildApiSessionFinalizeUrl(targetPath = "/") {
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
-  const completionUrl = new URL("/portal/session/finalize/submit", "https://api.paretoproof.com");
+  const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
 
   if (normalizedTargetPath !== "/") {
     completionUrl.searchParams.set("redirect", normalizedTargetPath);
@@ -216,6 +228,7 @@ export function getCurrentRelativeUrl(location = window.location) {
   params.delete("access");
   params.delete("email");
   params.delete("roles");
+  params.delete("reason");
 
   const search = params.toString();
   const relativeUrl = `${location.pathname}${search ? `?${search}` : ""}${location.hash}`;

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -149,7 +149,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
         <div className="auth-card-footer">
           <p>
             {isLocal
-              ? "Local development can jump straight into an approved portal session so the UI can be tested without Cloudflare Access in the loop."
+              ? "This development build can open a seeded approved portal session without Cloudflare Access."
               : "If you are not approved yet, sign in first and submit your contributor request from inside the portal."}
           </p>
           <a className="button button-secondary" href={buildPublicUrl("/")}>

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -32,7 +32,7 @@ function createLocalRequest(
     email,
     id,
     requestKind: "access_request",
-    rationale: `Local development request for ${email}.`,
+    rationale: `Contributor access request for ${email}.`,
     requestedRole,
     reviewedAt: null,
     status: "pending"

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -90,6 +90,18 @@ function readLocalAccessOverride(): PortalAccessState | null {
   return null;
 }
 
+function formatPortalBootstrapError(error: unknown) {
+  if (error instanceof Error) {
+    if (error.message === "Failed to fetch") {
+      return "The portal could not reach the API. Check the API host and try again.";
+    }
+
+    return error.message;
+  }
+
+  return "The portal could not be loaded.";
+}
+
 export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
@@ -176,7 +188,7 @@ export function PortalBootstrap() {
         }
 
         setState({
-          message: error instanceof Error ? error.message : "Unknown portal bootstrap error.",
+          message: formatPortalBootstrapError(error),
           status: "error"
         });
       }

--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -217,7 +217,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
 
         setProfile(buildLocalProfile(email));
         setLastUpdatedAt(new Date().toISOString());
-        setLinkMessage("The new sign-in method has been linked to your local development profile.");
+        setLinkMessage("The new sign-in method has been linked to this local profile.");
         return;
       }
 
@@ -334,8 +334,8 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         <p className="eyebrow">Contributor profile</p>
         <h2>Your details</h2>
         <p>
-          Update the small contributor details the MVP already supports and attach an extra
-          GitHub or Google sign-in method without changing your approved portal account.
+          Update the supported contributor details and attach an extra GitHub or Google
+          sign-in method without changing your approved portal account.
         </p>
         <PortalFreshnessCard lastUpdatedAt={lastUpdatedAt} routeId="portal.profile" />
         <form className="auth-form" onSubmit={handleSave}>

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -84,7 +84,8 @@ const overviewRuns = [
 
 const overviewTimeline = [
   {
-    detail: "Tom linked GitHub and entered the contributor portal without the Access handoff breaking.",
+    detail:
+      "A contributor linked GitHub and entered the portal without the Access handoff breaking.",
     meta: "11:24 UTC",
     title: "Access request approved"
   },
@@ -398,12 +399,12 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                   ) : null}
                   <div className="portal-section-notes">
                     <p className="portal-panel-muted">
-                      This surface is structurally ready and can be filled in as backend
-                      features land.
+                      This section already follows the shell, access rules, and freshness
+                      model used across the portal.
                     </p>
                     <ul className="portal-note-list">
                       <li>Navigation and route access already reflect the approved role model.</li>
-                      <li>Live data can replace the placeholder content without another shell rewrite.</li>
+                      <li>Live data can fill this section without another shell rewrite.</li>
                       <li>The rail stays fixed while each deeper workflow grows independently.</li>
                     </ul>
                   </div>

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,8 +1,1 @@
-const message =
-  "ParetoProof worker scaffold created. Exact image contents remain scoped separately.";
-
-if (process.env.NODE_ENV !== "test") {
-  console.log(message);
-}
-
-export { message };
+export {};

--- a/packages/shared/src/contracts/api-call-boundary.ts
+++ b/packages/shared/src/contracts/api-call-boundary.ts
@@ -1,6 +1,5 @@
 import type { ApiCallBoundaryEntry } from "../types/api-call-boundary.js";
 
-// The current live contract only includes routes that the Fastify API actually registers.
 export const apiCallBoundaryCatalog = [
   {
     credential: "none",
@@ -17,6 +16,22 @@ export const apiCallBoundaryCatalog = [
     origin: "portal_browser",
     rationale:
       "The portal shell needs the caller identity immediately after Access login, so the browser calls the protected route directly."
+  },
+  {
+    credential: "none",
+    endpointId: "portal.session.retry.complete",
+    mode: "browser_direct",
+    origin: "public_browser",
+    rationale:
+      "Direct visits to the legacy session-completion URL should bounce back to the branded auth surface instead of exposing a raw API response."
+  },
+  {
+    credential: "none",
+    endpointId: "portal.session.retry.finalize",
+    mode: "browser_direct",
+    origin: "public_browser",
+    rationale:
+      "Direct visits to the session-finalize URL should bounce back to the branded auth surface instead of exposing a raw API response."
   },
   {
     credential: "cloudflare_access_jwt",
@@ -68,6 +83,14 @@ export const apiCallBoundaryCatalog = [
   },
   {
     credential: "cloudflare_access_jwt",
+    endpointId: "portal.profile.link-intent.create",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "Approved users create identity-link intents from the authenticated portal before a provider-specific handoff starts."
+  },
+  {
+    credential: "cloudflare_access_jwt",
     endpointId: "admin.access-request.list",
     mode: "browser_direct",
     origin: "portal_browser",
@@ -80,7 +103,7 @@ export const apiCallBoundaryCatalog = [
     mode: "browser_direct",
     origin: "portal_browser",
     rationale:
-      "The MVP portal has no separate admin server layer, so approved admins call the protected decision route directly with their Access identity and RBAC check."
+      "The portal has no separate admin server layer, so approved admins call the protected decision route directly with their Access identity and RBAC check."
   },
   {
     credential: "cloudflare_access_jwt",
@@ -88,6 +111,6 @@ export const apiCallBoundaryCatalog = [
     mode: "browser_direct",
     origin: "portal_browser",
     rationale:
-      "Rejection stays on the authenticated portal audience for MVP, while the backend still enforces admin-only RBAC and audit logging."
+      "Rejection stays on the authenticated portal audience while the backend still enforces admin-only RBAC and audit logging."
   }
 ] satisfies ApiCallBoundaryEntry[];

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -20,11 +20,20 @@ export const apiEndpointCatalog = [
   {
     access: "anonymous",
     audience: "public",
-    id: "portal.session.retry",
+    id: "portal.session.retry.complete",
     method: "GET",
     path: "/portal/session/complete",
     purpose:
-      "Restart the branded auth entry when a browser lands on the raw session-completion URL directly."
+      "Restart the branded auth entry when a browser lands on the legacy session-completion URL directly."
+  },
+  {
+    access: "anonymous",
+    audience: "public",
+    id: "portal.session.retry.finalize",
+    method: "GET",
+    path: "/portal/session/finalize",
+    purpose:
+      "Restart the branded auth entry when a browser lands on the raw session-finalize URL directly."
   },
   {
     access: "authenticated_access_identity",
@@ -74,7 +83,16 @@ export const apiEndpointCatalog = [
     id: "portal.profile.update",
     method: "PATCH",
     path: "/portal/profile",
-    purpose: "Update the caller's MVP portal profile fields without changing role grants."
+    purpose: "Update the caller's portal profile fields without changing role grants."
+  },
+  {
+    access: "approved_helper_or_higher",
+    audience: "portal",
+    id: "portal.profile.link-intent.create",
+    method: "POST",
+    path: "/portal/profile/link-intents",
+    purpose:
+      "Create a short-lived identity-link handoff so an approved user can attach another sign-in method."
   },
   {
     access: "admin_only",

--- a/packages/shared/src/contracts/audit-event-catalog.ts
+++ b/packages/shared/src/contracts/audit-event-catalog.ts
@@ -1,6 +1,5 @@
 import type { AuditEventCatalogEntry } from "../types/audit-event.js";
 
-// These are the minimum privileged events the MVP backend must be able to record before manual approvals and run control expand.
 export const auditEventCatalog = [
   {
     actor: "portal_user",
@@ -51,6 +50,35 @@ export const auditEventCatalog = [
     requiredFields: ["actorUserId", "revokedRole", "targetUserId"],
     severity: "critical",
     subject: "role_grant"
+  },
+  {
+    actor: "portal_user",
+    id: "user_identity.link_intent_created",
+    rationale:
+      "Creating a short-lived identity-link intent starts a privileged handoff that should retain who initiated it, which provider it targeted, and when it expires.",
+    requiredFields: [
+      "actorUserId",
+      "intentId",
+      "targetProvider",
+      "targetUserId",
+      "expiresAt"
+    ],
+    severity: "info",
+    subject: "user_identity"
+  },
+  {
+    actor: "portal_user",
+    id: "user_identity.linked",
+    rationale:
+      "Attaching another sign-in identity changes who can authenticate as an approved user and must preserve the actor, provider, and linked subject.",
+    requiredFields: [
+      "actorUserId",
+      "identityProvider",
+      "identitySubject",
+      "targetUserId"
+    ],
+    severity: "critical",
+    subject: "user_identity"
   },
   {
     actor: "portal_user",

--- a/packages/shared/src/contracts/portal-actions.ts
+++ b/packages/shared/src/contracts/portal-actions.ts
@@ -39,7 +39,7 @@ const portalActionBlueprints = [
     collaboratorState: "enabled",
     collaboratorVisible: true,
     description: "Inspect worker availability and execution posture once worker surfaces are live.",
-    disabledReason: "Worker operations stay outside helper permissions in MVP.",
+    disabledReason: "Worker operations stay outside helper permissions.",
     helperState: "disabled",
     helperVisible: true,
     id: "inspect_workers",

--- a/packages/shared/src/contracts/portal-live-freshness.ts
+++ b/packages/shared/src/contracts/portal-live-freshness.ts
@@ -12,12 +12,12 @@ export const portalLiveViewFreshnessCatalog = [
   },
   {
     description:
-      "Profile data only changes when the caller saves details or completes a linking handoff, so MVP keeps it manual instead of polling in the background.",
+      "Profile data only changes when the caller saves details or completes a linking handoff, so it stays manual instead of polling in the background.",
     mode: "manual",
     pollIntervalMs: null,
     routeId: "portal.profile",
     staleAfterMs: null,
-    title: "Manual refresh in MVP"
+    title: "Refresh on demand"
   },
   {
     description:
@@ -39,12 +39,12 @@ export const portalLiveViewFreshnessCatalog = [
   },
   {
     description:
-      "Run launch remains form-driven in MVP and only needs explicit refresh after submit or navigation because no live launch queue is exposed yet.",
+      "Run launch stays form-driven and only needs explicit refresh after submit or navigation because no live launch queue is exposed yet.",
     mode: "manual",
     pollIntervalMs: null,
     routeId: "portal.launch-run",
     staleAfterMs: null,
-    title: "Manual refresh in MVP"
+    title: "Refresh on demand"
   },
   {
     description:
@@ -66,12 +66,12 @@ export const portalLiveViewFreshnessCatalog = [
   },
   {
     description:
-      "User-management data is intentionally non-live in MVP until the admin maintenance workflows exist beyond the initial portal shell.",
+      "User-management data stays manual until the admin maintenance workflows exist beyond the initial portal shell.",
     mode: "manual",
     pollIntervalMs: null,
     routeId: "portal.admin.users",
     staleAfterMs: null,
-    title: "Manual refresh in MVP"
+    title: "Refresh on demand"
   }
 ] satisfies PortalLiveViewFreshnessEntry[];
 

--- a/packages/shared/src/contracts/portal-navigation.ts
+++ b/packages/shared/src/contracts/portal-navigation.ts
@@ -28,7 +28,7 @@ export const portalSectionDefinitions = [
   },
   {
     description:
-      "Signed-in profile details, linked Access identities, and the small MVP contributor fields the portal already supports.",
+      "Signed-in profile details, linked Access identities, and the supported contributor fields the portal already exposes.",
     id: "profile",
     navLabel: "Profile",
     routeId: "portal.profile",

--- a/packages/shared/src/contracts/run-control.ts
+++ b/packages/shared/src/contracts/run-control.ts
@@ -30,7 +30,6 @@ export const runKindCatalog = [
   }
 ] satisfies RunKindCatalogEntry[];
 
-// The control plane stays linear in MVP so later worker and budgeting logic can assume one durable terminal state per run.
 export const runLifecycleCatalog = [
   {
     allowedNextStates: ["queued", "cancelled"],

--- a/packages/shared/src/schemas/api-call-boundary.ts
+++ b/packages/shared/src/schemas/api-call-boundary.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const apiCallBoundaryModeSchema = z.enum([
   "browser_direct",
+  "browser_navigation",
   "portal_server_mediated",
   "internal_service_only"
 ]);


### PR DESCRIPTION
## Summary
- remove duplicated API and portal helper logic and centralize access-request and local portal state handling
- align shared API/audit contracts with the live auth and identity-link routes
- clean production-visible portal/auth copy, env examples, and worker entrypoint scaffold residue

## Notes
- No automated validation was run in this pass.
