### PR TITLE
fix(worker): preserve offline ingest rejection diagnostics

### DIFF
--- a/apps/worker/src/lib/problem9-offline-ingest-cli.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest-cli.ts
@@ -9,7 +9,7 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
     return;
   }
 
-  const getRequiredValue = (flag: string): string => {
+  const getRequiredValue = (flag: "--access-jwt" | "--bundle-root"): string => {
     const index = args.findIndex((argument) => argument === flag);
 
     if (index === -1 || !args[index + 1]) {
@@ -19,14 +19,48 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
     return args[index + 1];
   };
 
+  const parsedOptions = (() => {
+    try {
+      return {
+        accessJwt: getRequiredValue("--access-jwt"),
+        bundleRoot: path.resolve(getRequiredValue("--bundle-root"))
+      };
+    } catch (error) {
+      return {
+        bundleRoot: null,
+        endpoint: null,
+        error: "offline_ingest_setup_failure",
+        issues: [
+          {
+            message: error instanceof Error ? error.message : String(error),
+            path:
+              error instanceof Error && error.message.includes("--access-jwt")
+                ? "--access-jwt"
+                : "--bundle-root"
+          }
+        ],
+        stage: "setup_failure",
+        status: "rejected" as const
+      };
+    }
+  })();
+
+  if (parsedOptions.status === "rejected") {
+    console.error(JSON.stringify(parsedOptions, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+
   const result = await runProblem9OfflineIngest({
-    accessJwt: getRequiredValue("--access-jwt"),
-    bundleRoot: path.resolve(getRequiredValue("--bundle-root"))
+    accessJwt: parsedOptions.accessJwt,
+    bundleRoot: parsedOptions.bundleRoot
   });
 
-  console.log(JSON.stringify(result, null, 2));
-
   if (result.status === "rejected") {
+    console.error(JSON.stringify(result, null, 2));
     process.exitCode = 1;
+    return;
   }
+
+  console.log(JSON.stringify(result, null, 2));
 }

--- a/apps/worker/src/lib/problem9-offline-ingest.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest.ts
@@ -16,12 +16,12 @@ import {
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 type RejectedOfflineIngestResult = {
-  bundleRoot: string;
-  endpoint: string;
+  bundleRoot: string | null;
+  endpoint: string | null;
   error: string;
   httpStatus?: number;
-  issues?: Array<{ message: string; path?: string }>;
-  stage: "local_validation" | "remote_rejection";
+  issues?: unknown[];
+  stage: "local_validation" | "remote_rejection" | "setup_failure";
   status: "rejected";
 };
 
@@ -61,23 +61,31 @@ export async function runProblem9OfflineIngest(
   },
   dependencies: OfflineIngestDependencies = {}
 ): Promise<Problem9OfflineIngestResult> {
+  const bundleRoot = path.resolve(options.bundleRoot);
   const runtimeEnv = await parseWorkerRuntimeEnv(
     {
       commandFamily: "offline_ingest_cli"
     },
     dependencies.runtimeEnv
-  );
+  ).catch((error: unknown) => toSetupFailureResult(error, bundleRoot));
+
+  if ("status" in runtimeEnv) {
+    return runtimeEnv;
+  }
+
   const apiBaseUrl = runtimeEnv.apiBaseUrl;
 
   if (!apiBaseUrl) {
-    throw new Error("Offline ingest runtime did not resolve API_BASE_URL.");
+    return toSetupFailureResult(
+      new Error("Offline ingest runtime did not resolve API_BASE_URL."),
+      bundleRoot
+    );
   }
 
   const endpoint = new URL(
     "/portal/admin/offline-ingest/problem9-run-bundles",
     apiBaseUrl
   ).toString();
-  const bundleRoot = path.resolve(options.bundleRoot);
   const localRequest = await loadProblem9OfflineIngestRequest(bundleRoot).catch((error: unknown) =>
     toLocalValidationResult(error, bundleRoot, endpoint)
   );
@@ -130,11 +138,6 @@ export async function runProblem9OfflineIngest(
         "issues" in responseBody &&
         Array.isArray(responseBody.issues)
           ? responseBody.issues
-              .filter((issue) => issue && typeof issue === "object" && "message" in issue)
-              .map((issue) => ({
-                message: String(issue.message),
-                path: "path" in issue && typeof issue.path === "string" ? issue.path : undefined
-              }))
           : undefined,
       stage: "remote_rejection",
       status: "rejected"
@@ -325,6 +328,22 @@ function toLocalValidationResult(
   };
 }
 
+function toSetupFailureResult(
+  error: unknown,
+  bundleRoot: string | null
+): RejectedOfflineIngestResult {
+  const parsed = parseSetupFailure(error);
+
+  return {
+    bundleRoot,
+    endpoint: null,
+    error: parsed.code,
+    issues: parsed.issues,
+    stage: "setup_failure",
+    status: "rejected"
+  };
+}
+
 function parseStructuredError(error: unknown): {
   code: string;
   issues: Array<{ message: string; path?: string }>;
@@ -361,6 +380,34 @@ function parseStructuredError(error: unknown): {
 
   return {
     code: "invalid_problem9_offline_ingest_bundle_root",
+    issues: [
+      {
+        message: String(error)
+      }
+    ]
+  };
+}
+
+function parseSetupFailure(error: unknown): {
+  code: string;
+  issues: Array<{ message: string; path?: string }>;
+} {
+  if (error instanceof Error) {
+    const pathMatch = error.message.match(/\b(API_BASE_URL|--access-jwt|--bundle-root)\b/);
+
+    return {
+      code: "offline_ingest_setup_failure",
+      issues: [
+        {
+          message: error.message,
+          path: pathMatch?.[1]
+        }
+      ]
+    };
+  }
+
+  return {
+    code: "offline_ingest_setup_failure",
     issues: [
       {
         message: String(error)

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -9,6 +9,7 @@ import {
   materializeProblem9PromptPackage
 } from "../src/lib/problem9-prompt-package.ts";
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
+import { runProblem9OfflineIngestCli } from "../src/lib/problem9-offline-ingest-cli.ts";
 import { runProblem9OfflineIngest } from "../src/lib/problem9-offline-ingest.ts";
 
 async function buildOfflineIngestBundleRoot(options: {
@@ -312,7 +313,16 @@ test("runProblem9OfflineIngest preserves API rejections for operator output", as
       fetchImpl: async () =>
         new Response(
           JSON.stringify({
-            error: "offline_ingest_duplicate_run"
+            error: "offline_ingest_duplicate_run",
+            issues: [
+              {
+                code: "invalid_type",
+                expected: "string",
+                message: "Expected string, received null",
+                path: ["bundle", "runBundle", "runId"],
+                received: "null"
+              }
+            ]
           }),
           {
             headers: {
@@ -332,8 +342,90 @@ test("runProblem9OfflineIngest preserves API rejections for operator output", as
     endpoint: "https://api.paretoproof.com/portal/admin/offline-ingest/problem9-run-bundles",
     error: "offline_ingest_duplicate_run",
     httpStatus: 409,
-    issues: undefined,
+    issues: [
+      {
+        code: "invalid_type",
+        expected: "string",
+        message: "Expected string, received null",
+        path: ["bundle", "runBundle", "runId"],
+        received: "null"
+      }
+    ],
     stage: "remote_rejection",
+    status: "rejected"
+  });
+});
+
+test("runProblem9OfflineIngest returns machine-readable setup failures for missing API base URL", async (t) => {
+  const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const result = await runProblem9OfflineIngest(
+    {
+      accessJwt: "test-access-jwt",
+      bundleRoot
+    },
+    {
+      runtimeEnv: {}
+    }
+  );
+
+  assert.deepEqual(result, {
+    bundleRoot,
+    endpoint: null,
+    error: "offline_ingest_setup_failure",
+    issues: [
+      {
+        message: "Invalid worker runtime environment: API_BASE_URL: is required",
+        path: "API_BASE_URL"
+      }
+    ],
+    stage: "setup_failure",
+    status: "rejected"
+  });
+});
+
+test("runProblem9OfflineIngestCli emits JSON setup failures for missing flags", async (t) => {
+  const originalExitCode = process.exitCode;
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const stderrLines: string[] = [];
+  const stdoutLines: string[] = [];
+
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map(String).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map(String).join(" "));
+  };
+
+  t.after(() => {
+    process.exitCode = originalExitCode;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+
+  await runProblem9OfflineIngestCli(["--bundle-root", path.join(os.tmpdir(), "bundle-root")]);
+
+  assert.equal(stdoutLines.length, 0);
+  assert.equal(process.exitCode, 1);
+  assert.deepEqual(JSON.parse(stderrLines.join("\n")), {
+    bundleRoot: null,
+    endpoint: null,
+    error: "offline_ingest_setup_failure",
+    issues: [
+      {
+        message: "Missing required --access-jwt <value> argument.",
+        path: "--access-jwt"
+      }
+    ],
+    stage: "setup_failure",
     status: "rejected"
   });
 });


### PR DESCRIPTION
## Summary

- preserve structured API `issues` arrays in offline-ingest CLI rejection output instead of narrowing them to `{ message, path }`
- add an explicit `setup_failure` rejection stage for missing `API_BASE_URL` and missing CLI flags so setup problems still emit machine-readable JSON
- cover both the structured 400 rejection path and setup-failure path with worker regression tests

## Linked issues

- Closes #537

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/worker test problem9-offline-ingest
bun --cwd apps/worker typecheck
bun --cwd apps/worker build
git -c safe.directory=C:/Users/Tom/.codex/worktrees/344c/ParetoProof diff --check
bun run check:bidi
```

Runtime artifacts were not required for this bug fix.

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary: the change only affects offline-ingest CLI error serialization and preserves server-supplied validation detail.

Cost/rate-limit impact: none.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan: merge and rely on the updated CLI rejection envelope in later operator and automation flows.

Rollback plan: revert this PR to restore the prior CLI rejection behavior.

## Notes

- Rejected offline-ingest results now write JSON to stderr while successful ingests still write accepted payloads to stdout.