### PR TITLE
fix(worker): validate runtime env by mode

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -9,6 +9,11 @@ Current runtime-secret contract:
 - the current hosted baseline is documented in `docs/modal-worker-secrets-baseline.md`
 - the broader local-versus-Modal injection model is documented in `docs/worker-secret-injection-baseline.md`
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
+- worker commands now validate runtime env by command family before execution starts:
+  - materializers stay env-free
+  - `run-problem9-attempt` validates by effective auth mode
+  - `run-problem9-attempt-in-devbox` requires a readable trusted-local `CODEX_HOME/auth.json`
+  - future hosted claim-loop and offline-ingest modes reserve `API_BASE_URL` and `WORKER_BOOTSTRAP_TOKEN` as their canonical runtime requirements
 
 Package materialization:
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
     "run:problem9-attempt": "tsx src/index.ts run-problem9-attempt",
     "run:problem9-attempt:trusted-local": "tsx src/index.ts run-problem9-attempt-in-devbox",
     "start": "node dist/index.js",
+    "test": "node --import tsx --test test/*.test.ts",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,8 +5,7 @@ import { runProblem9PromptPackageCli } from "./lib/problem9-prompt-package-cli.j
 import { runProblem9RunBundleCli } from "./lib/problem9-run-bundle-cli.js";
 
 const [command, ...args] = process.argv.slice(2);
