### PR TITLE
Bootstrap Modal worker secrets

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -7,3 +7,4 @@ Current runtime-secret contract:
 - local runs may set worker runtime variables in `apps/worker/.env`
 - hosted Modal workers receive the same variable names through Modal Secret injection
 - the current hosted baseline is documented in `docs/modal-worker-secrets-baseline.md`
+- use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source

--- a/docs/modal-worker-secrets-baseline.md
+++ b/docs/modal-worker-secrets-baseline.md
@@ -122,6 +122,16 @@ That means:
 
 The broader local-versus-Modal injection story, including trusted local Codex handling, belongs to issue `#148`. This document only fixes the hosted Modal worker secret inventory and attachment model.
 
+## Bootstrap helper
+
+The repository bootstrap helper for the base worker identity secret is:
+
+```bash
+bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply
+```
+
+By default the script targets Modal environment `main`, reads `apps/worker/.env`, and creates or updates the base secret object for the selected worker environment. It refuses the checked-in placeholder bootstrap token so a copied-but-unedited `.env` file cannot clobber a live Modal secret.
+
 ## Rotation rules
 
 - rotate `WORKER_BOOTSTRAP_TOKEN` at the worker deployment or pool level

--- a/infra/scripts/configure-modal-worker-secrets.mjs
+++ b/infra/scripts/configure-modal-worker-secrets.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+const REQUIRED_SECRETS = ["WORKER_BOOTSTRAP_TOKEN"];
+const DEFAULT_DOTENV_PATH = "apps/worker/.env";
+const DEFAULT_WORKER_ENVIRONMENT = "dev";
+const ALLOWED_WORKER_ENVIRONMENTS = new Set(["dev", "staging", "production"]);
+const PLACEHOLDER_VALUES = new Set(["replace-with-local-worker-bootstrap-token"]);
+
+const argv = process.argv.slice(2);
+const hasFlag = (flag) => argv.includes(flag);
+const readOption = (flag) => {
+  const index = argv.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+
+  return argv[index + 1];
+};
+
+const apply = hasFlag("--apply");
+const dotenvPath = readOption("--dotenv") ?? DEFAULT_DOTENV_PATH;
+const environment = readOption("--env") ?? process.env.MODAL_ENVIRONMENT ?? "main";
+const workerEnvironment = readOption("--worker-environment") ?? DEFAULT_WORKER_ENVIRONMENT;
+const secretName = readOption("--secret-name") ?? `paretoproof-worker-${workerEnvironment}`;
+
+if (!ALLOWED_WORKER_ENVIRONMENTS.has(workerEnvironment)) {
+  console.error(
+    `Invalid --worker-environment value: ${workerEnvironment}. Expected one of: ${Array.from(ALLOWED_WORKER_ENVIRONMENTS).join(", ")}.`
+  );
+  process.exit(1);
+}
+
+const parseDotenv = (source) => {
+  const parsed = {};
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separator = line.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, separator).trim();
+    let value = line.slice(separator + 1).trim();
+
+    if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    parsed[key] = value;
+  }
+
+  return parsed;
+};
+
+const fileValues = existsSync(dotenvPath) ? parseDotenv(readFileSync(dotenvPath, "utf8")) : {};
+const resolvedValues = {
+  ...fileValues,
+  ...Object.fromEntries(REQUIRED_SECRETS.map((name) => [name, process.env[name]]).filter(([, value]) => Boolean(value))),
+};
+
+const missing = REQUIRED_SECRETS.filter((name) => !resolvedValues[name]);
+if (missing.length > 0) {
+  console.error("Missing required worker secret values.");
+  console.error(`Checked process environment and ${dotenvPath}.`);
+  for (const name of missing) {
+    console.error(`- ${name}`);
+  }
+  console.error(
+    "Provide the values in a local worker .env file or as process environment variables, then re-run with --apply."
+  );
+  process.exit(1);
+}
+
+const placeholders = REQUIRED_SECRETS.filter((name) => PLACEHOLDER_VALUES.has(resolvedValues[name]));
+if (placeholders.length > 0) {
+  console.error("Refusing to sync placeholder worker secret values.");
+  console.error(`Checked process environment and ${dotenvPath}.`);
+  for (const name of placeholders) {
+    console.error(`- ${name}`);
+  }
+  console.error("Replace the example placeholder with a real secret value before re-running with --apply.");
+  process.exit(1);
+}
+
+const runModal = (args) => {
+  const result = spawnSync("modal", args, {
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim() || "(no output)";
+    throw new Error(`Modal command failed: ${detail}`);
+  }
+
+  return result.stdout;
+};
+
+const keyValues = REQUIRED_SECRETS.map((name) => `${name}=${resolvedValues[name]}`);
+
+if (apply) {
+  runModal(["secret", "create", secretName, "--env", environment, "--force", ...keyValues]);
+  console.log(`Set Modal secret ${secretName} in environment ${environment}.`);
+} else {
+  console.log(`Would set Modal secret ${secretName} in environment ${environment}.`);
+}
+
+console.log(`Secret keys: ${REQUIRED_SECRETS.join(", ")}`);
+console.log(`Worker environment: ${workerEnvironment}`);
+console.log(`Source dotenv path: ${dotenvPath}`);
+
+if (!apply) {
+  console.log("Dry run complete. Re-run with --apply to create or update the Modal secret.");
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:api": "bun --cwd apps/api build",
     "build:api:railway": "bun run build:shared && bun run build:api",
     "bootstrap:github:env-secrets": "node infra/scripts/configure-github-environment-secrets.mjs",
+    "bootstrap:modal:worker-secrets": "node infra/scripts/configure-modal-worker-secrets.mjs",
     "bootstrap:owner-admin:api": "bun --cwd apps/api bootstrap:owner-admin",
     "db:migrate:api": "bun --cwd apps/api db:migrate",
     "start:api:railway": "node apps/api/dist/index.js",


### PR DESCRIPTION
## Summary

- add a repository bootstrap script plus package command for syncing the base Modal worker identity secret from a local runtime-only source
- document that bootstrap helper inside the existing Modal worker secret baseline and worker README
- align the live Modal secret state with the new baseline by seeding `paretoproof-worker-dev` and removing the obsolete temporary secret name

## Linked issues

- Closes #101

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
node infra/scripts/configure-modal-worker-secrets.mjs
$env:WORKER_BOOTSTRAP_TOKEN='replace-with-local-worker-bootstrap-token'; node infra/scripts/configure-modal-worker-secrets.mjs
bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply
modal secret delete paretoproof-worker-runtime --env main --yes --allow-missing
modal secret list
bun install --frozen-lockfile
bun run typecheck:worker
bun run check:bidi
```

Modal verification: the authenticated Modal `main` environment now contains the `paretoproof-worker-dev` secret. The generated local `apps/worker/.env` used for bootstrap stayed ignored and was not committed.

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary: the change keeps secret values runtime-only, adds no build-time secret path, and rejects the checked-in placeholder bootstrap token before any Modal mutation can happen.

Cost impact: negligible. The repo change adds one local/bootstrap command and one base worker secret object in the existing Modal workspace.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout: run `bun run bootstrap:modal:worker-secrets -- --worker-environment <dev|staging|production> --apply` after setting `WORKER_BOOTSTRAP_TOKEN` locally whenever the base worker bootstrap token is created or rotated.

Rollback: delete or rotate the relevant `paretoproof-worker-<environment>` Modal secret and revert this PR if the bootstrap contract needs to change.

## Notes

- This branch was rebased onto `main` after `#401` landed so the helper follows the new `paretoproof-worker-<environment>` naming contract instead of the earlier temporary secret name.