### PR TITLE
Render the public benchmark routes instead of apex home

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const originalWindow = globalThis.window;
+
+function setWindowUrl(url) {
+  globalThis.window = {
+    location: new URL(url)
+  };
+}
+
+function renderPublicSiteAt(url) {
+  setWindowUrl(url);
+}
+
+async function loadPublicSiteModule() {
+  return import(`./public-site.tsx?test=${Date.now()}`);
+}
+
+async function renderPublicSiteAt(url) {
+  setWindowUrl(url);
+  const { PublicSite } = await loadPublicSiteModule();
+  return renderToStaticMarkup(PublicSite());
+}
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
+
+describe("resolvePublicSiteRoute", () => {
+  it("routes /benchmarks to the benchmark index", async () => {
+    setWindowUrl("http://127.0.0.1/");
+    const { resolvePublicSiteRoute } = await loadPublicSiteModule();
+
+    expect(resolvePublicSiteRoute("/benchmarks")).toEqual({ kind: "benchmarks" });
+  });
+
+  it("routes /reports/:benchmarkVersionId to the release summary view", async () => {
+    setWindowUrl("http://127.0.0.1/");
+    const { resolvePublicSiteRoute } = await loadPublicSiteModule();
+
+    expect(resolvePublicSiteRoute("/reports/problem-9-v1")).toEqual({
+      benchmarkVersionId: "problem-9-v1",
+      kind: "report"
+    });
+  });
+});
+
+describe("PublicSite", () => {
+  it("renders the benchmark index on /benchmarks", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/benchmarks");
+
+    expect(html).toContain("Read the current public benchmark slices");
+    expect(html).toContain("Problem 9");
+    expect(html).not.toContain("Measure frontier reasoning with reproducible proof workflows.");
+  });
+
+  it("renders the release summary on /reports/:benchmarkVersionId", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/reports/problem-9-v1");
+
+    expect(html).toContain("Problem 9 public release");
+    expect(html).toContain("One release table, presented as calm mobile-safe rows.");
+    expect(html).not.toContain("Measure frontier reasoning with reproducible proof workflows.");
+  });
+
+  it("keeps the project pack route intact", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/project");
+
+    expect(html).toContain("One public pack for project context, contributor entry, and contact rules.");
+  });
+});

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -5,6 +5,121 @@ const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discuss
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
 
 const projectRoute = "/project";
