### PR TITLE
Materialize Problem 9 benchmark package

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -9,3 +9,12 @@ Current runtime-secret contract:
 - the current hosted baseline is documented in `docs/modal-worker-secrets-baseline.md`
 - the broader local-versus-Modal injection model is documented in `docs/worker-secret-injection-baseline.md`
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
+
+Problem 9 package materialization:
+
+- repository-owned authoring source lives in `benchmarks/firstproof/problem9/`
+- the checked-in source tree does not include `benchmark-package.json`; that file is generated during materialization
+- build the worker package, then materialize with:
+  - `bun --cwd apps/worker build`
+  - `bun --cwd apps/worker materialize:problem9-package -- --output <directory>`
+- the command writes the canonical package under `<directory>/firstproof/Problem9/` and prints the deterministic manifest and package digests

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "bunx tsc -p tsconfig.json",
+    "materialize:problem9-package": "node dist/cli/materialize-problem9-package.js",
+    "materialize:problem9-package:dev": "tsx src/cli/materialize-problem9-package.ts",
     "start": "node dist/index.js",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },

--- a/apps/worker/src/cli/materialize-problem9-package.ts
+++ b/apps/worker/src/cli/materialize-problem9-package.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+
+import { materializeProblem9Package } from "../lib/problem9-package-materializer.js";
+
+function parseOutputDir(argv: string[]): string {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--output") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --output.");
+      }
+      return value;
+    }
+
+    if (argument.startsWith("--output=")) {
+      const value = argument.slice("--output=".length);
+      if (!value) {
+        throw new Error("Missing value for --output.");
+      }
+      return value;
+    }
+  }
+
+  throw new Error("Missing required --output <directory> argument.");
+}
+
+async function main(): Promise<void> {
+  const outputDir = parseOutputDir(process.argv.slice(2));
+  const result = await materializeProblem9Package({ outputDir });
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        materializedRoot: path.normalize(result.materializedRoot),
+        benchmarkManifestDigest: result.benchmarkManifestDigest,
+        packageDigest: result.packageDigest,
+        filesHashed: Object.keys(result.hashes),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/apps/worker/src/lib/problem9-package-materializer.ts
+++ b/apps/worker/src/lib/problem9-package-materializer.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+import { cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { z } from "zod";
+
+const MATERIALIZED_PACKAGE_ID = "firstproof/Problem9";
+const AUTHORING_SOURCE_ROOT = path.join("benchmarks", "firstproof", "problem9");
+const SOURCE_METADATA_PATH = path.join(AUTHORING_SOURCE_ROOT, "package-source.json");
+const GENERATED_MANIFEST_PATH = "benchmark-package.json";
+const MATERIALIZED_ROOT_SEGMENTS = ["firstproof", "Problem9"];
+const REQUIRED_MATERIALIZED_PATHS = [
+  GENERATED_MANIFEST_PATH,
+  "README.md",
+  "LICENSE",
+  "lean-toolchain",
+  "lake-manifest.json",
+  "lakefile.toml",
+  "statements/problem.md",
+  "FirstProof/Problem9/Statement.lean",
+  "FirstProof/Problem9/Support.lean",
+  "FirstProof/Problem9/Gold.lean",
+] as const;
+const AUTHORED_SOURCE_PATHS = REQUIRED_MATERIALIZED_PATHS.filter(
+  (relativePath) => relativePath !== GENERATED_MANIFEST_PATH,
+);
+
+const sourceMetadataSchema = z.object({
+  sourceSchemaVersion: z.literal(1),
+  packageId: z.literal(MATERIALIZED_PACKAGE_ID),
+  packageVersion: z.string().min(1),
+  benchmarkFamily: z.literal("firstproof"),
+  benchmarkItemId: z.literal("Problem9"),
+  lanePolicy: z.object({
+    sourceLaneId: z.literal("lean422_exact"),
+    supportedLanes: z
+      .array(
+        z.object({
+          laneId: z.enum(["lean422_exact", "lean424_interop"]),
+          leanVersion: z.string().min(1),
+          materialization: z.string().min(1),
+        }),
+      )
+      .min(2),
+  }),
+  canonicalModules: z.object({
+    statement: z.literal("FirstProof.Problem9.Statement"),
+    support: z.literal("FirstProof.Problem9.Support"),
+    gold: z.literal("FirstProof.Problem9.Gold"),
+  }),
+  requiredPaths: z.array(z.string().min(1)),
+});
+
+type SourceMetadata = z.infer<typeof sourceMetadataSchema>;
+
+export interface MaterializeProblem9PackageOptions {
+  outputDir: string;
+}
+
+export interface MaterializeProblem9PackageResult {
+  materializedRoot: string;
+  benchmarkManifestDigest: string;
+  packageDigest: string;
+  hashes: Record<string, string>;
+}
+
+function normalizePath(relativePath: string): string {
+  return relativePath.replaceAll("\\", "/");
+}
+
+function sha256String(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function sha256Buffer(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableValue(entry));
+  }
+
+  if (value && typeof value === "object") {
+    const stableEntries = Object.entries(value as Record<string, unknown>)
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([key, entryValue]) => [key, stableValue(entryValue)]);
+    return Object.fromEntries(stableEntries);
+  }
+
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return `${JSON.stringify(stableValue(value), null, 2)}\n`;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveRepoRoot(): Promise<string> {
+  let currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+  while (true) {
+    const packageJsonPath = path.join(currentDirectory, "package.json");
+    if (await pathExists(packageJsonPath)) {
+      const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+        name?: unknown;
+      };
+      if (packageJson.name === "paretoproof") {
+        return currentDirectory;
+      }
+    }
+
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error("Could not resolve the ParetoProof repository root.");
+    }
+
+    currentDirectory = parentDirectory;
+  }
+}
+
+function assertRequiredPathContract(metadata: SourceMetadata): void {
+  const metadataPaths = JSON.stringify(metadata.requiredPaths);
+  const expectedPaths = JSON.stringify(REQUIRED_MATERIALIZED_PATHS);
+  if (metadataPaths !== expectedPaths) {
+    throw new Error(
+      `Malformed source metadata: requiredPaths drifted from the canonical Problem 9 package layout.\nExpected: ${expectedPaths}\nReceived: ${metadataPaths}`,
+    );
+  }
+}
+
+async function readSourceMetadata(repoRoot: string): Promise<SourceMetadata> {
+  const metadataPath = path.join(repoRoot, SOURCE_METADATA_PATH);
+  const rawMetadata = await readFile(metadataPath, "utf8");
+  const parsedMetadata = sourceMetadataSchema.parse(JSON.parse(rawMetadata));
+  assertRequiredPathContract(parsedMetadata);
+  return parsedMetadata;
+}
+
+async function ensureRequiredSourceFiles(repoRoot: string): Promise<void> {
+  const sourceRoot = path.join(repoRoot, AUTHORING_SOURCE_ROOT);
+  const generatedManifestSourcePath = path.join(sourceRoot, GENERATED_MANIFEST_PATH);
+  if (await pathExists(generatedManifestSourcePath)) {
+    throw new Error(
+      `Authoring source must not check in ${GENERATED_MANIFEST_PATH}; it is generated during materialization.`,
+    );
+  }
+
+  for (const relativePath of AUTHORED_SOURCE_PATHS) {
+    const absolutePath = path.join(sourceRoot, relativePath);
+    if (!(await pathExists(absolutePath))) {
+      throw new Error(`Missing required Problem 9 authoring source file: ${normalizePath(relativePath)}`);
+    }
+  }
+}
+
+async function copyAuthoredSource(repoRoot: string, materializedRoot: string): Promise<Record<string, string>> {
+  const sourceRoot = path.join(repoRoot, AUTHORING_SOURCE_ROOT);
+  const hashes: Record<string, string> = {};
+
+  for (const relativePath of AUTHORED_SOURCE_PATHS) {
+    const sourcePath = path.join(sourceRoot, relativePath);
+    const destinationPath = path.join(materializedRoot, relativePath);
+    await mkdir(path.dirname(destinationPath), { recursive: true });
+    await cp(sourcePath, destinationPath);
+    const fileBytes = await readFile(destinationPath);
+    hashes[normalizePath(relativePath)] = sha256Buffer(fileBytes);
+  }
+
+  return Object.fromEntries(
+    Object.entries(hashes).sort(([leftPath], [rightPath]) => leftPath.localeCompare(rightPath)),
+  );
+}
+
+function buildManifestBase(metadata: SourceMetadata, hashes: Record<string, string>) {
+  return {
+    manifestSchemaVersion: 1,
+    packageId: metadata.packageId,
+    packageVersion: metadata.packageVersion,
+    benchmarkFamily: metadata.benchmarkFamily,
+    benchmarkItemId: metadata.benchmarkItemId,
+    lanePolicy: metadata.lanePolicy,
+    canonicalModules: metadata.canonicalModules,
+    requiredPaths: [...REQUIRED_MATERIALIZED_PATHS],
+    hashes,
+    generatedManifestBoundary: {
+      authoringSourceRoot: normalizePath(AUTHORING_SOURCE_ROOT),
+      sourceMetadataPath: normalizePath(SOURCE_METADATA_PATH),
+      materializedPackageRoot: normalizePath(path.join(...MATERIALIZED_ROOT_SEGMENTS)),
+      generatedFile: GENERATED_MANIFEST_PATH,
+      rootManifestRule:
+        "benchmark-package.json is generated after copied-file hashes are known. benchmarkManifestDigest hashes the normalized manifest content before digest fields are attached, and packageDigest hashes the normalized copied-file inventory plus canonical manifest metadata instead of trying to hash the final manifest as one of its own file entries.",
+    },
+  };
+}
+
+async function writeManifest(
+  materializedRoot: string,
+  metadata: SourceMetadata,
+  hashes: Record<string, string>,
+): Promise<MaterializeProblem9PackageResult> {
+  const manifestBase = buildManifestBase(metadata, hashes);
+  const benchmarkManifestDigest = sha256String(stableJson(manifestBase));
+  const packageDigest = sha256String(
+    stableJson({
+      ...manifestBase,
+      benchmarkManifestDigest,
+    }),
+  );
+  const finalManifest = {
+    ...manifestBase,
+    benchmarkManifestDigest,
+    packageDigest,
+  };
+
+  await writeFile(path.join(materializedRoot, GENERATED_MANIFEST_PATH), stableJson(finalManifest), "utf8");
+
+  return {
+    materializedRoot,
+    benchmarkManifestDigest,
+    packageDigest,
+    hashes,
+  };
+}
+
+export async function materializeProblem9Package(
+  options: MaterializeProblem9PackageOptions,
+): Promise<MaterializeProblem9PackageResult> {
+  const repoRoot = await resolveRepoRoot();
+  const metadata = await readSourceMetadata(repoRoot);
+  await ensureRequiredSourceFiles(repoRoot);
+
+  const outputDirectory = path.resolve(options.outputDir);
+  const materializedRoot = path.join(outputDirectory, ...MATERIALIZED_ROOT_SEGMENTS);
+  if (await pathExists(materializedRoot)) {
+    throw new Error(`Refusing to overwrite existing materialized package root: ${materializedRoot}`);
+  }
+
+  await mkdir(materializedRoot, { recursive: true });
+  const hashes = await copyAuthoredSource(repoRoot, materializedRoot);
+  return writeManifest(materializedRoot, metadata, hashes);
+}

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
@@ -1,0 +1,12 @@
+import FirstProof.Problem9.Statement
+
+namespace FirstProof.Problem9
+
+theorem problem9 (n : Nat) : problem9Target n := by
+  induction n with
+  | zero =>
+      simp [problem9Target, double]
+  | succ n ih =>
+      simp [problem9Target, double, ih, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
@@ -1,0 +1,8 @@
+import FirstProof.Problem9.Support
+
+namespace FirstProof.Problem9
+
+def problem9Target (n : Nat) : Prop :=
+  double n = n + n
+
+end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Support.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Support.lean
@@ -1,0 +1,7 @@
+namespace FirstProof.Problem9
+
+def double : Nat -> Nat
+  | 0 => 0
+  | n + 1 => Nat.succ (Nat.succ (double n))
+
+end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/LICENSE
+++ b/benchmarks/firstproof/problem9/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/benchmarks/firstproof/problem9/README.md
+++ b/benchmarks/firstproof/problem9/README.md
@@ -1,0 +1,23 @@
+# FirstProof Problem 9
+
+This directory is the repository-owned authoring source for the canonical `firstproof/Problem9` benchmark package.
+
+The checked-in source tree is not the final materialized package root. The worker materializer copies the immutable authored files from this directory, writes them into `firstproof/Problem9/`, and then generates `benchmark-package.json` there with deterministic hash metadata.
+
+Authoring-source boundary:
+
+- checked in here:
+  - `README.md`
+  - `LICENSE`
+  - `lean-toolchain`
+  - `lakefile.toml`
+  - `lake-manifest.json`
+  - `statements/problem.md`
+  - `FirstProof/Problem9/Statement.lean`
+  - `FirstProof/Problem9/Support.lean`
+  - `FirstProof/Problem9/Gold.lean`
+  - `package-source.json`
+- generated during materialization:
+  - `benchmark-package.json`
+
+The current package keeps the mathematical content intentionally small so the repository can establish one deterministic package contract before broader runner and verifier work lands.

--- a/benchmarks/firstproof/problem9/lake-manifest.json
+++ b/benchmarks/firstproof/problem9/lake-manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages": []
+}

