### PR TITLE
Restore missing report recovery actions on mobile

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2987,6 +2987,10 @@ a.button-secondary {
     display: inline-flex;
   }
 
+  .site-shell.site-report-unavailable-shell .hero-actions .button-secondary {
+    display: inline-flex;
+  }
+
   .site-shell.site-home-shell .site-header-actions {
     display: none;
   }


### PR DESCRIPTION
﻿## Summary

- restore the missing benchmark-release mobile recovery CTA by giving the unavailable-report shell the same compact secondary-button override as the released-report shell
- keep the broader benchmark-shell compact button-hiding rule unchanged for the other benchmark pages

## Linked issues

- Closes #649

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
```

- Targeted mobile Playwright QA on `/reports/not-a-real-release` at `320x568` and `390x844`
- After the fix:
  - at `320x568`, `Return to benchmark index` stayed visible at `423.17` to `471.77`
  - at `320x568`, `Read the project pack` returned at `481.77` to `530.36`
  - at `390x844`, both hero actions remained visible with the secondary CTA at `594.92` to `643.52`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Public frontend-only CSS change. No auth or backend behavior changed.
- No infrastructure or runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship the frontend patch normally.
- Rollback: revert this PR to restore the prior missing-report compact layout.

## Notes

- The underlying defect was the compact benchmark-shell rule hiding all secondary hero actions while only `site-benchmark-report-shell` restored them; `site-report-unavailable-shell` needed the same override.
