### PR TITLE
[Frontend] Refine public, auth, and portal entry messaging

### DIFF
--- a/apps/web/src/components/portal-freshness-card.tsx
+++ b/apps/web/src/components/portal-freshness-card.tsx
@@ -43,7 +43,7 @@ export function PortalFreshnessCard({
   return (
     <section className="portal-freshness-card">
       <div>
-        <p className="eyebrow">View freshness</p>
+        <p className="eyebrow">Refresh behavior</p>
         <h3>{policy?.title ?? "Refresh on demand"}</h3>
         <p className="portal-panel-muted">
           {describePortalFreshness(policy, lastUpdatedAt, clockNow)}

--- a/apps/web/src/lib/portal-freshness.ts
+++ b/apps/web/src/lib/portal-freshness.ts
@@ -32,23 +32,23 @@ export function describePortalFreshness(
   now = Date.now()
 ) {
   if (!policy) {
-    return "This view does not define a background refresh policy yet.";
+    return "This view does not refresh in the background yet.";
   }
 
   if (policy.mode === "manual") {
     if (!lastUpdatedAt) {
-      return policy.description;
+      return "This view refreshes when you reload it or complete an action here.";
     }
 
-    return `${policy.description} Last refreshed ${formatTimestamp(lastUpdatedAt)}.`;
+    return `This view refreshes when you reload it or complete an action here. Last refreshed ${formatTimestamp(lastUpdatedAt)}.`;
   }
 
   if (!lastUpdatedAt) {
-    return `${policy.description} It should mark itself stale after ${formatDuration(policy.staleAfterMs ?? policy.pollIntervalMs ?? 0)} without a successful refresh.`;
+    return `This view refreshes in the background. If fresh data stops arriving for ${formatDuration(policy.staleAfterMs ?? policy.pollIntervalMs ?? 0)} or longer, it will be marked stale.`;
   }
 
   const ageMs = Math.max(0, now - Date.parse(lastUpdatedAt));
-  return `Last refreshed ${formatTimestamp(lastUpdatedAt)}. This view becomes stale after ${formatDuration(policy.staleAfterMs ?? policy.pollIntervalMs ?? 0)} without a successful refresh. Current age: ${formatDuration(Math.round(ageMs / 1000) * 1000)}.`;
+  return `Last refreshed ${formatTimestamp(lastUpdatedAt)}. This view refreshes in the background and will be marked stale if no fresh data arrives for ${formatDuration(policy.staleAfterMs ?? policy.pollIntervalMs ?? 0)}. Current age: ${formatDuration(Math.round(ageMs / 1000) * 1000)}.`;
 }
 
 export function formatTimestamp(timestamp: string) {

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -13,9 +13,9 @@ type AuthEntryProps = {
 };
 
 const authChecks = [
-  "Provider identity should resolve into one ParetoProof account, not duplicate users.",
-  "Approval state needs to be surfaced before the portal handoff looks broken.",
-  "Recovery should explain what changed instead of dumping users into Access noise."
+  "We match this provider to your existing ParetoProof account whenever possible.",
+  "If your account still needs approval, we will say that clearly before portal entry.",
+  "If sign-in or recovery needs attention, you stay on a branded surface with next steps."
 ];
 
 export function AuthEntry({ redirectPath }: AuthEntryProps) {
@@ -78,21 +78,21 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
             </span>
             ParetoProof portal
           </p>
-          <h1>Use one clean entry, then route users into the right identity state.</h1>
+          <h1>Sign in to the contributor portal.</h1>
           <p className="auth-lead">
-            Provider choice, account linking, and contributor approval belong in one
-            deliberate handoff instead of a stack of awkward intermediary screens.
+            Use GitHub or Google to continue. If this browser already has an approved
+            ParetoProof session, we will take you straight into the portal.
           </p>
           {showRetryNotice ? (
             <p className="auth-panel-copy">
-              The secure API handoff URL only works after sign-in. Restart from this auth
-              entry and already-authenticated browsers will be sent straight to the portal.
+              That sign-in handoff did not finish cleanly. Start again here and we will
+              retry from a fresh branded entry.
             </p>
           ) : null}
           {showFailedNotice ? (
             <p className="auth-panel-copy">
-              The provider handoff could not be started cleanly. Restart from this auth
-              entry to try again instead of continuing on a broken intermediary screen.
+              The provider handoff could not be started cleanly. Start again here and we
+              will open a fresh sign-in flow.
             </p>
           ) : null}
           {isCheckingSession ? (
@@ -105,9 +105,9 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
         <div className="auth-provider-layout">
           <section className="auth-provider-panel">
             <p className="section-tag">Sign in</p>
-            <h2>Choose a trusted provider</h2>
+            <h2>Choose a sign-in method</h2>
             <p className="auth-panel-copy">
-              GitHub and Google stay first-class without changing the overall shell.
+              Pick the provider that matches the identity you use for ParetoProof.
             </p>
             <div className="auth-provider-list">
               <a className="auth-provider-button" href={githubStartUrl}>
@@ -116,7 +116,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
                 </span>
                 <span>
                   <strong>Continue with GitHub</strong>
-                  <small>Primary contributor sign-in for repository-linked work.</small>
+                  <small>Best for contributors working from GitHub-linked repositories.</small>
                 </span>
                 <span className="auth-provider-arrow" aria-hidden="true">
                   <AppIcon name="arrow-right" />
@@ -128,7 +128,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
                 </span>
                 <span>
                   <strong>Continue with Google</strong>
-                  <small>Fallback for approved contributors who operate outside GitHub.</small>
+                  <small>Use Google when your approved ParetoProof identity lives outside GitHub.</small>
                 </span>
                 <span className="auth-provider-arrow" aria-hidden="true">
                   <AppIcon name="arrow-right" />
@@ -138,8 +138,8 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
           </section>
 
           <aside className="auth-provider-panel auth-provider-panel-notes">
-            <p className="section-tag">Guardrails</p>
-            <h2>What the flow has to explain</h2>
+            <p className="section-tag">Before you continue</p>
+            <h2>What happens next</h2>
             <ul className="auth-check-list">
               {authChecks.map((item) => (
                 <li key={item}>
@@ -157,7 +157,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
           <p>
             {isLocal
               ? "This development build can open a seeded approved portal session without Cloudflare Access."
-              : "If you are not approved yet, sign in first and submit your contributor request from inside the portal."}
+              : "Not approved yet? Sign in first, then submit your contributor access request from inside the portal."}
           </p>
           <a className="button button-secondary" href={buildPublicUrl("/")}>
             Back to paretoproof.com

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -94,13 +94,13 @@ function readLocalAccessOverride(): PortalAccessState | null {
 function formatPortalBootstrapError(error: unknown) {
   if (error instanceof Error) {
     if (error.message === "Failed to fetch") {
-      return "The portal could not reach the API. Check the API host and try again.";
+      return "The portal could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.";
     }
 
-    return error.message;
+    return "The portal could not finish loading right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.";
   }
 
-  return "The portal could not be loaded.";
+  return "The portal could not finish loading right now. Try again in a moment.";
 }
 
 export function PortalBootstrap() {

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -103,19 +103,19 @@ const overviewTimeline = [
 
 const portalSectionBodyCopy: Record<PortalSectionDefinition["id"], string> = {
   access_requests:
-    "The approval queue, stale identity recovery, and decision notes need to stay calm and readable under real admin load.",
+    "Review contributor requests, resolve stale identities, and leave decision notes that other admins can trust.",
   launch:
-    "Launch should become a checklist-driven control surface once benchmark execution is wired through the backend.",
+    "Launch benchmark runs from one controlled workflow once execution is wired into the backend.",
   overview:
-    "The default view should show benchmark posture, approval state, and recent operational movement in one scan.",
+    "See approval state, run activity, and service posture in one scan.",
   profile:
-    "Profile is where contributors confirm linked identities, edit the small supported fields, and recover broken auth state.",
+    "Confirm your linked sign-in methods, update the supported profile fields, and recover access when something drifts.",
   runs:
-    "Runs should read like an audit log with dense but legible state instead of decorative tiles.",
+    "Browse recent and historical benchmark runs with enough detail to inspect status quickly.",
   users:
-    "This surface will grow into contributor and role management without forcing a shell redesign.",
+    "Manage contributor accounts and roles from the same authenticated workspace.",
   workers:
-    "Worker posture belongs in the same serious shell even before orchestration is fully live."
+    "Track worker availability and execution posture once orchestration is live."
 };
 
 function coercePortalRoles(rawRoles: string[]): PortalRole[] {
@@ -302,22 +302,21 @@ export function PortalShell({ email, roles }: PortalShellProps) {
 
             <section className="portal-overview-grid">
               <article className="portal-panel portal-overview-lead">
-                <p className="section-tag">Control plane overview</p>
-                <h2>One stable canvas for auth, approvals, and benchmark posture.</h2>
+                <p className="section-tag">Portal overview</p>
+                <h2>Start from the current state of the portal.</h2>
                 <p>
-                  The shell should read like an operational workspace. Navigation stays
-                  structural on the left, the content pane carries the dense information,
-                  and the visual hierarchy comes from seams and typography rather than
-                  oversized rounded cards.
+                  This landing view is where approved contributors should see service
+                  health, recent benchmark activity, and approval posture without decoding
+                  the system first.
                 </p>
                 {activeFreshnessPolicy ? (
                   <PortalFreshnessCard lastUpdatedAt={null} routeId={activeRouteId} />
                 ) : null}
                 <div className="portal-section-notes">
                   <ul className="portal-note-list">
-                    <li>Keep recent runs, approval posture, and launch state visible in one pass.</li>
-                    <li>Use symbols and labels in the rail instead of two-letter abbreviations.</li>
-                    <li>Reserve strong color for state, not for every container.</li>
+                    <li>Keep recent runs, approval posture, and API state visible in one pass.</li>
+                    <li>Make the next useful actions obvious for the current role.</li>
+                    <li>Reserve strong color for state changes, not for every container.</li>
                   </ul>
                 </div>
               </article>
@@ -399,13 +398,13 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                   ) : null}
                   <div className="portal-section-notes">
                     <p className="portal-panel-muted">
-                      This section already follows the shell, access rules, and freshness
-                      model used across the portal.
+                      This section is ready for live data and task-specific workflows as
+                      backend features come online.
                     </p>
                     <ul className="portal-note-list">
-                      <li>Navigation and route access already reflect the approved role model.</li>
-                      <li>Live data can fill this section without another shell rewrite.</li>
-                      <li>The rail stays fixed while each deeper workflow grows independently.</li>
+                      <li>Navigation and route access already follow the approved role model.</li>
+                      <li>Live data can replace the placeholder content without a shell rewrite.</li>
+                      <li>The rail stays fixed while each deeper workflow grows in place.</li>
                     </ul>
                   </div>
                 </article>

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -76,7 +76,7 @@ export function PublicSite() {
           </p>
           <div className="hero-actions">
             <a className="button" href={buildAuthUrl("/")}>
-              Enter the portal
+              Contributor sign in
             </a>
             <a className="button button-secondary" href="/benchmarks">
               Read the benchmark model


### PR DESCRIPTION
## Summary
- align the public entry CTA language so the primary portal action is named consistently
- rewrite the auth entry, retry, and portal-unavailable states to stay contributor-facing instead of describing internal system intent
- rewrite the first authenticated portal overview and freshness messaging so the shell reads like a real workspace rather than implementation notes

## Testing
- Playwright desktop: local public, auth retry, portal unavailable, approved portal overview
- Playwright mobile: local auth retry and approved portal overview
- Playwright state checks: pending, access-request-required, and insufficient-role portal routing
- desktop screenshot pass with pywinauto + screenshot skill against the updated portal overview