-
-if (!command) {
+const showWorkerUsage = () => {
   console.error(
     [
       "Usage:",
@@ -17,7 +16,11 @@ if (!command) {
       "  tsx src/index.ts run-problem9-attempt-in-devbox --image <docker-image> [--preflight-only] [--print-docker-command] [--benchmark-package-root <directory> --prompt-package-root <directory> --workspace <directory> --output <directory> --provider-model <model>]"
     ].join("\n")
   );
-  process.exitCode = 1;
+};
+
+if (!command || command === "--help") {
+  showWorkerUsage();
+  process.exitCode = command === "--help" ? 0 : 1;
 } else if (command === "materialize-problem9-package") {
   void runProblem9PackageCli(args).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/worker/src/lib/problem9-attempt-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-cli.ts
@@ -2,6 +2,13 @@ import path from "node:path";
 import { runProblem9Attempt } from "./problem9-attempt.js";
 
 export async function runProblem9AttemptCli(args: string[]): Promise<void> {
+  if (args.includes("--help")) {
+    console.error(
+      "Usage: tsx src/index.ts run-problem9-attempt --benchmark-package-root <directory> --prompt-package-root <directory> --workspace <directory> --output <directory> [--provider-family <family>] [--auth-mode <mode>] [--provider-model <model>] [--model-snapshot-id <id>] [--stub-scenario exact_canonical|compile_failure]"
+    );
+    return;
+  }
+
   const getRequiredValue = (flag: string): string => {
     const index = args.findIndex((argument) => argument === flag);
 

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -2,6 +2,9 @@ import { access, constants, mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import {
+  parseWorkerRuntimeEnv
+} from "./runtime.js";
+import {
   preflightProblem9AuthMode,
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
@@ -26,6 +29,17 @@ type DevboxWrapperOptions = {
 };
 
 export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<void> {
+  if (args.includes("--help")) {
+    console.error(
+      "Usage: tsx src/index.ts run-problem9-attempt-in-devbox --image <docker-image> [--preflight-only] [--print-docker-command] [--benchmark-package-root <directory> --prompt-package-root <directory> --workspace <directory> --output <directory> --provider-model <model>]"
+    );
+    return;
+  }
+
+  await parseWorkerRuntimeEnv({
+    commandFamily: "trusted_local_devbox"
+  });
+
   const options = parseDevboxWrapperOptions(args);
   const authPreflight = await preflightProblem9AuthMode("trusted_local_user");
 

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -9,6 +9,7 @@ import {
   preflightProblem9AuthMode
 } from "./problem9-auth.js";
 import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
+import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
 
@@ -228,6 +229,10 @@ export async function runProblem9Attempt(
 
   const effectiveProviderFamily = options.providerFamily ?? promptManifest.providerFamily;
   const effectiveAuthMode = (options.authMode ?? promptManifest.authMode) as Problem9AuthMode;
+  await parseWorkerRuntimeEnv({
+    authMode: effectiveAuthMode,
+    commandFamily: "problem9_attempt"
+  });
   const authPreflight = await preflightProblem9AuthMode(effectiveAuthMode);
 
   await rm(workspaceRoot, { force: true, recursive: true });

--- a/apps/worker/src/lib/problem9-auth.ts
+++ b/apps/worker/src/lib/problem9-auth.ts
@@ -1,7 +1,7 @@
-import { access, constants } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { spawn } from "node:child_process";
+import {
+  parseWorkerRuntimeEnv
+} from "./runtime.js";
 
 export const trustedLocalCodexContainerHome = "/run/paretoproof/codex-home";
 export const trustedLocalCodexContainerAuthJsonPath = `${trustedLocalCodexContainerHome}/auth.json`;
@@ -45,10 +45,12 @@ export async function preflightProblem9AuthMode(
 }
 
 async function preflightTrustedLocalUser(): Promise<Problem9AuthPreflight> {
-  const codexHome = resolveCodexHome();
-  const authJsonPath = path.join(codexHome, "auth.json");
-
-  await assertReadableFile(authJsonPath, "Trusted-local Codex auth.json is missing or unreadable.");
+  const runtimeEnv = await parseWorkerRuntimeEnv({
+    authMode: "trusted_local_user",
+    commandFamily: "problem9_attempt"
+  });
+  const codexHome = runtimeEnv.trustedLocalCodexHome!;
+  const authJsonPath = runtimeEnv.trustedLocalAuthJsonPath!;
 
   const loginStatusResult = await runCommand("codex", ["login", "status"], {
     env: {
@@ -75,42 +77,15 @@ async function preflightTrustedLocalUser(): Promise<Problem9AuthPreflight> {
 }
 
 async function preflightMachineApiKey(): Promise<Problem9AuthPreflight> {
-  if (!process.env.CODEX_API_KEY) {
-    throw new Error(
-      "Auth mode machine_api_key requires CODEX_API_KEY and does not fall back to trusted-local auth."
-    );
-  }
+  await parseWorkerRuntimeEnv({
+    authMode: "machine_api_key",
+    commandFamily: "problem9_attempt"
+  });
 
   return {
     authMode: "machine_api_key",
     envKeyName: "CODEX_API_KEY"
   };
-}
-
-function resolveCodexHome(): string {
-  if (process.env.CODEX_HOME) {
-    return process.env.CODEX_HOME;
-  }
-
-  if (process.platform === "win32") {
-    const userProfile = process.env.USERPROFILE;
-
-    if (!userProfile) {
-      throw new Error("Could not resolve USERPROFILE for trusted-local Codex auth.");
-    }
-
-    return path.join(userProfile, ".codex");
-  }
-
-  return path.join(os.homedir(), ".codex");
-}
-
-async function assertReadableFile(filePath: string, failureMessage: string): Promise<void> {
-  try {
-    await access(filePath, constants.R_OK);
-  } catch {
-    throw new Error(`${failureMessage} Expected readable file at ${filePath}.`);
-  }
 }
 
 async function runCommand(

--- a/apps/worker/src/lib/problem9-package-cli.ts
+++ b/apps/worker/src/lib/problem9-package-cli.ts
@@ -1,7 +1,17 @@
 import path from "node:path";
 import { materializeProblem9Package } from "./problem9-package.js";
+import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 export async function runProblem9PackageCli(args: string[]): Promise<void> {
+  if (args.includes("--help")) {
+    console.error("Usage: tsx src/index.ts materialize-problem9-package --output <directory>");
+    return;
+  }
+
+  await parseWorkerRuntimeEnv({
+    commandFamily: "materializer"
+  });
+
   const outputArgumentIndex = args.findIndex((argument) => argument === "--output");
 
   if (outputArgumentIndex === -1 || !args[outputArgumentIndex + 1]) {

--- a/apps/worker/src/lib/problem9-prompt-package-cli.ts
+++ b/apps/worker/src/lib/problem9-prompt-package-cli.ts
@@ -3,8 +3,20 @@ import {
   getDefaultProblem9PromptPackageOptions,
   materializeProblem9PromptPackage
 } from "./problem9-prompt-package.js";
+import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 export async function runProblem9PromptPackageCli(args: string[]): Promise<void> {
+  if (args.includes("--help")) {
+    console.error(
+      "Usage: tsx src/index.ts materialize-problem9-prompt-package --output <directory> --benchmark-package-root <directory> --run-id <id> --attempt-id <id> --lane-id <id> --run-mode <mode> --tool-profile <profile> --provider-family <family> --auth-mode <mode> --model-config-id <id> --harness-revision <revision>"
+    );
+    return;
+  }
+
+  await parseWorkerRuntimeEnv({
+    commandFamily: "materializer"
+  });
+
   const getRequiredValue = (flag: string): string => {
     const index = args.findIndex((argument) => argument === flag);
 

--- a/apps/worker/src/lib/problem9-run-bundle-cli.ts
+++ b/apps/worker/src/lib/problem9-run-bundle-cli.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
+import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 function parseBooleanFlag(rawValue: string, flag: string): boolean {
   if (rawValue === "true") {
@@ -14,6 +15,17 @@ function parseBooleanFlag(rawValue: string, flag: string): boolean {
 }
 
 export async function runProblem9RunBundleCli(args: string[]): Promise<void> {
+  if (args.includes("--help")) {
+    console.error(
+      "Usage: tsx src/index.ts materialize-problem9-run-bundle --output <directory> --benchmark-package-root <directory> --prompt-package-root <directory> --candidate-source <file> --compiler-diagnostics <file> --compiler-output <file> --verifier-output <file> --environment-input <file> --result <pass|fail> --semantic-equality <matched|mismatched|not_evaluated> --surface-equality <matched|drifted|not_evaluated> --contains-sorry <true|false> --contains-admit <true|false> --axiom-check <passed|failed|not_evaluated> --diagnostic-gate <passed|failed> --stop-reason <reason> [--failure-classification <file>]"
+    );
+    return;
+  }
+
+  await parseWorkerRuntimeEnv({
+    commandFamily: "materializer"
+  });
+
   const getRequiredValue = (flag: string): string => {
     const index = args.findIndex((argument) => argument === flag);
 

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -1,0 +1,215 @@
+import { access, constants } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import type { Problem9AuthMode } from "./problem9-auth.js";
+
+function normalizeOptionalEnvValue(value: unknown) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+const trimmedOptionalStringSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z.string().trim().optional()
+);
+
+const workerRawRuntimeEnvSchema = z.object({
+  API_BASE_URL: trimmedOptionalStringSchema,
+  CF_INTERNAL_API_SERVICE_TOKEN_ID: trimmedOptionalStringSchema,
+  CF_INTERNAL_API_SERVICE_TOKEN_SECRET: trimmedOptionalStringSchema,
+  CODEX_API_KEY: trimmedOptionalStringSchema,
+  CODEX_HOME: trimmedOptionalStringSchema,
+  HOME: trimmedOptionalStringSchema,
+  R2_ACCESS_KEY_ID: trimmedOptionalStringSchema,
+  R2_SECRET_ACCESS_KEY: trimmedOptionalStringSchema,
+  USERPROFILE: trimmedOptionalStringSchema,
+  WORKER_BOOTSTRAP_TOKEN: trimmedOptionalStringSchema
+});
+
+export type WorkerRuntimeMode =
+  | {
+      authMode: Problem9AuthMode;
+      commandFamily: "problem9_attempt";
+    }
+  | {
+      commandFamily: "materializer";
+    }
+  | {
+      commandFamily: "offline_ingest_cli";
+    }
+  | {
+      commandFamily: "trusted_local_devbox";
+    }
+  | {
+      authMode: "machine_api_key" | "machine_oauth";
+      commandFamily: "worker_claim_loop";
+    };
+
+export type WorkerRuntimeEnv = {
+  apiBaseUrl?: string;
+  codexApiKey?: string;
+  trustedLocalAuthJsonPath?: string;
+  trustedLocalCodexHome?: string;
+  workerBootstrapToken?: string;
+};
+
+function formatWorkerRuntimeEnvIssues(issues: z.ZodIssue[]) {
+  return issues
+    .map((issue) => {
+      const field = issue.path[0];
+      const message = issue.message === "Required" ? "is required" : issue.message;
+
+      if (typeof field !== "string") {
+        return message;
+      }
+
+      return `${field}: ${message}`;
+    })
+    .join("; ");
+}
+
+function resolveRequiredField(
+  fieldName: "API_BASE_URL" | "CODEX_API_KEY" | "WORKER_BOOTSTRAP_TOKEN",
+  value: string | undefined
+) {
+  if (!value) {
+    throw new Error(`Invalid worker runtime environment: ${fieldName}: is required`);
+  }
+
+  if (fieldName === "API_BASE_URL") {
+    try {
+      new URL(value);
+    } catch {
+      throw new Error("Invalid worker runtime environment: API_BASE_URL: must be a valid URL");
+    }
+  }
+
+  return value;
+}
+
+function assertRequiredFields(
+  entries: ReadonlyArray<
+    readonly [
+      fieldName: "API_BASE_URL" | "CODEX_API_KEY" | "WORKER_BOOTSTRAP_TOKEN",
+      value: string | undefined
+    ]
+  >
+) {
+  const missingFields = entries
+    .filter(([, value]) => !value)
+    .map(([fieldName]) => `${fieldName}: is required`);
+
+  if (missingFields.length > 0) {
+    throw new Error(`Invalid worker runtime environment: ${missingFields.join("; ")}`);
+  }
+}
+
+function resolveCodexHome(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
+  if (rawEnv.CODEX_HOME) {
+    return rawEnv.CODEX_HOME;
+  }
+
+  if (process.platform === "win32") {
+    if (!rawEnv.USERPROFILE) {
+      throw new Error(
+        "Invalid worker runtime environment: CODEX_HOME: could not be inferred because USERPROFILE is not set"
+      );
+    }
+
+    return path.join(rawEnv.USERPROFILE, ".codex");
+  }
+
+  return path.join(rawEnv.HOME ?? os.homedir(), ".codex");
+}
+
+async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
+  const trustedLocalCodexHome = resolveCodexHome(rawEnv);
+  const trustedLocalAuthJsonPath = path.join(trustedLocalCodexHome, "auth.json");
+
+  try {
+    await access(trustedLocalAuthJsonPath, constants.R_OK);
+  } catch {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires a readable Codex auth.json.",
+        `Expected file at ${trustedLocalAuthJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  return {
+    trustedLocalAuthJsonPath,
+    trustedLocalCodexHome
+  } satisfies Pick<WorkerRuntimeEnv, "trustedLocalAuthJsonPath" | "trustedLocalCodexHome">;
+}
+
+export async function parseWorkerRuntimeEnv(
+  mode: WorkerRuntimeMode,
+  rawEnv: Partial<Record<string, string | undefined>> = process.env
+): Promise<WorkerRuntimeEnv> {
+  const parsed = workerRawRuntimeEnvSchema.safeParse(rawEnv);
+
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid worker runtime environment: ${formatWorkerRuntimeEnvIssues(parsed.error.issues)}`
+    );
+  }
+
+  switch (mode.commandFamily) {
+    case "materializer":
+      return {};
+    case "problem9_attempt":
+      switch (mode.authMode) {
+        case "local_stub":
+          return {};
+        case "machine_api_key":
+          return {
+            codexApiKey: resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY)
+          };
+        case "machine_oauth":
+          return {};
+        case "trusted_local_user":
+          return resolveTrustedLocalEnv(parsed.data);
+      }
+    case "trusted_local_devbox":
+      return resolveTrustedLocalEnv(parsed.data);
+    case "worker_claim_loop":
+      assertRequiredFields([
+        ["API_BASE_URL", parsed.data.API_BASE_URL],
+        ["WORKER_BOOTSTRAP_TOKEN", parsed.data.WORKER_BOOTSTRAP_TOKEN],
+        ...(mode.authMode === "machine_api_key"
+          ? [["CODEX_API_KEY", parsed.data.CODEX_API_KEY] as const]
+          : [])
+      ]);
+
+      return {
+        apiBaseUrl: resolveRequiredField("API_BASE_URL", parsed.data.API_BASE_URL),
+        codexApiKey:
+          mode.authMode === "machine_api_key"
+            ? resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY)
+            : undefined,
+        workerBootstrapToken: resolveRequiredField(
+          "WORKER_BOOTSTRAP_TOKEN",
+          parsed.data.WORKER_BOOTSTRAP_TOKEN
+        )
+      };
+    case "offline_ingest_cli":
+      assertRequiredFields([
+        ["API_BASE_URL", parsed.data.API_BASE_URL],
+        ["WORKER_BOOTSTRAP_TOKEN", parsed.data.WORKER_BOOTSTRAP_TOKEN]
+      ]);
+
+      return {
+        apiBaseUrl: resolveRequiredField("API_BASE_URL", parsed.data.API_BASE_URL),
+        workerBootstrapToken: resolveRequiredField(
+          "WORKER_BOOTSTRAP_TOKEN",
+          parsed.data.WORKER_BOOTSTRAP_TOKEN
+        )
+      };
+  }
+}

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseWorkerRuntimeEnv } from "../src/lib/runtime.ts";
+
+test("parseWorkerRuntimeEnv keeps materializer mode env-free", async () => {
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      commandFamily: "materializer"
+    },
+    {
+      API_BASE_URL: "not-a-url"
+    }
+  );
+
+  assert.deepEqual(runtimeEnv, {});
+});
+
+test("parseWorkerRuntimeEnv keeps local stub attempts env-free", async () => {
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "local_stub",
+      commandFamily: "problem9_attempt"
+    },
+    {}
+  );
+
+  assert.deepEqual(runtimeEnv, {});
+});
+
+test("parseWorkerRuntimeEnv requires CODEX_API_KEY for machine_api_key attempts", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv({
+        authMode: "machine_api_key",
+        commandFamily: "problem9_attempt"
+      }),
+    /CODEX_API_KEY: is required/
+  );
+
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "machine_api_key",
+      commandFamily: "problem9_attempt"
+    },
+    {
+      CODEX_API_KEY: "worker-api-key"
+    }
+  );
+
+  assert.equal(runtimeEnv.codexApiKey, "worker-api-key");
+});
+
+test("parseWorkerRuntimeEnv requires readable trusted-local auth for trusted_local_user", async () => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-runtime-"));
+
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "trusted_local_user",
+          commandFamily: "problem9_attempt"
+        },
+        {
+          CODEX_HOME: codexHome
+        }
+      ),
+    /trusted_local_user requires a readable Codex auth\.json/
+  );
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(path.join(codexHome, "auth.json"), "{}", "utf8");
+
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "trusted_local_user",
+      commandFamily: "problem9_attempt"
+    },
+    {
+      CODEX_HOME: codexHome
+    }
+  );
+
+  assert.equal(runtimeEnv.trustedLocalCodexHome, codexHome);
+  assert.equal(runtimeEnv.trustedLocalAuthJsonPath, path.join(codexHome, "auth.json"));
+});
+
+test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop machine auth", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "machine_api_key",
+          commandFamily: "worker_claim_loop"
+        },
+        {
+          API_BASE_URL: "https://api.paretoproof.com"
+        }
+      ),
+    /WORKER_BOOTSTRAP_TOKEN: is required/
+  );
+
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "machine_api_key",
+      commandFamily: "worker_claim_loop"
+    },
+    {
+      API_BASE_URL: "https://api.paretoproof.com",
+      CODEX_API_KEY: "worker-api-key",
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    }
+  );
+
+  assert.deepEqual(runtimeEnv, {
+    apiBaseUrl: "https://api.paretoproof.com",
+    codexApiKey: "worker-api-key",
+    workerBootstrapToken: "bootstrap-token"
+  });
+});
+
+test("parseWorkerRuntimeEnv requires hosted worker env for future offline ingest", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          commandFamily: "offline_ingest_cli"
+        },
+        {
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        }
+      ),
+    /API_BASE_URL: is required/
+  );
+
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      commandFamily: "offline_ingest_cli"
+    },
+    {
+      API_BASE_URL: "https://api.paretoproof.com",
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    }
+  );
+
+  assert.deepEqual(runtimeEnv, {
+    apiBaseUrl: "https://api.paretoproof.com",
+    workerBootstrapToken: "bootstrap-token"
+  });
+});


### PR DESCRIPTION
## Summary
- add a canonical worker runtime parser with mode-specific validation for materializer, local attempt, trusted-local devbox, hosted claim-loop, and offline-ingest families
- validate `run-problem9-attempt` by effective auth mode before auth preflight or workspace mutation, and reuse the same runtime contract inside worker auth preflight
- add worker runtime-env tests plus `--help` support for the attempt command surfaces and document the worker runtime contract in the worker README

## Verification
- `bun run build:shared`
- `bun --cwd apps/worker typecheck`
- `bun --cwd apps/worker build`
- `bun --cwd apps/worker test`
- `bun run check:bidi`
- `bun --cwd apps/worker run:problem9-attempt -- --help`
- generated a benchmark package plus prompt package for `machine_api_key`, then ran `bun --cwd apps/worker run:problem9-attempt` with `CODEX_API_KEY` removed and confirmed fail-fast output: `Invalid worker runtime environment: CODEX_API_KEY: is required`

Closes #480