### PR TITLE
fix(web): stop admin control event crashes

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -366,9 +366,10 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               <span>Status</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as RequestFilterState["status"];
                   setFilters((current) => ({
                     ...current,
-                    status: event.currentTarget.value as RequestFilterState["status"]
+                    status: value
                   }));
                 }}
                 value={filters.status}
@@ -383,9 +384,10 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               <span>Request kind</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as RequestFilterState["requestKind"];
                   setFilters((current) => ({
                     ...current,
-                    requestKind: event.currentTarget.value as RequestFilterState["requestKind"]
+                    requestKind: value
                   }));
                 }}
                 value={filters.requestKind}
@@ -399,9 +401,10 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               <span>Requested role</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as RequestFilterState["requestedRole"];
                   setFilters((current) => ({
                     ...current,
-                    requestedRole: event.currentTarget.value as RequestFilterState["requestedRole"]
+                    requestedRole: value
                   }));
                 }}
                 value={filters.requestedRole}
@@ -415,9 +418,10 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               <span>Reviewer state</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as RequestFilterState["reviewerState"];
                   setFilters((current) => ({
                     ...current,
-                    reviewerState: event.currentTarget.value as RequestFilterState["reviewerState"]
+                    reviewerState: value
                   }));
                 }}
                 value={filters.reviewerState}
@@ -431,9 +435,10 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               <span>Sort</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as RequestFilterState["sortOrder"];
                   setFilters((current) => ({
                     ...current,
-                    sortOrder: event.currentTarget.value as RequestFilterState["sortOrder"]
+                    sortOrder: value
                   }));
                 }}
                 value={filters.sortOrder}
@@ -724,9 +729,10 @@ function AccessRequestDetailCard({
               <select
                 disabled={!isPending || isMutating}
                 onChange={(event) => {
+                  const value = event.currentTarget.value as PortalAdminApprovedRole;
                   onChangeDraft({
                     ...draft,
-                    approvedRole: event.currentTarget.value as PortalAdminApprovedRole
+                    approvedRole: value
                   });
                 }}
                 value={draft.approvedRole}
@@ -741,9 +747,10 @@ function AccessRequestDetailCard({
             <textarea
               disabled={!isPending || isMutating}
               onChange={(event) => {
+                const value = event.currentTarget.value;
                 onChangeDraft({
                   ...draft,
-                  decisionNote: event.currentTarget.value
+                  decisionNote: value
                 });
               }}
               rows={4}

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -243,9 +243,10 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               <span>Search</span>
               <input
                 onChange={(event) => {
+                  const value = event.currentTarget.value;
                   setFilters((current) => ({
                     ...current,
-                    search: event.currentTarget.value
+                    search: value
                   }));
                 }}
                 placeholder="Email, display name, or user id"
@@ -258,9 +259,10 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               <span>Access posture</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as UserFilters["accessPosture"];
                   setFilters((current) => ({
                     ...current,
-                    accessPosture: event.currentTarget.value as UserFilters["accessPosture"]
+                    accessPosture: value
                   }));
                 }}
                 value={filters.accessPosture}
@@ -277,9 +279,10 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               <span>Active role</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as UserFilters["activeRole"];
                   setFilters((current) => ({
                     ...current,
-                    activeRole: event.currentTarget.value as UserFilters["activeRole"]
+                    activeRole: value
                   }));
                 }}
                 value={filters.activeRole}
@@ -294,10 +297,10 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               <span>Identity provider</span>
               <select
                 onChange={(event) => {
+                  const value = event.currentTarget.value as UserFilters["identityProvider"];
                   setFilters((current) => ({
                     ...current,
-                    identityProvider: event.currentTarget
-                      .value as UserFilters["identityProvider"]
+                    identityProvider: value
                   }));
                 }}
                 value={filters.identityProvider}


### PR DESCRIPTION
## Summary
- capture control values before React state-updater callbacks run in the admin request and admin users routes
- remove the currentTarget lifetime bug that was crashing admin filter changes and request-detail edits
- keep the fix scoped to the affected admin controls without changing route behavior

## Verification
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- targeted local browser repro on /admin/access-requests changing Status to pproved
- targeted local browser repro on /admin/users changing Access posture to pproved
- targeted local browser repro typing into the request-detail Decision note

Closes #556