### PR TITLE
fix(api): validate runtime env at startup

### DIFF
--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { FastifyRequest } from "fastify";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { normalizeOptionalEmail } from "../lib/email.js";
+import { parseApiRuntimeEnv } from "../config/runtime.js";
 import type { PortalIdentityProvider } from "@paretoproof/shared";
 
 type CloudflareAccessTokenClaims = JWTPayload & {
@@ -245,26 +246,16 @@ export function selectCloudflareAccessVerifier(
 }
 
 export function createCloudflareAccessVerifierSetFromEnv() {
-  const teamDomain = process.env.CF_ACCESS_TEAM_DOMAIN;
-  const portalAudience =
-    process.env.CF_ACCESS_PORTAL_AUD ?? process.env.CF_ACCESS_AUD;
-  const internalAudience =
-    process.env.CF_ACCESS_INTERNAL_AUD ?? portalAudience;
-
-  if (!teamDomain || !portalAudience || !internalAudience) {
-    throw new Error(
-      "CF_ACCESS_TEAM_DOMAIN plus CF_ACCESS_PORTAL_AUD/CF_ACCESS_AUD are required for Access JWT validation."
-    );
-  }
+  const runtimeEnv = parseApiRuntimeEnv();
 
   return {
     internal: createCloudflareAccessVerifier({
-      audience: internalAudience,
-      teamDomain
+      audience: runtimeEnv.internalAccessAudience,
+      teamDomain: runtimeEnv.teamDomain
     }),
     portal: createCloudflareAccessVerifier({
-      audience: portalAudience,
-      teamDomain
+      audience: runtimeEnv.portalAccessAudience,
+      teamDomain: runtimeEnv.teamDomain
     })
   };
 }

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -1,21 +1,142 @@
-function readRequiredEnv(name: string) {
-  const value = process.env[name]?.trim();
+import { z } from "zod";
 
-  if (!value) {
-    throw new Error(`${name} is required for the API runtime.`);
+function normalizeOptionalEnvValue(value: unknown) {
+  if (typeof value !== "string") {
+    return value;
   }
 
-  return value;
+  const trimmedValue = value.trim();
+
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+const trimmedOptionalStringSchema = z
+  .preprocess(normalizeOptionalEnvValue, z.string().trim().optional());
+
+const requiredTrimmedStringSchema = z
+  .string()
+  .trim()
+  .min(1, "must not be empty");
+
+const portSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z.coerce
+    .number()
+    .int("must be an integer")
+    .min(0, "must be at least 0")
+    .max(65535, "must be at most 65535")
+    .optional()
+);
+
+const optionalBooleanStringSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z.enum(["true", "false"]).optional()
+);
+
+const rawApiRuntimeEnvSchema = z
+  .object({
+    ACCESS_PROVIDER_STATE_SECRET: requiredTrimmedStringSchema,
+    CF_ACCESS_AUD: trimmedOptionalStringSchema,
+    CF_ACCESS_INTERNAL_AUD: trimmedOptionalStringSchema,
+    CF_ACCESS_PORTAL_AUD: trimmedOptionalStringSchema,
+    CF_ACCESS_TEAM_DOMAIN: requiredTrimmedStringSchema,
+    CORS_ALLOWED_ORIGINS: trimmedOptionalStringSchema,
+    CORS_ALLOW_LOCALHOST: optionalBooleanStringSchema,
+    DATABASE_URL: requiredTrimmedStringSchema,
+    HOST: trimmedOptionalStringSchema,
+    NODE_ENV: trimmedOptionalStringSchema,
+    PORT: portSchema
+  })
+  .superRefine((env, context) => {
+    if (!(env.CF_ACCESS_PORTAL_AUD ?? env.CF_ACCESS_AUD)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required",
+        path: ["CF_ACCESS_PORTAL_AUD"]
+      });
+    }
+  });
+
+export type ApiRuntimeEnv = {
+  accessProviderStateSecret: string;
+  corsAllowedOrigins: string[];
+  corsAllowLocalhost: boolean;
+  databaseUrl: string;
+  host: string;
+  internalAccessAudience: string;
+  nodeEnv?: string;
+  port: number;
+  portalAccessAudience: string;
+  teamDomain: string;
+};
+
+function formatApiRuntimeEnvIssues(issues: z.ZodIssue[]) {
+  return issues
+    .map((issue) => {
+      const field = issue.path[0];
+      const message = issue.message === "Required" ? "is required" : issue.message;
+
+      if (typeof field !== "string") {
+        return message;
+      }
+
+      return `${field}: ${message}`;
+    })
+    .join("; ");
+}
+
+function normalizeCorsAllowedOrigins(value: string | undefined) {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+}
+
+export function parseApiRuntimeEnv(
+  rawEnv: Partial<Record<string, string | undefined>> = process.env
+): ApiRuntimeEnv {
+  const parsed = rawApiRuntimeEnvSchema.safeParse(rawEnv);
+
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid API runtime environment: ${formatApiRuntimeEnvIssues(parsed.error.issues)}`
+    );
+  }
+
+  const {
+    ACCESS_PROVIDER_STATE_SECRET,
+    CF_ACCESS_AUD,
+    CF_ACCESS_INTERNAL_AUD,
+    CF_ACCESS_PORTAL_AUD,
+    CF_ACCESS_TEAM_DOMAIN,
+    CORS_ALLOWED_ORIGINS,
+    CORS_ALLOW_LOCALHOST,
+    DATABASE_URL,
+    HOST,
+    NODE_ENV,
+    PORT
+  } = parsed.data;
+
+  const portalAccessAudience = CF_ACCESS_PORTAL_AUD ?? CF_ACCESS_AUD!;
+
+  return {
+    accessProviderStateSecret: ACCESS_PROVIDER_STATE_SECRET,
+    corsAllowedOrigins: normalizeCorsAllowedOrigins(CORS_ALLOWED_ORIGINS),
+    corsAllowLocalhost: CORS_ALLOW_LOCALHOST === "true",
+    databaseUrl: DATABASE_URL,
+    host: HOST ?? "0.0.0.0",
+    internalAccessAudience: CF_ACCESS_INTERNAL_AUD ?? portalAccessAudience,
+    nodeEnv: NODE_ENV,
+    port: PORT === undefined ? 3000 : Number(PORT),
+    portalAccessAudience,
+    teamDomain: CF_ACCESS_TEAM_DOMAIN
+  };
 }
 
 export function assertApiRuntimeEnv() {
-  readRequiredEnv("DATABASE_URL");
-  readRequiredEnv("ACCESS_PROVIDER_STATE_SECRET");
-  readRequiredEnv("CF_ACCESS_TEAM_DOMAIN");
-
-  if (!(process.env.CF_ACCESS_PORTAL_AUD?.trim() || process.env.CF_ACCESS_AUD?.trim())) {
-    throw new Error(
-      "CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required for Access JWT validation."
-    );
-  }
+  parseApiRuntimeEnv();
 }

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -2,13 +2,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
 
-export function createDbClient() {
-  const connectionString = process.env.DATABASE_URL;
-
-  if (!connectionString) {
-    throw new Error("DATABASE_URL is required to create the API database client.");
-  }
-
+export function createDbClient(connectionString: string) {
   const sql = postgres(connectionString);
 
   return drizzle(sql, { schema });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,15 +1,12 @@
-import { assertApiRuntimeEnv } from "./config/runtime.js";
+import { parseApiRuntimeEnv } from "./config/runtime.js";
 import { buildServer } from "./server/build-server.js";
 
-const port = Number(process.env.PORT ?? 3000);
-const host = process.env.HOST ?? "0.0.0.0";
-
 const start = async () => {
-  assertApiRuntimeEnv();
-  const app = await buildServer();
+  const runtimeEnv = parseApiRuntimeEnv();
+  const app = await buildServer(runtimeEnv);
 
   try {
-    await app.listen({ host, port });
+    await app.listen({ host: runtimeEnv.host, port: runtimeEnv.port });
   } catch (error) {
     app.log.error(error);
     process.exit(1);

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -1,6 +1,7 @@
 import cors from "@fastify/cors";
 import formbody from "@fastify/formbody";
 import Fastify from "fastify";
+import type { ApiRuntimeEnv } from "../config/runtime.js";
 import { createAccessGuard } from "../auth/require-access.js";
 import { createDbClient } from "../db/client.js";
 import { registerAdminRoutes } from "../routes/admin.js";
@@ -13,32 +14,29 @@ import {
   normalizeOrigin
 } from "./trusted-mutation-origin.js";
 
-function readAllowedCorsOrigins() {
+function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
   const baselineOrigins = [
     "https://auth.paretoproof.com",
     "https://github.auth.paretoproof.com",
     "https://google.auth.paretoproof.com",
     "https://portal.paretoproof.com"
   ];
-  const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS?.split(",")
-    .map((origin) => origin.trim())
-    .filter(Boolean);
 
-  return [...new Set([...baselineOrigins, ...(configuredOrigins ?? [])].map(normalizeOrigin))];
+  return [
+    ...new Set(
+      [...baselineOrigins, ...runtimeEnv.corsAllowedOrigins].map(normalizeOrigin)
+    )
+  ];
 }
 
-function shouldAllowLocalhostCors() {
-  return process.env.CORS_ALLOW_LOCALHOST === "true";
-}
-
-export async function buildServer() {
+export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
   const app = Fastify({
     logger: true
   });
-  const db = createDbClient();
+  const db = createDbClient(runtimeEnv.databaseUrl);
   const requireAccess = createAccessGuard(db);
-  const allowedOrigins = readAllowedCorsOrigins();
-  const allowLocalhostCors = shouldAllowLocalhostCors();
+  const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
+  const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
 
   await app.register(cors, {
     credentials: true,

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseApiRuntimeEnv } from "../src/config/runtime.ts";
+
+test("parseApiRuntimeEnv accepts the documented local API runtime contract", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof"
+  });
+
+  assert.deepEqual(runtimeEnv, {
+    accessProviderStateSecret: "state-secret",
+    corsAllowedOrigins: [],
+    corsAllowLocalhost: false,
+    databaseUrl: "postgres://localhost:5432/paretoproof",
+    host: "0.0.0.0",
+    internalAccessAudience: "portal-audience",
+    nodeEnv: undefined,
+    port: 3000,
+    portalAccessAudience: "portal-audience",
+    teamDomain: "paretoproof.cloudflareaccess.com"
+  });
+});
+
+test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    CF_ACCESS_AUD: "legacy-audience",
+    CF_ACCESS_INTERNAL_AUD: "internal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    CORS_ALLOWED_ORIGINS: "https://staging.paretoproof.com, https://admin.paretoproof.com ",
+    CORS_ALLOW_LOCALHOST: "true",
+    DATABASE_URL: "postgres://railway.internal:5432/paretoproof",
+    HOST: "127.0.0.1",
+    NODE_ENV: "production",
+    PORT: "4310"
+  });
+
+  assert.deepEqual(runtimeEnv, {
+    accessProviderStateSecret: "state-secret",
+    corsAllowedOrigins: [
+      "https://staging.paretoproof.com",
+      "https://admin.paretoproof.com"
+    ],
+    corsAllowLocalhost: true,
+    databaseUrl: "postgres://railway.internal:5432/paretoproof",
+    host: "127.0.0.1",
+    internalAccessAudience: "internal-audience",
+    nodeEnv: "production",
+    port: 4310,
+    portalAccessAudience: "legacy-audience",
+    teamDomain: "paretoproof.cloudflareaccess.com"
+  });
+});
+
+test("parseApiRuntimeEnv rejects runtimes without a portal access audience", () => {
+  assert.throws(
+    () =>
+      parseApiRuntimeEnv({
+        ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+        CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+        DATABASE_URL: "postgres://localhost:5432/paretoproof"
+      }),
+    /CF_ACCESS_PORTAL_AUD: CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required/
+  );
+});
+
+test("parseApiRuntimeEnv reports omitted required variables explicitly", () => {
+  assert.throws(
+    () =>
+      parseApiRuntimeEnv({
+        CF_ACCESS_PORTAL_AUD: "portal-audience",
+        CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+        DATABASE_URL: "postgres://localhost:5432/paretoproof"
+      }),
+    /ACCESS_PROVIDER_STATE_SECRET: is required/
+  );
+});
+
+test("parseApiRuntimeEnv rejects missing and malformed values with explicit field names", () => {
+  assert.throws(
+    () =>
+      parseApiRuntimeEnv({
+        ACCESS_PROVIDER_STATE_SECRET: "   ",
+        CF_ACCESS_PORTAL_AUD: "portal-audience",
+        CF_ACCESS_TEAM_DOMAIN: "",
+        CORS_ALLOW_LOCALHOST: "maybe",
+        DATABASE_URL: "",
+        PORT: "70000"
+      }),
+    /ACCESS_PROVIDER_STATE_SECRET: must not be empty; CF_ACCESS_TEAM_DOMAIN: must not be empty; CORS_ALLOW_LOCALHOST: Invalid enum value\..*DATABASE_URL: must not be empty; PORT: must be at most 65535/
+  );
+});


### PR DESCRIPTION
## Summary
- replace the thin API startup assertion with a canonical parsed runtime contract
- thread parsed runtime config through API startup, DB creation, CORS setup, and Access verifier construction
- add focused runtime env tests and verify valid plus invalid startup behavior

## Verification
- `bun run build:shared`
- `bun --cwd apps/api typecheck`
- `bun --cwd apps/api build`
- `bun --cwd apps/api test`
- `bun run check:bidi`
- valid startup boot via `node --import tsx src/index.ts` with a health probe on `/health`
- invalid startup boot via `node --import tsx src/index.ts` with `ACCESS_PROVIDER_STATE_SECRET` removed

Closes #479