### PR TITLE
Keep benchmark ops evidence visible on small phones

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -398,7 +398,11 @@ function PortalRunsSurface({
       <div className="portal-panel-header">
         <div>
           <p className="section-tag">Run slice</p>
-          <h2>Filtered rows route into canonical detail pages.</h2>
+          <h2>
+            {isCompactLayout
+              ? "Runs route into canonical detail pages."
+              : "Filtered rows route into canonical detail pages."}
+          </h2>
         </div>
         <span className="role-chip role-chip-muted">
           {loadState.data?.summary.returnedCount ?? 0} shown

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -252,6 +252,10 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     () => resolveActiveSection(pathname, matchedPortalRoute?.id ?? null, sections),
     [matchedPortalRoute, pathname, sections]
   );
+  const benchmarkOpsRouteActive =
+    activeSection?.id === "runs" ||
+    activeSection?.id === "launch" ||
+    activeSection?.id === "workers";
   const activeSectionHref = activeSection ? getSectionHref(activeSection) : "/";
   const activeRouteId = matchedPortalRoute?.id ?? activeSection?.routeId ?? "portal.home";
   const activeFreshnessPolicy = useMemo(
@@ -336,6 +340,8 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     <main
       className={`portal-shell${
         activeSection?.id === "profile" ? " portal-shell-profile-active" : ""
+      }${
+        benchmarkOpsRouteActive ? " portal-shell-benchmark-ops-active" : ""
       }`}
     >
       <aside

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1194,12 +1194,13 @@ a.button-secondary {
 }
 
 .portal-run-slice-compact {
-  gap: 8px;
-  padding-top: 10px;
+  gap: 6px;
+  padding-top: 6px;
 }
 
 .portal-run-slice-compact .portal-panel-header {
-  gap: 8px;
+  gap: 6px;
+  align-items: center;
 }
 
 .portal-run-slice-compact .section-tag {
@@ -1207,8 +1208,18 @@ a.button-secondary {
 }
 
 .portal-run-slice-compact h2 {
-  font-size: 1.08rem;
-  line-height: 1.08;
+  font-size: 1rem;
+  line-height: 1.04;
+}
+
+.portal-run-slice-compact .role-chip {
+  min-height: 1.5rem;
+  padding: 0.18rem 0.42rem;
+  font-size: 0.74rem;
+}
+
+.portal-run-slice-compact .portal-run-card-list {
+  gap: 8px;
 }
 
 .portal-run-card {
@@ -1219,8 +1230,19 @@ a.button-secondary {
 }
 
 .portal-run-slice-compact .portal-run-card {
-  padding-top: 8px;
-  gap: 4px;
+  padding-top: 6px;
+  gap: 3px;
+}
+
+.portal-run-slice-compact .portal-run-card-title {
+  font-size: 0.92rem;
+  line-height: 1.25;
+}
+
+.portal-run-slice-compact .portal-run-card-meta,
+.portal-run-slice-compact .portal-run-card-timestamp {
+  font-size: 0.78rem;
+  line-height: 1.3;
 }
 
 .portal-run-detail-main-compact {
@@ -2693,6 +2715,48 @@ a.button-secondary {
   }
 
   .portal-shell-profile-active .role-chip {
+    min-height: 1.5rem;
+    padding: 0.18rem 0.42rem;
+    font-size: 0.74rem;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-sidebar {
+    padding-bottom: 10px;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-nav {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 5px;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-nav-link {
+    gap: 4px;
+    padding: 7px 4px;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-nav-label {
+    font-size: 0.66rem;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-main {
+    gap: 10px;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-topbar {
+    gap: 6px;
+  }
+
+  .portal-shell-benchmark-ops-active .portal-topbar h1 {
+    font-size: clamp(1.72rem, 8.6vw, 2.1rem);
+  }
+
+  .portal-shell-benchmark-ops-active .portal-identity {
+    align-items: flex-start;
+    flex-direction: row;
+    gap: 6px;
+  }
+
+  .portal-shell-benchmark-ops-active .role-chip {
     min-height: 1.5rem;
     padding: 0.18rem 0.42rem;
     font-size: 0.74rem;


### PR DESCRIPTION
## Summary
- compact the benchmark-ops portal shell on tiny phones so the nav and topbar consume less vertical space
- tighten the compact runs slice heading and card density so the first run row stays inside the initial viewport
- preserve the recent benchmark-ops mobile fixes while pulling /runs, /runs/:runId, /launch, and /workers back into a safer compact range

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- bun --cwd apps/web test:functions
- mobile Playwright QA at 320x568 for /runs, /runs/PP-318, /launch, /workers, /profile, and /?surface=auth&handoff=retry`n
Closes #635