### PR TITLE
Relax link-flow cookie SameSite policy

### DIFF
--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -159,6 +159,7 @@ export function buildSignedAccessCookie(
   value: string,
   options?: {
     maxAgeSeconds?: number;
+    sameSite?: "Strict" | "Lax";
   }
 ) {
   const secret = process.env.ACCESS_PROVIDER_STATE_SECRET;
@@ -168,12 +169,13 @@ export function buildSignedAccessCookie(
   }
 
   const maxAgeSeconds = options?.maxAgeSeconds ?? 600;
+  const sameSite = options?.sameSite ?? "Strict";
 
   return [
     `${name}=${createSignedAccessValue(value, secret, maxAgeSeconds)}`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Strict",
+    `SameSite=${sameSite}`,
     `Max-Age=${maxAgeSeconds}`,
     "Secure",
     "HttpOnly"

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -98,7 +98,7 @@ function sanitizePortalRedirectPath(rawRedirectPath: string | null) {
 }
 
 function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkIntent") {
-  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Strict; Max-Age=0; Secure; HttpOnly`;
+  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Lax; Max-Age=0; Secure; HttpOnly`;
 }
 
 function buildPortalAuthStartUrl(options: {
@@ -293,7 +293,7 @@ export function registerPortalRoutes(
         buildSignedAccessCookie(
           "PortalAccessProvider",
           `${providerHint}|${identity.subject}`,
-          { maxAgeSeconds: 24 * 60 * 60 }
+          { maxAgeSeconds: 24 * 60 * 60, sameSite: "Lax" }
         )
       );
     } else {
@@ -649,7 +649,12 @@ export function registerPortalRoutes(
         })
       };
 
-      reply.header("set-cookie", buildSignedAccessCookie("PortalLinkIntent", intent.id));
+      reply.header(
+        "set-cookie",
+        buildSignedAccessCookie("PortalLinkIntent", intent.id, {
+          sameSite: "Lax"
+        })
+      );
 
       return {
         intent: responseBody

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -76,7 +76,7 @@ async function buildProviderHintCookie(env: AccessStartEnv, provider: Provider) 
     `PortalAccessProvider=${value}`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Strict",
+    "SameSite=Lax",
     "Max-Age=600",
     "Secure",
     "HttpOnly"
@@ -88,7 +88,7 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
     `${name}=`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Strict",
+    "SameSite=Lax",
     "Max-Age=0",
     "Secure",
     "HttpOnly"


### PR DESCRIPTION
## Summary
- relax the link-flow cookies used by auth finalize from SameSite=Strict to SameSite=Lax
- keep the change scoped to PortalLinkIntent and PortalAccessProvider
- preserve domain-wide auth cookie scope across *.paretoproof.com while surviving external auth returns

## Issue
- Closes #340