### PR TITLE
Keep missing benchmark report action visible on small phones

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -635,7 +635,7 @@ function PublicBenchmarkReport({
 
   if (!report) {
     return (
-      <main className="site-shell">
+      <main className="site-shell site-benchmark-shell site-report-unavailable-shell">
         <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
 
         <section className="site-hero">


### PR DESCRIPTION
## Summary
- route the missing benchmark-report fallback through the existing compact benchmark-shell rules
- keep the recovery CTA visible on the smallest supported phone size without changing the normal released-report layout
- leave the nearby home, benchmarks, and existing report entry surfaces unchanged

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted static mobile QA with Playwright on the built app at 320x568 and 390x844

## Viewport checks
- before: /reports/not-a-real-release Return to benchmark index bottom 575.66 at 320x568`n- after: /reports/not-a-real-release Return to benchmark index bottom 471.77 at 320x568`n- regression checks remained visible at 320x568: /reports/problem-9-v1 Open methodology, /benchmarks first Open release summary, / Open the project pack`n- larger-phone checks remained visible at 390x844 for all four routes above

## Notes
- Closes #619