--- a/benchmarks/firstproof/problem9/lakefile.toml
+++ b/benchmarks/firstproof/problem9/lakefile.toml
@@ -1,0 +1,6 @@
+name = "firstproof-problem9"
+version = "0.1.0"
+defaultTargets = ["FirstProof"]
+
+[[lean_lib]]
+name = "FirstProof"

--- a/benchmarks/firstproof/problem9/lean-toolchain
+++ b/benchmarks/firstproof/problem9/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.22.0

--- a/benchmarks/firstproof/problem9/package-source.json
+++ b/benchmarks/firstproof/problem9/package-source.json
@@ -1,0 +1,39 @@
+{
+  "sourceSchemaVersion": 1,
+  "packageId": "firstproof/Problem9",
+  "packageVersion": "2026.03.13.1",
+  "benchmarkFamily": "firstproof",
+  "benchmarkItemId": "Problem9",
+  "lanePolicy": {
+    "sourceLaneId": "lean422_exact",
+    "supportedLanes": [
+      {
+        "laneId": "lean422_exact",
+        "leanVersion": "4.22.0",
+        "materialization": "canonical_source"
+      },
+      {
+        "laneId": "lean424_interop",
+        "leanVersion": "4.24.0",
+        "materialization": "deterministic_compatibility_materialization"
+      }
+    ]
+  },
+  "canonicalModules": {
+    "statement": "FirstProof.Problem9.Statement",
+    "support": "FirstProof.Problem9.Support",
+    "gold": "FirstProof.Problem9.Gold"
+  },
+  "requiredPaths": [
+    "benchmark-package.json",
+    "README.md",
+    "LICENSE",
+    "lean-toolchain",
+    "lake-manifest.json",
+    "lakefile.toml",
+    "statements/problem.md",
+    "FirstProof/Problem9/Statement.lean",
+    "FirstProof/Problem9/Support.lean",
+    "FirstProof/Problem9/Gold.lean"
+  ]
+}

