### PR TITLE
Fix tiny-phone profile save visibility

### DIFF
--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -333,7 +333,11 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   );
 
   return (
-    <main className="portal-shell">
+    <main
+      className={`portal-shell${
+        activeSection?.id === "profile" ? " portal-shell-profile-active" : ""
+      }`}
+    >
       <aside
         aria-label="Portal navigation"
         className={`portal-sidebar${navigationCollapsed ? " portal-sidebar-collapsed" : ""}`}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2614,6 +2614,48 @@ a.button-secondary {
     padding: 0.5rem 0.82rem;
   }
 
+  .portal-shell-profile-active .portal-sidebar {
+    padding-bottom: 10px;
+  }
+
+  .portal-shell-profile-active .portal-nav {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 5px;
+  }
+
+  .portal-shell-profile-active .portal-nav-link {
+    gap: 4px;
+    padding: 7px 4px;
+  }
+
+  .portal-shell-profile-active .portal-nav-label {
+    font-size: 0.66rem;
+  }
+
+  .portal-shell-profile-active .portal-main {
+    gap: 10px;
+  }
+
+  .portal-shell-profile-active .portal-topbar {
+    gap: 6px;
+  }
+
+  .portal-shell-profile-active .portal-topbar h1 {
+    font-size: clamp(1.72rem, 8.6vw, 2.1rem);
+  }
+
+  .portal-shell-profile-active .portal-identity {
+    align-items: flex-start;
+    flex-direction: row;
+    gap: 6px;
+  }
+
+  .portal-shell-profile-active .role-chip {
+    min-height: 1.5rem;
+    padding: 0.18rem 0.42rem;
+    font-size: 0.74rem;
+  }
+
   .site-project-shell {
     gap: 14px;
   }


### PR DESCRIPTION
## Summary
- keep the `/profile` route on tiny phones route-scoped so multi-role portal users do not lose the first `Save profile` action below the fold
- add a profile-only portal shell class and compact the tiny-phone nav plus topbar role-chip stack without changing other portal routes

## Linked Issues
- Closes #625

## Verification
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- Targeted mobile Playwright QA on `/profile` at `320x568` and `390x844` for helper, collaborator, admin, and `admin,collaborator`
- Regression spot-checks at `320x568` for `/`, `/runs`, `/launch`, `/workers`, `/admin/access-requests`, and `/admin/users`

## Measured Results
- Before fix: `/profile` `Save profile` bottom was `652.42` for `admin` and `686.81` for `admin,collaborator` at `320x568`
- After fix: `/profile` `Save profile` bottom is `520.63` for `admin` and `520.63` for `admin,collaborator` at `320x568`