### PR TITLE
Restore project pack deep links after hydration

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -1,6 +1,7 @@
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { buildAuthUrl, buildPublicUrl } from "../lib/surface";
 import { useCompactLayout } from "../lib/use-compact-layout";
+import { useEffect } from "react";
 
 const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discussions";
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
@@ -764,6 +765,34 @@ function PublicBenchmarkReport({
 }
 
 function PublicProjectPack() {
+  useEffect(() => {
+    function scrollProjectHashIntoView() {
+      if (!window.location.hash) {
+        return;
+      }
+
+      const target = document.querySelector(window.location.hash);
+
+      if (!target) {
+        return;
+      }
+
+      window.requestAnimationFrame(() => {
+        target.scrollIntoView({
+          behavior: "auto",
+          block: "start"
+        });
+      });
+    }
+
+    scrollProjectHashIntoView();
+    window.addEventListener("hashchange", scrollProjectHashIntoView);
+
+    return () => {
+      window.removeEventListener("hashchange", scrollProjectHashIntoView);
+    };
+  }, []);
+
   return (
     <main className="site-shell site-project-shell">
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />


### PR DESCRIPTION
﻿## Summary

- restore direct hash landing for the public project pack after React hydration
- keep in-page project section links working by honoring hash changes after mount
- leave the base `/project` route unchanged when no hash is present

## Linked issues

- Closes #641

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
# targeted Playwright QA via node + playwright against http://127.0.0.1:4371
# verified:
# - /project at 320x568
# - /project#overview, /project#contributors, /project#contact at 320x568 and 390x844
# - in-page click from /project to #contact at 320x568
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Frontend-only navigation behavior change. No auth, backend, or infrastructure behavior changed. No material runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Ships with the normal web deploy. Roll back by reverting the project-pack hash-navigation effect if it causes unwanted scroll jumps.

## Notes

- Before the fix, direct loads to `/project#overview`, `/project#contributors`, and `/project#contact` all stayed at `scrollY = 0` after hydration.
- After the fix at `320x568`, those routes land at `scrollY` `1058`, `2487`, and `4058` respectively.
