### PR TITLE
Keep the first public benchmark card visible on mobile

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2099,6 +2099,40 @@ a.button-secondary {
     font-size: 1rem;
   }
 
+  .site-shell.site-benchmark-shell {
+    gap: 14px;
+  }
+
+  .site-shell.site-benchmark-shell .site-header,
+  .site-shell.site-benchmark-shell .site-hero,
+  .site-shell.site-benchmark-shell .site-footer {
+    padding: 14px;
+  }
+
+  .site-shell.site-benchmark-shell .site-header-main,
+  .site-shell.site-benchmark-shell .site-header-actions,
+  .site-shell.site-benchmark-shell .site-hero-copy {
+    gap: 8px;
+  }
+
+  .site-shell.site-benchmark-shell .site-signal-column {
+    display: none;
+  }
+
+  .site-shell.site-benchmark-shell .site-hero {
+    gap: 10px;
+    padding-top: 12px;
+  }
+
+  .site-shell.site-benchmark-shell .site-hero-copy h1 {
+    font-size: clamp(1.82rem, 8.4vw, 2.35rem);
+    line-height: 0.98;
+  }
+
+  .site-shell.site-benchmark-shell .site-lead {
+    font-size: 0.94rem;
+  }
+
   .auth-shell {
     align-items: start;
     padding: 8px 0;
@@ -2328,6 +2362,10 @@ a.button-secondary {
 
   .site-shell.site-benchmark-shell .site-primary-nav,
   .site-shell.site-benchmark-shell .site-header-actions .button-secondary {
+    display: none;
+  }
+
+  .site-shell.site-benchmark-shell .hero-actions .button-secondary {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- compress the benchmark-index route on small screens so the first actual benchmark entry surfaces inside the initial viewport
- hide the route-specific signal stack at `<=420px` and drop the secondary benchmark hero CTA at `<=360px` instead of changing the rest of the public-site shells
- preserve the report page, apex home, and project-pack mobile entry layouts

## Linked Issues
- Closes #603

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/benchmarks`, `/reports/problem-9-v1`, `/`, and `/project`
  - `/benchmarks` first card top moved from `621.46875` to `562.875` at `320x568`
  - `/benchmarks` first card top moved from `1218.453125` to `728.6875` at `390x844`
  - `/reports/problem-9-v1` `Open methodology`, `/` primary CTA, and `/project` pill row remained visible at both tested breakpoints