### PR TITLE
Restore benchmark summary metrics on mobile

### DIFF
--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -344,6 +344,12 @@ const footerProjectLinks = [
   { id: "contact", label: "Contact rules" }
 ];
 
+type PublicBenchmarkSummaryCard = {
+  detail: string;
+  label: string;
+  value: string;
+};
+
 function PublicHeader({
   currentPath,
   homeHref
@@ -455,6 +461,44 @@ function PublicFooter({ isProjectRoute }: { isProjectRoute: boolean }) {
   );
 }
 
+function PublicBenchmarkSummary({
+  ariaLabel,
+  cards,
+  compact
+}: {
+  ariaLabel: string;
+  cards: PublicBenchmarkSummaryCard[];
+  compact: boolean;
+}) {
+  if (compact) {
+    return (
+      <section className="site-benchmark-mobile-summary" aria-label={ariaLabel}>
+        {cards.map((card) => (
+          <article className="site-benchmark-mobile-card" key={card.label}>
+            <span className="site-benchmark-mobile-value">{card.value}</span>
+            <h2>{card.label}</h2>
+            <p>{card.detail}</p>
+          </article>
+        ))}
+      </section>
+    );
+  }
+
+  return (
+    <aside className="site-signal-column" aria-label={ariaLabel}>
+      {cards.map((card) => (
+        <article className="site-signal-row" key={card.label}>
+          <span className="site-signal-value">{card.value}</span>
+          <div>
+            <h2>{card.label}</h2>
+            <p>{card.detail}</p>
+          </div>
+        </article>
+      ))}
+    </aside>
+  );
+}
+
 function PublicLanding() {
   return (
     <main className="site-shell site-home-shell">
@@ -514,6 +558,27 @@ function PublicLanding() {
 
 function PublicBenchmarkIndex() {
   const isCompactLayout = useCompactLayout(480);
+  const showInFlowSummary = useCompactLayout(640);
+  const benchmarkIndexLead = showInFlowSummary
+    ? "The benchmark index shows which slices are public, which release is current, and whether publication is complete, partial, or withheld."
+    : "The benchmark index is release-oriented, not run-oriented. It shows which benchmark slices are public, which release is current, and whether the visible numbers are complete, partial, or historically superseded.";
+  const benchmarkIndexSummaryCards: PublicBenchmarkSummaryCard[] = [
+    {
+      detail: "Public benchmark release summaries listed on the apex site.",
+      label: "Released slices",
+      value: publicBenchmarks.length.toString().padStart(2, "0")
+    },
+    {
+      detail: "Each benchmark card points at one current public release state.",
+      label: "Latest reference",
+      value: "01"
+    },
+    {
+      detail: "Partial publication stays visible as scope, not benchmark failure.",
+      label: "Data-quality first",
+      value: "QA"
+    }
+  ];
 
   const benchmarkCards = (
     <section
@@ -558,11 +623,7 @@ function PublicBenchmarkIndex() {
             Public benchmark releases
           </p>
           <h1>Read the current public benchmark slices without dropping into portal internals.</h1>
-          <p className="site-lead">
-            The benchmark index is release-oriented, not run-oriented. It shows which benchmark
-            slices are public, which release is current, and whether the visible numbers are
-            complete, partial, or historically superseded.
-          </p>
+          <p className="site-lead">{benchmarkIndexLead}</p>
           <div className="hero-actions">
             <a className="button" href={buildBenchmarkReportUrl(publicBenchmarks[0].benchmarkVersionId)}>
               Open latest release
@@ -572,30 +633,11 @@ function PublicBenchmarkIndex() {
             </a>
           </div>
         </div>
-
-        <aside className="site-signal-column" aria-label="Benchmark index summary">
-          <article className="site-signal-row">
-            <span className="site-signal-value">{publicBenchmarks.length.toString().padStart(2, "0")}</span>
-            <div>
-              <h2>Released slices</h2>
-              <p>Each card points at one public benchmark release summary instead of a private run table.</p>
-            </div>
-          </article>
-          <article className="site-signal-row">
-            <span className="site-signal-value">01</span>
-            <div>
-              <h2>Latest reference</h2>
-              <p>Each benchmark lists one current public reference point and its release state.</p>
-            </div>
-          </article>
-          <article className="site-signal-row">
-            <span className="site-signal-value">QA</span>
-            <div>
-              <h2>Data-quality first</h2>
-              <p>Partial or withheld publication is called out as release scope, not benchmark failure.</p>
-            </div>
-          </article>
-        </aside>
+        <PublicBenchmarkSummary
+          ariaLabel="Benchmark index summary"
+          cards={benchmarkIndexSummaryCards}
+          compact={showInFlowSummary}
+        />
       </section>
 
       {benchmarkCards}
@@ -629,6 +671,7 @@ function PublicBenchmarkReport({
 }: {
   benchmarkVersionId: string;
 }) {
+  const showInFlowSummary = useCompactLayout(640);
   const report =
     publicBenchmarkReports[benchmarkVersionId as keyof typeof publicBenchmarkReports] ?? null;
 
@@ -666,9 +709,15 @@ function PublicBenchmarkReport({
     );
   }
 
+  const reportSummaryCards: PublicBenchmarkSummaryCard[] = report.summaryCards.map((card) => ({
+    detail: report.releaseLabel,
+    label: card.label,
+    value: card.value
+  }));
+
   return (
     <main className="site-shell site-benchmark-shell site-benchmark-report-shell">
-        <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
+      <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
 
       <section className="site-hero">
         <div className="site-hero-copy">
@@ -689,18 +738,11 @@ function PublicBenchmarkReport({
             </a>
           </div>
         </div>
-
-        <aside className="site-signal-column" aria-label="Release summary">
-          {report.summaryCards.map((card) => (
-            <article className="site-signal-row" key={card.label}>
-              <span className="site-signal-value">{card.value}</span>
-              <div>
-                <h2>{card.label}</h2>
-                <p>{report.releaseLabel}</p>
-              </div>
-            </article>
-          ))}
-        </aside>
+        <PublicBenchmarkSummary
+          ariaLabel="Release summary"
+          cards={reportSummaryCards}
+          compact={showInFlowSummary}
+        />
       </section>
 
       <section className="site-band-grid" aria-label="Release metadata">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -342,6 +342,40 @@ a.button-secondary {
   color: var(--navy);
 }
 
+.site-benchmark-mobile-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.site-benchmark-mobile-card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(244, 248, 255, 0.98));
+}
+
+.site-benchmark-mobile-card h2 {
+  font-size: 1rem;
+  letter-spacing: -0.03em;
+}
+
+.site-benchmark-mobile-card p {
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.site-benchmark-mobile-value {
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: var(--navy);
+}
+
 .site-band-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
﻿## Summary

- restore public benchmark summary metrics on compact benchmark index and report routes instead of dropping them with the mobile benchmark-shell CSS
- add a shared benchmark summary renderer that keeps the desktop hero aside and switches to compact in-flow metric cards when the benchmark aside would otherwise disappear
- tighten the compact benchmark index lead copy so the first restored metric row is actually visible at tiny-phone height while the primary CTA stays in view

## Linked issues

- Closes #647

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
```

- Targeted mobile Playwright QA on `/benchmarks`, `/reports/problem-9-v1`, and `/reports/statement-formalization-pilot-v1` at `320x568` and `390x844`
- After the fix:
  - `/benchmarks` summary block moved to `496.78` with the first compact summary card at `509.78`, while `Open latest release` stayed visible at `438.19` to `486.78` at `320x568`
  - `/reports/problem-9-v1` summary block moved to `465.98` with the first compact summary card at `478.98`, while `Open methodology` stayed visible at `348.8` to `397.39` at `320x568`
  - `/reports/statement-formalization-pilot-v1` summary block moved to `516.81` with the first compact summary card at `529.81`, while `Open methodology` stayed visible at `399.63` to `448.22` at `320x568`
  - the same summary blocks stayed visible at `390x844` on all three routes

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Public frontend-only layout change. No auth or API behavior changed.
- No infrastructure or runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship the frontend patch normally.
- Rollback: revert this PR to restore the prior benchmark-shell mobile layout.

## Notes

- The underlying defect was the benchmark-shell mobile CSS hiding `.site-signal-column` up to `640px`, which removed the public summary metrics entirely from compact benchmark routes.
