### PR TITLE
fix(web): preserve active Runs filters on empty results

### DIFF
--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildRunsModelOptions,
+  buildRunsProviderOptions,
   defaultPortalRunsQuery,
   parsePortalRunsQuery
 } from "./portal-benchmark-ops.ts";
@@ -27,5 +29,22 @@ describe("parsePortalRunsQuery", () => {
     expect(query.runKind).toBe("single_run");
     expect(query.verdict).toEqual(["pass", "fail"]);
     expect(query.runLifecycle).toEqual(["queued", "running"]);
+  });
+});
+
+describe("buildRunsProviderOptions", () => {
+  it("preserves the active provider when the current result set is empty", () => {
+    expect(buildRunsProviderOptions([], "google")).toEqual(["google"]);
+  });
+});
+
+describe("buildRunsModelOptions", () => {
+  it("preserves the active model config when the current result set is empty", () => {
+    expect(buildRunsModelOptions([], "google-gemini-pro")).toEqual([
+      {
+        label: "google-gemini-pro",
+        modelConfigId: "google-gemini-pro"
+      }
+    ]);
   });
 });

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1004,6 +1004,42 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
     .join("\n");
 }
 
+export type PortalRunsModelFilterOption = {
+  label: string;
+  modelConfigId: string;
+};
+
+export function buildRunsProviderOptions(
+  items: PortalRunListItem[],
+  selectedProviderFamily: string | null
+) {
+  const providerOptions = Array.from(new Set(items.map((item) => item.providerFamily)));
+
+  if (selectedProviderFamily && !providerOptions.includes(selectedProviderFamily)) {
+    providerOptions.push(selectedProviderFamily);
+  }
+
+  return providerOptions;
+}
+
+export function buildRunsModelOptions(
+  items: PortalRunListItem[],
+  selectedModelConfigId: string | null
+): PortalRunsModelFilterOption[] {
+  const modelOptions = new Map(
+    items.map((item) => [item.modelConfigId, item.modelConfigLabel] as const)
+  );
+
+  if (selectedModelConfigId && !modelOptions.has(selectedModelConfigId)) {
+    modelOptions.set(selectedModelConfigId, selectedModelConfigId);
+  }
+
+  return Array.from(modelOptions, ([modelConfigId, label]) => ({
+    label,
+    modelConfigId
+  }));
+}
+
 function escapeCsvValue(value: string) {
   if (/[",\n]/.test(value)) {
     return `"${value.replaceAll('"', '""')}"`;

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -21,7 +21,9 @@ import {
 } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import {
+  buildRunsModelOptions,
   buildPortalRunsQueryString,
+  buildRunsProviderOptions,
   buildRunsCsv,
   defaultPortalRunsQuery,
   fetchPortalLaunchView,
@@ -354,13 +356,13 @@ function PortalRunsSurface({
   pathname: string;
   query: PortalRunsListQuery;
 }) {
-  const providerOptions = Array.from(
-    new Set(loadState.data?.items.map((item) => item.providerFamily) ?? [])
+  const providerOptions = buildRunsProviderOptions(
+    loadState.data?.items ?? [],
+    query.providerFamily
   );
-  const modelOptions = Array.from(
-    new Set(
-      (loadState.data?.items ?? []).map((item) => `${item.modelConfigId}::${item.modelConfigLabel}`)
-    )
+  const modelOptions = buildRunsModelOptions(
+    loadState.data?.items ?? [],
+    query.modelConfigId
   );
 
   return (
@@ -499,14 +501,11 @@ function PortalRunsSurface({
               value={query.modelConfigId ?? ""}
             >
               <option value="">All configs</option>
-              {modelOptions.map((entry) => {
-                const [modelConfigId, label] = entry.split("::");
-                return (
-                  <option key={modelConfigId} value={modelConfigId}>
-                    {label}
-                  </option>
-                );
-              })}
+              {modelOptions.map((entry) => (
+                <option key={entry.modelConfigId} value={entry.modelConfigId}>
+                  {entry.label}
+                </option>
+              ))}
             </select>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- preserve the selected provider and model filter values when the current Runs result set is empty
- move Runs filter option construction into small lib helpers so the behavior is testable
- add regression coverage for empty-result provider/model option preservation

## Verification
- bun test apps/web/src/lib/portal-benchmark-ops.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- targeted local browser repro on /runs with providerFamily=google and verdict=pass

Closes #554