### PR TITLE
Keep auth-start failures on the branded auth entry

### DIFF
--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -1,3 +1,4 @@
+const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
 
 type Provider = "github" | "google";
@@ -94,14 +95,27 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
   ].join("; ");
 }
 
+function buildAuthFailureUrl(redirectPath: string) {
+  const authUrl = new URL(authOrigin);
+
+  if (redirectPath !== "/") {
+    authUrl.searchParams.set("redirect", redirectPath);
+  }
+
+  authUrl.searchParams.set("handoff", "failed");
+
+  return authUrl.toString();
+}
+
 export async function handleAccessStart(
   request: Request,
   env: AccessStartEnv,
   provider: Provider
 ) {
+  const requestUrl = new URL(request.url);
+  const redirectPath = sanitizeRedirectPath(requestUrl.searchParams.get("redirect"));
+
   try {
-    const requestUrl = new URL(request.url);
-    const redirectPath = sanitizeRedirectPath(requestUrl.searchParams.get("redirect"));
     const flow = requestUrl.searchParams.get("flow") === "link" ? "link" : "sign_in";
     const providerUrl = new URL("/", providerOrigins[provider]);
     const providerHintCookie = await buildProviderHintCookie(env, provider);
@@ -126,16 +140,13 @@ export async function handleAccessStart(
       status: 302
     });
   } catch (error) {
-    return new Response(
-      JSON.stringify({
-        error: error instanceof Error ? error.message : "Unknown Access start failure."
-      }),
-      {
-        headers: {
-          "content-type": "application/json; charset=utf-8"
-        },
-        status: 502
-      }
-    );
+    void error;
+
+    return new Response(null, {
+      headers: {
+        location: buildAuthFailureUrl(redirectPath)
+      },
+      status: 302
+    });
   }
 }

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -26,6 +26,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const portalUrl = useMemo(() => buildPortalUrl(redirectPath), [redirectPath]);
   const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);
   const handoffMode = new URLSearchParams(window.location.search).get("handoff");
+  const showFailedNotice = handoffMode === "failed";
   const showRetryNotice = handoffMode === "retry";
 
   useEffect(() => {
@@ -86,6 +87,12 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
             <p className="auth-panel-copy">
               The secure API handoff URL only works after sign-in. Restart from this auth
               entry and already-authenticated browsers will be sent straight to the portal.
+            </p>
+          ) : null}
+          {showFailedNotice ? (
+            <p className="auth-panel-copy">
+              The provider handoff could not be started cleanly. Restart from this auth
+              entry to try again instead of continuing on a broken intermediary screen.
             </p>
           ) : null}
           {isCheckingSession ? (


### PR DESCRIPTION
## Summary\n- redirect auth-start failures back to uth.paretoproof.com instead of returning raw JSON\n- preserve the intended portal redirect path on failure\n- show a branded failure notice on the auth entry page so the browser stays inside ParetoProof surfaces\n\n## Issue\nCloses #331\n\n## Notes\n- no automated validation was run in this pass\n