### PR TITLE
fix(shared): align offline ingest auth modes

### DIFF
--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -121,7 +121,7 @@ async function buildOfflineIngestRequest(options: {
 
   await materializeProblem9PromptPackage({
     attemptId: `attempt-${idSuffix}-1`,
-    authMode: "trusted_local_codex",
+    authMode: "trusted_local_user",
     benchmarkPackageRoot,
     harnessRevision: "harness-test-rev",
     jobId: `job-${idSuffix}-1`,

--- a/packages/shared/src/schemas/problem9-offline-ingest.ts
+++ b/packages/shared/src/schemas/problem9-offline-ingest.ts
@@ -56,7 +56,12 @@ export const problem9PackageRefSchema = z.object({
 });
 
 export const problem9PromptPackageManifestSchema = z.object({
-  authMode: z.enum(["machine", "trusted_local_codex", "trusted_local_provider"]),
+  authMode: z.enum([
+    "trusted_local_user",
+    "machine_api_key",
+    "machine_oauth",
+    "local_stub"
+  ]),
   benchmarkItemId: z.literal("Problem9"),
   benchmarkPackageDigest: sha256Schema,
   benchmarkPackageId: z.literal("firstproof/Problem9"),

--- a/packages/shared/src/types/problem9-offline-ingest.ts
+++ b/packages/shared/src/types/problem9-offline-ingest.ts
@@ -104,7 +104,11 @@ export type Problem9PackageRef = {
 };
 
 export type Problem9PromptPackageManifest = {
-  authMode: "machine" | "trusted_local_codex" | "trusted_local_provider";
+  authMode:
+    | "trusted_local_user"
+    | "machine_api_key"
+    | "machine_oauth"
+    | "local_stub";
   benchmarkItemId: "Problem9";
   benchmarkPackageDigest: string;
   benchmarkPackageId: "firstproof/Problem9";


### PR DESCRIPTION
## Summary
- align the shared offline-ingest schema and exported types with the worker auth-mode rename from #459
- update the API offline-ingest fixture to use the current `trusted_local_user` auth mode
- restore `bun run test:api` on current `main`-based worktrees

## Verification
- `bun run test:api`
- `bun run check:bidi`

Closes #466
