### PR TITLE
fix(worker): preserve offline ingest error payloads

### DIFF
--- a/apps/worker/src/lib/problem9-offline-ingest-cli.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest-cli.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
-import { runProblem9OfflineIngest } from "./problem9-offline-ingest.js";
+import {
+  Problem9OfflineIngestCliError,
+  runProblem9OfflineIngest
+} from "./problem9-offline-ingest.js";
 
 export async function runProblem9OfflineIngestCli(args: string[]): Promise<void> {
   if (args.includes("--help")) {
@@ -19,14 +22,44 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
     return args[index + 1];
   };
 
-  const result = await runProblem9OfflineIngest({
-    accessJwt: getRequiredValue("--access-jwt"),
-    bundleRoot: path.resolve(getRequiredValue("--bundle-root"))
-  });
+  const getOptionalValue = (flag: string): string | undefined => {
+    const index = args.findIndex((argument) => argument === flag);
+    return index === -1 || !args[index + 1] ? undefined : args[index + 1];
+  };
 
-  console.log(JSON.stringify(result, null, 2));
+  const unresolvedApiBaseUrl = process.env.API_BASE_URL ?? "";
+  const unresolvedBundleRoot = getOptionalValue("--bundle-root");
 
-  if (result.status === "rejected") {
-    process.exitCode = 1;
+  try {
+    const result = await runProblem9OfflineIngest({
+      accessJwt: getRequiredValue("--access-jwt"),
+      bundleRoot: path.resolve(getRequiredValue("--bundle-root"))
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+
+    if (result.status === "rejected") {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    if (error instanceof Problem9OfflineIngestCliError) {
+      throw error;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    throw new Problem9OfflineIngestCliError({
+      bundleRoot: unresolvedBundleRoot ? path.resolve(unresolvedBundleRoot) : "",
+      endpoint: "",
+      error: "offline_ingest_setup_error",
+      kind: "setup_error",
+      issues: [
+        {
+          message
+        }
+      ],
+      stage: "setup_error",
+      status: "rejected"
+    });
   }
 }

--- a/apps/worker/src/lib/problem9-offline-ingest.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest.ts
@@ -20,8 +20,9 @@ type RejectedOfflineIngestResult = {
   endpoint: string;
   error: string;
   httpStatus?: number;
-  issues?: Array<{ message: string; path?: string }>;
-  stage: "local_validation" | "remote_rejection";
+  issues?: unknown[];
+  kind?: "setup_error";
+  stage: "local_validation" | "remote_rejection" | "setup_error";
   status: "rejected";
 };
 
@@ -34,6 +35,16 @@ type AcceptedOfflineIngestResult = Problem9OfflineIngestResponse & {
 export type Problem9OfflineIngestResult =
   | AcceptedOfflineIngestResult
   | RejectedOfflineIngestResult;
+
+export class Problem9OfflineIngestCliError extends Error {
+  readonly result: RejectedOfflineIngestResult;
+
+  constructor(result: RejectedOfflineIngestResult) {
+    super(JSON.stringify(result, null, 2));
+    this.name = "Problem9OfflineIngestCliError";
+    this.result = result;
+  }
+}
 
 type OfflineIngestDependencies = {
   fetchImpl?: typeof fetch;
@@ -130,11 +141,6 @@ export async function runProblem9OfflineIngest(
         "issues" in responseBody &&
         Array.isArray(responseBody.issues)
           ? responseBody.issues
-              .filter((issue) => issue && typeof issue === "object" && "message" in issue)
-              .map((issue) => ({
-                message: String(issue.message),
-                path: "path" in issue && typeof issue.path === "string" ? issue.path : undefined
-              }))
           : undefined,
       stage: "remote_rejection",
       status: "rejected"

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -8,8 +8,12 @@ import {
   getDefaultProblem9PromptPackageOptions,
   materializeProblem9PromptPackage
 } from "../src/lib/problem9-prompt-package.ts";
+import { runProblem9OfflineIngestCli } from "../src/lib/problem9-offline-ingest-cli.ts";
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
-import { runProblem9OfflineIngest } from "../src/lib/problem9-offline-ingest.ts";
+import {
+  Problem9OfflineIngestCliError,
+  runProblem9OfflineIngest
+} from "../src/lib/problem9-offline-ingest.ts";
 
 async function buildOfflineIngestBundleRoot(options: {
   result: "pass" | "fail";
@@ -338,6 +342,61 @@ test("runProblem9OfflineIngest preserves API rejections for operator output", as
   });
 });
 
+test("runProblem9OfflineIngest preserves structured API validation issues", async (t) => {
+  const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const result = await runProblem9OfflineIngest(
+    {
+      accessJwt: "test-access-jwt",
+      bundleRoot
+    },
+    {
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_problem9_offline_ingest_payload",
+            issues: [
+              {
+                message: "Digest mismatch for candidate source",
+                path: ["bundle", "candidateSource"]
+              }
+            ]
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 400
+          }
+        ),
+      runtimeEnv: {
+        API_BASE_URL: "https://api.paretoproof.com"
+      }
+    }
+  );
+
+  assert.deepEqual(result, {
+    bundleRoot,
+    endpoint: "https://api.paretoproof.com/portal/admin/offline-ingest/problem9-run-bundles",
+    error: "invalid_problem9_offline_ingest_payload",
+    httpStatus: 400,
+    issues: [
+      {
+        message: "Digest mismatch for candidate source",
+        path: ["bundle", "candidateSource"]
+      }
+    ],
+    stage: "remote_rejection",
+    status: "rejected"
+  });
+});
+
 test("runProblem9OfflineIngest converts transport failures into rejected output", async (t) => {
   const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
     result: "pass"
@@ -374,4 +433,35 @@ test("runProblem9OfflineIngest converts transport failures into rejected output"
     stage: "remote_rejection",
     status: "rejected"
   });
+});
+
+test("runProblem9OfflineIngestCli emits structured setup failures for missing flags", async (t) => {
+  const originalApiBaseUrl = process.env.API_BASE_URL;
+
+  t.after(() => {
+    if (originalApiBaseUrl === undefined) {
+      delete process.env.API_BASE_URL;
+      return;
+    }
+
+    process.env.API_BASE_URL = originalApiBaseUrl;
+  });
+
+  delete process.env.API_BASE_URL;
+
+  await assert.rejects(
+    () => runProblem9OfflineIngestCli(["--bundle-root", "C:\\temp\\bundle"]),
+    (error: unknown) => {
+      assert.ok(error instanceof Problem9OfflineIngestCliError);
+      assert.equal(error.result.error, "offline_ingest_setup_error");
+      assert.equal(error.result.kind, "setup_error");
+      assert.equal(error.result.stage, "setup_error");
+      assert.deepEqual(error.result.issues, [
+        {
+          message: "Missing required --access-jwt <value> argument."
+        }
+      ]);
+      return true;
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- preserve structured `issues` arrays from offline-ingest API rejection payloads instead of narrowing them to strings
- wrap CLI setup failures in the same machine-readable JSON rejection format used for other offline-ingest failures
- add regressions for one structured 400 rejection and one setup-error path

## Verification
- bun --cwd apps/worker typecheck
- bun --cwd apps/worker test
- bun --cwd apps/worker build
- bun run check:bidi
- git -c safe.directory=''C:/Users/Tom/.codex/worktrees/45c8/ParetoProof'' diff --check

Closes #537