### PR TITLE
Keep auth sign-in choices visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2004,3 +2004,65 @@ a.button-secondary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+@media (max-width: 420px) {
+  .auth-shell {
+    align-items: start;
+    padding: 8px 0;
+  }
+
+  .auth-card,
+  .auth-inline-status {
+    padding: 16px;
+  }
+
+  .auth-card {
+    gap: 16px;
+  }
+
+  .auth-card-intro {
+    gap: 10px;
+  }
+
+  .auth-card h1,
+  .auth-inline-status h1 {
+    font-size: clamp(1.75rem, 9vw, 2.4rem);
+    line-height: 0.98;
+  }
+
+  .auth-lead,
+  .auth-panel-copy,
+  .auth-card-footer p {
+    font-size: 0.95rem;
+  }
+
+  .auth-provider-panel {
+    padding: 16px;
+    gap: 10px;
+  }
+
+  .auth-provider-button {
+    grid-template-columns: 38px minmax(0, 1fr) 18px;
+    gap: 10px;
+    padding: 12px 0;
+  }
+
+  .auth-provider-mark {
+    width: 38px;
+    height: 38px;
+  }
+
+  .auth-check-list {
+    gap: 10px;
+  }
+
+  .auth-check-list li {
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .auth-check-mark {
+    width: 28px;
+    height: 28px;
+  }
+}


### PR DESCRIPTION
## Summary
- tighten the auth entry card and provider panels only at the narrowest breakpoint so the first sign-in option is visible on small phones
- keep the existing provider choices and notes panel structure intact while reducing auth-specific copy and spacing density
- avoid changing the public home, project-pack, or portal layout systems outside the auth surface

## Linked Issues
- Closes #585

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/?surface=auth`, `/`, and `/project`
  - `320x568`: auth first provider moved from bottom `661.3125` to `543.625`
  - `390x844`: auth first provider remains visible with bottom `441.34375`
  - `/project` still fits at `390x844` with pill row bottom `798.9375`
  - note: `/` at `320x568` still keeps its primary CTA below the fold; that appears to be separate follow-on work, not fallout from this auth-only change