### PR TITLE
Fix apex landing tiny-phone actions

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -456,7 +456,7 @@ function PublicFooter({ isProjectRoute }: { isProjectRoute: boolean }) {
 
 function PublicLanding() {
   return (
-    <main className="site-shell">
+    <main className="site-shell site-home-shell">
       <PublicHeader currentPath={window.location.pathname} />
 
       <section className="site-hero">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2842,6 +2842,36 @@ a.button-secondary {
     display: inline-flex;
   }
 
+  .site-shell.site-home-shell .site-header-actions {
+    display: none;
+  }
+
+  .site-shell.site-home-shell .site-header {
+    padding-bottom: 10px;
+  }
+
+  .site-shell.site-home-shell .site-hero {
+    gap: 8px;
+    padding-top: 10px;
+  }
+
+  .site-shell.site-home-shell .site-hero-copy {
+    gap: 8px;
+  }
+
+  .site-shell.site-home-shell .site-hero-copy h1 {
+    font-size: clamp(1.68rem, 8.7vw, 2.18rem);
+    line-height: 0.98;
+  }
+
+  .site-shell.site-home-shell .site-lead {
+    font-size: 0.9rem;
+  }
+
+  .site-shell.site-home-shell .hero-actions {
+    gap: 8px;
+  }
+
   .site-shell.site-benchmark-shell .site-hero {
     gap: 10px;
     padding-top: 12px;


### PR DESCRIPTION
## Summary
- keep both apex landing hero actions visible on the smallest supported phone size
- add a home-only shell class and tiny-phone density pass that removes redundant header chrome while preserving the surrounding public routes

## Linked Issues
- Closes #633

## Verification
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- Targeted mobile Playwright QA on `/`, `/project`, `/benchmarks`, and `/reports/problem-9-v1` at `320x568` and `390x844`

## Measured Results
- Before fix: `/` secondary hero `Contributor sign in` bottom was `615.13` at `320x568`
- After fix: `/` secondary hero `Contributor sign in` bottom is `521.92` and `Open the project pack` bottom is `465.33` at `320x568`
- `/project`, `/benchmarks`, and `/reports/problem-9-v1` stayed green on the same viewport