### PR TITLE
Make Pages deploy target explicit

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -45,6 +45,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/web
           command: >-
-            pages deploy
+            pages deploy dist
             --project-name=paretoproof-web
             --branch=main


### PR DESCRIPTION
## Summary\n- make the Cloudflare Pages deploy command target the built dist directory explicitly\n- salvage the only remaining worthwhile delta from the stale ahead branches\n\n## Branch audit\nI audited the ahead branches shown in GitHub before opening this PR.\n\n- codex/issue-306-auth-completion-fallback was already merged through #307, so there was nothing left to salvage.\n- codex/fix-review-followups had one still-useful delta: the Pages deploy command should be explicit about the built output directory. Its other changes were already on main or had been superseded by later auth and portal work.\n- codex/fix-remaining-review-bugs was correctly left unmerged. Current main already contains the recovery and approval flows it attempted to introduce, while the old branch itself was closed as superseded and carried defects later tracked in #280 and #282.\n\n## Verification\n- confirmed pps/web/wrangler.toml already points Pages at ./dist; this change makes the workflow explicit instead of relying on implicit resolution\n