### PR TITLE
Enforce runtime env contract examples

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Test hidden Unicode guard fixtures
         run: node --test infra/scripts/check-bidi-chars.test.mjs
 
+      - name: Check runtime env examples
+        run: node infra/scripts/check-runtime-env-examples.mjs
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,25 +1,35 @@
-# Local API runtime example. Copy to apps/api/.env and keep real values local only.
+# Local API env example. Copy to apps/api/.env and keep real values local only.
+# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.
+
+# App runtime config for local API startup. Required for routine local API development.
 HOST=0.0.0.0
 PORT=3000
 NODE_ENV=development
 DATABASE_URL=postgres://user:password@host:5432/paretoproof
-MIGRATION_DATABASE_URL=postgres://user:password@host:5432/paretoproof
 
-# Owner-run bootstrap helper. Not required for routine local API work.
+# Owner-ops config. Only set these when you are intentionally running owner workflows.
+MIGRATION_DATABASE_URL=postgres://user:password@host:5432/paretoproof
 OWNER_EMAIL=owner@example.com
 
-# Cloudflare Access validation for local parity against the current auth model.
+# App runtime config for local Cloudflare Access parity and internal worker auth.
 CF_ACCESS_TEAM_DOMAIN=paretoproof.cloudflareaccess.com
 CF_ACCESS_PORTAL_AUD=replace-with-portal-cloudflare-access-audience
 CF_ACCESS_INTERNAL_AUD=replace-with-internal-cloudflare-access-audience
 ACCESS_PROVIDER_STATE_SECRET=replace-with-the-pages-provider-hint-secret
+WORKER_BOOTSTRAP_TOKEN=replace-with-the-worker-bootstrap-token
 
-# Owner-level platform credentials. Leave unset unless you are intentionally doing platform ops.
+# Owner-ops platform credentials. Leave unset unless you are intentionally doing platform ops.
 CLOUDFLARE_API_TOKEN=replace-with-a-cloudflare-api-token-or-use-email-key-auth
 CLOUDFLARE_EMAIL=owner@example.com
 CLOUDFLARE_GLOBAL_API_KEY=replace-with-a-cloudflare-global-api-key-when-not-using-api-token
 CLOUDFLARE_ACCOUNT_ID=replace-with-your-cloudflare-account-id
 
-# Local browser origins. Expand only for deliberate local testing.
+# Optional local runtime overrides. Expand only for deliberate local testing.
 CORS_ALLOWED_ORIGINS=https://auth.paretoproof.com,https://portal.paretoproof.com
 CORS_ALLOW_LOCALHOST=false
+
+# Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them.
+# CF_INTERNAL_API_SERVICE_TOKEN_ID=
+# CF_INTERNAL_API_SERVICE_TOKEN_SECRET=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -2,6 +2,11 @@
 
 `apps/api` is the Fastify control plane. It owns authentication mapping, run orchestration, database access, and the internal contracts that separate the browser from worker execution.
 
+Runtime env guidance:
+
+- use [docs/runtime-env-contract-baseline.md](../../docs/runtime-env-contract-baseline.md) as the authoritative source for required versus optional API variables by mode
+- use [`.env.example`](./.env.example) only as the local developer-facing example for routine startup and owner ops
+
 ## Offline Problem 9 ingest
 
 The admin surface now exposes `POST /portal/admin/offline-ingest/problem9-run-bundles`.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,9 @@
-# Optional local override. The web app can usually derive the local API origin automatically.
+# Local web env example. Copy to apps/web/.env only when you need a local override.
+# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.
+
+# Public build-time config. Optional in local development because the app can usually derive the API origin.
 VITE_API_BASE_URL=http://127.0.0.1:3000
+
+# Hosted web runtime note:
+# ACCESS_PROVIDER_STATE_SECRET belongs to the Pages auth-entry function runtime, not the browser bundle,
+# so it is intentionally documented in the runtime contract instead of listed in this local browser example.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -3,3 +3,8 @@
 `apps/web` is the React and Vite frontend. It will contain the public site and the authenticated portal UI, while authentication and execution authority remain outside the browser.
 
 Cloudflare Pages is configured around this app through the local Wrangler config. The project name is `paretoproof-web`, the build output is `dist`, and deployments should build the workspace from the repository root before uploading the finished bundle to Pages.
+
+Runtime env guidance:
+
+- use [docs/runtime-env-contract-baseline.md](../../docs/runtime-env-contract-baseline.md) as the authoritative source for browser build-time overrides versus Pages auth-entry runtime secrets
+- use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -1,14 +1,15 @@
-# Local worker runtime example. Copy to apps/worker/.env and keep real values local only.
-# Use a local API origin for routine development unless you intentionally need hosted parity.
+# Local worker env example. Copy to apps/worker/.env and keep real values local only.
+# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.
+
+# Current local development mode:
+# materializer commands stay env-free; set API_BASE_URL only when exercising hosted-parity worker flows.
 API_BASE_URL=http://127.0.0.1:3000
 
