### PR TITLE
Keep launch preflight controls visible on mobile

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -36,6 +36,7 @@ import {
 import { usePortalPolling } from "../lib/portal-freshness";
 import { evaluationVerdictLabels, runLifecycleStateLabels } from "../lib/results-state";
 import { buildPortalUrl } from "../lib/surface";
+import { useCompactLayout } from "../lib/use-compact-layout";
 
 type PortalBenchmarkOpsSurfaceProps = {
   activeRouteId: string;
@@ -744,6 +745,7 @@ function PortalLaunchSurface({
   selection: LaunchSelectionState;
   setSelection: Dispatch<SetStateAction<LaunchSelectionState>>;
 }) {
+  const isCompactLayout = useCompactLayout(480);
   const benchmark = loadState.data?.benchmarks.find(
     (item) => item.benchmarkVersionId === selection.benchmarkVersionId
   );
@@ -753,24 +755,30 @@ function PortalLaunchSurface({
 
   return (
     <section className="portal-workspace-grid">
-      <article className="portal-panel portal-surface-main">
+      <article
+        className={`portal-panel portal-surface-main${
+          isCompactLayout ? " portal-launch-panel-compact" : ""
+        }`}
+      >
         <div className="portal-panel-header">
           <div>
-            <p className="section-tag">Create run intent</p>
+            {!isCompactLayout ? <p className="section-tag">Create run intent</p> : null}
             <h2>Launch stays focused on preflight, not history.</h2>
           </div>
           <span className="role-chip role-chip-tonal">
             {loadState.data?.submissionMode ?? "preflight_only"}
           </span>
         </div>
-        <PortalFreshnessCard
-          isRefreshing={loadState.isLoading}
-          lastUpdatedAt={loadState.lastUpdatedAt}
-          onRefresh={() => {
-            void onRefresh();
-          }}
-          routeId={activeRouteId}
-        />
+        {!isCompactLayout ? (
+          <PortalFreshnessCard
+            isRefreshing={loadState.isLoading}
+            lastUpdatedAt={loadState.lastUpdatedAt}
+            onRefresh={() => {
+              void onRefresh();
+            }}
+            routeId={activeRouteId}
+          />
+        ) : null}
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
         <div className="portal-form-grid">
           <label className="portal-field">
@@ -822,6 +830,16 @@ function PortalLaunchSurface({
             </select>
           </label>
         </div>
+        {isCompactLayout ? (
+          <PortalFreshnessCard
+            isRefreshing={loadState.isLoading}
+            lastUpdatedAt={loadState.lastUpdatedAt}
+            onRefresh={() => {
+              void onRefresh();
+            }}
+            routeId={activeRouteId}
+          />
+        ) : null}
         {benchmark && modelConfig ? (
           <div className="portal-results-contract-grid">
             <article className="portal-results-contract-card">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -955,6 +955,15 @@ a.button-secondary {
   padding-top: 8px;
 }
 
+.portal-launch-panel-compact {
+  gap: 6px;
+  padding-top: 12px;
+}
+
+.portal-launch-panel-compact .portal-form-grid {
+  margin-top: -2px;
+}
+
 .portal-grid-profile-compact .portal-profile-form-panel {
   gap: 8px;
 }


### PR DESCRIPTION
## Summary
- move the launch preflight selectors ahead of the heavier freshness block on compact/mobile layouts
- tighten the compact launch panel spacing so the first benchmark-package selector fits inside the initial small-phone viewport
- preserve the recent `/workers` and `/runs/:runId` mobile fit while keeping the desktop launch layout intact

## Linked Issues
- Closes #597

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/launch`, `/workers`, and `/runs/PP-318`
  - `/launch` at `320x568`: first selector moved from bottom `872.703125` to `567.171875`
  - `/launch` at `390x844`: first selector moved from bottom `823.28125` to `517.75`
  - `/workers` `Jump to runs` stayed visible at `320x568` and `390x844`
  - `/runs/PP-318` `Back to runs` stayed visible at `320x568` and `390x844`