### PR TITLE
Redirect live unauthenticated portal loads to auth

### DIFF
--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -146,8 +146,14 @@ export function PortalBootstrap() {
           headers: {
             Accept: "application/json"
           },
+          redirect: "manual",
           signal: controller.signal
         });
+
+        if (response.type === "opaqueredirect") {
+          setState({ status: "unauthenticated" });
+          return;
+        }
 
         if (response.status === 401) {
           setState({ status: "unauthenticated" });


### PR DESCRIPTION
## Summary
- treat unauthenticated live portal bootstrap redirects as auth redirects instead of generic API outages
- preserve the current portal path by letting the existing unauthenticated branch send the browser to the branded auth entry

## Issue
Closes #333

## Browser evidence
Using Playwright against the live site:
- `https://portal.paretoproof.com/profile` without an API audience session rendered `Portal unavailable`
- the bootstrap request to `https://api.paretoproof.com/portal/me` was redirected into Cloudflare Access
- `fetch(..., { redirect: "manual" })` exposed that state as `response.type === "opaqueredirect"`

This patch treats that case as unauthenticated instead of as a true API outage.

## Notes
- no automated validation was run in this pass
