### PR TITLE
Keep run detail evidence visible on small phones

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -840,27 +840,39 @@ function PortalRunDetailSurface({
 }) {
   const detail = loadState.data;
   const runsIndexHref = buildRunsIndexHref(search);
+  const isCompactLayout = useCompactLayout(480);
+  const freshnessCard = (
+    <PortalFreshnessCard
+      isRefreshing={loadState.isLoading}
+      lastUpdatedAt={loadState.lastUpdatedAt}
+      onRefresh={() => {
+        void onRefresh();
+      }}
+      routeId={activeRouteId}
+    />
+  );
 
   return (
-    <section className="portal-workspace-grid">
-      <article className="portal-panel portal-surface-main">
+    <section
+      className={`portal-workspace-grid${
+        isCompactLayout ? " portal-run-detail-workspace-compact" : ""
+      }`}
+    >
+      <article
+        className={`portal-panel portal-surface-main${
+          isCompactLayout ? " portal-run-detail-main-compact" : ""
+        }`}
+      >
         <div className="portal-panel-header">
           <div>
-            <p className="section-tag">Canonical run detail</p>
+            {!isCompactLayout ? <p className="section-tag">Canonical run detail</p> : null}
             <h2>{detail?.item.runId ?? "Run detail"}</h2>
           </div>
           <a className="button button-secondary" href={runsIndexHref}>
             Back to runs
           </a>
         </div>
-        <PortalFreshnessCard
-          isRefreshing={loadState.isLoading}
-          lastUpdatedAt={loadState.lastUpdatedAt}
-          onRefresh={() => {
-            void onRefresh();
-          }}
-          routeId={activeRouteId}
-        />
+        {!isCompactLayout ? freshnessCard : null}
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
         {detail ? (
           <>
@@ -886,6 +898,7 @@ function PortalRunDetailSurface({
                 <small>{detail.item.failure.summary ?? "No terminal failure summary."}</small>
               </article>
             </div>
+            {isCompactLayout ? freshnessCard : null}
             <div className="portal-detail-grid">
               <article className="portal-filter-card">
                 <p className="section-tag">Lineage</p>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1223,6 +1223,51 @@ a.button-secondary {
   gap: 4px;
 }
 
+.portal-run-detail-main-compact {
+  gap: 8px;
+  padding-top: 10px;
+}
+
+.portal-run-detail-main-compact .portal-panel-header {
+  gap: 8px;
+}
+
+.portal-run-detail-main-compact h2 {
+  font-size: 1.08rem;
+  line-height: 1.08;
+}
+
+.portal-run-detail-main-compact .portal-summary-grid {
+  gap: 8px;
+}
+
+.portal-run-detail-main-compact .portal-summary-card {
+  padding: 10px;
+  gap: 4px;
+}
+
+.portal-run-detail-main-compact .portal-summary-card small {
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.portal-run-detail-main-compact .portal-freshness-card {
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.portal-run-detail-main-compact .portal-freshness-card .eyebrow {
+  display: none;
+}
+
+.portal-run-detail-main-compact .portal-freshness-card h3 {
+  font-size: 0.92rem;
+}
+
+.portal-run-detail-main-compact .portal-freshness-actions {
+  gap: 8px;
+}
+
 .portal-run-card-header,
 .portal-run-card-footer {
   display: flex;
@@ -2150,6 +2195,12 @@ a.button-secondary {
 
   .portal-run-card-timestamp {
     font-size: 0.8rem;
+  }
+
+  .portal-run-detail-main-compact .portal-panel-header .button,
+  .portal-run-detail-main-compact .portal-panel-header a.button {
+    min-height: 2.35rem;
+    padding: 0.48rem 0.78rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a compact run-detail layout pass for /runs/:runId`n- move freshness below the first evidence summary on compact widths and tighten the detail header density
- keep the runs index, launch, and workers entry layouts unchanged

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted static mobile Playwright QA on the built app at 320x568 and 390x844

## Viewport checks
- before: /runs/PP-318 first .portal-summary-grid top 895.17 at 320x568`n- after: /runs/PP-318 first .portal-summary-grid top 520.83 at 320x568`n- after: /runs/PP-318 first .portal-summary-grid top 514.75 at 390x844`n- regression checks remained green at 320x568: /runs first run card top 523.14, /launch first form grid top 517.17, /workers Jump to runs bottom 464.77`n
## Notes
- Closes #621