### PR TITLE
Stabilize workspace build by pinning Zod and hardening TS scripts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,12 +5,12 @@
   "scripts": {
     "bootstrap:owner-admin": "tsx scripts/bootstrap-owner-admin.ts",
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "bunx tsc -p tsconfig.json",
     "build:railway": "cd ../.. && bun run build:shared && bun --cwd apps/api build",
     "db:migrate": "tsx scripts/apply-drizzle-migrations.ts",
     "start": "node dist/index.js",
     "start:railway": "node dist/index.js",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@fastify/cors": "^11.1.0",
@@ -20,7 +20,7 @@
     "fastify": "latest",
     "jose": "^6.2.0",
     "postgres": "latest",
-    "zod": "latest"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json",
     "pages:deploy": "wrangler pages deploy --project-name=paretoproof-web"
   },
   "dependencies": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,13 +4,13 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "bunx tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@paretoproof/shared": "workspace:*",
-    "zod": "latest"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "fastify": "latest",
         "jose": "^6.2.0",
         "postgres": "latest",
-        "zod": "latest",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "@types/node": "latest",
@@ -44,7 +44,7 @@
       "name": "@paretoproof/worker",
       "dependencies": {
         "@paretoproof/shared": "workspace:*",
-        "zod": "latest",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "@types/node": "latest",
@@ -55,7 +55,7 @@
     "packages/shared": {
       "name": "@paretoproof/shared",
       "dependencies": {
-        "zod": "latest",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "typescript": "latest",
@@ -335,7 +335,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -547,7 +547,7 @@
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -556,8 +556,6 @@
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@paretoproof/worker/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,11 +13,11 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "build": "bunx tsc -p tsconfig.json",
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "zod": "latest"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "typescript": "latest"

--- a/packages/shared/src/schemas/access-request.ts
+++ b/packages/shared/src/schemas/access-request.ts
@@ -11,7 +11,7 @@ export const portalAccessRequestKindSchema = z.enum([
 ]);
 
 export const portalAccessRequestInputSchema = z.object({
-  rationale: z.string().trim().max(500).nullish().transform((value) => {
+  rationale: z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
     if (!value) {
       return null;
     }
@@ -22,7 +22,7 @@ export const portalAccessRequestInputSchema = z.object({
 });
 
 export const portalAccessRecoveryInputSchema = z.object({
-  rationale: z.string().trim().max(500).nullish().transform((value) => {
+  rationale: z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
     if (!value) {
       return null;
     }
@@ -31,7 +31,7 @@ export const portalAccessRecoveryInputSchema = z.object({
   })
 });
 
-const portalAccessDecisionNoteSchema = z.string().trim().max(500).nullish().transform((value) => {
+const portalAccessDecisionNoteSchema = z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
   if (!value) {
     return null;
   }
@@ -68,3 +68,4 @@ export const portalAdminAccessRequestApproveInputSchema = z.object({
 export const portalAdminAccessRequestRejectInputSchema = z.object({
   decisionNote: portalAccessDecisionNoteSchema
 });
+

--- a/packages/shared/src/schemas/profile.ts
+++ b/packages/shared/src/schemas/profile.ts
@@ -30,7 +30,7 @@ export const portalProfileSchema = z.object({
 });
 
 export const portalProfileUpdateInputSchema = z.object({
-  displayName: z.union([z.string().trim().max(80), z.null()]).transform((value) => {
+  displayName: z.union([z.string().trim().max(80), z.null()]).transform((value: string | null) => {
     if (!value) {
       return null;
     }
@@ -41,7 +41,7 @@ export const portalProfileUpdateInputSchema = z.object({
 
 export const portalProfileLinkIntentInputSchema = z.object({
   provider: portalLinkableIdentityProviderSchema,
-  redirectPath: z.string().trim().max(500).nullish().transform((value) => {
+  redirectPath: z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
     if (!value) {
       return null;
     }
@@ -55,3 +55,4 @@ export const portalProfileLinkIntentSchema = z.object({
   provider: portalLinkableIdentityProviderSchema,
   startUrl: z.string().url()
 });
+


### PR DESCRIPTION
## Summary
- switch workspace build/typecheck scripts from `tsc` to `bunx tsc` for reliable binary resolution under Bun workspaces
- add explicit callback parameter types in shared schema transforms to satisfy strict TS checks
- pin `zod` to `^3.25.76` in shared/api/worker to avoid `zod@4` Vite resolution break

## Validation
- `bun run typecheck`
- `bun run build`