### PR TITLE
fix: persist local pending portal state

### DIFF
--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { buildLocalPendingPortalUrl } from "./portal-bootstrap.tsx";
+
+describe("buildLocalPendingPortalUrl", () => {
+  it("promotes the local access state to pending and clears denial-only params", () => {
+    expect(
+      buildLocalPendingPortalUrl(
+        "?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local&roles=helper"
+      )
+    ).toBe("/pending?surface=portal&access=pending&email=lin%40paretoproof.local");
+  });
+
+  it("preserves the local email when no denial reason is present", () => {
+    expect(
+      buildLocalPendingPortalUrl("?surface=portal&access=denied&email=ada@paretoproof.local")
+    ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
+  });
+});

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -1,4 +1,7 @@
-import type { PortalAccessRequestInput } from "@paretoproof/shared";
+import type {
+  PortalAccessRecoveryInput,
+  PortalAccessRequestInput
+} from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
@@ -102,6 +105,27 @@ function readLocalAccessOverride(): PortalAccessState | null {
   }
 
   return null;
+}
+
+export function buildLocalPendingPortalUrl(
+  currentSearch = window.location.search
+) {
+  const currentParams = new URLSearchParams(currentSearch);
+  const nextParams = new URLSearchParams(currentParams);
+
+  nextParams.set("surface", "portal");
+  nextParams.set("access", "pending");
+  nextParams.delete("reason");
+  nextParams.delete("roles");
+
+  const email = currentParams.get("email");
+
+  if (email) {
+    nextParams.set("email", email);
+  }
+
+  const nextSearch = nextParams.toString();
+  return `/pending${nextSearch ? `?${nextSearch}` : ""}`;
 }
 
 function formatPortalBootstrapError(error: unknown) {
@@ -243,7 +267,7 @@ export function PortalBootstrap() {
         email: state.status === "denied" || state.status === "pending" ? state.email : null,
         status: "pending"
       });
-      window.history.replaceState({}, "", buildPortalUrl("/pending"));
+      window.history.replaceState({}, "", buildLocalPendingPortalUrl());
       return;
     }
 
@@ -270,13 +294,13 @@ export function PortalBootstrap() {
     window.location.replace(buildPortalUrl("/pending"));
   }
 
-  async function submitAccessRecovery(payload: { rationale: string | null }) {
+  async function submitAccessRecovery(payload: PortalAccessRecoveryInput) {
     if (isLocalHostname(window.location.hostname)) {
       setState({
         email: state.status === "denied" || state.status === "pending" ? state.email : null,
         status: "pending"
       });
-      window.history.replaceState({}, "", buildPortalUrl("/pending"));
+      window.history.replaceState({}, "", buildLocalPendingPortalUrl());
       return;
     }
 


### PR DESCRIPTION
## Summary
- make local access-request and recovery submissions rewrite to a canonical pending URL with ccess=pending`n- clear denial-only query params from the local pending route so reload stays on the pending screen
- add a focused regression test for the pending URL helper

Closes #568

## Testing
- bun test apps/web/src/routes/portal-bootstrap.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- targeted browser QA verifying local access-request and recovery flows stay on /pending after reload