### PR TITLE
Fix web shared-package resolution on fresh checkouts

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@paretoproof/shared": [
+        "../../packages/shared/src/index.ts"
+      ]
+    },
     "types": [
       "vite/client"
     ]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@paretoproof/shared": path.resolve(__dirname, "../../packages/shared/src/index.ts")
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- fix `apps/web` so Vite resolves `@paretoproof/shared` directly from the workspace source instead of requiring `packages/shared/dist`
- align `apps/web` TypeScript path resolution with the same workspace-source entry so fresh-checkout typecheck also works
- preserve the existing shared contract surface without changing runtime auth or API behavior

## Linked Issues
- Closes #583

## Verification
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- `bun run check:bidi`
- fresh dev-server verification against a new Vite port, loading the auth surface successfully after the original `@paretoproof/shared` resolution failure was removed