### PR TITLE
Preserve link flow on provider auth redirects

### DIFF
--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -124,6 +124,10 @@ export async function handleAccessStart(
       providerUrl.searchParams.set("redirect", redirectPath);
     }
 
+    if (flow === "link") {
+      providerUrl.searchParams.set("flow", "link");
+    }
+
     const headers = new Headers({
       location: providerUrl.toString()
     });


### PR DESCRIPTION
## Summary
- preserve low=link when the generic auth-start route redirects to provider-branded auth surfaces
- keep non-link auth starts unchanged
- prevent provider-link handoffs from degrading into normal auth starts

## Issue
- Closes #342