### PR TITLE
fix(web): harden portal runs query parsing

### DIFF
--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import {
+  defaultPortalRunsQuery,
+  parsePortalRunsQuery
+} from "./portal-benchmark-ops.ts";
+
+describe("parsePortalRunsQuery", () => {
+  it("falls back on malformed query params without discarding valid filters", () => {
+    const query = parsePortalRunsQuery(
+      "?providerFamily=openai&q=%20PP-318%20&limit=9999&sort=bad&runKind=nope&verdict=pass,wrong&runLifecycle=queued,broken"
+    );
+
+    expect(query).toEqual({
+      ...defaultPortalRunsQuery,
+      providerFamily: "openai",
+      q: "PP-318"
+    });
+  });
+
+  it("keeps valid enum and csv params when they parse cleanly", () => {
+    const query = parsePortalRunsQuery(
+      "?limit=50&sort=duration_desc&runKind=single_run&verdict=pass,fail&runLifecycle=queued,running"
+    );
+
+    expect(query.limit).toBe(50);
+    expect(query.sort).toBe("duration_desc");
+    expect(query.runKind).toBe("single_run");
+    expect(query.verdict).toEqual(["pass", "fail"]);
+    expect(query.runLifecycle).toEqual(["queued", "running"]);
+  });
+});

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -14,6 +14,7 @@ import {
   type PortalRunsSortId,
   type PortalWorkerIncidentSeverity,
   type PortalWorkersViewResponse,
+  runKindSchema,
   type RunLifecycleState
 } from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
@@ -702,6 +703,15 @@ function parseNullableParam(value: string | null) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function parseQueryField<TValue>(
+  parser: { safeParse: (value: unknown) => { success: true; data: TValue } | { success: false } },
+  value: unknown,
+  fallback: TValue
+) {
+  const result = parser.safeParse(value);
+  return result.success ? result.data : fallback;
+}
+
 function createRunsListResponse(query: PortalRunsListQuery): PortalRunsListResponse {
   const filteredItems = sortPortalRuns(
     localRunItems.filter((item) => matchesPortalRunsQuery(item, query)),
@@ -870,8 +880,13 @@ export function parsePortalRunsQuery(search: string): PortalRunsListQuery {
   const params = new URLSearchParams(search);
   const sortCandidate = params.get("sort");
   const lifecycleCandidate = params.get("lifecycleBucket");
-
-  return portalRunsListQuerySchema.parse({
+  const lifecycleBucket = portalRunsLifecycleBuckets.some((bucket) => bucket.id === lifecycleCandidate)
+    ? (lifecycleCandidate as PortalRunsListQuery["lifecycleBucket"])
+    : null;
+  const sort = portalRunsSortIds.includes((sortCandidate ?? "") as PortalRunsSortId)
+    ? (sortCandidate as PortalRunsSortId)
+    : defaultPortalRunsQuery.sort;
+  const candidateQuery = {
     attemptId: parseNullableParam(params.get("attemptId")),
     authMode: parseNullableParam(params.get("authMode")),
     benchmarkPackageDigest: parseNullableParam(params.get("benchmarkPackageDigest")),
@@ -880,23 +895,38 @@ export function parsePortalRunsQuery(search: string): PortalRunsListQuery {
     failureCode: parseNullableParam(params.get("failureCode")),
     failureFamily: parseNullableParam(params.get("failureFamily")),
     jobId: parseNullableParam(params.get("jobId")),
-    lifecycleBucket: portalRunsLifecycleBuckets.some((bucket) => bucket.id === lifecycleCandidate)
-      ? lifecycleCandidate
-      : null,
-    limit: parseNullableParam(params.get("limit")) ?? defaultPortalRunsQuery.limit,
+    lifecycleBucket,
+    limit: parseQueryField(
+      portalRunsListQuerySchema.shape.limit,
+      parseNullableParam(params.get("limit")) ?? undefined,
+      defaultPortalRunsQuery.limit
+    ),
     modelConfigId: parseNullableParam(params.get("modelConfigId")),
     providerFamily: parseNullableParam(params.get("providerFamily")),
     q: parseNullableParam(params.get("q")),
     runId: parseNullableParam(params.get("runId")),
-    runKind: parseNullableParam(params.get("runKind")),
-    runLifecycle: params.get("runLifecycle") ?? undefined,
+    runKind: parseQueryField(
+      runKindSchema.nullable(),
+      parseNullableParam(params.get("runKind")),
+      defaultPortalRunsQuery.runKind
+    ),
+    runLifecycle: parseQueryField(
+      portalRunsListQuerySchema.shape.runLifecycle,
+      params.get("runLifecycle") ?? undefined,
+      defaultPortalRunsQuery.runLifecycle
+    ),
     runMode: parseNullableParam(params.get("runMode")),
-    sort: portalRunsSortIds.includes((sortCandidate ?? "") as PortalRunsSortId)
-      ? sortCandidate
-      : defaultPortalRunsQuery.sort,
+    sort,
     toolProfile: parseNullableParam(params.get("toolProfile")),
-    verdict: params.get("verdict") ?? undefined
-  });
+    verdict: parseQueryField(
+      portalRunsListQuerySchema.shape.verdict,
+      params.get("verdict") ?? undefined,
+      defaultPortalRunsQuery.verdict
+    )
+  } satisfies PortalRunsListQuery;
+
+  const parsedQuery = portalRunsListQuerySchema.safeParse(candidateQuery);
+  return parsedQuery.success ? parsedQuery.data : defaultPortalRunsQuery;
 }
 
 export function buildPortalRunsQueryString(query: PortalRunsListQuery) {


### PR DESCRIPTION
## Summary
- harden `parsePortalRunsQuery()` so malformed numeric, enum, and CSV params fall back to canonical defaults instead of throwing during route render
- preserve valid filters from the same URL when some params are malformed
- add targeted regression coverage for malformed and valid runs query strings

## Linked Issues
- Closes #552

## Verification
- `bun run build:shared`
- `bun test apps/web/src/lib/portal-benchmark-ops.test.js`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- `bun run check:bidi`