### PR TITLE
Keep profile save action visible on mobile

### DIFF
--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -13,6 +13,7 @@ import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import { createApiFormBody } from "../lib/api-form";
 import { isLocalHostname } from "../lib/surface";
+import { useCompactLayout } from "../lib/use-compact-layout";
 
 type PortalProfilePanelProps = {
   email: string | null;
@@ -199,6 +200,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
   );
   const [isSaving, setIsSaving] = useState(false);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
+  const isCompactLayout = useCompactLayout(480);
 
   useEffect(() => {
     let cancelled = false;
@@ -441,12 +443,16 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
       <article className="portal-panel">
         <p className="eyebrow">Contributor profile</p>
         <h2>Your details</h2>
-        <p>
-          Update the supported contributor details and attach an extra GitHub or Google
-          sign-in method without changing your approved portal account.
-        </p>
-        <PortalFreshnessCard lastUpdatedAt={lastUpdatedAt} routeId="portal.profile" />
-        <form className="auth-form" onSubmit={handleSave}>
+        {!isCompactLayout ? (
+          <p>
+            Update the supported contributor details and attach an extra GitHub or Google
+            sign-in method without changing your approved portal account.
+          </p>
+        ) : null}
+        <form
+          className={`auth-form${isCompactLayout ? " portal-profile-form-compact" : ""}`}
+          onSubmit={handleSave}
+        >
           <label className="auth-field">
             <span>Display name</span>
             <input
@@ -459,20 +465,36 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
               value={displayNameInput}
             />
           </label>
-          <label className="auth-field">
-            <span>Primary email</span>
-            <input
-              className="auth-input"
-              disabled
-              name="email"
-              value={profile.email ?? ""}
-            />
-          </label>
+          {!isCompactLayout ? (
+            <label className="auth-field">
+              <span>Primary email</span>
+              <input
+                className="auth-input"
+                disabled
+                name="email"
+                value={profile.email ?? ""}
+              />
+            </label>
+          ) : null}
           {errorMessage ? <p className="form-error">{errorMessage}</p> : null}
           <button className="button" disabled={isSaving} type="submit">
             {isSaving ? "Saving..." : "Save profile"}
           </button>
+          {isCompactLayout ? (
+            <p className="portal-panel-muted">
+              Primary email: <strong>{profile.email ?? "No email available"}</strong>
+            </p>
+          ) : null}
         </form>
+        {isCompactLayout ? (
+          <PortalFreshnessCard lastUpdatedAt={lastUpdatedAt} routeId="portal.profile" />
+        ) : null}
+        {isCompactLayout ? (
+          <p className="portal-panel-muted">
+            Attach an extra GitHub or Google sign-in method below without changing the
+            approved portal account.
+          </p>
+        ) : null}
       </article>
 
       <article className="portal-panel">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -615,6 +615,11 @@ a.button-secondary {
   margin-top: 8px;
 }
 
+.portal-profile-form-compact {
+  gap: 12px;
+  margin-top: 0;
+}
+
 .auth-field {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
## Summary
- surface the profile form controls before the heavier freshness/status block on compact layouts
- keep the full profile explanation and disabled primary-email field on wider layouts while using a tighter compact form on mobile
- preserve the existing `/runs` compact portal behavior while bringing `Save profile` into the initial viewport on small phones

## Linked Issues
- Closes #593

## Verification
- `bun install`
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/profile` and `/runs`
  - `/profile` at `320x568`: `Save profile` moved from bottom `996.578125` to `562.8125`
  - `/profile` at `390x844`: `Save profile` moved from bottom `951.96875` to `569.390625`
  - `/runs` `Export CSV` remained visible at both `320x568` and `390x844`