### PR TITLE
Fix local redirect param preservation

### DIFF
--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -105,6 +105,9 @@ function preserveLocalPortalState(targetPath: string, location = window.location
   const currentParams = new URLSearchParams(location.search);
 
   for (const key of ["surface", "access", "email", "reason", "roles"]) {
+    if (redirectUrl.searchParams.has(key)) {
+      continue;
+    }
     const value = currentParams.get(key);
 
     if (value) {

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -120,6 +120,9 @@ function copyLocalPortalState(targetUrl: URL, currentLocation = window.location)
   const currentParams = new URLSearchParams(currentLocation.search);
 
   for (const key of localPortalStateParamKeys) {
+    if (targetUrl.searchParams.has(key)) {
+      continue;
+    }
     const value = currentParams.get(key);
 
     if (value) {


### PR DESCRIPTION
## Summary
- prevent local query-state copying from overwriting explicit target params
- preserve explicit redirect reasons such as eason=insufficient_role
- keep local auth/portal redirect behavior stable

## Testing
- node URL behavior check for explicit param precedence