--- a/benchmarks/firstproof/problem9/statements/problem.md
+++ b/benchmarks/firstproof/problem9/statements/problem.md
@@ -1,0 +1,12 @@
+# Problem 9
+
+Define a function `double : Nat -> Nat` by recursion:
+
+- `double 0 = 0`
+- `double (n + 1) = Nat.succ (Nat.succ (double n))`
+
+Formally prove that for every natural number `n`, the recursive function agrees with ordinary addition:
+
+`double n = n + n`
+
+This benchmark item is intentionally small. Its purpose in the MVP is to establish one deterministic benchmark-package contract that workers and run bundles can materialize reproducibly from the repository.

--- a/docs/problem9-benchmark-package-baseline.md
+++ b/docs/problem9-benchmark-package-baseline.md
@@ -94,14 +94,17 @@ The package version is therefore the only supported way to say "this is a differ
 - `lanePolicy`: the supported Lean lanes for this package version
 - `canonicalModules`: `Statement`, `Support`, and `Gold`
 - `hashes`: SHA-256 digests for every immutable file in the package root
+- `benchmarkManifestDigest`: deterministic digest for the generated root manifest content before digest fields are attached
 - `packageDigest`: the SHA-256 digest of the normalized whole-package snapshot
 
 The required hash set for MVP is:
 
