### PR TITLE
Keep portal overview metrics visible on small phones

### DIFF
--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -256,6 +256,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     activeSection?.id === "runs" ||
     activeSection?.id === "launch" ||
     activeSection?.id === "workers";
+  const overviewRouteActive = activeSection?.id === "overview";
   const activeSectionHref = activeSection ? getSectionHref(activeSection) : "/";
   const activeRouteId = matchedPortalRoute?.id ?? activeSection?.routeId ?? "portal.home";
   const activeFreshnessPolicy = useMemo(
@@ -339,6 +340,8 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   return (
     <main
       className={`portal-shell${
+        overviewRouteActive ? " portal-shell-overview-active" : ""
+      }${
         activeSection?.id === "profile" ? " portal-shell-profile-active" : ""
       }${
         benchmarkOpsRouteActive ? " portal-shell-benchmark-ops-active" : ""
@@ -459,7 +462,6 @@ export function PortalShell({ email, roles }: PortalShellProps) {
 
         {activeSection?.id === "overview" ? (
           <>
-            {compactLayout ? overviewActionRail : null}
             <section className="portal-metric-strip" aria-label="Portal metrics">
               {overviewMetrics.map((metric) => (
                 <article className="portal-metric-cell" key={metric.label}>
@@ -469,6 +471,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                 </article>
               ))}
             </section>
+            {compactLayout ? overviewActionRail : null}
 
             <section className="portal-overview-grid">
               <article className="portal-panel portal-overview-lead">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2687,6 +2687,48 @@ a.button-secondary {
     padding-bottom: 10px;
   }
 
+  .portal-shell-overview-active .portal-sidebar {
+    padding-bottom: 10px;
+  }
+
+  .portal-shell-overview-active .portal-nav {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 5px;
+  }
+
+  .portal-shell-overview-active .portal-nav-link {
+    gap: 4px;
+    padding: 7px 4px;
+  }
+
+  .portal-shell-overview-active .portal-nav-label {
+    font-size: 0.66rem;
+  }
+
+  .portal-shell-overview-active .portal-main {
+    gap: 10px;
+  }
+
+  .portal-shell-overview-active .portal-topbar {
+    gap: 6px;
+  }
+
+  .portal-shell-overview-active .portal-topbar h1 {
+    font-size: clamp(1.72rem, 8.6vw, 2.1rem);
+  }
+
+  .portal-shell-overview-active .portal-identity {
+    align-items: flex-start;
+    flex-direction: row;
+    gap: 6px;
+  }
+
+  .portal-shell-overview-active .role-chip {
+    min-height: 1.5rem;
+    padding: 0.18rem 0.42rem;
+    font-size: 0.74rem;
+  }
+
   .portal-shell-profile-active .portal-nav {
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 5px;


### PR DESCRIPTION
﻿## Summary

- keep the portal overview metric strip above the fold on small phones for collaborator and admin-capable users
- add an overview-specific compact shell pass so role-heavy topbar chrome consumes less vertical space
- render the overview metrics before the compact action rail so the route opens with actual portal state instead of shell-only chrome

## Linked issues

- Closes #639

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
# targeted mobile Playwright QA via node + playwright against http://127.0.0.1:4371
# verified portal home for roles helper, collaborator, admin, and admin,collaborator at 320x568 and 390x844
# regression spot-checks on:
# - /profile?surface=portal&access=approved&roles=admin,collaborator&email=local@example.com at 320x568
# - /runs?surface=portal&access=approved&roles=admin,collaborator&email=local@example.com at 320x568
# - /?surface=auth&handoff=retry at 320x568
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Frontend-only compact-layout change. No auth, backend, or infrastructure behavior changed. No material runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Ships with the normal web deploy. Roll back by reverting the overview-specific compact shell pass if it hides useful overview controls.

## Notes

- After the fix at 320x568, the first overview metric card moved to 321.08 for `collaborator` and 332.69 for both `admin` and `admin,collaborator`.
