### PR TITLE
fix(web): preserve runs slice through detail routing

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildRunDetailTargetPath,
+  buildRunsIndexTargetPath
+} from "./portal-benchmark-ops-surfaces.tsx";
+
+describe("portal benchmark ops route targets", () => {
+  it("keeps the current runs query when routing into run detail", () => {
+    expect(
+      buildRunDetailTargetPath(
+        "PP-320",
+        "?surface=portal&access=approved&roles=helper&providerFamily=google"
+      )
+    ).toBe(
+      "/runs/PP-320?surface=portal&access=approved&roles=helper&providerFamily=google"
+    );
+  });
+
+  it("normalizes query strings without a leading question mark", () => {
+    expect(
+      buildRunDetailTargetPath(
+        "PP 320",
+        "surface=portal&access=approved&roles=helper&providerFamily=google"
+      )
+    ).toBe(
+      "/runs/PP%20320?surface=portal&access=approved&roles=helper&providerFamily=google"
+    );
+  });
+
+  it("preserves the originating runs slice for the back-to-runs action", () => {
+    expect(
+      buildRunsIndexTargetPath(
+        "?surface=portal&access=approved&roles=helper&providerFamily=google"
+      )
+    ).toBe(
+      "/runs?surface=portal&access=approved&roles=helper&providerFamily=google"
+    );
+  });
+});

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -96,8 +96,28 @@ function toDisplayError(error: unknown) {
   return error instanceof Error ? error.message : "Request failed.";
 }
 
-function buildRunDetailHref(runId: string) {
-  return buildPortalUrl(`/runs/${encodeURIComponent(runId)}`);
+function normalizeRouteSearch(search: string) {
+  if (!search) {
+    return "";
+  }
+
+  return search.startsWith("?") ? search : `?${search}`;
+}
+
+export function buildRunsIndexTargetPath(search = "") {
+  return `/runs${normalizeRouteSearch(search)}`;
+}
+
+export function buildRunsIndexHref(search = "") {
+  return buildPortalUrl(buildRunsIndexTargetPath(search));
+}
+
+export function buildRunDetailTargetPath(runId: string, search = "") {
+  return `/runs/${encodeURIComponent(runId)}${normalizeRouteSearch(search)}`;
+}
+
+export function buildRunDetailHref(runId: string, search = "") {
+  return buildPortalUrl(buildRunDetailTargetPath(runId, search));
 }
 
 function updateRunsQuery(
@@ -300,6 +320,7 @@ export function PortalBenchmarkOpsSurface({
         activeRouteId={activeRouteId}
         loadState={runDetailState}
         onRefresh={loadRunDetail}
+        search={search}
       />
     );
   }
@@ -313,6 +334,7 @@ export function PortalBenchmarkOpsSurface({
         onReplaceLocation={onReplaceLocation}
         pathname={pathname}
         query={runsQuery}
+        search={search}
       />
     );
   }
@@ -350,11 +372,13 @@ function PortalRunsSurface({
   onRefresh,
   onReplaceLocation,
   pathname,
-  query
+  query,
+  search
 }: SurfaceProps<PortalRunsListResponse> & {
   onReplaceLocation: PortalBenchmarkOpsSurfaceProps["onReplaceLocation"];
   pathname: string;
   query: PortalRunsListQuery;
+  search: string;
 }) {
   const providerOptions = buildRunsProviderOptions(
     loadState.data?.items ?? [],
@@ -556,7 +580,7 @@ function PortalRunsSurface({
             {loadState.data.items.map((item) => (
               <div className="portal-table-row" key={item.runId} role="row">
                 <span>
-                  <a className="portal-inline-link" href={buildRunDetailHref(item.runId)}>
+                  <a className="portal-inline-link" href={buildRunDetailHref(item.runId, search)}>
                     {item.runId}
                   </a>
                 </span>
@@ -586,9 +610,13 @@ function PortalRunsSurface({
 function PortalRunDetailSurface({
   activeRouteId,
   loadState,
-  onRefresh
-}: SurfaceProps<PortalRunDetailResponse>) {
+  onRefresh,
+  search
+}: SurfaceProps<PortalRunDetailResponse> & {
+  search: string;
+}) {
   const detail = loadState.data;
+  const runsIndexHref = buildRunsIndexHref(search);
 
   return (
     <section className="portal-workspace-grid">
@@ -598,7 +626,7 @@ function PortalRunDetailSurface({
             <p className="section-tag">Canonical run detail</p>
             <h2>{detail?.item.runId ?? "Run detail"}</h2>
           </div>
-          <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+          <a className="button button-secondary" href={runsIndexHref}>
             Back to runs
           </a>
         </div>
@@ -687,7 +715,7 @@ function PortalRunDetailSurface({
         <div className="portal-action-list">
           <PortalLinkCard
             copy="Return to the canonical filtered run index."
-            href={buildPortalUrl("/runs")}
+            href={runsIndexHref}
             title="Runs"
           />
           <PortalLinkCard


### PR DESCRIPTION
## Summary
- preserve the current Runs query when linking from the list into `/runs/:runId`
- use the preserved query for the detail page's built-in return path back to `/runs`
- add route-target regression coverage for the preserved-slice behavior

## Verification
- bun test apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- local browser repro on `/runs?providerFamily=google` -> `PP-320` -> `Back to runs`

Closes #562