### PR TITLE
fix: require rationale for access requests

### DIFF
--- a/apps/web/src/routes/access-request-screen.tsx
+++ b/apps/web/src/routes/access-request-screen.tsx
@@ -43,7 +43,7 @@ export function AccessRequestScreen({
         });
 
         if (!parsed.success) {
-          setErrorMessage("Check the request details and try again.");
+          setErrorMessage("Add a short recovery note before submitting.");
           return;
         }
 
@@ -59,7 +59,7 @@ export function AccessRequestScreen({
       });
 
       if (!parsed.success) {
-        setErrorMessage("Check the request details and try again.");
+        setErrorMessage("Add a short note explaining why you need access.");
         return;
       }
 

--- a/packages/shared/src/schemas/access-request.test.js
+++ b/packages/shared/src/schemas/access-request.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+  portalAccessRecoveryInputSchema,
+  portalAccessRequestInputSchema
+} from "./access-request.js";
+
+describe("portal access request inputs", () => {
+  it("rejects blank access-request rationale values", () => {
+    expect(
+      portalAccessRequestInputSchema.safeParse({
+        rationale: "   ",
+        requestedRole: "helper"
+      }).success
+    ).toBeFalse();
+  });
+
+  it("rejects blank recovery rationale values", () => {
+    expect(
+      portalAccessRecoveryInputSchema.safeParse({
+        rationale: "   "
+      }).success
+    ).toBeFalse();
+  });
+
+  it("trims accepted rationale values", () => {
+    const parsed = portalAccessRequestInputSchema.safeParse({
+      rationale: "  Need contributor access for benchmark triage.  ",
+      requestedRole: "collaborator"
+    });
+
+    expect(parsed.success).toBeTrue();
+
+    if (!parsed.success) {
+      return;
+    }
+
+    expect(parsed.data.rationale).toBe("Need contributor access for benchmark triage.");
+  });
+});

--- a/packages/shared/src/schemas/access-request.ts
+++ b/packages/shared/src/schemas/access-request.ts
@@ -10,25 +10,15 @@ export const portalAccessRequestKindSchema = z.enum([
   "identity_recovery"
 ]);
 
-export const portalAccessRequestInputSchema = z.object({
-  rationale: z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
-    if (!value) {
-      return null;
-    }
+const portalRequestRationaleSchema = z.string().trim().min(1).max(500);
 
-    return value;
-  }),
+export const portalAccessRequestInputSchema = z.object({
+  rationale: portalRequestRationaleSchema,
   requestedRole: portalSelfServiceAccessRequestRoleSchema
 });
 
 export const portalAccessRecoveryInputSchema = z.object({
-  rationale: z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {
-    if (!value) {
-      return null;
-    }
-
-    return value;
-  })
+  rationale: portalRequestRationaleSchema
 });
 
 const portalAccessDecisionNoteSchema = z.string().trim().max(500).nullish().transform((value: string | null | undefined) => {

--- a/packages/shared/src/types/access-request.ts
+++ b/packages/shared/src/types/access-request.ts
@@ -3,12 +3,12 @@ export type PortalSelfServiceAccessRequestRole = "collaborator" | "helper";
 export type PortalAccessRequestKind = "access_request" | "identity_recovery";
 
 export type PortalAccessRequestInput = {
-  rationale: string | null;
+  rationale: string;
   requestedRole: PortalSelfServiceAccessRequestRole;
 };
 
 export type PortalAccessRecoveryInput = {
-  rationale: string | null;
+  rationale: string;
 };
 
 export type PortalAdminApprovedRole = "collaborator" | "helper";


### PR DESCRIPTION
## Summary
- require a non-empty rationale for access-request and identity-recovery submissions in the shared contract
- show explicit frontend validation messages when the note is missing
- add shared-schema regression coverage for blank and trimmed rationale values

Closes #566

## Testing
- bun test packages/shared/src/schemas/access-request.test.js
- bun run build:shared
- bun run typecheck
- bun --cwd apps/web build
- targeted browser QA for blank and filled access-request plus recovery flows on local preview