### PR TITLE
Keep project-pack entry visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2120,6 +2120,91 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .site-project-shell {
+    gap: 14px;
+  }
+
+  .site-project-shell .site-header,
+  .site-project-shell .site-hero,
+  .site-project-shell .site-project-section,
+  .site-project-shell .site-footer {
+    padding: 14px;
+  }
+
+  .site-project-shell .site-header {
+    gap: 8px;
+    padding-bottom: 10px;
+  }
+
+  .site-project-shell .site-header-main,
+  .site-project-shell .site-header-actions,
+  .site-project-shell .site-hero-copy {
+    gap: 6px;
+  }
+
+  .site-project-shell .site-tagline,
+  .site-project-shell .site-primary-nav {
+    display: none;
+  }
+
+  .site-project-shell .site-brand {
+    gap: 10px;
+  }
+
+  .site-project-shell .site-brand-mark {
+    width: 38px;
+    height: 38px;
+  }
+
+  .site-project-shell .button,
+  .site-project-shell a.button {
+    min-height: 2.5rem;
+    padding: 0.6rem 0.9rem;
+    font-size: 0.92rem;
+  }
+
+  .site-project-shell .site-hero {
+    gap: 12px;
+    padding-top: 12px;
+  }
+
+  .site-project-shell .site-hero-copy h1 {
+    font-size: clamp(1.68rem, 8.7vw, 2.2rem);
+    line-height: 0.98;
+  }
+
+  .site-project-shell .site-lead {
+    font-size: 0.92rem;
+  }
+
+  .site-project-shell .site-pill-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .site-project-shell .site-pill-link {
+    min-height: 1.9rem;
+    padding: 0.36rem 0.68rem;
+    font-size: 0.82rem;
+    text-align: center;
+  }
+
+  .site-project-shell .site-signal-column {
+    gap: 0;
+    padding-top: 8px;
+  }
+
+  .site-project-shell .site-signal-row {
+    gap: 12px;
+    padding: 10px 0;
+  }
+
+  .site-project-shell .site-signal-value {
+    min-width: 4.25rem;
+    font-size: 1rem;
+  }
+
   .site-shell:not(.site-project-shell) .site-header,
   .site-shell:not(.site-project-shell) .site-hero,
   .site-shell:not(.site-project-shell) .site-footer {


### PR DESCRIPTION
## Summary
- tighten the `/project` route specifically on very small phones so the three-section pill row is visible in the initial viewport
- keep the recent apex-home and auth small-phone fixes intact by scoping the new compression to `.site-project-shell`
- override the inherited stacked mobile pill layout on the smallest project breakpoint so the section pills stay in a compact three-column row

## Linked Issues
- Closes #589

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/project`, `/`, and `/?surface=auth`
  - `320x568`: `/project` pill row moved from bottom `882.046875` before the fix, to `610.828125` after the first project pass, to `554.828125` on the final head
  - `320x568`: home primary CTA still fits with bottom `556.53125`
  - `320x568`: auth first provider still fits with bottom `543.625`
  - `390x844`: `/project`, home, and auth all remain inside the initial viewport