### PR TITLE
fix(api): enforce trusted origins on portal mutations

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "db:migrate": "tsx scripts/apply-drizzle-migrations.ts",
     "start": "node dist/index.js",
     "start:railway": "node dist/index.js",
-    "test": "node --import tsx --test test/portal-session-finalize.test.ts",
+    "test": "node --import tsx --test test/*.test.ts",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -6,10 +6,11 @@ import { createDbClient } from "../db/client.js";
 import { registerAdminRoutes } from "../routes/admin.js";
 import { registerHealthRoute } from "../routes/health.js";
 import { registerPortalRoutes } from "../routes/portal.js";
-
-function normalizeOrigin(value: string) {
-  return value.replace(/\/+$/, "");
-}
+import {
+  createTrustedMutationOriginHook,
+  isAllowedLocalOrigin,
+  normalizeOrigin
+} from "./trusted-mutation-origin.js";
 
 function readAllowedCorsOrigins() {
   const baselineOrigins = [
@@ -25,10 +26,6 @@ function readAllowedCorsOrigins() {
   return [...new Set([...baselineOrigins, ...(configuredOrigins ?? [])].map(normalizeOrigin))];
 }
 
-function isAllowedLocalOrigin(origin: string) {
-  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin);
-}
-
 function shouldAllowLocalhostCors() {
   return process.env.CORS_ALLOW_LOCALHOST === "true";
 }
@@ -40,6 +37,7 @@ export async function buildServer() {
   const db = createDbClient();
   const requireAccess = createAccessGuard(db);
   const allowedOrigins = readAllowedCorsOrigins();
+  const allowLocalhostCors = shouldAllowLocalhostCors();
 
   await app.register(cors, {
     credentials: true,
@@ -50,7 +48,6 @@ export async function buildServer() {
       }
 
       const normalizedOrigin = normalizeOrigin(origin);
-      const allowLocalhostCors = shouldAllowLocalhostCors();
 
       if (
         allowedOrigins.includes(normalizedOrigin) ||
@@ -64,6 +61,13 @@ export async function buildServer() {
     }
   });
   await app.register(formbody);
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: allowLocalhostCors,
+      allowedOrigins
+    })
+  );
 
   registerHealthRoute(app);
   registerPortalRoutes(app, db, requireAccess);

--- a/apps/api/src/server/trusted-mutation-origin.ts
+++ b/apps/api/src/server/trusted-mutation-origin.ts
@@ -1,0 +1,65 @@
+import type {
+  FastifyReply,
+  FastifyRequest,
+  HookHandlerDoneFunction
+} from "fastify";
+
+export function normalizeOrigin(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+export function isAllowedLocalOrigin(origin: string) {
+  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin);
+}
+
+export function shouldEnforceTrustedMutationOrigin(method: string, routePath: string) {
+  return (
+    method !== "GET" &&
+    method !== "HEAD" &&
+    method !== "OPTIONS" &&
+    routePath.startsWith("/portal/")
+  );
+}
+
+export function createTrustedMutationOriginHook(options: {
+  allowLocalhostOrigins: boolean;
+  allowedOrigins: string[];
+}) {
+  return (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    done: HookHandlerDoneFunction
+  ) => {
+    const routePath = request.routeOptions.url ?? request.raw.url ?? "";
+
+    if (!shouldEnforceTrustedMutationOrigin(request.method, routePath)) {
+      done();
+      return;
+    }
+
+    const requestOrigin =
+      typeof request.headers.origin === "string" && request.headers.origin.length > 0
+        ? normalizeOrigin(request.headers.origin)
+        : null;
+
+    if (!requestOrigin) {
+      reply.code(403).send({
+        error: "trusted_origin_required"
+      });
+      return;
+    }
+
+    const originAllowed =
+      options.allowedOrigins.includes(requestOrigin) ||
+      (options.allowLocalhostOrigins && isAllowedLocalOrigin(requestOrigin));
+
+    if (!originAllowed) {
+      reply.code(403).send({
+        error: "trusted_origin_not_allowed"
+      });
+      return;
+    }
+
+    done();
+  };
+}

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { createTrustedMutationOriginHook } from "../src/server/trusted-mutation-origin.ts";
+
+test("trusted mutation origin hook rejects state-changing portal requests without an Origin header", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: ["https://portal.paretoproof.com"]
+    })
+  );
+
+  app.post("/portal/access-requests", async () => ({ ok: true }));
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "test"
+    },
+    url: "/portal/access-requests"
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_required"
+  });
+});
+
+test("trusted mutation origin hook rejects state-changing portal requests from untrusted origins", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: ["https://portal.paretoproof.com"]
+    })
+  );
+
+  app.post("/portal/admin/access-requests/req_123/approve", async () => ({ ok: true }));
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      approvedRole: "helper",
+      decisionNote: "test"
+    },
+    url: "/portal/admin/access-requests/req_123/approve",
+    headers: {
+      origin: "https://evil.example"
+    }
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_not_allowed"
+  });
+});
+
+test("trusted mutation origin hook allows trusted portal origins and safe GET redirects", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: ["https://portal.paretoproof.com"]
+    })
+  );
+
+  app.post("/portal/profile", async () => ({ ok: true }));
+  app.get("/portal/session/finalize/submit", async () => ({ ok: true }));
+
+  const trustedPost = await app.inject({
+    method: "POST",
+    payload: {
+      displayName: "Ada"
+    },
+    url: "/portal/profile",
+    headers: {
+      origin: "https://portal.paretoproof.com"
+    }
+  });
+
+  const redirectGet = await app.inject({
+    method: "GET",
+    url: "/portal/session/finalize/submit"
+  });
+
+  assert.equal(trustedPost.statusCode, 200);
+  assert.deepEqual(trustedPost.json(), {
+    ok: true
+  });
+  assert.equal(redirectGet.statusCode, 200);
+  assert.deepEqual(redirectGet.json(), {
+    ok: true
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit trusted-Origin hook for state-changing `/portal/*` routes instead of relying on implicit CORS behavior as the only CSRF boundary
- cover the shared guard with API tests for missing Origin, untrusted Origin, trusted Origin, and the existing safe GET finalize redirect path
- normalize the malformed security audit issues `#439`, `#440`, and `#442` into the execution-issue template and put them on the backend/roadmap boards

## Linked issues
- Closes #440
- Closes #442
- Related: #439

## Verification
- `bun run build:shared; bun --cwd apps/api typecheck`
- `bun run test:api`
- `bun run check:bidi`