-- whole-package SHA-256 over the normalized file tree
-- per-file SHA-256 for `benchmark-package.json`, `README.md`, `LICENSE`, `lean-toolchain`, `lakefile.toml`, `lake-manifest.json`, `statements/problem.md`, `FirstProof/Problem9/Statement.lean`, `FirstProof/Problem9/Support.lean`, and `FirstProof/Problem9/Gold.lean`
+- whole-package SHA-256 over the normalized package inventory and canonical manifest metadata
+- per-file SHA-256 for `README.md`, `LICENSE`, `lean-toolchain`, `lakefile.toml`, `lake-manifest.json`, `statements/problem.md`, `FirstProof/Problem9/Statement.lean`, `FirstProof/Problem9/Support.lean`, and `FirstProof/Problem9/Gold.lean`
 
 Normalization must ignore local build output and editor noise. Files such as `.lake/`, `.git/`, `.DS_Store`, `*.olean`, transient logs, and other generated outputs are not part of the package boundary and must never contribute to the package digest.
+
+The generated root manifest is a special case on purpose. The checked-in authoring source under `benchmarks/firstproof/problem9/` may keep source metadata that helps produce the package, but the materialized canonical package root includes a generated `benchmark-package.json`. Because a generated root manifest cannot embed a byte hash of its own final file content without circularity, the package contract should treat `benchmarkManifestDigest` and `packageDigest` like run-bundle root-manifest digests: derived from normalized manifest content and normalized copied-file inventory, not from trying to include the final generated manifest as one of its own ordinary file entries.
 
 ## Compatibility with downstream run and artifact work
 


### PR DESCRIPTION
## Summary
- add the repository-owned Problem 9 benchmark package authoring source tree under enchmarks/firstproof/problem9/
- add a worker materialization library and CLI that emits the canonical irstproof/Problem9 package with generated digest metadata
- document the authoring-source versus generated-manifest boundary in the worker README and package-boundary baseline

## Linked Issues
- Closes #415

## Verification
- bun run typecheck:worker
- bun run check:bidi
- bun --cwd apps/worker build
- build and run the materializer twice into clean temp directories; confirmed identical enchmarkManifestDigest, packageDigest, and file-hash inventory
