### PR TITLE
fix(web): validate local denied reason override

### DIFF
--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -42,6 +42,21 @@ type PortalMeResponse = {
   };
 };
 
+function parseDeniedReason(
+  reason: string | null
+): PortalMeResponse["access"]["reason"] | null {
+  if (
+    reason === "access_request_required" ||
+    reason === "identity_recovery_required" ||
+    reason === "rejected_or_withdrawn" ||
+    reason === "unknown_identity"
+  ) {
+    return reason;
+  }
+
+  return null;
+}
+
 function readRouteDeniedReason(search = window.location.search) {
   const reason = new URLSearchParams(search).get("reason");
 
@@ -70,9 +85,7 @@ function readLocalAccessOverride(): PortalAccessState | null {
   if (accessState === "denied") {
     return {
       email: params.get("email"),
-      reason:
-        (params.get("reason") as PortalMeResponse["access"]["reason"] | null) ??
-        "access_request_required",
+      reason: parseDeniedReason(params.get("reason")) ?? "access_request_required",
       status: "denied"
     };
   }


### PR DESCRIPTION
## Summary\n- validate local denied reason query values in portal bootstrap\n- fall back to access_request_required when the local override is invalid\n\n## Verification\n- git diff --check\n- static inspection of local denied-state bootstrap path\n\n## Notes\n- full TypeScript validation is blocked in this sandbox because workspace toolchain deps are incomplete (	sc not installed locally).