### PR TITLE
Fix benchmark report actions on tiny phones

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -666,8 +666,8 @@ function PublicBenchmarkReport({
   }
 
   return (
-    <main className="site-shell">
-      <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
+    <main className="site-shell site-benchmark-shell site-benchmark-report-shell">
+        <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
 
       <section className="site-hero">
         <div className="site-hero-copy">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2838,6 +2838,10 @@ a.button-secondary {
     display: none;
   }
 
+  .site-shell.site-benchmark-report-shell .hero-actions .button-secondary {
+    display: inline-flex;
+  }
+
   .site-shell.site-benchmark-shell .site-hero {
     gap: 10px;
     padding-top: 12px;


### PR DESCRIPTION
## Summary
- align the published benchmark report route with the compact benchmark-shell behavior on tiny phones
- restore the report-specific secondary hero action on that compact shell so both report actions stay above the fold

## Linked Issues
- Closes #631

## Verification
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- Targeted mobile Playwright QA on `/reports/statement-formalization-pilot-v1`, `/reports/problem-9-v1`, `/benchmarks`, and `/` at `320x568` and `390x844`

## Measured Results
- Before fix: `/reports/statement-formalization-pilot-v1` pushed `Browse benchmark index` to `610.7` bottom at `320x568`
- After fix: `/reports/statement-formalization-pilot-v1` keeps `Browse benchmark index` at `506.81` bottom and `/reports/problem-9-v1` keeps it at `455.98` bottom on the same viewport
- `/benchmarks` stayed in its compact state with `Open latest release` at `533.88` bottom and the secondary hero action still hidden on `320x568`