### PR TITLE
Drop stale local roles from non-approved portal routes

### DIFF
--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -43,4 +43,27 @@ describe("resolvePortalRouteRedirect", () => {
     expect(redirect.searchParams.get("roles")).toBe("helper");
     expect(redirect.searchParams.has("reason")).toBe(false);
   });
+
+  it("strips stale approved roles from pending routes", () => {
+    setWindowUrl(
+      "http://localhost/admin/users?surface=portal&access=pending&roles=admin&email=ada@paretoproof.local"
+    );
+
+    const redirect = new URL(
+      resolvePortalRouteRedirect({
+        pathname: "/admin/users",
+        roles: [],
+        search:
+          "?surface=portal&access=pending&roles=admin&email=ada@paretoproof.local",
+        status: "pending"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/pending");
+    expect(redirect.searchParams.get("surface")).toBe("portal");
+    expect(redirect.searchParams.get("access")).toBe("pending");
+    expect(redirect.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(redirect.searchParams.has("roles")).toBe(false);
+  });
 });

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -36,7 +36,7 @@ describe("buildPortalUrl", () => {
 
   it("keeps denied reasons on denied-flow targets", () => {
     setWindowUrl(
-      "http://localhost/denied?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local"
+      "http://localhost/denied?surface=portal&access=denied&reason=access_request_required&roles=helper&email=lin@paretoproof.local"
     );
 
     const portalUrl = new URL(buildPortalUrl("/access-request"));
@@ -46,5 +46,20 @@ describe("buildPortalUrl", () => {
     expect(portalUrl.searchParams.get("access")).toBe("denied");
     expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
     expect(portalUrl.searchParams.get("reason")).toBe("access_request_required");
+    expect(portalUrl.searchParams.has("roles")).toBe(false);
+  });
+
+  it("drops stale approved roles when the current preview access is pending", () => {
+    setWindowUrl(
+      "http://localhost/pending?surface=portal&access=pending&roles=admin&email=ada@paretoproof.local"
+    );
+
+    const portalUrl = new URL(buildPortalUrl("/"));
+
+    expect(portalUrl.pathname).toBe("/");
+    expect(portalUrl.searchParams.get("surface")).toBe("portal");
+    expect(portalUrl.searchParams.get("access")).toBe("pending");
+    expect(portalUrl.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(portalUrl.searchParams.has("roles")).toBe(false);
   });
 });

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -6,7 +6,7 @@ export type AccessProvider = "github" | "google";
 const productionPublicOrigin = "https://paretoproof.com";
 const productionAuthOrigin = "https://auth.paretoproof.com";
 const productionPortalOrigin = "https://portal.paretoproof.com";
-const localPortalStateParamKeys = ["access", "email", "roles"] as const;
+const localPortalStateParamKeys = ["access", "email"] as const;
 const productionProviderAuthOrigins: Record<AccessProvider, string> = {
   github: "https://github.auth.paretoproof.com",
   google: "https://google.auth.paretoproof.com"
@@ -123,6 +123,10 @@ function shouldPreserveLocalPortalReason(
   return targetUrl.pathname === "/access-request" || targetUrl.pathname === "/denied";
 }
 
+function shouldPreserveLocalPortalRoles(currentParams: URLSearchParams) {
+  return currentParams.get("access") === "approved";
+}
+
 export function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
   if (!isLocalOrigin(currentLocation.hostname)) {
     return;
@@ -138,6 +142,17 @@ export function copyLocalPortalState(targetUrl: URL, currentLocation = window.lo
 
     if (value) {
       targetUrl.searchParams.set(key, value);
+    }
+  }
+
+  if (
+    !targetUrl.searchParams.has("roles") &&
+    shouldPreserveLocalPortalRoles(currentParams)
+  ) {
+    const roles = currentParams.get("roles");
+
+    if (roles) {
+      targetUrl.searchParams.set("roles", roles);
     }
   }
 


### PR DESCRIPTION
## Summary
- stop copying preview role grants into pending and denied portal URLs
- keep approved local preview routes preserving roles for normal portal navigation
- add focused regression coverage for pending cleanup and denied-flow preservation

Closes #575.

## Verification
- bun run build:shared
- bun test apps/web/src/lib/surface.test.js apps/web/src/lib/portal-route-access.test.js apps/web/src/routes/portal-bootstrap.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi