### PR TITLE
Fix benchmark index mobile context ordering

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -548,8 +548,6 @@ function PublicBenchmarkIndex() {
     <main className="site-shell site-benchmark-shell">
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
 
-      {isCompactLayout ? benchmarkCards : null}
-
       <section className="site-hero">
         <div className="site-hero-copy">
           <p className="eyebrow">
@@ -599,7 +597,7 @@ function PublicBenchmarkIndex() {
         </aside>
       </section>
 
-      {!isCompactLayout ? benchmarkCards : null}
+      {benchmarkCards}
 
       <section className="site-band-grid" aria-label="Reporting rules">
         <article className="site-band">


### PR DESCRIPTION
## Summary
- keep the benchmark index context-first on mobile by rendering the benchmark hero before the release cards again
- preserve the compact benchmark card layout while restoring the route heading and primary CTA to the initial viewport

## Linked Issues
- Closes #629

## Verification
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- Targeted mobile Playwright QA on `/benchmarks`, `/`, and `/reports/problem-9-v1` at `320x568` and `390x844`

## Measured Results
- Before fix: `/benchmarks` heading started at `1058.59` and the hero CTA was offscreen at `320x568`
- After fix: `/benchmarks` heading starts at `195.59` and `Open latest release` bottoms at `533.88` at `320x568`
- Wider mobile also stayed green: at `390x844`, the heading starts at `327.75` and `Open latest release` bottoms at `641.09`