### PR TITLE
fix(worker): preserve offline ingest rejection details

### DIFF
--- a/apps/worker/src/lib/problem9-offline-ingest-cli.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest-cli.ts
@@ -18,15 +18,60 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
 
     return args[index + 1];
   };
+  let bundleRoot: string | null = null;
 
-  const result = await runProblem9OfflineIngest({
-    accessJwt: getRequiredValue("--access-jwt"),
-    bundleRoot: path.resolve(getRequiredValue("--bundle-root"))
-  });
+  try {
+    bundleRoot = path.resolve(getRequiredValue("--bundle-root"));
+    const result = await runProblem9OfflineIngest({
+      accessJwt: getRequiredValue("--access-jwt"),
+      bundleRoot
+    });
 
-  console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(result, null, 2));
 
-  if (result.status === "rejected") {
+    if (result.status === "rejected") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    if (!isOfflineIngestSetupError(error)) {
+      throw error;
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          bundleRoot,
+          endpoint: null,
+          error: classifyOfflineIngestSetupError(error.message),
+          issues: [
+            {
+              message: error.message
+            }
+          ],
+          stage: "setup_failure",
+          status: "rejected"
+        },
+        null,
+        2
+      )
+    );
     process.exitCode = 1;
   }
+}
+
+function isOfflineIngestSetupError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    (error.message.startsWith("Missing required --") ||
+      error.message.startsWith("Invalid worker runtime environment:") ||
+      error.message === "Offline ingest runtime did not resolve API_BASE_URL.")
+  );
+}
+
+function classifyOfflineIngestSetupError(errorMessage: string) {
+  if (errorMessage.startsWith("Missing required --")) {
+    return "invalid_problem9_offline_ingest_cli_arguments";
+  }
+
+  return "invalid_problem9_offline_ingest_runtime_env";
 }

--- a/apps/worker/src/lib/problem9-offline-ingest.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest.ts
@@ -20,7 +20,7 @@ type RejectedOfflineIngestResult = {
   endpoint: string;
   error: string;
   httpStatus?: number;
-  issues?: Array<{ message: string; path?: string }>;
+  issues?: Array<Record<string, unknown>>;
   stage: "local_validation" | "remote_rejection";
   status: "rejected";
 };