+const benchmarksRoute = "/benchmarks";
+const reportsRoutePrefix = "/reports/";
+
+const publicBenchmarks = [
+  {
+    benchmarkVersionId: "problem-9-v1",
+    description:
+      "Offline Lean proof-generation bundle focused on reproducible execution, failure taxonomy, and benchmark-package integrity.",
+    headlineMetric: "61% pass rate",
+    latestReleaseLabel: "Release 2026-03",
+    releaseStatus: "complete",
+    scopeNote: "Single released slice covering the current Problem 9 proof-generation bundle.",
+    taskType: "Proof generation",
+    title: "Problem 9"
+  },
+  {
+    benchmarkVersionId: "statement-formalization-pilot-v1",
+    description:
+      "Pilot release for public statement-formalization reporting while canonical artifact and verification contracts stabilize.",
+    headlineMetric: "Partial publication",
+    latestReleaseLabel: "Release 2026-02",
+    releaseStatus: "partial",
+    scopeNote: "Published subset only while the remaining benchmark package stays withheld for methodology review.",
+    taskType: "Statement formalization",
+    title: "Statement Formalization Pilot"
+  }
+] as const;
+
+const publicBenchmarkReports = {
+  "problem-9-v1": {
+    benchmarkVersionId: "problem-9-v1",
+    completeness: "complete",
+    dateLabel: "March 2026",
+    description:
+      "Public release for the Problem 9 proof-generation benchmark slice under the current offline run-bundle contract.",
+    includedConfigs: "3 configs",
+    latestStatus: "mixed",
+    methodologyHref: `${publicDocsBaseUrl}/public-benchmark-reporting-ux-baseline.md`,
+    qualityNotice:
+      "Complete public release for the current disclosed slice. Held-out or internal-only benchmark material remains out of scope for this report.",
+    qualityState: "complete",
+    releaseLabel: "Release 2026-03",
+    results: [
+      {
+        displayLabel: "OpenAI GPT-OSS",
+        includedCount: "36 / 59 solved",
+        providerLabel: "OpenAI family",
+        status: "mixed",
+        updatedAt: "Updated Mar 2026"
+      },
+      {
+        displayLabel: "Claude Sonnet",
+        includedCount: "31 / 59 solved",
+        providerLabel: "Anthropic family",
+        status: "mixed",
+        updatedAt: "Updated Mar 2026"
+      },
+      {
+        displayLabel: "Gemini 2.5 Pro",
+        includedCount: "24 / 59 solved",
+        providerLabel: "Google family",
+        status: "fail",
+        updatedAt: "Updated Mar 2026"
+      }
+    ],
+    scopeNote:
+      "Includes the currently disclosed proof-generation benchmark package and released model configurations only.",
+    summaryCards: [
+      { label: "Configs included", value: "03" },
+      { label: "Evaluated items", value: "59" },
+      { label: "Solved count", value: "36 top score" },
+      { label: "Release state", value: "complete" }
+    ],
+    title: "Problem 9 public release"
+  },
+  "statement-formalization-pilot-v1": {
+    benchmarkVersionId: "statement-formalization-pilot-v1",
+    completeness: "partial",
+    dateLabel: "February 2026",
+    description:
+      "Public pilot release for statement-formalization reporting while the remaining package stays withheld for methodology and verification review.",
+    includedConfigs: "2 configs",
+    latestStatus: "partial",
+    methodologyHref: `${publicDocsBaseUrl}/public-benchmark-reporting-ux-baseline.md`,
+    qualityNotice:
+      "Partial publication: some intended rows are still withheld while the canonical formal-statement verification policy is finalized.",
+    qualityState: "partial",
+    releaseLabel: "Release 2026-02",
+    results: [
+      {
+        displayLabel: "OpenAI GPT-OSS",
+        includedCount: "18 / 34 solved",
+        providerLabel: "OpenAI family",
+        status: "mixed",
+        updatedAt: "Updated Feb 2026"
+      },
+      {
+        displayLabel: "Claude Sonnet",
+        includedCount: "14 / 34 solved",
+        providerLabel: "Anthropic family",
+        status: "mixed",
+        updatedAt: "Updated Feb 2026"
+      }
+    ],
+    scopeNote:
+      "Covers only the public pilot subset. Withheld statement sets are excluded from all shown metrics.",
+    summaryCards: [
+      { label: "Configs included", value: "02" },
+      { label: "Evaluated items", value: "34" },
+      { label: "Solved count", value: "18 top score" },
+      { label: "Release state", value: "partial" }
+    ],
+    title: "Statement formalization pilot release"
+  }
+} as const;
 
 const publicSignals = [
   {
@@ -192,6 +307,35 @@ function buildProjectSectionUrl(sectionId: string) {
   return buildPublicUrl(`${projectRoute}#${sectionId}`);
 }
 
+function buildBenchmarkReportUrl(benchmarkVersionId: string) {
+  return buildPublicUrl(`${reportsRoutePrefix}${encodeURIComponent(benchmarkVersionId)}`);
+}
+
+function formatReleaseStatus(status: string) {
+  return status.replaceAll("_", " ");
+}
+
+export function resolvePublicSiteRoute(pathname: string) {
+  if (pathname === projectRoute || pathname.startsWith(`${projectRoute}/`)) {
+    return { kind: "project" as const };
+  }
+
+  if (pathname === benchmarksRoute || pathname.startsWith(`${benchmarksRoute}/`)) {
+    return { kind: "benchmarks" as const };
+  }
+
+  if (pathname.startsWith(reportsRoutePrefix)) {
+    const benchmarkVersionId = pathname.slice(reportsRoutePrefix.length).split("/")[0] ?? "";
+
+    return {
+      benchmarkVersionId: decodeURIComponent(benchmarkVersionId),
+      kind: "report" as const
+    };
+  }
+
+  return { kind: "home" as const };
+}
+
 const footerProjectLinks = [
   { id: "overview", label: "Project overview" },
   { id: "contributors", label: "Contributor path" },
@@ -206,6 +350,10 @@ function PublicHeader({
   homeHref?: string;
 }) {
   const isProjectRoute = currentPath === projectRoute || currentPath.startsWith(`${projectRoute}/`);
+  const isBenchmarksRoute =
+    currentPath === benchmarksRoute ||
+    currentPath.startsWith(`${benchmarksRoute}/`) ||
+    currentPath.startsWith(reportsRoutePrefix);
 
   return (
     <header className="site-header">
@@ -228,6 +376,12 @@ function PublicHeader({
             href={buildPublicUrl(projectRoute)}
           >
             Project
+          </a>
+          <a
+            className={`site-nav-link${isBenchmarksRoute ? " site-nav-link-active" : ""}`}
+            href={buildPublicUrl(benchmarksRoute)}
+          >
+            Benchmarks
           </a>
         </nav>
       </div>
@@ -349,6 +503,249 @@ function PublicLanding() {
             <p>{band.body}</p>
           </article>
         ))}
+      </section>
+
+      <PublicFooter isProjectRoute={false} />
+    </main>
+  );
+}
+
+function PublicBenchmarkIndex() {
+  return (
+    <main className="site-shell">
+      <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
+
+      <section className="site-hero">
+        <div className="site-hero-copy">
+          <p className="eyebrow">
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="flask" />
+            </span>
+            Public benchmark releases
+          </p>
+          <h1>Read the current public benchmark slices without dropping into portal internals.</h1>
+          <p className="site-lead">
+            The benchmark index is release-oriented, not run-oriented. It shows which benchmark
+            slices are public, which release is current, and whether the visible numbers are
+            complete, partial, or historically superseded.
+          </p>
+          <div className="hero-actions">
+            <a className="button" href={buildBenchmarkReportUrl(publicBenchmarks[0].benchmarkVersionId)}>
+              Open latest release
+            </a>
+            <a className="button button-secondary" href={buildPublicUrl(projectRoute)}>
+              Read the project pack
+            </a>
+          </div>
+        </div>
+
+        <aside className="site-signal-column" aria-label="Benchmark index summary">
+          <article className="site-signal-row">
+            <span className="site-signal-value">{publicBenchmarks.length.toString().padStart(2, "0")}</span>
+            <div>
+              <h2>Released slices</h2>
+              <p>Each card points at one public benchmark release summary instead of a private run table.</p>
+            </div>
+          </article>
+          <article className="site-signal-row">
+            <span className="site-signal-value">01</span>
+            <div>
+              <h2>Latest reference</h2>
+              <p>Each benchmark lists one current public reference point and its release state.</p>
+            </div>
+          </article>
+          <article className="site-signal-row">
+            <span className="site-signal-value">QA</span>
+            <div>
+              <h2>Data-quality first</h2>
+              <p>Partial or withheld publication is called out as release scope, not benchmark failure.</p>
+            </div>
+          </article>
+        </aside>
+      </section>
+
+      <section className="site-card-grid" aria-label="Public benchmark index">
+        {publicBenchmarks.map((benchmark) => (
+          <article className="site-panel-card" key={benchmark.benchmarkVersionId}>
+            <div className="site-panel-copy">
+              <p className="section-tag">{benchmark.taskType}</p>
+              <h3>{benchmark.title}</h3>
+              <p>{benchmark.description}</p>
+              <p>
+                Latest release: <strong>{benchmark.latestReleaseLabel}</strong>
+              </p>
+              <p>
+                Status: <strong>{formatReleaseStatus(benchmark.releaseStatus)}</strong>
+              </p>
+              <p>
+                Headline metric: <strong>{benchmark.headlineMetric}</strong>
+              </p>
+              <p>{benchmark.scopeNote}</p>
+            </div>
+            <a className="button button-secondary" href={buildBenchmarkReportUrl(benchmark.benchmarkVersionId)}>
+              Open release summary
+            </a>
+          </article>
+        ))}
+      </section>
+
+      <section className="site-band-grid" aria-label="Reporting rules">
+        <article className="site-band">
+          <p className="section-tag">Release flow</p>
+          <h2>Public reporting stays release-centric.</h2>
+          <p>
+            Benchmark cards route into one release summary page with stable top-line metrics,
+            one visible notice block, and links to methodology rather than private evidence consoles.
+          </p>
+        </article>
+        <article className="site-band">
+          <p className="section-tag">What not to expect</p>
+          <h2>No public run drilldown.</h2>
+          <p>
+            Per-run evidence, artifact inspection, and operational rerun context remain in the
+            authenticated portal. The public site only shows released benchmark slices.
+          </p>
+        </article>
+      </section>
+
+      <PublicFooter isProjectRoute={false} />
+    </main>
+  );
+}
+
+function PublicBenchmarkReport({
+  benchmarkVersionId
+}: {
+  benchmarkVersionId: string;
+}) {
+  const report =
+    publicBenchmarkReports[benchmarkVersionId as keyof typeof publicBenchmarkReports] ?? null;
+
+  if (!report) {
+    return (
+      <main className="site-shell">
+        <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
+
+        <section className="site-hero">
+          <div className="site-hero-copy">
+            <p className="eyebrow">
+              <span className="inline-icon" aria-hidden="true">
+                <AppIcon name="shield" />
+              </span>
+              Benchmark release unavailable
+            </p>
+            <h1>No public benchmark release matches this report id.</h1>
+            <p className="site-lead">
+              This route is reserved for released benchmark summaries. If the release is partial,
+              withheld, or not yet public, the benchmark index remains the canonical public entry point.
+            </p>
+            <div className="hero-actions">
+              <a className="button" href={buildPublicUrl(benchmarksRoute)}>
+                Return to benchmark index
+              </a>
+              <a className="button button-secondary" href={buildPublicUrl(projectRoute)}>
+                Read the project pack
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <PublicFooter isProjectRoute={false} />
+      </main>
+    );
+  }
+
+  return (
+    <main className="site-shell">
+      <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
+
+      <section className="site-hero">
+        <div className="site-hero-copy">
+          <p className="eyebrow">
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="flask" />
+            </span>
+            Benchmark release summary
+          </p>
+          <h1>{report.title}</h1>
+          <p className="site-lead">{report.description}</p>
+          <div className="hero-actions">
+            <a className="button" href={report.methodologyHref} rel="noreferrer" target="_blank">
+              Open methodology
+            </a>
+            <a className="button button-secondary" href={buildPublicUrl(benchmarksRoute)}>
+              Browse benchmark index
+            </a>
+          </div>
+        </div>
+
+        <aside className="site-signal-column" aria-label="Release summary">
+          {report.summaryCards.map((card) => (
+            <article className="site-signal-row" key={card.label}>
+              <span className="site-signal-value">{card.value}</span>
+              <div>
+                <h2>{card.label}</h2>
+                <p>{report.releaseLabel}</p>
+              </div>
+            </article>
+          ))}
+        </aside>
+      </section>
+
+      <section className="site-band-grid" aria-label="Release metadata">
+        <article className="site-band">
+          <p className="section-tag">Release metadata</p>
+          <h2>{report.releaseLabel}</h2>
+          <p>
+            Version id: <strong>{report.benchmarkVersionId}</strong>
+          </p>
+          <p>
+            Release date: <strong>{report.dateLabel}</strong>
+          </p>
+          <p>{report.scopeNote}</p>
+        </article>
+        <article className="site-band">
+          <p className="section-tag">Data quality</p>
+          <h2>{formatReleaseStatus(report.qualityState)}</h2>
+          <p>{report.qualityNotice}</p>
+        </article>
+        <article className="site-band">
+          <p className="section-tag">Public scope</p>
+          <h2>{report.includedConfigs}</h2>
+          <p>
+            Outcome state: <strong>{formatReleaseStatus(report.latestStatus)}</strong>
+          </p>
+          <p>Portal drilldown and per-run evidence remain out of scope for the public release page.</p>
+        </article>
+      </section>
+
+      <section className="site-project-section" aria-label="Public results table">
+        <div className="site-section-copy">
+          <p className="section-tag">Primary public results</p>
+          <h2>One release table, presented as calm mobile-safe rows.</h2>
+          <p className="site-lead">
+            Public reporting keeps one visible results surface per release. It distinguishes
+            benchmark outcome from data quality instead of collapsing everything into one badge.
+          </p>
+        </div>
+
+        <div className="site-card-grid">
+          {report.results.map((row) => (
+            <article className="site-panel-card" key={row.displayLabel}>
+              <div className="site-panel-copy">
+                <p className="section-tag">{row.providerLabel}</p>
+                <h3>{row.displayLabel}</h3>
+                <p>
+                  Solved or pass summary: <strong>{row.includedCount}</strong>
+                </p>
+                <p>
+                  Status: <strong>{formatReleaseStatus(row.status)}</strong>
+                </p>
+                <p>{row.updatedAt}</p>
+              </div>
+            </article>
+          ))}
+        </div>
       </section>
 
       <PublicFooter isProjectRoute={false} />
@@ -552,10 +949,18 @@ function PublicProjectPack() {
 }
 
 export function PublicSite() {
-  const pathname = window.location.pathname;
+  const route = resolvePublicSiteRoute(window.location.pathname);
 
-  if (pathname === "/project" || pathname.startsWith("/project/")) {
+  if (route.kind === "project") {
     return <PublicProjectPack />;
+  }
+
+  if (route.kind === "benchmarks") {
+    return <PublicBenchmarkIndex />;
+  }
+
+  if (route.kind === "report") {
+    return <PublicBenchmarkReport benchmarkVersionId={route.benchmarkVersionId} />;
   }
 
   return <PublicLanding />;


### PR DESCRIPTION
## Summary
- add explicit public benchmark-index and release-summary route handling for `/benchmarks` and `/reports/:benchmarkVersionId`
- keep `/` and `/project` intact while exposing the benchmark surface through the shared public header
- add route regression coverage so these public paths cannot silently fall back to the apex home hero again

## Linked Issues
- Closes #599

## Verification
- `bun test apps/web/src/routes/public-site.test.js`
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted browser QA on `/`, `/project`, `/benchmarks`, and `/reports/problem-9-v1`
  - before the fix, `/benchmarks` and `/reports/problem-9-v1` both rendered the apex-home hero `Measure frontier reasoning with reproducible proof workflows.`
  - after the fix, `/benchmarks` renders the benchmark index and `/reports/problem-9-v1` renders the release summary while `/` and `/project` remain unchanged