### PR TITLE
Keep portal access request action visible on small phones

### DIFF
--- a/apps/web/src/routes/access-request-screen.tsx
+++ b/apps/web/src/routes/access-request-screen.tsx
@@ -79,7 +79,7 @@ export function AccessRequestScreen({
 
   return (
     <main className="auth-shell">
-      <section className="auth-card auth-card-polished auth-status-card">
+      <section className="auth-card auth-card-polished auth-status-card auth-access-request-card">
         <p className="eyebrow">
           <span className="inline-icon" aria-hidden="true">
             <AppIcon name="key" />

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -618,6 +618,10 @@ a.button-secondary {
   width: min(840px, 100%);
 }
 
+.auth-access-request-card {
+  width: min(780px, 100%);
+}
+
 .auth-form {
   display: grid;
   gap: 14px;
@@ -2342,6 +2346,46 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .auth-access-request-card {
+    gap: 10px;
+  }
+
+  .auth-access-request-card .eyebrow {
+    display: none;
+  }
+
+  .auth-access-request-card p {
+    font-size: 0.9rem;
+  }
+
+  .auth-access-request-card .auth-form {
+    gap: 8px;
+    margin-top: 0;
+  }
+
+  .auth-access-request-card .auth-field {
+    gap: 4px;
+  }
+
+  .auth-access-request-card .auth-field span {
+    font-size: 0.84rem;
+  }
+
+  .auth-access-request-card .auth-field select,
+  .auth-access-request-card .auth-field textarea {
+    padding: 0.64rem 0.76rem;
+  }
+
+  .auth-access-request-card .auth-field textarea {
+    min-height: 6.25rem;
+  }
+
+  .auth-access-request-card .button,
+  .auth-access-request-card a.button {
+    min-height: 2.24rem;
+    padding: 0.5rem 0.82rem;
+  }
+
   .portal-grid-admin-workspace .portal-admin-list-panel {
     gap: 6px;
     padding-top: 6px;


### PR DESCRIPTION
## Summary
- scope a tiny-phone density pass to the portal access request / identity recovery card
- keep the submit action closer to the initial viewport without changing the wider auth shell
- leave the rest of the auth and portal surfaces untouched

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi

## Notes
- Closes #617
- Browser-level viewport QA was blocked in this environment because every attempted long-lived local Vite launch path was refused by shell policy, so this PR is verified with static build/typecheck checks only.