### PR TITLE
Keep workers queue summary visible on small phones

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -1132,27 +1132,39 @@ function PortalWorkersSurface({
   onRefresh
 }: SurfaceProps<PortalWorkersViewResponse>) {
   const data = loadState.data;
+  const isCompactLayout = useCompactLayout(480);
+  const freshnessCard = (
+    <PortalFreshnessCard
+      isRefreshing={loadState.isLoading}
+      lastUpdatedAt={loadState.lastUpdatedAt}
+      onRefresh={() => {
+        void onRefresh();
+      }}
+      routeId={activeRouteId}
+    />
+  );
 
   return (
-    <section className="portal-workspace-grid">
-      <article className="portal-panel portal-surface-main">
+    <section
+      className={`portal-workspace-grid${
+        isCompactLayout ? " portal-workers-workspace-compact" : ""
+      }`}
+    >
+      <article
+        className={`portal-panel portal-surface-main${
+          isCompactLayout ? " portal-workers-main-compact" : ""
+        }`}
+      >
         <div className="portal-panel-header">
           <div>
-            <p className="section-tag">Execution posture</p>
+            {!isCompactLayout ? <p className="section-tag">Execution posture</p> : null}
             <h2>Workers owns queue and lease health.</h2>
           </div>
           <a className="button button-secondary" href={buildPortalUrl("/runs")}>
             Jump to runs
           </a>
         </div>
-        <PortalFreshnessCard
-          isRefreshing={loadState.isLoading}
-          lastUpdatedAt={loadState.lastUpdatedAt}
-          onRefresh={() => {
-            void onRefresh();
-          }}
-          routeId={activeRouteId}
-        />
+        {!isCompactLayout ? freshnessCard : null}
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
         {data ? (
           <>
@@ -1178,6 +1190,7 @@ function PortalWorkersSurface({
                 <small>Route refresh evidence</small>
               </article>
             </div>
+            {isCompactLayout ? freshnessCard : null}
             <div className="portal-results-contract-grid">
               {data.workerPools.map((pool) => (
                 <article className="portal-results-contract-card" key={pool.workerPool}>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1268,6 +1268,51 @@ a.button-secondary {
   gap: 8px;
 }
 
+.portal-workers-main-compact {
+  gap: 8px;
+  padding-top: 10px;
+}
+
+.portal-workers-main-compact .portal-panel-header {
+  gap: 8px;
+}
+
+.portal-workers-main-compact h2 {
+  font-size: 1.08rem;
+  line-height: 1.08;
+}
+
+.portal-workers-main-compact .portal-summary-grid {
+  gap: 8px;
+}
+
+.portal-workers-main-compact .portal-summary-card {
+  padding: 10px;
+  gap: 4px;
+}
+
+.portal-workers-main-compact .portal-summary-card small {
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.portal-workers-main-compact .portal-freshness-card {
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.portal-workers-main-compact .portal-freshness-card .eyebrow {
+  display: none;
+}
+
+.portal-workers-main-compact .portal-freshness-card h3 {
+  font-size: 0.92rem;
+}
+
+.portal-workers-main-compact .portal-freshness-actions {
+  gap: 8px;
+}
+
 .portal-run-card-header,
 .portal-run-card-footer {
   display: flex;
@@ -2199,6 +2244,12 @@ a.button-secondary {
 
   .portal-run-detail-main-compact .portal-panel-header .button,
   .portal-run-detail-main-compact .portal-panel-header a.button {
+    min-height: 2.35rem;
+    padding: 0.48rem 0.78rem;
+  }
+
+  .portal-workers-main-compact .portal-panel-header .button,
+  .portal-workers-main-compact .portal-panel-header a.button {
     min-height: 2.35rem;
     padding: 0.48rem 0.78rem;
   }


### PR DESCRIPTION
## Summary
- add a compact workers layout pass for /workers`n- move freshness below the first worker queue summary on compact widths and tighten the header density
- keep the runs, run detail, and launch mobile entry layouts unchanged

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted static mobile Playwright QA on the built app at 320x568

## Viewport checks
- before: /workers first .portal-summary-grid top 868.27 at 320x568`n- after: /workers first .portal-summary-grid top 453.14 at 320x568`n- regression checks remained green at 320x568: /runs/PP-318 first .portal-summary-grid top 520.83, /runs first run card top 523.14, /launch first form grid top 517.17`n
## Notes
- Closes #623