### PR TITLE
fix(ci): pin worker image publish actions

### DIFF
--- a/.github/workflows/publish-worker-image.yml
+++ b/.github/workflows/publish-worker-image.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Generate image metadata
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.WORKER_IMAGE }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and publish worker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: apps/worker/Dockerfile


### PR DESCRIPTION
## Summary
- pin every third-party action in the privileged worker-image publish workflow to an immutable commit SHA
- keep the existing GHCR publish behavior unchanged while removing mutable-tag supply-chain exposure
- clean up issue `#438` so it matches the execution-issue template and board expectations

Closes #438.

## Verification
- `bun run check:bidi`
- `git -c safe.directory=C:/Users/Tom/.codex/worktrees/426a/ParetoProof diff --check`
- verified all five `uses:` entries in `.github/workflows/publish-worker-image.yml` match `@[0-9a-f]{40}`