### PR TITLE
Keep profile link feedback visible on small phones

### DIFF
--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -438,6 +438,8 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
     );
   }
 
+  const showCompactLinkFeedback = compactLayout && Boolean(linkMessage);
+
   const profileForm = (
     <form className="auth-form" onSubmit={handleSave}>
       <label className="auth-field">
@@ -452,10 +454,13 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
           value={displayNameInput}
         />
       </label>
-      <label className="auth-field">
-        <span>Primary email</span>
-        <input className="auth-input" disabled name="email" value={profile.email ?? ""} />
-      </label>
+      {!showCompactLinkFeedback ? (
+        <label className="auth-field">
+          <span>Primary email</span>
+          <input className="auth-input" disabled name="email" value={profile.email ?? ""} />
+        </label>
+      ) : null}
+      {showCompactLinkFeedback ? <p className="portal-panel-muted">{linkMessage}</p> : null}
       {errorMessage ? <p className="form-error">{errorMessage}</p> : null}
       <button className="button" disabled={isSaving} type="submit">
         {isSaving ? "Saving..." : "Save profile"}
@@ -516,7 +521,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         Link an extra sign-in method from here. The portal only marks it as linked after the
         Cloudflare Access handoff returns and the backend confirms the new identity.
       </p>
-      {linkMessage ? <p className="portal-panel-muted">{linkMessage}</p> : null}
+      {!compactLayout && linkMessage ? <p className="portal-panel-muted">{linkMessage}</p> : null}
     </article>
   );
 


### PR DESCRIPTION
﻿## Summary

- keep profile link-return feedback visible in the compact profile form on small phones
- trade the redundant read-only email field for the link-result message only in the compact link-feedback state
- keep wider layouts and the existing identity-panel feedback placement unchanged

## Linked issues

- Closes #643

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
# targeted mobile Playwright QA via node + playwright against http://127.0.0.1:4371
# verified /profile?surface=portal&access=approved&roles=admin&email=local@example.com&link=
# - linked
# - conflict
# - provider_mismatch
# - invalid
# at 320x568 and 390x844
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Frontend-only compact-layout change. No auth, backend, or infrastructure behavior changed. No material runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Ships with the normal web deploy. Roll back by reverting the compact link-feedback placement if it hides needed form context.

## Notes

- Before the fix at 320x568, the link-result message landed at `1197.83` while the save action sat at `520.63`.
- After the fix at 320x568, the link-result message lands at `410.16` and the save action stays visible at `500.19`.