-# Worker identity is runtime-only. Use the same variable name locally that hosted Modal workers receive
-# through Modal Secret injection. Keep the value out of git and out of Docker build inputs.
-# WORKER_BOOTSTRAP_TOKEN=
+# Hosted-parity worker runtime config. Leave commented unless you are running claim-loop style flows.
+# WORKER_BOOTSTRAP_TOKEN=replace-with-the-worker-bootstrap-token
 
-# Hosted or other non-interactive OpenAI-family runs use machine auth via API key.
-# Trusted local Codex auth does not belong in this file; keep it on the host and mount it only at runtime.
-# CODEX_API_KEY=
+# Mode-specific hosted provider auth. Trusted-local Codex auth does not belong in this file.
+# CODEX_API_KEY=replace-with-a-machine-api-key-for-hosted-worker-modes
 
 # Reserved later-scope worker runtime variables. Only set these when the specific workflow requires them.
 # CF_INTERNAL_API_SERVICE_TOKEN_ID=

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -2,18 +2,13 @@
 
 `apps/worker` holds the control code that remote worker runtimes will execute. The exact image contents and Lean toolchain policy remain a separate scope, but the worker service boundary is now fixed.
 
-Current runtime-secret contract:
+Runtime env guidance:
 
-- local runs may set worker runtime variables in `apps/worker/.env`
-- hosted Modal workers receive the same variable names through Modal Secret injection
-- the current hosted baseline is documented in `docs/modal-worker-secrets-baseline.md`
-- the broader local-versus-Modal injection model is documented in `docs/worker-secret-injection-baseline.md`
+- use [docs/runtime-env-contract-baseline.md](../../docs/runtime-env-contract-baseline.md) as the authoritative source for required versus optional worker variables by mode
+- use [`.env.example`](./.env.example) only as the local developer-facing example
+- hosted Modal secret inventory still lives in [docs/modal-worker-secrets-baseline.md](../../docs/modal-worker-secrets-baseline.md)
+- local-versus-Modal injection rules still live in [docs/worker-secret-injection-baseline.md](../../docs/worker-secret-injection-baseline.md)
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
-- worker commands now validate runtime env by command family before execution starts:
-  - materializers stay env-free
-  - `run-problem9-attempt` validates by effective auth mode
-  - `run-problem9-attempt-in-devbox` requires a readable trusted-local `CODEX_HOME/auth.json`
-  - future hosted claim-loop and offline-ingest modes reserve `API_BASE_URL` and `WORKER_BOOTSTRAP_TOKEN` as their canonical runtime requirements
 
 Package materialization:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,3 +5,4 @@
 Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
 - `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts.
+- `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -1,0 +1,165 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+const checks = [
+  {
+    file: "apps/api/.env.example",
+    markers: [
+      "# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.",
+      "# App runtime config for local API startup. Required for routine local API development.",
+      "# Owner-ops config. Only set these when you are intentionally running owner workflows.",
+      "# App runtime config for local Cloudflare Access parity and internal worker auth.",
+      "# Optional local runtime overrides. Expand only for deliberate local testing.",
+      "# Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them."
+    ],
+    variables: [
+      { name: "HOST", commented: false },
+      { name: "PORT", commented: false },
+      { name: "NODE_ENV", commented: false },
+      { name: "DATABASE_URL", commented: false },
+      { name: "MIGRATION_DATABASE_URL", commented: false },
+      { name: "OWNER_EMAIL", commented: false },
+      { name: "CF_ACCESS_TEAM_DOMAIN", commented: false },
+      { name: "CF_ACCESS_PORTAL_AUD", commented: false },
+      { name: "CF_ACCESS_INTERNAL_AUD", commented: false },
+      { name: "ACCESS_PROVIDER_STATE_SECRET", commented: false },
+      { name: "WORKER_BOOTSTRAP_TOKEN", commented: false },
+      { name: "CLOUDFLARE_API_TOKEN", commented: false },
+      { name: "CLOUDFLARE_EMAIL", commented: false },
+      { name: "CLOUDFLARE_GLOBAL_API_KEY", commented: false },
+      { name: "CLOUDFLARE_ACCOUNT_ID", commented: false },
+      { name: "CORS_ALLOWED_ORIGINS", commented: false },
+      { name: "CORS_ALLOW_LOCALHOST", commented: false },
+      { name: "CF_INTERNAL_API_SERVICE_TOKEN_ID", commented: true },
+      { name: "CF_INTERNAL_API_SERVICE_TOKEN_SECRET", commented: true },
+      { name: "R2_ACCESS_KEY_ID", commented: true },
+      { name: "R2_SECRET_ACCESS_KEY", commented: true }
+    ]
+  },
+  {
+    file: "apps/web/.env.example",
+    markers: [
+      "# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.",
+      "# Public build-time config. Optional in local development because the app can usually derive the API origin.",
+      "# Hosted web runtime note:"
+    ],
+    variables: [{ name: "VITE_API_BASE_URL", commented: false }],
+    forbiddenVariables: ["ACCESS_PROVIDER_STATE_SECRET"]
+  },
+  {
+    file: "apps/worker/.env.example",
+    markers: [
+      "# The authoritative mode split lives in docs/runtime-env-contract-baseline.md.",
+      "# Current local development mode:",
+      "# Hosted-parity worker runtime config. Leave commented unless you are running claim-loop style flows.",
+      "# Mode-specific hosted provider auth. Trusted-local Codex auth does not belong in this file.",
+      "# Reserved later-scope worker runtime variables. Only set these when the specific workflow requires them."
+    ],
+    variables: [
+      { name: "API_BASE_URL", commented: false },
+      { name: "WORKER_BOOTSTRAP_TOKEN", commented: true },
+      { name: "CODEX_API_KEY", commented: true },
+      { name: "CF_INTERNAL_API_SERVICE_TOKEN_ID", commented: true },
+      { name: "CF_INTERNAL_API_SERVICE_TOKEN_SECRET", commented: true },
+      { name: "R2_ACCESS_KEY_ID", commented: true },
+      { name: "R2_SECRET_ACCESS_KEY", commented: true }
+    ]
+  }
+];
+
+const readmeChecks = [
+  {
+    file: "apps/api/README.md",
+    requiredSnippets: [
+      "docs/runtime-env-contract-baseline.md",
+      "`.env.example`"
+    ]
+  },
+  {
+    file: "apps/web/README.md",
+    requiredSnippets: [
+      "docs/runtime-env-contract-baseline.md",
+      "`.env.example`"
+    ]
+  },
+  {
+    file: "apps/worker/README.md",
+    requiredSnippets: [
+      "docs/runtime-env-contract-baseline.md",
+      "`.env.example`"
+    ]
+  }
+];
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function parseEnvEntries(contents) {
+  const entries = [];
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    let match = line.match(/^([A-Z0-9_]+)=/);
+    if (match) {
+      entries.push({ name: match[1], commented: false });
+      continue;
+    }
+
+    match = line.match(/^#\s*([A-Z0-9_]+)=/);
+    if (match) {
+      entries.push({ name: match[1], commented: true });
+    }
+  }
+
+  return entries;
+}
+
+function formatEntry(entry) {
+  return `${entry.commented ? "#" : ""}${entry.name}`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+for (const check of checks) {
+  const contents = readRepoFile(check.file);
+  const entries = parseEnvEntries(contents);
+  const actual = entries.map(formatEntry);
+  const expected = check.variables.map(formatEntry);
+
+  for (const marker of check.markers) {
+    assert(contents.includes(marker), `${check.file} is missing required guidance line: ${marker}`);
+  }
+
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${check.file} variables drifted.\nExpected: ${expected.join(", ")}\nActual: ${actual.join(", ")}`
+  );
+
+  for (const forbiddenVariable of check.forbiddenVariables ?? []) {
+    assert(
+      !entries.some((entry) => entry.name === forbiddenVariable),
+      `${check.file} must not declare ${forbiddenVariable}.`
+    );
+  }
+}
+
+for (const check of readmeChecks) {
+  const contents = readRepoFile(check.file);
+
+  for (const requiredSnippet of check.requiredSnippets) {
+    assert(
+      contents.includes(requiredSnippet),
+      `${check.file} must reference ${requiredSnippet}.`
+    );
+  }
+}
+
+console.log("Runtime env examples and README pointers match the approved contract shape.");

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
+    "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "test:bidi": "node --test infra/scripts/check-bidi-chars.test.mjs",
     "build": "bun run build:shared && bun run build:web && bun run build:api && bun run build:worker",
     "typecheck": "bun run typecheck:shared && bun run typecheck:web && bun run typecheck:api && bun run typecheck:worker",


### PR DESCRIPTION
## Summary
- align the checked-in app env examples with the approved local-versus-hosted runtime contract
- point app README env guidance back to the canonical runtime-env baseline instead of duplicating runtime-secret rules
- add a repository env-contract drift check and run it in pull-request CI

## Testing
- bun run check:env-contract
- bun run check:bidi

Closes #481