### PR TITLE
Expose admin queues earlier on mobile

### DIFF
--- a/apps/web/src/lib/use-compact-layout.ts
+++ b/apps/web/src/lib/use-compact-layout.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export function useCompactLayout(maxWidthPx = 900) {
+  const query = `(max-width: ${maxWidthPx}px)`;
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    function handleChange(event: MediaQueryListEvent) {
+      setMatches(event.matches);
+    }
+
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -17,6 +17,7 @@ import {
 } from "../lib/portal-admin";
 import { usePortalPolling } from "../lib/portal-freshness";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import { useCompactLayout } from "../lib/use-compact-layout";
 
 type PortalAccessRequestPanelProps = {
   email: string | null;
@@ -75,6 +76,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
   const [requests, setRequests] = useState<PortalAdminAccessRequestListItem[]>([]);
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
+  const isCompactLayout = useCompactLayout();
   const {
     isPolling,
     lastUpdatedAt,
@@ -341,235 +343,250 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
     );
   }
 
-  return (
-    <section className="portal-grid portal-grid-stack portal-grid-admin-workspace">
-      <article className="portal-panel">
-        <p className="section-tag">Admin requests</p>
-        <h2>Request review stays anchored to one queue and one detail pane.</h2>
-        <p>
-          Signed in{email ? ` as ${email}` : ""}. Review access requests and recovery
-          requests here, keep the request object explicit, and surface visible notes for
-          every decision.
-        </p>
-        <PortalFreshnessCard
-          isRefreshing={isPolling || isDetailLoading || isMutatingId !== null}
-          lastUpdatedAt={lastUpdatedAt}
-          onRefresh={() => {
-            void pollNow().catch(() => {
-              setErrorMessage("The admin request queue could not be refreshed.");
-            });
+  const introPanel = (
+    <article className="portal-panel">
+      <p className="section-tag">Admin requests</p>
+      <h2>Request review stays anchored to one queue and one detail pane.</h2>
+      <p>
+        Signed in{email ? ` as ${email}` : ""}. Review access requests and recovery
+        requests here, keep the request object explicit, and surface visible notes for
+        every decision.
+      </p>
+      <PortalFreshnessCard
+        isRefreshing={isPolling || isDetailLoading || isMutatingId !== null}
+        lastUpdatedAt={lastUpdatedAt}
+        onRefresh={() => {
+          void pollNow().catch(() => {
+            setErrorMessage("The admin request queue could not be refreshed.");
+          });
+        }}
+        routeId="portal.admin.access-requests"
+      />
+      {errorMessage ? <p className="form-error">{errorMessage}</p> : null}
+    </article>
+  );
+
+  const filterFields = (
+    <div className="portal-admin-filter-grid">
+      <label className="auth-field">
+        <span>Status</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as RequestFilterState["status"];
+            setFilters((current) => ({
+              ...current,
+              status: value
+            }));
           }}
-          routeId="portal.admin.access-requests"
-        />
-        {errorMessage ? <p className="form-error">{errorMessage}</p> : null}
+          value={filters.status}
+        >
+          <option value="all">All statuses</option>
+          <option value="pending">Pending first</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+      </label>
+      <label className="auth-field">
+        <span>Request kind</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as RequestFilterState["requestKind"];
+            setFilters((current) => ({
+              ...current,
+              requestKind: value
+            }));
+          }}
+          value={filters.requestKind}
+        >
+          <option value="all">All kinds</option>
+          <option value="access_request">Access requests</option>
+          <option value="identity_recovery">Recovery requests</option>
+        </select>
+      </label>
+      <label className="auth-field">
+        <span>Requested role</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as RequestFilterState["requestedRole"];
+            setFilters((current) => ({
+              ...current,
+              requestedRole: value
+            }));
+          }}
+          value={filters.requestedRole}
+        >
+          <option value="all">Any role</option>
+          <option value="collaborator">Collaborator</option>
+          <option value="helper">Helper</option>
+        </select>
+      </label>
+      <label className="auth-field">
+        <span>Reviewer state</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as RequestFilterState["reviewerState"];
+            setFilters((current) => ({
+              ...current,
+              reviewerState: value
+            }));
+          }}
+          value={filters.reviewerState}
+        >
+          <option value="all">Reviewed and unreviewed</option>
+          <option value="unreviewed">Unreviewed</option>
+          <option value="reviewed">Reviewed</option>
+        </select>
+      </label>
+      <label className="auth-field">
+        <span>Sort</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as RequestFilterState["sortOrder"];
+            setFilters((current) => ({
+              ...current,
+              sortOrder: value
+            }));
+          }}
+          value={filters.sortOrder}
+        >
+          <option value="oldest">Oldest submitted</option>
+          <option value="newest">Newest submitted</option>
+          <option value="recently_reviewed">Recently reviewed</option>
+        </select>
+      </label>
+    </div>
+  );
+
+  const queueContent =
+    filteredRequests.length === 0 ? (
+      <div className="portal-admin-empty-state">
+        <p className="section-tag">Empty state</p>
+        <h2>No requests match the current slice.</h2>
+        <p>Change the filters to bring back recently reviewed or different request kinds.</p>
+      </div>
+    ) : (
+      <div className="portal-admin-record-list">
+        {filteredRequests.map((requestItem) => {
+          const isSelected = requestItem.id === selectedRequestId;
+
+          return (
+            <button
+              className={`portal-admin-record${isSelected ? " portal-admin-record-active" : ""}`}
+              key={requestItem.id}
+              onClick={() => {
+                setSelectedRequestId(requestItem.id);
+              }}
+              type="button"
+            >
+              <div className="portal-admin-record-header">
+                <strong>{requestItem.email}</strong>
+                <span
+                  className={`portal-state-badge portal-admin-status-${requestItem.status}`}
+                >
+                  {formatRequestStatusLabel(requestItem.status)}
+                </span>
+              </div>
+              <p className="portal-panel-muted">
+                {requestItem.requestKind === "identity_recovery"
+                  ? `Identity recovery - preserve ${requestItem.requestedRole}`
+                  : `Access request - ${requestItem.requestedRole}`}
+              </p>
+              <div className="portal-admin-meta-row">
+                <span>Submitted {formatDateTime(requestItem.createdAt)}</span>
+                <span>
+                  {requestItem.reviewer
+                    ? `Reviewed by ${requestItem.reviewer.label}`
+                    : "Awaiting reviewer"}
+                </span>
+              </div>
+              <div className="portal-filter-chip-row">
+                {requestItem.matchedUserPosture ? (
+                  <span className="role-chip role-chip-muted">
+                    {formatAccessPostureLabel(
+                      requestItem.matchedUserPosture.accessPosture
+                    )}
+                  </span>
+                ) : null}
+                {requestItem.matchedUser ? (
+                  <span className="role-chip role-chip-muted">
+                    User {requestItem.matchedUser.userId.slice(0, 8)}
+                  </span>
+                ) : (
+                  <span className="role-chip role-chip-muted">No matched user</span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    );
+
+  const layout = (
+    <section className="portal-admin-layout">
+      <article className="portal-panel portal-admin-list-panel">
+        <div className="portal-panel-header">
+          <div>
+            <p className="section-tag">Queue</p>
+            <h2>Scoped filters keep pending work visible.</h2>
+          </div>
+          <span className="role-chip role-chip-tonal">
+            {filteredRequests.length} visible
+          </span>
+        </div>
+
+        {isCompactLayout ? queueContent : filterFields}
+        {isCompactLayout ? filterFields : queueContent}
       </article>
 
-      <section className="portal-admin-layout">
-        <article className="portal-panel portal-admin-list-panel">
-          <div className="portal-panel-header">
-            <div>
-              <p className="section-tag">Queue</p>
-              <h2>Scoped filters keep pending work visible.</h2>
-            </div>
-            <span className="role-chip role-chip-tonal">
-              {filteredRequests.length} visible
-            </span>
+      <article className="portal-panel portal-admin-detail-panel">
+        {!selectedRequest ? (
+          <div className="portal-admin-empty-state">
+            <p className="section-tag">Selection</p>
+            <h2>Choose a request to inspect the full workflow context.</h2>
+            <p>
+              Request review stays local to this route, so the queue and the evidence
+              stay visible together.
+            </p>
           </div>
-
-          <div className="portal-admin-filter-grid">
-            <label className="auth-field">
-              <span>Status</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as RequestFilterState["status"];
-                  setFilters((current) => ({
-                    ...current,
-                    status: value
-                  }));
-                }}
-                value={filters.status}
-              >
-                <option value="all">All statuses</option>
-                <option value="pending">Pending first</option>
-                <option value="approved">Approved</option>
-                <option value="rejected">Rejected</option>
-              </select>
-            </label>
-            <label className="auth-field">
-              <span>Request kind</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as RequestFilterState["requestKind"];
-                  setFilters((current) => ({
-                    ...current,
-                    requestKind: value
-                  }));
-                }}
-                value={filters.requestKind}
-              >
-                <option value="all">All kinds</option>
-                <option value="access_request">Access requests</option>
-                <option value="identity_recovery">Recovery requests</option>
-              </select>
-            </label>
-            <label className="auth-field">
-              <span>Requested role</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as RequestFilterState["requestedRole"];
-                  setFilters((current) => ({
-                    ...current,
-                    requestedRole: value
-                  }));
-                }}
-                value={filters.requestedRole}
-              >
-                <option value="all">Any role</option>
-                <option value="collaborator">Collaborator</option>
-                <option value="helper">Helper</option>
-              </select>
-            </label>
-            <label className="auth-field">
-              <span>Reviewer state</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as RequestFilterState["reviewerState"];
-                  setFilters((current) => ({
-                    ...current,
-                    reviewerState: value
-                  }));
-                }}
-                value={filters.reviewerState}
-              >
-                <option value="all">Reviewed and unreviewed</option>
-                <option value="unreviewed">Unreviewed</option>
-                <option value="reviewed">Reviewed</option>
-              </select>
-            </label>
-            <label className="auth-field">
-              <span>Sort</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as RequestFilterState["sortOrder"];
-                  setFilters((current) => ({
-                    ...current,
-                    sortOrder: value
-                  }));
-                }}
-                value={filters.sortOrder}
-              >
-                <option value="oldest">Oldest submitted</option>
-                <option value="newest">Newest submitted</option>
-                <option value="recently_reviewed">Recently reviewed</option>
-              </select>
-            </label>
+        ) : isDetailLoading || !detail ? (
+          <div className="portal-admin-empty-state">
+            <p className="section-tag">Selection</p>
+            <h2>Loading request detail</h2>
+            <p>Pulling linked identities, related history, and audit echoes.</p>
           </div>
-
-          {filteredRequests.length === 0 ? (
-            <div className="portal-admin-empty-state">
-              <p className="section-tag">Empty state</p>
-              <h2>No requests match the current slice.</h2>
-              <p>Change the filters to bring back recently reviewed or different request kinds.</p>
-            </div>
-          ) : (
-            <div className="portal-admin-record-list">
-              {filteredRequests.map((requestItem) => {
-                const isSelected = requestItem.id === selectedRequestId;
-
-                return (
-                  <button
-                    className={`portal-admin-record${isSelected ? " portal-admin-record-active" : ""}`}
-                    key={requestItem.id}
-                    onClick={() => {
-                      setSelectedRequestId(requestItem.id);
-                    }}
-                    type="button"
-                  >
-                    <div className="portal-admin-record-header">
-                      <strong>{requestItem.email}</strong>
-                      <span
-                        className={`portal-state-badge portal-admin-status-${requestItem.status}`}
-                      >
-                        {formatRequestStatusLabel(requestItem.status)}
-                      </span>
-                    </div>
-                    <p className="portal-panel-muted">
-                      {requestItem.requestKind === "identity_recovery"
-                        ? `Identity recovery - preserve ${requestItem.requestedRole}`
-                        : `Access request - ${requestItem.requestedRole}`}
-                    </p>
-                    <div className="portal-admin-meta-row">
-                      <span>Submitted {formatDateTime(requestItem.createdAt)}</span>
-                      <span>
-                        {requestItem.reviewer ? `Reviewed by ${requestItem.reviewer.label}` : "Awaiting reviewer"}
-                      </span>
-                    </div>
-                    <div className="portal-filter-chip-row">
-                      {requestItem.matchedUserPosture ? (
-                        <span className="role-chip role-chip-muted">
-                          {formatAccessPostureLabel(
-                            requestItem.matchedUserPosture.accessPosture
-                          )}
-                        </span>
-                      ) : null}
-                      {requestItem.matchedUser ? (
-                        <span className="role-chip role-chip-muted">
-                          User {requestItem.matchedUser.userId.slice(0, 8)}
-                        </span>
-                      ) : (
-                        <span className="role-chip role-chip-muted">No matched user</span>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </article>
-
-        <article className="portal-panel portal-admin-detail-panel">
-          {!selectedRequest ? (
-            <div className="portal-admin-empty-state">
-              <p className="section-tag">Selection</p>
-              <h2>Choose a request to inspect the full workflow context.</h2>
-              <p>
-                Request review stays local to this route, so the queue and the evidence
-                stay visible together.
-              </p>
-            </div>
-          ) : isDetailLoading || !detail ? (
-            <div className="portal-admin-empty-state">
-              <p className="section-tag">Selection</p>
-              <h2>Loading request detail</h2>
-              <p>Pulling linked identities, related history, and audit echoes.</p>
-            </div>
-          ) : (
-            <AccessRequestDetailCard
-              detail={detail}
-              draft={
-                drafts[detail.id] ?? {
-                  approvedRole:
-                    detail.requestedRole === "collaborator" ? "collaborator" : "helper",
-                  decisionNote: detail.decisionNote ?? ""
-                }
+        ) : (
+          <AccessRequestDetailCard
+            detail={detail}
+            draft={
+              drafts[detail.id] ?? {
+                approvedRole:
+                  detail.requestedRole === "collaborator" ? "collaborator" : "helper",
+                decisionNote: detail.decisionNote ?? ""
               }
-              isMutating={isMutatingId === detail.id}
-              onApprove={() => {
-                void handleDecision("approve");
-              }}
-              onChangeDraft={(nextDraft) => {
-                setDrafts((current) => ({
-                  ...current,
-                  [detail.id]: nextDraft
-                }));
-              }}
-              onReject={() => {
-                void handleDecision("reject");
-              }}
-            />
-          )}
-        </article>
-      </section>
+            }
+            isMutating={isMutatingId === detail.id}
+            onApprove={() => {
+              void handleDecision("approve");
+            }}
+            onChangeDraft={(nextDraft) => {
+              setDrafts((current) => ({
+                ...current,
+                [detail.id]: nextDraft
+              }));
+            }}
+            onReject={() => {
+              void handleDecision("reject");
+            }}
+          />
+        )}
+      </article>
+    </section>
+  );
+
+  return (
+    <section className="portal-grid portal-grid-stack portal-grid-admin-workspace">
+      {isCompactLayout ? layout : introPanel}
+      {isCompactLayout ? introPanel : layout}
     </section>
   );
 }

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -9,6 +9,7 @@ import {
   summarizeUserPosture
 } from "../lib/portal-admin";
 import { usePortalPolling } from "../lib/portal-freshness";
+import { useCompactLayout } from "../lib/use-compact-layout";
 
 type PortalAdminUsersPanelProps = {
   email: string | null;
@@ -93,6 +94,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [users, setUsers] = useState<PortalAdminUserListItem[]>([]);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
+  const isCompactLayout = useCompactLayout();
   const {
     isPolling,
     lastUpdatedAt,
@@ -232,325 +234,338 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     );
   }
 
+  const introPanel = (
+    <article className="portal-panel">
+      <p className="section-tag">Admin users</p>
+      <h2>Inspect approved accounts and apply corrective access changes.</h2>
+      <p>
+        Signed in{email ? ` as ${email}` : ""}. This route is user-owned: inspect account
+        posture, request history, identity links, and the single MVP corrective action to revoke
+        an active contributor role.
+      </p>
+      <PortalFreshnessCard
+        isRefreshing={isPolling || isMutating}
+        lastUpdatedAt={lastUpdatedAt}
+        onRefresh={() => {
+          void pollNow().catch(() => {
+            // refreshUsers already exposes the visible error state.
+          });
+        }}
+        routeId="portal.admin.users"
+      />
+      {listError ? (
+        <p className="portal-admin-feedback portal-admin-feedback-error">{listError}</p>
+      ) : null}
+    </article>
+  );
+
+  const filterFields = (
+    <div className="portal-admin-filter-grid">
+      <label className="auth-field">
+        <span>Search</span>
+        <input
+          onChange={(event) => {
+            const value = event.currentTarget.value;
+            setFilters((current) => ({
+              ...current,
+              search: value
+            }));
+          }}
+          placeholder="Email, display name, or user id"
+          type="search"
+          value={filters.search}
+        />
+      </label>
+
+      <label className="auth-field">
+        <span>Access posture</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as UserFilters["accessPosture"];
+            setFilters((current) => ({
+              ...current,
+              accessPosture: value
+            }));
+          }}
+          value={filters.accessPosture}
+        >
+          <option value="all">All postures</option>
+          <option value="approved">Approved</option>
+          <option value="pending_request">Pending request</option>
+          <option value="review_history_only">Review history only</option>
+          <option value="no_active_role">No active role</option>
+        </select>
+      </label>
+
+      <label className="auth-field">
+        <span>Active role</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as UserFilters["activeRole"];
+            setFilters((current) => ({
+              ...current,
+              activeRole: value
+            }));
+          }}
+          value={filters.activeRole}
+        >
+          <option value="all">All roles</option>
+          <option value="helper">Helper</option>
+          <option value="collaborator">Collaborator</option>
+        </select>
+      </label>
+
+      <label className="auth-field">
+        <span>Identity provider</span>
+        <select
+          onChange={(event) => {
+            const value = event.currentTarget.value as UserFilters["identityProvider"];
+            setFilters((current) => ({
+              ...current,
+              identityProvider: value
+            }));
+          }}
+          value={filters.identityProvider}
+        >
+          <option value="all">Any provider</option>
+          <option value="cloudflare_github">GitHub</option>
+          <option value="cloudflare_google">Google</option>
+        </select>
+      </label>
+    </div>
+  );
+
+  const userList =
+    visibleUsers.length === 0 ? (
+      <article className="portal-admin-card portal-admin-card-empty">
+        <h3>No users match this slice.</h3>
+        <p>Adjust the directory filters to bring the relevant contributor accounts back in.</p>
+      </article>
+    ) : (
+      <div className="portal-admin-list">
+        {visibleUsers.map((item) => {
+          const isActive = item.userId === selectedUserId;
+
+          return (
+            <button
+              className={`portal-admin-card portal-admin-list-card${
+                isActive ? " portal-admin-list-card-active" : ""
+              }`}
+              key={item.userId}
+              onClick={() => {
+                setSelectedUserId(item.userId);
+                setActionMessage(null);
+              }}
+              type="button"
+            >
+              <div className="portal-admin-row">
+                <div>
+                  <p className="portal-action-title">
+                    {item.displayName ?? item.email}
+                  </p>
+                  <p className="portal-action-copy">{summarizeUserPosture(item)}</p>
+                </div>
+                <span className="role-chip role-chip-tonal">
+                  {item.activeRole?.role ?? item.accessPosture}
+                </span>
+              </div>
+              <p className="portal-admin-meta">{item.email}</p>
+              <div className="portal-admin-chip-row">
+                {item.linkedIdentityProviders.length === 0 ? (
+                  <span className="role-chip role-chip-muted">No linked identities</span>
+                ) : (
+                  item.linkedIdentityProviders.map((provider) => (
+                    <span className="role-chip role-chip-muted" key={provider}>
+                      {provider}
+                    </span>
+                  ))
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    );
+
+  const layout = (
+    <section className="portal-admin-layout">
+      <aside className="portal-admin-list-shell">
+        {isCompactLayout ? userList : filterFields}
+        {isCompactLayout ? filterFields : userList}
+      </aside>
+
+      <section className="portal-admin-detail-shell">
+        {detailError ? (
+          <article className="portal-admin-card portal-admin-card-empty">
+            <h3>User detail unavailable</h3>
+            <p>{detailError}</p>
+          </article>
+        ) : detailItem ? (
+          <>
+            <article className="portal-admin-card">
+              <div className="portal-admin-row">
+                <div>
+                  <p className="section-tag">User detail</p>
+                  <h3>{detailItem.displayName ?? detailItem.email}</h3>
+                </div>
+                <span className="role-chip role-chip-tonal">
+                  {detailItem.activeRole?.role ?? detailItem.accessPosture}
+                </span>
+              </div>
+              <p className="portal-admin-meta">
+                {detailItem.email} - user id {detailItem.userId}
+              </p>
+              <div className="portal-admin-chip-row">
+                <span className="role-chip role-chip-muted">
+                  Active sessions {detailItem.sessionPosture.activeSessionCount}
+                </span>
+                <span className="role-chip role-chip-muted">
+                  Latest session expiry {formatTimestamp(detailItem.sessionPosture.latestSessionExpiresAt)}
+                </span>
+              </div>
+              {actionMessage ? (
+                <p
+                  className={`portal-admin-feedback ${
+                    actionMessage.includes("could not") || actionMessage.includes("no active")
+                      ? "portal-admin-feedback-error"
+                      : "portal-admin-feedback-success"
+                  }`}
+                >
+                  {actionMessage}
+                </p>
+              ) : null}
+            </article>
+
+            <div className="portal-admin-two-column">
+              <article className="portal-admin-card">
+                <p className="section-tag">Linked identities</p>
+                <h3>Who can authenticate as this user</h3>
+                <div className="portal-admin-stack">
+                  {detailItem.linkedIdentities.map((identity) => (
+                    <article className="portal-admin-mini-card" key={identity.id}>
+                      <strong>{identity.provider}</strong>
+                      <p>{identity.providerEmail ?? identity.providerSubject}</p>
+                      <small>Last seen {formatTimestamp(identity.lastSeenAt)}</small>
+                    </article>
+                  ))}
+                </div>
+              </article>
+
+              <article className="portal-admin-card">
+                <p className="section-tag">Role history</p>
+                <h3>Grant and revocation posture</h3>
+                <div className="portal-admin-stack">
+                  {detailItem.roleGrantHistory.length === 0 ? (
+                    <p className="portal-action-copy">No role history has been recorded yet.</p>
+                  ) : (
+                    detailItem.roleGrantHistory.map((roleGrant) => (
+                      <article
+                        className="portal-admin-mini-card"
+                        key={`${roleGrant.role}-${roleGrant.grantedAt}`}
+                      >
+                        <strong>{roleGrant.role}</strong>
+                        <p>Granted {formatTimestamp(roleGrant.grantedAt)}</p>
+                        <small>
+                          {roleGrant.revokedAt
+                            ? `Revoked ${formatTimestamp(roleGrant.revokedAt)}`
+                            : "Still active"}
+                        </small>
+                      </article>
+                    ))
+                  )}
+                </div>
+              </article>
+            </div>
+
+            <article className="portal-admin-card">
+              <p className="section-tag">Corrective action</p>
+              <h3>Revoke the current contributor role from this user.</h3>
+              <p className="portal-action-copy">
+                This is the only MVP corrective action on the users route. It removes the active
+                helper or collaborator role and clears current sessions so the next sign-in
+                resolves the new posture cleanly.
+              </p>
+              <div className="auth-form">
+                <label className="auth-field">
+                  <span>Visible revocation reason</span>
+                  <textarea
+                    disabled={!detailItem.activeRole || isMutating}
+                    onChange={(event) => {
+                      setRevocationReason(event.currentTarget.value);
+                    }}
+                    rows={4}
+                    value={revocationReason}
+                  />
+                </label>
+              </div>
+              <div className="portal-request-actions">
+                <button
+                  className="button"
+                  disabled={!detailItem.activeRole || isMutating}
+                  onClick={() => {
+                    void handleRevoke();
+                  }}
+                  type="button"
+                >
+                  {isMutating ? "Revoking..." : "Revoke active role"}
+                </button>
+              </div>
+            </article>
+
+            <div className="portal-admin-two-column">
+              <article className="portal-admin-card">
+                <p className="section-tag">Request history</p>
+                <h3>How this posture was reached</h3>
+                <div className="portal-admin-stack">
+                  {detailItem.requestHistory.length === 0 ? (
+                    <p className="portal-action-copy">
+                      No request history is attached to this user yet.
+                    </p>
+                  ) : (
+                    detailItem.requestHistory.map((requestItem) => (
+                      <article className="portal-admin-mini-card" key={requestItem.id}>
+                        <strong>
+                          {requestItem.requestKind === "identity_recovery"
+                            ? "Identity recovery"
+                            : "Access request"}
+                        </strong>
+                        <p>{requestItem.decisionNote ?? requestItem.rationale ?? "No note recorded."}</p>
+                        <small>{formatTimestamp(requestItem.reviewedAt ?? requestItem.createdAt)}</small>
+                      </article>
+                    ))
+                  )}
+                </div>
+              </article>
+
+              <article className="portal-admin-card">
+                <p className="section-tag">Audit history</p>
+                <h3>Recent privileged events for this user</h3>
+                <div className="portal-admin-stack">
+                  {detailItem.auditHistory.map((entry) => (
+                    <article className="portal-admin-mini-card" key={entry.id}>
+                      <strong>{entry.eventId}</strong>
+                      <p>{entry.actor?.label ?? "System context"} - {entry.severity}</p>
+                      <small>{formatTimestamp(entry.createdAt)}</small>
+                    </article>
+                  ))}
+                </div>
+              </article>
+            </div>
+          </>
+        ) : (
+          <article className="portal-admin-card portal-admin-card-empty">
+            <h3>Select a user</h3>
+            <p>Choose a user row to inspect account posture, history, and corrective actions.</p>
+          </article>
+        )}
+      </section>
+    </section>
+  );
+
   return (
     <section className="portal-grid portal-grid-stack portal-grid-admin-workspace">
-      <article className="portal-panel">
-        <p className="section-tag">Admin users</p>
-        <h2>Inspect approved accounts and apply corrective access changes.</h2>
-        <p>
-          Signed in{email ? ` as ${email}` : ""}. This route is user-owned: inspect account
-          posture, request history, identity links, and the single MVP corrective action to revoke
-          an active contributor role.
-        </p>
-        <PortalFreshnessCard
-          isRefreshing={isPolling || isMutating}
-          lastUpdatedAt={lastUpdatedAt}
-          onRefresh={() => {
-            void pollNow().catch(() => {
-              // refreshUsers already exposes the visible error state.
-            });
-          }}
-          routeId="portal.admin.users"
-        />
-        {listError ? (
-          <p className="portal-admin-feedback portal-admin-feedback-error">{listError}</p>
-        ) : null}
-      </article>
-
-      <section className="portal-admin-layout">
-        <aside className="portal-admin-list-shell">
-          <div className="portal-admin-filter-grid">
-            <label className="auth-field">
-              <span>Search</span>
-              <input
-                onChange={(event) => {
-                  const value = event.currentTarget.value;
-                  setFilters((current) => ({
-                    ...current,
-                    search: value
-                  }));
-                }}
-                placeholder="Email, display name, or user id"
-                type="search"
-                value={filters.search}
-              />
-            </label>
-
-            <label className="auth-field">
-              <span>Access posture</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as UserFilters["accessPosture"];
-                  setFilters((current) => ({
-                    ...current,
-                    accessPosture: value
-                  }));
-                }}
-                value={filters.accessPosture}
-              >
-                <option value="all">All postures</option>
-                <option value="approved">Approved</option>
-                <option value="pending_request">Pending request</option>
-                <option value="review_history_only">Review history only</option>
-                <option value="no_active_role">No active role</option>
-              </select>
-            </label>
-
-            <label className="auth-field">
-              <span>Active role</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as UserFilters["activeRole"];
-                  setFilters((current) => ({
-                    ...current,
-                    activeRole: value
-                  }));
-                }}
-                value={filters.activeRole}
-              >
-                <option value="all">All roles</option>
-                <option value="helper">Helper</option>
-                <option value="collaborator">Collaborator</option>
-              </select>
-            </label>
-
-            <label className="auth-field">
-              <span>Identity provider</span>
-              <select
-                onChange={(event) => {
-                  const value = event.currentTarget.value as UserFilters["identityProvider"];
-                  setFilters((current) => ({
-                    ...current,
-                    identityProvider: value
-                  }));
-                }}
-                value={filters.identityProvider}
-              >
-                <option value="all">Any provider</option>
-                <option value="cloudflare_github">GitHub</option>
-                <option value="cloudflare_google">Google</option>
-              </select>
-            </label>
-          </div>
-
-          {visibleUsers.length === 0 ? (
-            <article className="portal-admin-card portal-admin-card-empty">
-              <h3>No users match this slice.</h3>
-              <p>Adjust the directory filters to bring the relevant contributor accounts back in.</p>
-            </article>
-          ) : (
-            <div className="portal-admin-list">
-              {visibleUsers.map((item) => {
-                const isActive = item.userId === selectedUserId;
-
-                return (
-                  <button
-                    className={`portal-admin-card portal-admin-list-card${
-                      isActive ? " portal-admin-list-card-active" : ""
-                    }`}
-                    key={item.userId}
-                    onClick={() => {
-                      setSelectedUserId(item.userId);
-                      setActionMessage(null);
-                    }}
-                    type="button"
-                  >
-                    <div className="portal-admin-row">
-                      <div>
-                        <p className="portal-action-title">
-                          {item.displayName ?? item.email}
-                        </p>
-                        <p className="portal-action-copy">{summarizeUserPosture(item)}</p>
-                      </div>
-                      <span className="role-chip role-chip-tonal">
-                        {item.activeRole?.role ?? item.accessPosture}
-                      </span>
-                    </div>
-                    <p className="portal-admin-meta">{item.email}</p>
-                    <div className="portal-admin-chip-row">
-                      {item.linkedIdentityProviders.length === 0 ? (
-                        <span className="role-chip role-chip-muted">No linked identities</span>
-                      ) : (
-                        item.linkedIdentityProviders.map((provider) => (
-                          <span className="role-chip role-chip-muted" key={provider}>
-                            {provider}
-                          </span>
-                        ))
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </aside>
-
-        <section className="portal-admin-detail-shell">
-          {detailError ? (
-            <article className="portal-admin-card portal-admin-card-empty">
-              <h3>User detail unavailable</h3>
-              <p>{detailError}</p>
-            </article>
-          ) : detailItem ? (
-            <>
-              <article className="portal-admin-card">
-                <div className="portal-admin-row">
-                  <div>
-                    <p className="section-tag">User detail</p>
-                    <h3>{detailItem.displayName ?? detailItem.email}</h3>
-                  </div>
-                  <span className="role-chip role-chip-tonal">
-                    {detailItem.activeRole?.role ?? detailItem.accessPosture}
-                  </span>
-                </div>
-                <p className="portal-admin-meta">
-                  {detailItem.email} - user id {detailItem.userId}
-                </p>
-                <div className="portal-admin-chip-row">
-                  <span className="role-chip role-chip-muted">
-                    Active sessions {detailItem.sessionPosture.activeSessionCount}
-                  </span>
-                  <span className="role-chip role-chip-muted">
-                    Latest session expiry {formatTimestamp(detailItem.sessionPosture.latestSessionExpiresAt)}
-                  </span>
-                </div>
-                {actionMessage ? (
-                  <p
-                    className={`portal-admin-feedback ${
-                      actionMessage.includes("could not") || actionMessage.includes("no active")
-                        ? "portal-admin-feedback-error"
-                        : "portal-admin-feedback-success"
-                    }`}
-                  >
-                    {actionMessage}
-                  </p>
-                ) : null}
-              </article>
-
-              <div className="portal-admin-two-column">
-                <article className="portal-admin-card">
-                  <p className="section-tag">Linked identities</p>
-                  <h3>Who can authenticate as this user</h3>
-                  <div className="portal-admin-stack">
-                    {detailItem.linkedIdentities.map((identity) => (
-                      <article className="portal-admin-mini-card" key={identity.id}>
-                        <strong>{identity.provider}</strong>
-                        <p>{identity.providerEmail ?? identity.providerSubject}</p>
-                        <small>Last seen {formatTimestamp(identity.lastSeenAt)}</small>
-                      </article>
-                    ))}
-                  </div>
-                </article>
-
-                <article className="portal-admin-card">
-                  <p className="section-tag">Role history</p>
-                  <h3>Grant and revocation posture</h3>
-                  <div className="portal-admin-stack">
-                    {detailItem.roleGrantHistory.length === 0 ? (
-                      <p className="portal-action-copy">No role history has been recorded yet.</p>
-                    ) : (
-                      detailItem.roleGrantHistory.map((roleGrant) => (
-                        <article
-                          className="portal-admin-mini-card"
-                          key={`${roleGrant.role}-${roleGrant.grantedAt}`}
-                        >
-                          <strong>{roleGrant.role}</strong>
-                          <p>Granted {formatTimestamp(roleGrant.grantedAt)}</p>
-                          <small>
-                            {roleGrant.revokedAt
-                              ? `Revoked ${formatTimestamp(roleGrant.revokedAt)}`
-                              : "Still active"}
-                          </small>
-                        </article>
-                      ))
-                    )}
-                  </div>
-                </article>
-              </div>
-
-              <article className="portal-admin-card">
-                <p className="section-tag">Corrective action</p>
-                <h3>Revoke the current contributor role from this user.</h3>
-                <p className="portal-action-copy">
-                  This is the only MVP corrective action on the users route. It removes the active
-                  helper or collaborator role and clears current sessions so the next sign-in
-                  resolves the new posture cleanly.
-                </p>
-                <div className="auth-form">
-                  <label className="auth-field">
-                    <span>Visible revocation reason</span>
-                    <textarea
-                      disabled={!detailItem.activeRole || isMutating}
-                      onChange={(event) => {
-                        setRevocationReason(event.currentTarget.value);
-                      }}
-                      rows={4}
-                      value={revocationReason}
-                    />
-                  </label>
-                </div>
-                <div className="portal-request-actions">
-                  <button
-                    className="button"
-                    disabled={!detailItem.activeRole || isMutating}
-                    onClick={() => {
-                      void handleRevoke();
-                    }}
-                    type="button"
-                  >
-                    {isMutating ? "Revoking..." : "Revoke active role"}
-                  </button>
-                </div>
-              </article>
-
-              <div className="portal-admin-two-column">
-                <article className="portal-admin-card">
-                  <p className="section-tag">Request history</p>
-                  <h3>How this posture was reached</h3>
-                  <div className="portal-admin-stack">
-                    {detailItem.requestHistory.length === 0 ? (
-                      <p className="portal-action-copy">
-                        No request history is attached to this user yet.
-                      </p>
-                    ) : (
-                      detailItem.requestHistory.map((requestItem) => (
-                        <article className="portal-admin-mini-card" key={requestItem.id}>
-                          <strong>
-                            {requestItem.requestKind === "identity_recovery"
-                              ? "Identity recovery"
-                              : "Access request"}
-                          </strong>
-                          <p>{requestItem.decisionNote ?? requestItem.rationale ?? "No note recorded."}</p>
-                          <small>{formatTimestamp(requestItem.reviewedAt ?? requestItem.createdAt)}</small>
-                        </article>
-                      ))
-                    )}
-                  </div>
-                </article>
-
-                <article className="portal-admin-card">
-                  <p className="section-tag">Audit history</p>
-                  <h3>Recent privileged events for this user</h3>
-                  <div className="portal-admin-stack">
-                    {detailItem.auditHistory.map((entry) => (
-                      <article className="portal-admin-mini-card" key={entry.id}>
-                        <strong>{entry.eventId}</strong>
-                        <p>{entry.actor?.label ?? "System context"} - {entry.severity}</p>
-                        <small>{formatTimestamp(entry.createdAt)}</small>
-                      </article>
-                    ))}
-                  </div>
-                </article>
-              </div>
-            </>
-          ) : (
-            <article className="portal-admin-card portal-admin-card-empty">
-              <h3>Select a user</h3>
-              <p>Choose a user row to inspect account posture, history, and corrective actions.</p>
-            </article>
-          )}
-        </section>
-      </section>
+      {isCompactLayout ? layout : introPanel}
+      {isCompactLayout ? introPanel : layout}
     </section>
   );
 }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1826,39 +1826,12 @@ a.button-secondary {
     border-radius: 0;
   }
 
-  .portal-grid-admin-workspace {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .portal-grid-admin-workspace > .portal-admin-layout {
-    order: 1;
-  }
-
-  .portal-grid-admin-workspace > .portal-panel {
-    order: 2;
-  }
-
-  .portal-grid-admin-workspace .portal-admin-list-panel,
-  .portal-grid-admin-workspace .portal-admin-list-shell {
-    display: flex;
-    flex-direction: column;
-  }
-
   .portal-grid-admin-workspace .portal-admin-list-panel {
     padding-top: 8px;
     gap: 8px;
   }
 
-  .portal-grid-admin-workspace .portal-admin-record-list,
-  .portal-grid-admin-workspace .portal-admin-list,
-  .portal-grid-admin-workspace .portal-admin-list-panel > .portal-admin-empty-state,
-  .portal-grid-admin-workspace .portal-admin-list-shell > .portal-admin-card-empty {
-    order: 1;
-  }
-
   .portal-grid-admin-workspace .portal-admin-filter-grid {
-    order: 2;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 


### PR DESCRIPTION
## Summary
- move the mobile admin layout ahead of the descriptive intro block
- show admin queue rows before the mobile filter stack
- keep the desktop admin layouts and existing portal shell intact

Closes #579.

## Verification
- bun --cwd apps/web build
- bun run check:bidi
- targeted mobile browser QA on `/admin/access-requests` and `/admin/users` at `390x844`