### PR TITLE
fix(infra): widen hidden Unicode guard

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Check for hidden bidi characters
+      - name: Check for hidden Unicode control characters
         run: node infra/scripts/check-bidi-chars.mjs
+
+      - name: Test hidden Unicode guard fixtures
+        run: node --test infra/scripts/check-bidi-chars.test.mjs
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,4 +4,4 @@
 
 Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
-- `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain bidirectional Unicode control characters that could hide malicious diffs.
+- `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts.

--- a/infra/scripts/check-bidi-chars.mjs
+++ b/infra/scripts/check-bidi-chars.mjs
@@ -1,12 +1,30 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
-const bidiPattern = /[\u202A-\u202E\u2066-\u2069]/u;
+const defaultRepoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const formatCharacterPattern = /\p{Cf}/u;
+const controlCharacterPattern = /\p{Cc}/u;
+const allowedControlCodePoints = new Set([0x0009, 0x000A, 0x000D]);
 
-function readTrackedFiles() {
+function resolveCliRepoRoot(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--repo-root") {
+      const repoRootArg = argv[index + 1];
+
+      if (!repoRootArg) {
+        throw new Error("Missing value for --repo-root.");
+      }
+
+      return resolve(repoRootArg);
+    }
+  }
+
+  return defaultRepoRoot;
+}
+
+export function readTrackedFiles(repoRoot = defaultRepoRoot) {
   const output = execFileSync("git", ["ls-files", "-z"], {
     cwd: repoRoot,
     encoding: "buffer"
@@ -18,7 +36,35 @@ function readTrackedFiles() {
     .filter(Boolean);
 }
 
-function findBidiLocations(relativePath) {
+export function isForbiddenHiddenCodePoint(codePoint) {
+  const character = String.fromCodePoint(codePoint);
+
+  if (formatCharacterPattern.test(character)) {
+    return true;
+  }
+
+  return controlCharacterPattern.test(character) && !allowedControlCodePoints.has(codePoint);
+}
+
+function formatCodePoint(codePoint) {
+  return `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+export function findForbiddenCodePoints(text) {
+  const matches = [];
+
+  for (const character of text) {
+    const codePoint = character.codePointAt(0);
+
+    if (codePoint !== undefined && isForbiddenHiddenCodePoint(codePoint)) {
+      matches.push(codePoint);
+    }
+  }
+
+  return [...new Set(matches)];
+}
+
+export function findHiddenUnicodeLocations(relativePath, repoRoot = defaultRepoRoot) {
   const absolutePath = resolve(repoRoot, relativePath);
   const fileBuffer = readFileSync(absolutePath);
 
@@ -31,32 +77,54 @@ function findBidiLocations(relativePath) {
   const matches = [];
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
-    const line = lines[lineIndex];
+    const codePoints = findForbiddenCodePoints(lines[lineIndex]);
 
-    if (!bidiPattern.test(line)) {
+    if (codePoints.length === 0) {
       continue;
     }
 
-    matches.push(`${relativePath}:${lineIndex + 1}`);
+    matches.push({
+      path: relativePath,
+      lineNumber: lineIndex + 1,
+      codePoints
+    });
   }
 
   return matches;
 }
 
-const offenders = [];
+export function scanTrackedFiles(repoRoot = defaultRepoRoot) {
+  const offenders = [];
 
-for (const relativePath of readTrackedFiles()) {
-  offenders.push(...findBidiLocations(relativePath));
-}
-
-if (offenders.length > 0) {
-  console.error("Disallowed bidirectional Unicode control characters found:");
-
-  for (const offender of offenders) {
-    console.error(`- ${offender}`);
+  for (const relativePath of readTrackedFiles(repoRoot)) {
+    offenders.push(...findHiddenUnicodeLocations(relativePath, repoRoot));
   }
 
-  process.exit(1);
+  return offenders;
 }
 
-console.log("No bidirectional Unicode control characters found in tracked files.");
+export function formatOffender(offender) {
+  return `${offender.path}:${offender.lineNumber} (${offender.codePoints.map(formatCodePoint).join(", ")})`;
+}
+
+export function runCli(argv = process.argv.slice(2), io = { log: console.log, error: console.error }) {
+  const repoRoot = resolveCliRepoRoot(argv);
+  const offenders = scanTrackedFiles(repoRoot);
+
+  if (offenders.length > 0) {
+    io.error("Disallowed hidden or bidirectional Unicode control characters found:");
+
+    for (const offender of offenders) {
+      io.error(`- ${formatOffender(offender)}`);
+    }
+
+    return 1;
+  }
+
+  io.log("No disallowed hidden or bidirectional Unicode control characters found in tracked files.");
+  return 0;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(runCli());
+}

--- a/infra/scripts/check-bidi-chars.test.mjs
+++ b/infra/scripts/check-bidi-chars.test.mjs
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { formatOffender, scanTrackedFiles } from "./check-bidi-chars.mjs";
+
+const fixturesRoot = resolve(fileURLToPath(new URL("./fixtures/check-bidi-chars", import.meta.url)));
+const allowedFixtures = JSON.parse(readFileSync(resolve(fixturesRoot, "allowed.json"), "utf8"));
+const disallowedFixtures = JSON.parse(readFileSync(resolve(fixturesRoot, "disallowed.json"), "utf8"));
+const scriptPath = fileURLToPath(new URL("./check-bidi-chars.mjs", import.meta.url));
+
+function materializeFixtureContent(fixture) {
+  if ("text" in fixture) {
+    return fixture.text;
+  }
+
+  return fixture.codePoints
+    .map((codePoint) => String.fromCodePoint(Number.parseInt(codePoint, 16)))
+    .join("");
+}
+
+function createTempRepo(fixtures) {
+  const repoRoot = mkdtempSync(resolve(tmpdir(), "paretoproof-bidi-"));
+
+  try {
+    execFileSync("git", ["init", "--initial-branch=main"], { cwd: repoRoot, stdio: "ignore" });
+
+    for (const fixture of fixtures) {
+      const absolutePath = resolve(repoRoot, fixture.path);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, materializeFixtureContent(fixture), "utf8");
+    }
+
+    execFileSync("git", ["add", "."], { cwd: repoRoot, stdio: "ignore" });
+    return repoRoot;
+  } catch (error) {
+    rmSync(repoRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+function disposeTempRepo(repoRoot) {
+  rmSync(repoRoot, { force: true, recursive: true });
+}
+
+test("scanTrackedFiles ignores visible text, tabs, and CRLF fixtures", () => {
+  const repoRoot = createTempRepo(allowedFixtures);
+
+  try {
+    assert.deepEqual(scanTrackedFiles(repoRoot), []);
+  } finally {
+    disposeTempRepo(repoRoot);
+  }
+});
+
+test("scanTrackedFiles reports hidden format and control characters from fixtures", () => {
+  const repoRoot = createTempRepo(disallowedFixtures);
+
+  try {
+    const offenders = scanTrackedFiles(repoRoot).map((offender) => ({
+      path: offender.path,
+      lineNumber: offender.lineNumber,
+      formatted: formatOffender(offender)
+    })).sort((left, right) => left.path.localeCompare(right.path));
+
+    assert.deepEqual(
+      offenders,
+      disallowedFixtures.map((fixture) => ({
+        path: fixture.path,
+        lineNumber: 1,
+        formatted: `${fixture.path}:1 (${fixture.expectedCodePoints.join(", ")})`
+      })).sort((left, right) => left.path.localeCompare(right.path))
+    );
+  } finally {
+    disposeTempRepo(repoRoot);
+  }
+});
+
+test("CLI exits nonzero for a tracked file with GitHub warning-class hidden Unicode", () => {
+  const repoRoot = createTempRepo([disallowedFixtures[0]]);
+
+  try {
+    const result = spawnSync(process.execPath, [scriptPath, "--repo-root", repoRoot], {
+      encoding: "utf8"
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Disallowed hidden or bidirectional Unicode control characters found:/u);
+    assert.match(result.stderr, /apps\/web\/src\/forbidden-zws\.ts:1 \(U\+200B\)/u);
+  } finally {
+    disposeTempRepo(repoRoot);
+  }
+});

--- a/infra/scripts/fixtures/check-bidi-chars/allowed.json
+++ b/infra/scripts/fixtures/check-bidi-chars/allowed.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "ascii-with-tabs",
+    "path": "docs/allowed.txt",
+    "text": "plain text\\twith tabs\\nand visible unicode π"
+  },
+  {
+    "name": "crlf-line-endings",
+    "path": "infra/examples/allowed-crlf.txt",
+    "text": "first line\\r\\nsecond line\\r\\n"
+  }
+]

--- a/infra/scripts/fixtures/check-bidi-chars/disallowed.json
+++ b/infra/scripts/fixtures/check-bidi-chars/disallowed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "zero-width-space",
+    "path": "apps/web/src/forbidden-zws.ts",
+    "codePoints": ["0061", "200B", "0062"],
+    "expectedCodePoints": ["U+200B"]
+  },
+  {
+    "name": "left-to-right-isolate",
+    "path": "apps/api/src/forbidden-bidi.ts",
+    "codePoints": ["0061", "2066", "0062"],
+    "expectedCodePoints": ["U+2066"]
+  },
+  {
+    "name": "tag-character",
+    "path": "packages/shared/src/forbidden-tag.ts",
+    "codePoints": ["0061", "E0001", "0062"],
+    "expectedCodePoints": ["U+E0001"]
+  },
+  {
+    "name": "escape-control",
+    "path": "infra/examples/forbidden-escape.txt",
+    "codePoints": ["0061", "001B", "0062"],
+    "expectedCodePoints": ["U+001B"]
+  }
+]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
+    "test:bidi": "node --test infra/scripts/check-bidi-chars.test.mjs",
     "build": "bun run build:shared && bun run build:web && bun run build:api && bun run build:worker",
     "typecheck": "bun run typecheck:shared && bun run typecheck:web && bun run typecheck:api && bun run typecheck:worker",
     "dev:web": "bun --cwd apps/web dev",


### PR DESCRIPTION
## Summary
- expand the hidden Unicode guard from a narrow bidi range to Unicode format characters plus non-whitespace control characters
- add fixture-driven Node tests that materialize allowed and disallowed tracked files in temp repos, including a GitHub warning-class zero-width-space case
- run the guard tests in PR CI and document the broadened policy in infra docs

## Testing
- node --test infra/scripts/check-bidi-chars.test.mjs
- bun run check:bidi
- bun run test:bidi
- git -c safe.directory=C:/Users/Tom/.codex/worktrees/a0c8/ParetoProof diff --check

Closes #492