### PR TITLE
fix: drop stale local denial reasons

### DIFF
--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { mergeLocalPortalStateSearch } from "./surface.ts";
+
+describe("mergeLocalPortalStateSearch", () => {
+  it("drops stale denial reasons once local access is approved", () => {
+    expect(
+      mergeLocalPortalStateSearch(
+        "",
+        "?surface=portal&access=approved&roles=helper&reason=insufficient_role&email=lin@paretoproof.local"
+      )
+    ).toBe("access=approved&email=lin%40paretoproof.local&roles=helper");
+  });
+
+  it("preserves denial reasons while the local access state is denied", () => {
+    expect(
+      mergeLocalPortalStateSearch(
+        "",
+        "?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local"
+      )
+    ).toBe("access=denied&email=lin%40paretoproof.local&reason=access_request_required");
+  });
+
+  it("keeps an explicit target reason untouched", () => {
+    expect(
+      mergeLocalPortalStateSearch(
+        "?reason=existing",
+        "?surface=portal&access=approved&reason=insufficient_role"
+      )
+    ).toBe("reason=existing&access=approved");
+  });
+});

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -112,23 +112,44 @@ function buildLocalSurfaceUrl(
   return surfaceUrl.toString();
 }
 
+export function mergeLocalPortalStateSearch(
+  targetSearch: string,
+  currentSearch: string
+) {
+  const targetParams = new URLSearchParams(targetSearch);
+  const currentParams = new URLSearchParams(currentSearch);
+  const currentAccess = currentParams.get("access");
+
+  for (const key of localPortalStateParamKeys) {
+    if (targetParams.has(key)) {
+      continue;
+    }
+
+    const value = currentParams.get(key);
+
+    if (!value) {
+      continue;
+    }
+
+    if (key === "reason" && currentAccess !== "denied") {
+      continue;
+    }
+
+    targetParams.set(key, value);
+  }
+
+  return targetParams.toString();
+}
+
 function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
   if (!isLocalOrigin(currentLocation.hostname)) {
     return;
   }
 
-  const currentParams = new URLSearchParams(currentLocation.search);
-
-  for (const key of localPortalStateParamKeys) {
-    if (targetUrl.searchParams.has(key)) {
-      continue;
-    }
-    const value = currentParams.get(key);
-
-    if (value) {
-      targetUrl.searchParams.set(key, value);
-    }
-  }
+  targetUrl.search = mergeLocalPortalStateSearch(
+    targetUrl.search,
+    currentLocation.search
+  );
 }
 
 export function buildAuthUrl(targetPath = "/", hostname = window.location.hostname) {


### PR DESCRIPTION
## Summary
- stop copying local denial-only reasons once preview access state is no longer denied
- keep explicit target params intact while preserving valid denied-state reasons
- add regression coverage for approved, denied, and pre-seeded target query states

Closes #572