### PR TITLE
Keep the public benchmark index CTA visible on mobile

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -512,7 +512,7 @@ function PublicLanding() {
 
 function PublicBenchmarkIndex() {
   return (
-    <main className="site-shell">
+    <main className="site-shell site-benchmark-shell">
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
 
       <section className="site-hero">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2304,4 +2304,44 @@ a.button-secondary {
   .site-shell:not(.site-project-shell) .site-hero-copy h1 {
     font-size: clamp(1.75rem, 9vw, 2.3rem);
   }
+
+  .site-shell.site-benchmark-shell {
+    gap: 14px;
+  }
+
+  .site-shell.site-benchmark-shell .site-header,
+  .site-shell.site-benchmark-shell .site-hero,
+  .site-shell.site-benchmark-shell .site-footer {
+    padding: 14px;
+  }
+
+  .site-shell.site-benchmark-shell .site-header-main,
+  .site-shell.site-benchmark-shell .site-header-actions,
+  .site-shell.site-benchmark-shell .site-hero-copy {
+    gap: 6px;
+  }
+
+  .site-shell.site-benchmark-shell .site-tagline,
+  .site-shell.site-benchmark-shell .site-signal-column {
+    display: none;
+  }
+
+  .site-shell.site-benchmark-shell .site-primary-nav,
+  .site-shell.site-benchmark-shell .site-header-actions .button-secondary {
+    display: none;
+  }
+
+  .site-shell.site-benchmark-shell .site-hero {
+    gap: 10px;
+    padding-top: 12px;
+  }
+
+  .site-shell.site-benchmark-shell .site-hero-copy h1 {
+    font-size: clamp(1.68rem, 8.7vw, 2.2rem);
+    line-height: 0.98;
+  }
+
+  .site-shell.site-benchmark-shell .site-lead {
+    font-size: 0.92rem;
+  }
 }


### PR DESCRIPTION
## Summary
- tighten the benchmark-index route only at the tiniest breakpoint instead of changing the whole public-site shell
- hide redundant benchmark-route header chrome and the nonessential signal column on the tiny benchmark layout so the main release CTA surfaces first
- keep the report page, apex home, and project-pack mobile entry surfaces intact

## Linked Issues
- Closes #601

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/benchmarks`, `/reports/problem-9-v1`, `/`, and `/project`
  - `/benchmarks` at `320x568`: primary CTA moved from bottom `639.046875` to `533.875`
  - `/benchmarks` at `390x844`: primary CTA remained visible with bottom `713.515625`
  - `/reports/problem-9-v1` `Open methodology`, `/` primary CTA, and `/project` pill row remained visible at both tested breakpoints