### PR TITLE
Fix auth handoff notices on tiny phones

### DIFF
--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -28,6 +28,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const handoffMode = new URLSearchParams(window.location.search).get("handoff");
   const showFailedNotice = handoffMode === "failed";
   const showRetryNotice = handoffMode === "retry";
+  const showAuxiliaryStatus = showFailedNotice || showRetryNotice || isCheckingSession;
 
   useEffect(() => {
     if (isLocal) {
@@ -70,7 +71,11 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
 
   return (
     <main className="auth-shell">
-      <section className="auth-card auth-card-polished">
+      <section
+        className={`auth-card auth-card-polished${
+          showAuxiliaryStatus ? " auth-card-handoff-state" : ""
+        }`}
+      >
         <div className="auth-card-intro">
           <p className="eyebrow">
             <span className="inline-icon" aria-hidden="true">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2582,6 +2582,48 @@ a.button-secondary {
     display: none;
   }
 
+  .auth-card-handoff-state {
+    gap: 10px;
+  }
+
+  .auth-card-handoff-state .auth-card-intro {
+    gap: 6px;
+  }
+
+  .auth-card-handoff-state h1 {
+    font-size: clamp(1.56rem, 8.1vw, 2rem);
+  }
+
+  .auth-card-handoff-state .auth-lead,
+  .auth-card-handoff-state .auth-panel-copy,
+  .auth-card-handoff-state .auth-card-footer p {
+    font-size: 0.86rem;
+    line-height: 1.42;
+  }
+
+  .auth-card-handoff-state .auth-provider-panel {
+    padding: 12px;
+    gap: 6px;
+  }
+
+  .auth-card-handoff-state .auth-provider-panel .section-tag,
+  .auth-card-handoff-state .auth-provider-panel .auth-panel-copy {
+    display: none;
+  }
+
+  .auth-card-handoff-state .auth-provider-panel h2 {
+    font-size: 1.05rem;
+  }
+
+  .auth-card-handoff-state .auth-provider-button {
+    padding: 8px 0;
+  }
+
+  .auth-card-handoff-state .auth-provider-button small {
+    margin-top: 1px;
+    font-size: 0.8rem;
+  }
+
   .portal-grid-profile-compact .portal-profile-form-panel {
     gap: 6px;
     padding-top: 6px;


### PR DESCRIPTION
## Summary
- keep the auth entry mobile-safe when retry or failed handoff notices are present on tiny phones
- add a notice-state auth card class and tighten only that tiny-phone variant so both provider buttons remain in the initial viewport

## Linked Issues
- Closes #627

## Verification
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- Targeted mobile Playwright QA on `/?surface=auth`, `/?surface=auth&handoff=retry`, and `/?surface=auth&handoff=failed` at `320x568` and `390x844`
- Regression spot-checks at `320x568` for `/` and `/profile?surface=portal&access=approved&roles=admin,collaborator&email=local@example.com`

## Measured Results
- Before fix: `/?surface=auth&handoff=retry` and `/?surface=auth&handoff=failed` pushed the provider list to `592.64` bottom at `320x568`
- After fix: both handoff states keep the provider list at `476.61` bottom at `320x568`
- Default auth entry remained at `515.5` bottom and the profile save button remained at `520.63` bottom on the same viewport