### PR TITLE
[Frontend] Fix local API base URL resolution for non-localhost dev hosts

### DIFF
--- a/apps/web/src/lib/api-base-url.ts
+++ b/apps/web/src/lib/api-base-url.ts
@@ -13,5 +13,8 @@ export function getApiBaseUrl() {
     return "https://api.paretoproof.com";
   }
 
-  return "http://localhost:3000";
+  const localApiUrl = new URL(window.location.origin);
+  localApiUrl.port = "3000";
+
+  return trimTrailingSlash(localApiUrl.origin);
 }


### PR DESCRIPTION
## Summary
- derive the default local API base URL from the current window origin instead of hardcoding localhost
- keep the local frontend and local API on the same host when the app is served from 127.0.0.1, ::1, or *.localhost
- preserve the existing production API host behavior

## Testing
- not run (targeted bug fix)
