### PR TITLE
Keep the first public benchmark action visible on mobile

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -1,5 +1,6 @@
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { buildAuthUrl, buildPublicUrl } from "../lib/surface";
+import { useCompactLayout } from "../lib/use-compact-layout";
 
 const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discussions";
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
@@ -511,9 +512,43 @@ function PublicLanding() {
 }
 
 function PublicBenchmarkIndex() {
+  const isCompactLayout = useCompactLayout(480);
+
+  const benchmarkCards = (
+    <section
+      className={`site-card-grid${isCompactLayout ? " site-benchmark-card-grid-compact" : ""}`}
+      aria-label="Public benchmark index"
+    >
+      {publicBenchmarks.map((benchmark) => (
+        <article className="site-panel-card" key={benchmark.benchmarkVersionId}>
+          <div className="site-panel-copy">
+            <p className="section-tag">{benchmark.taskType}</p>
+            <h3>{benchmark.title}</h3>
+            <p>{benchmark.description}</p>
+            <p>
+              Latest release: <strong>{benchmark.latestReleaseLabel}</strong>
+            </p>
+            <p>
+              Status: <strong>{formatReleaseStatus(benchmark.releaseStatus)}</strong>
+            </p>
+            <p>
+              Headline metric: <strong>{benchmark.headlineMetric}</strong>
+            </p>
+            <p>{benchmark.scopeNote}</p>
+          </div>
+          <a className="button button-secondary" href={buildBenchmarkReportUrl(benchmark.benchmarkVersionId)}>
+            Open release summary
+          </a>
+        </article>
+      ))}
+    </section>
+  );
+
   return (
     <main className="site-shell site-benchmark-shell">
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
+
+      {isCompactLayout ? benchmarkCards : null}
 
       <section className="site-hero">
         <div className="site-hero-copy">
@@ -564,30 +599,7 @@ function PublicBenchmarkIndex() {
         </aside>
       </section>
 
-      <section className="site-card-grid" aria-label="Public benchmark index">
-        {publicBenchmarks.map((benchmark) => (
-          <article className="site-panel-card" key={benchmark.benchmarkVersionId}>
-            <div className="site-panel-copy">
-              <p className="section-tag">{benchmark.taskType}</p>
-              <h3>{benchmark.title}</h3>
-              <p>{benchmark.description}</p>
-              <p>
-                Latest release: <strong>{benchmark.latestReleaseLabel}</strong>
-              </p>
-              <p>
-                Status: <strong>{formatReleaseStatus(benchmark.releaseStatus)}</strong>
-              </p>
-              <p>
-                Headline metric: <strong>{benchmark.headlineMetric}</strong>
-              </p>
-              <p>{benchmark.scopeNote}</p>
-            </div>
-            <a className="button button-secondary" href={buildBenchmarkReportUrl(benchmark.benchmarkVersionId)}>
-              Open release summary
-            </a>
-          </article>
-        ))}
-      </section>
+      {!isCompactLayout ? benchmarkCards : null}
 
       <section className="site-band-grid" aria-label="Reporting rules">
         <article className="site-band">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -433,6 +433,15 @@ a.button-secondary {
   letter-spacing: -0.03em;
 }
 
+.site-benchmark-card-grid-compact .site-panel-card {
+  padding: 12px;
+  gap: 8px;
+}
+
+.site-benchmark-card-grid-compact .site-panel-copy {
+  gap: 6px;
+}
+
 .site-footer {
   border: 1px solid var(--line);
   border-radius: 18px;


### PR DESCRIPTION
## Summary
- move the actual benchmark cards ahead of the explanatory hero on compact benchmark-index layouts so the first actionable entry surfaces first in the DOM and viewport
- add a small compact card-density pass for the benchmark shell so the first card action fits on the smallest tested phone size
- preserve the report page, apex home, and project-pack mobile entry layouts

## Linked Issues
- Closes #605

## Verification
- `bun --cwd apps/web build`
- `bun run check:bidi`
- targeted mobile browser QA on `/benchmarks`, `/reports/problem-9-v1`, `/`, and `/project`
  - `/benchmarks` first card action moved from `1047.96875` to `565.09375` at `320x568`
  - `/benchmarks` first card action moved from `1593.765625` to `644.0625` at `390x844`
  - `/reports/problem-9-v1` `Open methodology`, `/` primary CTA, and `/project` pill row remained visible at both tested breakpoints