### PR TITLE
Add pull request CI workflow

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "package.json"
-      - "bun.lock"
-      - "tsconfig.base.json"
-      - ".github/workflows/pull-request-ci.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add a baseline pull-request CI workflow for changes targeting main
- install the Bun workspace and run the existing root 	ypecheck and uild contracts
- keep the workflow secret-free so it can run on normal pull requests and provide a stable required check for merge protection

## Notes
- this creates the repo-local CI check surface; merge blocking still depends on branch protection using that check

Closes #113