### PR TITLE
Keep admin access queue visible on small phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2298,6 +2298,49 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .portal-grid-admin-workspace .portal-admin-list-panel {
+    gap: 6px;
+    padding-top: 6px;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel .portal-panel-header {
+    gap: 8px;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel .section-tag {
+    display: none;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel h2 {
+    font-size: 1.04rem;
+    line-height: 1.05;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel .role-chip {
+    min-height: 1.5rem;
+    padding: 0.18rem 0.42rem;
+    font-size: 0.74rem;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-record {
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-record-header,
+  .portal-grid-admin-workspace .portal-admin-meta-row {
+    gap: 8px;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-meta-row {
+    font-size: 0.84rem;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-filter-grid {
+    gap: 8px;
+    padding-top: 10px;
+  }
+
   .auth-card {
     gap: 12px;
   }


### PR DESCRIPTION
## Summary

- tighten the compact admin queue only on the tiniest phone breakpoint
- reduce the queue-panel header and record density so the first admin access-request card surfaces meaningfully in the initial small-phone viewport
- leave the larger admin breakpoint and the admin users workspace layout unchanged

## Linked issues

- Closes #613

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun run check:bidi
```

- Mobile browser QA on `http://127.0.0.1:4364`:
  - `/admin/access-requests?surface=portal&access=approved&roles=admin&email=ada@paretoproof.local`
    - before: first queue card top `559.45` at `320x568`
    - after: first queue card top `516.23` at `320x568`
    - `390x844`: first queue card top remained `553.38`
  - Regression checks:
    - `/admin/users`: first user card top `463.48` at `320x568`, `457.41` at `390x844`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Threat boundary: presentation-only CSS change on existing admin review surfaces; admin mutations and auth stay unchanged
- Cost/rate-limit impact: none

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship with the normal web deploy after merge to `main`
- Rollback: revert the tiny-phone admin queue density pass if it hurts admin review clarity

## Notes

- Local QA reused the current Vite dev server on port `4364`