### PR TITLE
Keep auth providers visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2298,6 +2298,57 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .auth-card {
+    gap: 12px;
+  }
+
+  .auth-card-intro {
+    gap: 8px;
+  }
+
+  .auth-card h1 {
+    font-size: clamp(1.62rem, 8.5vw, 2.1rem);
+  }
+
+  .auth-lead,
+  .auth-panel-copy {
+    font-size: 0.9rem;
+  }
+
+  .auth-provider-panel {
+    padding: 14px;
+    gap: 8px;
+  }
+
+  .auth-provider-panel .section-tag,
+  .auth-provider-panel .auth-panel-copy {
+    display: none;
+  }
+
+  .auth-provider-panel h2 {
+    font-size: 1.12rem;
+  }
+
+  .auth-provider-button {
+    grid-template-columns: 36px minmax(0, 1fr) 16px;
+    gap: 8px;
+    padding: 10px 0;
+  }
+
+  .auth-provider-button small {
+    margin-top: 2px;
+    font-size: 0.84rem;
+  }
+
+  .auth-provider-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  .auth-provider-panel-notes {
+    display: none;
+  }
+
   .portal-grid-profile-compact .portal-profile-form-panel {
     gap: 6px;
     padding-top: 6px;


### PR DESCRIPTION
## Summary

- tighten the auth entry only on the tiniest phone breakpoint
- compress the auth intro and provider cards, and remove the secondary notes panel from the tiny-phone initial view so both GitHub and Google stay above the fold at `320x568`
- leave the larger auth breakpoint and nearby public routes unchanged

## Linked issues

- Closes #611

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun run check:bidi
```

- Mobile browser QA on `http://127.0.0.1:4362`:
  - `/?surface=auth`
    - before: Google button bottom `682.63` at `320x568`
    - after: GitHub button bottom `378.5` and Google button bottom `515.5` at `320x568`
    - `390x844`: GitHub button bottom `441.34`, Google button bottom `542.34`
  - Regression checks:
    - `/` primary CTA stayed visible at `320x568`
    - `/project` pill row stayed visible at `320x568`
    - `/benchmarks` first release summary action stayed visible at `320x568`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Threat boundary: presentation-only CSS change on the auth entry shell; provider behavior and redirects are unchanged
- Cost/rate-limit impact: none

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship with the normal web deploy after merge to `main`
- Rollback: revert the tiny-phone auth density pass if it hurts auth-entry clarity

## Notes

- Local QA reused the current Vite dev server on port `4362`