### PR TITLE
Keep admin detail actions reachable on small phones

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -6,7 +6,7 @@ import {
   type PortalAdminApprovedRole,
   type PortalIdentityProvider
 } from "@paretoproof/shared";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import {
   approvePortalAdminAccessRequest,
@@ -75,6 +75,9 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
   const [isMutatingId, setIsMutatingId] = useState<string | null>(null);
   const [requests, setRequests] = useState<PortalAdminAccessRequestListItem[]>([]);
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
+  const detailPanelRef = useRef<HTMLElement | null>(null);
+  const detailActionRef = useRef<HTMLElement | null>(null);
+  const pendingCompactRevealRequestIdRef = useRef<string | null>(null);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const isCompactLayout = useCompactLayout();
   const {
@@ -246,6 +249,34 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
     };
   }, [apiBaseUrl, selectedRequestId]);
 
+  useEffect(() => {
+    if (
+      !isCompactLayout ||
+      !selectedRequestId ||
+      pendingCompactRevealRequestIdRef.current !== selectedRequestId
+    ) {
+      return;
+    }
+
+    const detailPanel = detailActionRef.current ?? detailPanelRef.current;
+
+    if (!detailPanel) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      detailPanel.scrollIntoView({
+        behavior: "auto",
+        block: "start"
+      });
+      pendingCompactRevealRequestIdRef.current = null;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [isCompactLayout, selectedRequestId]);
+
   function applyRequests(nextItems: PortalAdminAccessRequestListItem[]) {
     setDrafts((currentDrafts) => {
       const nextDrafts: Record<string, RequestDraftState> = {};
@@ -329,6 +360,19 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
     } finally {
       setIsMutatingId(null);
     }
+  }
+
+  function revealSelectedRequestDetail(requestId: string) {
+    if (isCompactLayout && requestId === selectedRequestId) {
+      (detailActionRef.current ?? detailPanelRef.current)?.scrollIntoView({
+        behavior: "auto",
+        block: "start"
+      });
+      return;
+    }
+
+    pendingCompactRevealRequestIdRef.current = requestId;
+    setSelectedRequestId(requestId);
   }
 
   if (isLoading) {
@@ -474,7 +518,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               className={`portal-admin-record${isSelected ? " portal-admin-record-active" : ""}`}
               key={requestItem.id}
               onClick={() => {
-                setSelectedRequestId(requestItem.id);
+                revealSelectedRequestDetail(requestItem.id);
               }}
               type="button"
             >
@@ -538,7 +582,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
         {isCompactLayout ? filterFields : queueContent}
       </article>
 
-      <article className="portal-panel portal-admin-detail-panel">
+      <article className="portal-panel portal-admin-detail-panel" ref={detailPanelRef}>
         {!selectedRequest ? (
           <div className="portal-admin-empty-state">
             <p className="section-tag">Selection</p>
@@ -577,6 +621,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
             onReject={() => {
               void handleDecision("reject");
             }}
+            actionSectionRef={detailActionRef}
           />
         )}
       </article>
@@ -592,6 +637,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
 }
 
 type AccessRequestDetailCardProps = {
+  actionSectionRef: React.RefObject<HTMLElement | null>;
   detail: PortalAdminAccessRequestDetail;
   draft: RequestDraftState;
   isMutating: boolean;
@@ -601,6 +647,7 @@ type AccessRequestDetailCardProps = {
 };
 
 function AccessRequestDetailCard({
+  actionSectionRef,
   detail,
   draft,
   isMutating,
@@ -751,7 +798,7 @@ function AccessRequestDetailCard({
         </article>
       </div>
 
-      <article className="portal-admin-card">
+      <article className="portal-admin-card" ref={actionSectionRef}>
         <p className="section-tag">Decision action</p>
         <h3>Admin actions stay request-scoped.</h3>
         <div className="auth-form">

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -1,5 +1,5 @@
 import type { PortalAdminUserListItem } from "@paretoproof/shared";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import {
@@ -93,6 +93,9 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   const [revocationReason, setRevocationReason] = useState("");
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [users, setUsers] = useState<PortalAdminUserListItem[]>([]);
+  const detailShellRef = useRef<HTMLElement | null>(null);
+  const correctiveActionRef = useRef<HTMLElement | null>(null);
+  const pendingCompactRevealUserIdRef = useRef<string | null>(null);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const isCompactLayout = useCompactLayout();
   const {
@@ -162,6 +165,34 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     };
   }, [apiBaseUrl, selectedUserId]);
 
+  useEffect(() => {
+    if (
+      !isCompactLayout ||
+      !selectedUserId ||
+      pendingCompactRevealUserIdRef.current !== selectedUserId
+    ) {
+      return;
+    }
+
+    const detailShell = correctiveActionRef.current ?? detailShellRef.current;
+
+    if (!detailShell) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      detailShell.scrollIntoView({
+        behavior: "auto",
+        block: "start"
+      });
+      pendingCompactRevealUserIdRef.current = null;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [isCompactLayout, selectedUserId]);
+
   async function refreshUsers(initialLoad = false) {
     try {
       const nextItems = await loadPortalAdminUsers(apiBaseUrl);
@@ -220,6 +251,19 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     } finally {
       setIsMutating(false);
     }
+  }
+
+  function revealSelectedUserDetail(userId: string) {
+    if (isCompactLayout && userId === selectedUserId) {
+      (correctiveActionRef.current ?? detailShellRef.current)?.scrollIntoView({
+        behavior: "auto",
+        block: "start"
+      });
+      return;
+    }
+
+    pendingCompactRevealUserIdRef.current = userId;
+    setSelectedUserId(userId);
   }
 
   if (isLoading) {
@@ -353,7 +397,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               }`}
               key={item.userId}
               onClick={() => {
-                setSelectedUserId(item.userId);
+                revealSelectedUserDetail(item.userId);
                 setActionMessage(null);
               }}
               type="button"
@@ -394,7 +438,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
         {isCompactLayout ? filterFields : userList}
       </aside>
 
-      <section className="portal-admin-detail-shell">
+      <section className="portal-admin-detail-shell" ref={detailShellRef}>
         {detailError ? (
           <article className="portal-admin-card portal-admin-card-empty">
             <h3>User detail unavailable</h3>
@@ -477,7 +521,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               </article>
             </div>
 
-            <article className="portal-admin-card">
+            <article className="portal-admin-card" ref={correctiveActionRef}>
               <p className="section-tag">Corrective action</p>
               <h3>Revoke the current contributor role from this user.</h3>
               <p className="portal-action-copy">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1854,6 +1854,11 @@ a.button-secondary {
   align-content: start;
 }
 
+.portal-admin-detail-panel,
+.portal-admin-detail-shell {
+  scroll-margin-top: 16px;
+}
+
 .portal-admin-list-card {
   cursor: pointer;
 }


### PR DESCRIPTION
﻿## Summary

- reveal the compact admin detail action section after selecting a queue or user record on small phones
- preserve the existing list-first admin layout while making the selected action card the landing target
- add a small scroll margin so the revealed action card does not butt against the portal chrome

## Linked issues

- Closes #637

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
# targeted mobile Playwright QA via node + playwright against http://127.0.0.1:4371
# verified on:
# - /admin/access-requests?surface=portal&access=approved&roles=admin&email=local@example.com at 320x568 and 390x844
# - /admin/users?surface=portal&access=approved&roles=admin&email=local@example.com at 320x568 and 390x844
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Frontend-only compact-layout behavior change. No backend, auth, or secret-handling changes. No material runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Ships with the normal web deploy. Roll back by reverting the compact admin selection reveal if it causes unexpected navigation behavior on mobile.

## Notes

- Targeted QA confirmed the selected action cards land in-view after tapping the first admin record on both compact routes.
