### PR TITLE
fix(web): hide stale admin user detail

### DIFF
--- a/apps/web/src/routes/portal-admin-users-panel.test.js
+++ b/apps/web/src/routes/portal-admin-users-panel.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import {
+  resolveSelectedAdminUserId
+} from "./portal-admin-users-panel.tsx";
+
+const adaUser = {
+  userId: "user-ada"
+};
+
+const linUser = {
+  userId: "user-lin"
+};
+
+describe("resolveSelectedAdminUserId", () => {
+  it("keeps the current selection when it remains visible", () => {
+    expect(
+      resolveSelectedAdminUserId("user-ada", [
+        adaUser,
+        linUser
+      ])
+    ).toBe("user-ada");
+  });
+
+  it("switches to the first visible user when the current selection is filtered out", () => {
+    expect(
+      resolveSelectedAdminUserId("user-ada", [
+        linUser
+      ])
+    ).toBe("user-lin");
+  });
+
+  it("clears the selection when the current filter slice is empty", () => {
+    expect(resolveSelectedAdminUserId("user-ada", [])).toBeNull();
+  });
+});

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -28,6 +28,17 @@ const initialFilters: UserFilters = {
   search: ""
 };
 
+export function resolveSelectedAdminUserId(
+  selectedUserId: string | null,
+  visibleUsers: PortalAdminUserListItem[]
+) {
+  if (selectedUserId && visibleUsers.some((user) => user.userId === selectedUserId)) {
+    return selectedUserId;
+  }
+
+  return visibleUsers[0]?.userId ?? null;
+}
+
 function formatTimestamp(timestamp: string | null) {
   if (!timestamp) {
     return "None";
@@ -73,6 +84,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   const [detailItem, setDetailItem] = useState<Awaited<
     ReturnType<typeof loadPortalAdminUserDetail>
   > | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [filters, setFilters] = useState<UserFilters>(initialFilters);
   const [isLoading, setIsLoading] = useState(true);
   const [isMutating, setIsMutating] = useState(false);
@@ -101,6 +113,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     if (!selectedUserId) {
       setDetailItem(null);
       setDetailError(null);
+      setIsDetailLoading(false);
       return;
     }
 
@@ -108,6 +121,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     setDetailItem(null);
     setDetailError(null);
     setRevocationReason("");
+    setIsDetailLoading(true);
 
     async function loadDetail() {
       const currentUserId = selectedUserId;
@@ -132,6 +146,10 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
 
         setDetailItem(null);
         setDetailError(error instanceof Error ? error.message : "The user detail could not be loaded.");
+      } finally {
+        if (!cancelled) {
+          setIsDetailLoading(false);
+        }
       }
     }
 
@@ -147,13 +165,6 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
       const nextItems = await loadPortalAdminUsers(apiBaseUrl);
       setUsers(nextItems);
       setListError(null);
-      setSelectedUserId((current) => {
-        if (current && nextItems.some((item) => item.userId === current)) {
-          return current;
-        }
-
-        return nextItems[0]?.userId ?? null;
-      });
       markUpdated();
     } catch (error) {
       setListError(
@@ -165,6 +176,16 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
       }
     }
   }
+
+  useEffect(() => {
+    const nextSelectedUserId = resolveSelectedAdminUserId(selectedUserId, visibleUsers);
+
+    if (nextSelectedUserId === selectedUserId) {
+      return;
+    }
+
+    setSelectedUserId(nextSelectedUserId);
+  }, [selectedUserId, visibleUsers]);
 
   async function handleRevoke() {
     if (!detailItem || isMutating) {


### PR DESCRIPTION
## Summary
- keep the admin users detail pane aligned with the visible filtered directory
- clear or reseat the selection when filters exclude the previously selected user
- add focused regression coverage for the user-selection resolution rule

## Verification
- bun test apps/web/src/routes/portal-admin-users-panel.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- targeted local browser repro on /admin/users with a zero-match search filter

Closes #560