@@ -129,12 +129,7 @@ export async function runProblem9OfflineIngest(
         typeof responseBody === "object" &&
         "issues" in responseBody &&
         Array.isArray(responseBody.issues)
-          ? responseBody.issues
-              .filter((issue) => issue && typeof issue === "object" && "message" in issue)
-              .map((issue) => ({
-                message: String(issue.message),
-                path: "path" in issue && typeof issue.path === "string" ? issue.path : undefined
-              }))
+          ? normalizeOfflineIngestIssues(responseBody.issues)
           : undefined,
       stage: "remote_rejection",
       status: "rejected"
@@ -371,4 +366,18 @@ function parseStructuredError(error: unknown): {
 
 function normalizeText(text: string): string {
   return text.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function normalizeOfflineIngestIssues(
+  issues: unknown[]
+): Array<Record<string, unknown>> {
+  return issues.map((issue) => {
+    if (issue && typeof issue === "object" && !Array.isArray(issue)) {
+      return { ...(issue as Record<string, unknown>) };
+    }
+
+    return {
+      message: String(issue)
+    };
+  });
 }

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -9,6 +9,7 @@ import {
   materializeProblem9PromptPackage
 } from "../src/lib/problem9-prompt-package.ts";
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
+import { runProblem9OfflineIngestCli } from "../src/lib/problem9-offline-ingest-cli.ts";
 import { runProblem9OfflineIngest } from "../src/lib/problem9-offline-ingest.ts";
 
 async function buildOfflineIngestBundleRoot(options: {
@@ -312,7 +313,15 @@ test("runProblem9OfflineIngest preserves API rejections for operator output", as
       fetchImpl: async () =>
         new Response(
           JSON.stringify({
-            error: "offline_ingest_duplicate_run"
+            error: "offline_ingest_duplicate_run",
+            issues: [
+              {
+                code: "too_small",
+                minimum: 11,
+                path: ["bundle", "artifactManifest", "artifacts"],
+                received: 10
+              }
+            ]
           }),
           {
             headers: {
@@ -332,7 +341,14 @@ test("runProblem9OfflineIngest preserves API rejections for operator output", as
     endpoint: "https://api.paretoproof.com/portal/admin/offline-ingest/problem9-run-bundles",
     error: "offline_ingest_duplicate_run",
     httpStatus: 409,
-    issues: undefined,
+    issues: [
+      {
+        code: "too_small",
+        minimum: 11,
+        path: ["bundle", "artifactManifest", "artifacts"],
+        received: 10
+      }
+    ],
     stage: "remote_rejection",
     status: "rejected"
   });
@@ -372,6 +388,91 @@ test("runProblem9OfflineIngest converts transport failures into rejected output"
       }
     ],
     stage: "remote_rejection",
+    status: "rejected"
+  });
+});
+
+test("runProblem9OfflineIngestCli emits JSON for missing required flags", async () => {
+  const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
+  const loggedMessages: string[] = [];
+
+  console.log = (...args: unknown[]) => {
+    loggedMessages.push(args.map((argument) => String(argument)).join(" "));
+  };
+
+  try {
+    process.exitCode = undefined;
+
+    await runProblem9OfflineIngestCli(["--bundle-root", "problem9-run-bundle"]);
+
+    assert.equal(process.exitCode, 1);
+    assert.equal(loggedMessages.length, 1);
+    assert.deepEqual(JSON.parse(loggedMessages[0] ?? ""), {
+      bundleRoot: path.resolve("problem9-run-bundle"),
+      endpoint: null,
+      error: "invalid_problem9_offline_ingest_cli_arguments",
+      issues: [
+        {
+          message: "Missing required --access-jwt <value> argument."
+        }
+      ],
+      stage: "setup_failure",
+      status: "rejected"
+    });
+  } finally {
+    console.log = originalConsoleLog;
+    process.exitCode = originalExitCode;
+  }
+});
+
+test("runProblem9OfflineIngestCli emits JSON for missing runtime config", async (t) => {
+  const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
+    result: "pass"
+  });
+  const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
+  const originalApiBaseUrl = process.env.API_BASE_URL;
+  const loggedMessages: string[] = [];
+
+  t.after(async () => {
+    console.log = originalConsoleLog;
+    process.exitCode = originalExitCode;
+
+    if (typeof originalApiBaseUrl === "string") {
+      process.env.API_BASE_URL = originalApiBaseUrl;
+    } else {
+      delete process.env.API_BASE_URL;
+    }
+
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  console.log = (...args: unknown[]) => {
+    loggedMessages.push(args.map((argument) => String(argument)).join(" "));
+  };
+  delete process.env.API_BASE_URL;
+  process.exitCode = undefined;
+
+  await runProblem9OfflineIngestCli([
+    "--bundle-root",
+    bundleRoot,
+    "--access-jwt",
+    "test-access-jwt"
+  ]);
+
+  assert.equal(process.exitCode, 1);
+  assert.equal(loggedMessages.length, 1);
+  assert.deepEqual(JSON.parse(loggedMessages[0] ?? ""), {
+    bundleRoot,
+    endpoint: null,
+    error: "invalid_problem9_offline_ingest_runtime_env",
+    issues: [
+      {
+        message: "Invalid worker runtime environment: API_BASE_URL: is required"
+      }
+    ],
+    stage: "setup_failure",
     status: "rejected"
   });
 });


### PR DESCRIPTION
## Summary
- preserve structured API `issues` arrays in offline-ingest rejection output instead of flattening them
- emit machine-readable JSON rejection payloads for CLI setup failures such as missing flags or missing `API_BASE_URL`
- add regression coverage for structured remote rejections and CLI setup-failure output

## Verification
- bun --cwd apps/worker typecheck
- bun --cwd apps/worker test
- bun run check:bidi
- git -c safe.directory='C:/Users/Tom/.codex/worktrees/79ce/ParetoProof' diff --check

Closes #537