### PR TITLE
Fix local approved-route denial reason leaks

### DIFF
--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { resolvePortalRouteRedirect } from "./portal-route-access.ts";
+
+const originalWindow = globalThis.window;
+
+function setWindowUrl(url) {
+  globalThis.window = {
+    location: new URL(url)
+  };
+}
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
+
+describe("resolvePortalRouteRedirect", () => {
+  it("strips stale denial reasons from approved routes", () => {
+    setWindowUrl(
+      "http://localhost/profile?surface=portal&access=approved&roles=helper&reason=insufficient_role&email=lin@paretoproof.local"
+    );
+
+    const redirect = new URL(
+      resolvePortalRouteRedirect({
+        pathname: "/profile",
+        reason: "insufficient_role",
+        roles: ["helper"],
+        search:
+          "?surface=portal&access=approved&roles=helper&reason=insufficient_role&email=lin@paretoproof.local",
+        status: "approved"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/profile");
+    expect(redirect.searchParams.get("surface")).toBe("portal");
+    expect(redirect.searchParams.get("access")).toBe("approved");
+    expect(redirect.searchParams.get("email")).toBe("lin@paretoproof.local");
+    expect(redirect.searchParams.get("roles")).toBe("helper");
+    expect(redirect.searchParams.has("reason")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -3,7 +3,7 @@ import {
   type AppRouteMatrixEntry,
   type RouteRedirectTarget
 } from "@paretoproof/shared";
-import { buildPublicUrl, isLocalHostname } from "./surface";
+import { buildPublicUrl, copyLocalPortalState, isLocalHostname } from "./surface";
 
 type PortalAccessStatus = "approved" | "denied" | "pending" | "unauthenticated";
 
@@ -102,20 +102,17 @@ function preserveLocalPortalState(targetPath: string, location = window.location
   }
 
   const redirectUrl = new URL(targetPath, location.origin);
-  const currentParams = new URLSearchParams(location.search);
-
-  for (const key of ["surface", "access", "email", "reason", "roles"]) {
-    if (redirectUrl.searchParams.has(key)) {
-      continue;
-    }
-    const value = currentParams.get(key);
-
-    if (value) {
-      redirectUrl.searchParams.set(key, value);
-    }
-  }
+  redirectUrl.searchParams.set("surface", "portal");
+  copyLocalPortalState(redirectUrl, location);
 
   return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
+}
+
+function stripRouteDeniedReason(search = "") {
+  const params = new URLSearchParams(search);
+  params.delete("reason");
+  const nextSearch = params.toString();
+  return nextSearch ? `?${nextSearch}` : "";
 }
 
 function readRouteDeniedReason(
@@ -168,6 +165,16 @@ export function findMatchedPortalRoute(pathname: string) {
 export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
   const matchedRoute = findPortalRoute(context.pathname);
   const routeDeniedReason = readRouteDeniedReason(context.search);
+
+  if (
+    context.status === "approved" &&
+    routeDeniedReason &&
+    matchedRoute?.id !== "portal.denied"
+  ) {
+    return preserveLocalPortalState(
+      `${context.pathname}${stripRouteDeniedReason(context.search)}`
+    );
+  }
 
   if (context.status === "approved" && matchedRoute?.id === "portal.pending") {
     return preserveLocalPortalState("/");

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { buildPortalUrl } from "./surface.ts";
+
+const originalWindow = globalThis.window;
+
+function setWindowUrl(url) {
+  globalThis.window = {
+    location: new URL(url)
+  };
+}
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
+
+describe("buildPortalUrl", () => {
+  it("drops stale denial reasons when building approved portal routes", () => {
+    setWindowUrl(
+      "http://localhost/denied?surface=portal&access=approved&roles=helper&reason=insufficient_role&email=lin@paretoproof.local"
+    );
+
+    const portalUrl = new URL(buildPortalUrl("/"));
+
+    expect(portalUrl.pathname).toBe("/");
+    expect(portalUrl.searchParams.get("surface")).toBe("portal");
+    expect(portalUrl.searchParams.get("access")).toBe("approved");
+    expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
+    expect(portalUrl.searchParams.get("roles")).toBe("helper");
+    expect(portalUrl.searchParams.has("reason")).toBe(false);
+  });
+
+  it("keeps denied reasons on denied-flow targets", () => {
+    setWindowUrl(
+      "http://localhost/denied?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local"
+    );
+
+    const portalUrl = new URL(buildPortalUrl("/access-request"));
+
+    expect(portalUrl.pathname).toBe("/access-request");
+    expect(portalUrl.searchParams.get("surface")).toBe("portal");
+    expect(portalUrl.searchParams.get("access")).toBe("denied");
+    expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
+    expect(portalUrl.searchParams.get("reason")).toBe("access_request_required");
+  });
+});

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -6,7 +6,7 @@ export type AccessProvider = "github" | "google";
 const productionPublicOrigin = "https://paretoproof.com";
 const productionAuthOrigin = "https://auth.paretoproof.com";
 const productionPortalOrigin = "https://portal.paretoproof.com";
-const localPortalStateParamKeys = ["access", "email", "roles", "reason"] as const;
+const localPortalStateParamKeys = ["access", "email", "roles"] as const;
 const productionProviderAuthOrigins: Record<AccessProvider, string> = {
   github: "https://github.auth.paretoproof.com",
   google: "https://google.auth.paretoproof.com"
@@ -112,7 +112,18 @@ function buildLocalSurfaceUrl(
   return surfaceUrl.toString();
 }
 
-function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
+function shouldPreserveLocalPortalReason(
+  targetUrl: URL,
+  currentParams: URLSearchParams
+) {
+  if (currentParams.get("access") !== "denied") {
+    return false;
+  }
+
+  return targetUrl.pathname === "/access-request" || targetUrl.pathname === "/denied";
+}
+
+export function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
   if (!isLocalOrigin(currentLocation.hostname)) {
     return;
   }
@@ -127,6 +138,17 @@ function copyLocalPortalState(targetUrl: URL, currentLocation = window.location)
 
     if (value) {
       targetUrl.searchParams.set(key, value);
+    }
+  }
+
+  if (
+    !targetUrl.searchParams.has("reason") &&
+    shouldPreserveLocalPortalReason(targetUrl, currentParams)
+  ) {
+    const reason = currentParams.get("reason");
+
+    if (reason) {
+      targetUrl.searchParams.set("reason", reason);
     }
   }
 }


### PR DESCRIPTION
## Summary
- stop copying local denial reasons into approved portal URLs
- reuse the shared local portal-state copier from portal route redirects
- add focused regression tests for approved-route cleanup and denied-flow preservation

Closes #572.

## Verification
- bun run build:shared
- bun test apps/web/src/lib/surface.test.js apps/web/src/lib/portal-route-access.test.js apps/web/src/routes/portal-bootstrap.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi