### PR TITLE
Fix local stub snapshot IDs for compile-failure attempts

### DIFF
--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -401,11 +401,13 @@ export async function runProblem9Attempt(
     await buildEnvironmentInput({
       benchmarkManifest,
       compileRoot,
-      modelSnapshotId:
-        options.modelSnapshotId ??
-        (effectiveAuthMode === "local_stub"
-          ? "local_stub/problem9_exact_canonical.v1"
-          : options.providerModel ?? promptManifest.modelConfigId)
+      modelSnapshotId: resolveProblem9ModelSnapshotId({
+        authMode: effectiveAuthMode,
+        fallbackModelConfigId: promptManifest.modelConfigId,
+        overrideModelSnapshotId: options.modelSnapshotId,
+        providerModel: options.providerModel,
+        stubScenario: options.stubScenario
+      })
     })
   );
 
@@ -983,6 +985,24 @@ async function buildEnvironmentInput(options: {
     },
     verifierVersion: "problem9-local-verifier.v1"
   };
+}
+
+export function resolveProblem9ModelSnapshotId(options: {
+  authMode: Problem9AuthMode;
+  fallbackModelConfigId: string;
+  overrideModelSnapshotId?: string;
+  providerModel?: string;
+  stubScenario: "compile_failure" | "exact_canonical";
+}): string {
+  if (options.overrideModelSnapshotId) {
+    return options.overrideModelSnapshotId;
+  }
+
+  if (options.authMode === "local_stub") {
+    return `local_stub/problem9_${options.stubScenario}.v1`;
+  }
+
+  return options.providerModel ?? options.fallbackModelConfigId;
 }
 
 function buildFailureClassification(failure: AttemptTerminalFailure): Record<string, unknown> {

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveProblem9ModelSnapshotId } from "../src/lib/problem9-attempt.ts";
+
+test("resolveProblem9ModelSnapshotId uses the selected local stub scenario by default", () => {
+  assert.equal(
+    resolveProblem9ModelSnapshotId({
+      authMode: "local_stub",
+      fallbackModelConfigId: "prompt/default-model",
+      stubScenario: "exact_canonical"
+    }),
+    "local_stub/problem9_exact_canonical.v1"
+  );
+
+  assert.equal(
+    resolveProblem9ModelSnapshotId({
+      authMode: "local_stub",
+      fallbackModelConfigId: "prompt/default-model",
+      stubScenario: "compile_failure"
+    }),
+    "local_stub/problem9_compile_failure.v1"
+  );
+});
+
+test("resolveProblem9ModelSnapshotId preserves explicit overrides and non-stub provider defaults", () => {
+  assert.equal(
+    resolveProblem9ModelSnapshotId({
+      authMode: "local_stub",
+      fallbackModelConfigId: "prompt/default-model",
+      overrideModelSnapshotId: "override/snapshot.v1",
+      stubScenario: "compile_failure"
+    }),
+    "override/snapshot.v1"
+  );
+
+  assert.equal(
+    resolveProblem9ModelSnapshotId({
+      authMode: "machine_api_key",
+      fallbackModelConfigId: "prompt/default-model",
+      providerModel: "provider/selected-model",
+      stubScenario: "exact_canonical"
+    }),
+    "provider/selected-model"
+  );
+
+  assert.equal(
+    resolveProblem9ModelSnapshotId({
+      authMode: "machine_api_key",
+      fallbackModelConfigId: "prompt/default-model",
+      stubScenario: "exact_canonical"
+    }),
+    "prompt/default-model"
+  );
+});


### PR DESCRIPTION
## Summary
- align local_stub default snapshot ids with the selected Problem 9 stub scenario
- keep explicit model snapshot overrides and non-stub provider defaults unchanged
- add regression coverage for exact_canonical, compile_failure, and override behavior

## Testing
- bun --cwd apps/worker typecheck
- bun --cwd apps/worker test
- bun --cwd apps/worker build
- bun run check:bidi
- git -c safe.directory='C:/Users/Tom/.codex/worktrees/45c8/ParetoProof' diff --check

Closes #517