### PR TITLE
Keep contributor entry actions visible on small phones

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -765,6 +765,8 @@ function PublicBenchmarkReport({
 }
 
 function PublicProjectPack() {
+  const isCompactLayout = useCompactLayout(480);
+
   useEffect(() => {
     function scrollProjectHashIntoView() {
       if (!window.location.hash) {
@@ -877,6 +879,17 @@ function PublicProjectPack() {
             </p>
           </div>
 
+          {isCompactLayout ? (
+            <div className="hero-actions">
+              <a className="button" href={buildAuthUrl("/")}>
+                Start contributor sign in
+              </a>
+              <a className="button button-secondary" href={githubDiscussionsUrl}>
+                Ask a public question first
+              </a>
+            </div>
+          ) : null}
+
           <div className="site-card-grid">
             {contributorSteps.map((step) => (
               <article className="site-panel-card" key={step.title}>
@@ -891,14 +904,16 @@ function PublicProjectPack() {
             ))}
           </div>
 
-          <div className="hero-actions">
-            <a className="button" href={buildAuthUrl("/")}>
-              Start contributor sign in
-            </a>
-            <a className="button button-secondary" href={githubDiscussionsUrl}>
-              Ask a public question first
-            </a>
-          </div>
+          {!isCompactLayout ? (
+            <div className="hero-actions">
+              <a className="button" href={buildAuthUrl("/")}>
+                Start contributor sign in
+              </a>
+              <a className="button button-secondary" href={githubDiscussionsUrl}>
+                Ask a public question first
+              </a>
+            </div>
+          ) : null}
         </article>
 
         <article className="site-project-section" id="contact">


### PR DESCRIPTION
﻿## Summary

- keep the contributor-section actions near the `#contributors` deep-link landing on small phones
- render the contributor CTA row before the contributor cards only in the compact project-pack layout
- leave the desktop and wider project-pack reading order unchanged

## Linked issues

- Closes #645

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
# targeted Playwright QA via node + playwright against http://127.0.0.1:4371
# verified /project#contributors at 320x568 and 390x844
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Frontend-only public-site layout change. No auth, backend, or infrastructure behavior changed. No material runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Ships with the normal web deploy. Roll back by reverting the compact contributor-section ordering if it weakens the broader project-pack reading flow.

## Notes

- Before the fix at 320x568, `Start contributor sign in` landed at `1441.41` after `/project#contributors`.
- After the fix at 320x568, it lands at `393.53`, with the section heading still landing at `40.7`.
