### PR TITLE
Keep portal profile save action visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2298,6 +2298,38 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .portal-grid-profile-compact .portal-profile-form-panel {
+    gap: 6px;
+    padding-top: 6px;
+  }
+
+  .portal-grid-profile-compact .portal-profile-form-panel h2 {
+    display: none;
+  }
+
+  .portal-grid-profile-compact .auth-form {
+    gap: 6px;
+  }
+
+  .portal-grid-profile-compact .auth-field {
+    gap: 4px;
+  }
+
+  .portal-grid-profile-compact .auth-field span {
+    font-size: 0.84rem;
+  }
+
+  .portal-grid-profile-compact .auth-input,
+  .portal-grid-profile-compact .auth-field input {
+    padding: 0.64rem 0.76rem;
+  }
+
+  .portal-grid-profile-compact .portal-profile-form-panel .button,
+  .portal-grid-profile-compact .portal-profile-form-panel a.button {
+    min-height: 2.24rem;
+    padding: 0.5rem 0.82rem;
+  }
+
   .portal-overview-actions-compact {
     gap: 8px;
     padding-top: 0;


### PR DESCRIPTION
## Summary

- tighten the compact `/profile` form only on the tiniest phone breakpoint
- hide the extra compact-profile heading and reduce field, input, and submit sizing just enough to keep `Save profile` inside the initial `320x568` viewport
- leave the larger compact breakpoint and nearby portal routes unchanged

## Linked issues

- Closes #609

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun run check:bidi
```

- Mobile browser QA on `http://127.0.0.1:4360`:
  - `/profile?surface=portal&access=approved&roles=collaborator&email=ada@paretoproof.local`
    - before: `Save profile` bottom `635.47` at `320x568`
    - after: `Save profile` bottom `567.11` at `320x568`
    - `390x844`: `Save profile` bottom `642.05`
  - Regression checks:
    - `/runs`: first run card bottom `563.73` at `320x568`
    - `/launch`: first selector bottom `567.17` at `320x568`
    - `/workers`: `Jump to runs` bottom `464.77` at `320x568`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Threat boundary: presentation-only CSS change on an existing approved portal route
- Cost/rate-limit impact: none

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship with the normal web deploy after merge to `main`
- Rollback: revert this tiny-phone compact-profile density pass if it hurts small-screen profile usability

## Notes

- Local QA reused the current Vite dev server on port `4360`