### PR TITLE
Keep apex home CTA visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2006,6 +2006,58 @@ a.button-secondary {
 }
 
 @media (max-width: 420px) {
+  .site-shell:not(.site-project-shell) {
+    gap: 16px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-header,
+  .site-shell:not(.site-project-shell) .site-hero,
+  .site-shell:not(.site-project-shell) .site-footer {
+    padding: 16px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-header {
+    gap: 12px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-header-main,
+  .site-shell:not(.site-project-shell) .site-header-actions,
+  .site-shell:not(.site-project-shell) .site-hero-copy {
+    gap: 10px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-hero {
+    gap: 14px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-hero-copy h1 {
+    font-size: clamp(1.9rem, 9.5vw, 2.6rem);
+    line-height: 0.97;
+  }
+
+  .site-shell:not(.site-project-shell) .site-lead {
+    font-size: 0.95rem;
+  }
+
+  .site-shell:not(.site-project-shell) .hero-actions {
+    gap: 10px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-signal-column {
+    gap: 0;
+    padding-top: 10px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-signal-row {
+    gap: 12px;
+    padding: 12px 0;
+  }
+
+  .site-shell:not(.site-project-shell) .site-signal-value {
+    min-width: 4.75rem;
+    font-size: 1rem;
+  }
+
   .auth-shell {
     align-items: start;
     padding: 8px 0;
@@ -2064,5 +2116,32 @@ a.button-secondary {
   .auth-check-mark {
     width: 28px;
     height: 28px;
+  }
+}
+
+@media (max-width: 360px) {
+  .site-shell:not(.site-project-shell) .site-header,
+  .site-shell:not(.site-project-shell) .site-hero,
+  .site-shell:not(.site-project-shell) .site-footer {
+    padding: 14px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-header-main,
+  .site-shell:not(.site-project-shell) .site-header-actions,
+  .site-shell:not(.site-project-shell) .site-hero-copy {
+    gap: 6px;
+  }
+
+  .site-shell:not(.site-project-shell) .site-tagline {
+    display: none;
+  }
+
+  .site-shell:not(.site-project-shell) .site-tagline,
+  .site-shell:not(.site-project-shell) .site-lead {
+    font-size: 0.92rem;
+  }
+
+  .site-shell:not(.site-project-shell) .site-hero-copy h1 {
+    font-size: clamp(1.75rem, 9vw, 2.3rem);
   }
 }


### PR DESCRIPTION
## Summary
- tighten the apex home hero only on very small phones so the primary CTA row is visible without scrolling
- scope the new compression to the non-project public landing so the recent auth and project-pack mobile fixes remain untouched
- trim only nonessential landing chrome at the smallest breakpoint, including the header tagline, instead of changing the core CTA content

## Linked Issues
- Closes #587

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/`, `/?surface=auth`, and `/project`
  - `320x568`: home primary CTA moved from bottom `706.90625` before any fixes, to `643.15625` after the first pass, to `556.53125` on the final head
  - `320x568`: auth first provider remains visible with bottom `543.625`
  - `390x844`: home CTA, auth first provider, and `/project` pill row all remain inside the initial viewport
  - note: `/project` at `320x568` still overflows, which appears to be separate follow-on work outside this issue