### PR TITLE
feat(web): wire public content navigation

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -4,6 +4,8 @@ import { buildAuthUrl, buildPublicUrl } from "../lib/surface";
 const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discussions";
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
 
+const projectRoute = "/project";
+
 const publicSignals = [
   {
     detail: "versioned harness inputs, environment metadata, and comparable outputs",
@@ -186,19 +188,48 @@ const projectResources: Array<{
   }
 ];
 
-function PublicHeader({ homeHref }: { homeHref?: string }) {
+function buildProjectSectionUrl(sectionId: string) {
+  return buildPublicUrl(`${projectRoute}#${sectionId}`);
+}
+
+const footerProjectLinks = [
+  { id: "overview", label: "Project overview" },
+  { id: "contributors", label: "Contributor path" },
+  { id: "contact", label: "Contact rules" }
+];
+
+function PublicHeader({
+  currentPath,
+  homeHref
+}: {
+  currentPath: string;
+  homeHref?: string;
+}) {
+  const isProjectRoute = currentPath === projectRoute || currentPath.startsWith(`${projectRoute}/`);
+
   return (
     <header className="site-header">
-      <div className="site-brand">
-        <span className="site-brand-mark" aria-hidden="true">
-          <AppIcon name="spark" />
-        </span>
-        <div>
-          <p className="eyebrow">ParetoProof</p>
-          <p className="site-tagline">
-            Formal benchmark infrastructure for mathematical reasoning systems.
-          </p>
+      <div className="site-header-main">
+        <div className="site-brand">
+          <span className="site-brand-mark" aria-hidden="true">
+            <AppIcon name="spark" />
+          </span>
+          <div>
+            <p className="eyebrow">ParetoProof</p>
+            <p className="site-tagline">
+              Formal benchmark infrastructure for mathematical reasoning systems.
+            </p>
+          </div>
         </div>
+
+        <nav className="site-primary-nav" aria-label="Primary">
+          <a
+            className={`site-nav-link${isProjectRoute ? " site-nav-link-active" : ""}`}
+            href={buildPublicUrl(projectRoute)}
+          >
+            Project
+          </a>
+        </nav>
       </div>
 
       <div className="site-header-actions">
@@ -215,10 +246,63 @@ function PublicHeader({ homeHref }: { homeHref?: string }) {
   );
 }
 
+function PublicFooter({ isProjectRoute }: { isProjectRoute: boolean }) {
+  return (
+    <footer className="site-footer" aria-label="Project entry points">
+      <div className="site-footer-grid">
+        <section className="site-footer-panel">
+          <p className="section-tag">Project route</p>
+          <h2>One public entry, three anchored sections.</h2>
+          <p>
+            The public site exposes one consolidated `Project` destination, then routes
+            readers into the exact section they need.
+          </p>
+          <div className="site-footer-links">
+            {footerProjectLinks.map((link) => (
+              <a
+                className="site-footer-link"
+                href={isProjectRoute ? `#${link.id}` : buildProjectSectionUrl(link.id)}
+                key={link.id}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section className="site-footer-panel">
+          <p className="section-tag">Public routing</p>
+          <h2>Keep discoverability on the apex surface.</h2>
+          <p>
+            Contributor sign-in still routes into auth, public questions still route to
+            GitHub Discussions, and the apex site keeps the project explanation in one place.
+          </p>
+          <div className="site-footer-links">
+            <a className="site-footer-link" href={buildAuthUrl("/")}>
+              Contributor sign in
+            </a>
+            <a className="site-footer-link" href={githubDiscussionsUrl} rel="noreferrer" target="_blank">
+              GitHub Discussions
+            </a>
+            <a
+              className="site-footer-link"
+              href={`${publicDocsBaseUrl}/README.md`}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Working docs
+            </a>
+          </div>
+        </section>
+      </div>
+    </footer>
+  );
+}
+
 function PublicLanding() {
   return (
     <main className="site-shell">
-      <PublicHeader />
+      <PublicHeader currentPath={window.location.pathname} />
 
       <section className="site-hero">
         <div className="site-hero-copy">
@@ -266,6 +350,8 @@ function PublicLanding() {
           </article>
         ))}
       </section>
+
+      <PublicFooter isProjectRoute={false} />
     </main>
   );
 }
@@ -273,7 +359,7 @@ function PublicLanding() {
 function PublicProjectPack() {
   return (
     <main className="site-shell site-project-shell">
-      <PublicHeader homeHref={buildPublicUrl("/")} />
+      <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
 
       <section className="site-hero site-hero-project">
         <div className="site-hero-copy">
@@ -459,6 +545,8 @@ function PublicProjectPack() {
           </div>
         </article>
       </section>
+
+      <PublicFooter isProjectRoute />
     </main>
   );
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -171,6 +171,11 @@ a.button-secondary {
   gap: 16px;
 }
 
+.site-header-main {
+  display: grid;
+  gap: 14px;
+}
+
 .site-brand {
   display: flex;
   align-items: flex-start;
@@ -245,12 +250,55 @@ a.button-secondary {
 .hero-actions,
 .site-header-actions,
 .site-pill-row,
+.site-footer-links,
 .portal-link-actions,
 .portal-request-actions,
 .portal-identity {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.site-primary-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.site-nav-link,
+.site-footer-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.3rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.74);
+  color: var(--ink);
+  font-weight: 700;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background-color 160ms ease;
+}
+
+.site-nav-link:hover,
+.site-nav-link:focus-visible,
+.site-footer-link:hover,
+.site-footer-link:focus-visible,
+.site-panel-card-link:hover,
+.site-panel-card-link:focus-visible,
+.site-pill-link:hover,
+.site-pill-link:focus-visible {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+
+.site-nav-link-active {
+  background: rgba(17, 42, 103, 0.08);
+  border-color: rgba(17, 42, 103, 0.16);
+  color: var(--navy);
 }
 
 .site-signal-column {
@@ -362,14 +410,6 @@ a.button-secondary {
     box-shadow 160ms ease;
 }
 
-.site-panel-card-link:hover,
-.site-panel-card-link:focus-visible,
-.site-pill-link:hover,
-.site-pill-link:focus-visible {
-  border-color: var(--line-strong);
-  transform: translateY(-1px);
-}
-
 .site-panel-mark {
   display: inline-flex;
   width: 38px;
@@ -391,6 +431,38 @@ a.button-secondary {
   margin: 0;
   font-size: 1.12rem;
   letter-spacing: -0.03em;
+}
+
+.site-footer {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(249, 251, 255, 0.96));
+  padding: 24px;
+}
+
+.site-footer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.site-footer-panel {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.site-footer-panel h2 {
+  font-size: 1.3rem;
+  letter-spacing: -0.03em;
+}
+
+.site-footer-panel p {
+  color: var(--ink-soft);
+  line-height: 1.6;
 }
 
 .site-band {
@@ -1100,6 +1172,10 @@ a.button-secondary {
     padding: 20px;
   }
 
+  .site-footer-grid {
+    grid-template-columns: 1fr;
+  }
+
   .portal-metric-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1136,6 +1212,7 @@ a.button-secondary {
   .site-header,
   .site-hero,
   .site-project-section,
+  .site-footer,
   .auth-card,
   .auth-inline-status,
   .portal-main {
@@ -1208,9 +1285,11 @@ a.button-secondary {
 
 @media (max-width: 640px) {
   .site-header,
+  .site-header-main,
   .site-header-actions,
   .hero-actions,
   .site-pill-row,
+  .site-footer-links,
   .portal-identity,
   .portal-request-header,
   .portal-request-actions,


### PR DESCRIPTION
﻿## Summary

- wire a single `Project` primary-nav link into the shared public header so the content pack is discoverable from both the landing page and the `/project` route
- add footer-level project-routing panels that point into the consolidated project-pack anchors without reintroducing separate top-level About/Contact/Contribution tabs
- extend the public styles for the new header nav, footer panels, footer links, and responsive stacking behavior

## Linked issues

- Closes #497

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun run build:shared
bun --cwd apps/web typecheck
bun run build:web
bun run check:bidi
git -c safe.directory=C:/Users/Tom/.codex/worktrees/a0c8/ParetoProof diff --check
```

Browser QA performed against the built `apps/web/dist` bundle served locally from a temporary Node HTTP server inside `js_repl`:
- desktop landing page first fold with the new header nav visible
- desktop route from header `Project` link into `/project`
- desktop footer route from `Contact rules` into the in-page `#contact` anchor
- mobile `/project` first fold with header nav present
- mobile layout sanity check for footer-link count and no horizontal overflow

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary and mitigation:
- all new entry points stay on the public apex surface except the existing auth CTA; the change does not add a new public form, privileged route, or auth bypass

Cost or rate-limit impact:
- none

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- merge after CI and review so the public content pack has stable discoverability from header and footer entry points

Rollback plan:
- revert the header/footer wiring if the apex public navigation model changes before launch

## Notes

- this intentionally keeps one top-level `Project` entry instead of splitting About, Contact, and Contribution back into separate primary-nav lanes
