### PR TITLE
Tighten project overview deep-link spacing on mobile

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2932,6 +2932,23 @@ a.button-secondary {
     text-align: center;
   }
 
+  .site-project-shell #overview {
+    padding: 12px;
+  }
+
+  .site-project-shell #overview .site-section-copy {
+    gap: 6px;
+  }
+
+  .site-project-shell #overview .site-card-grid {
+    gap: 10px;
+  }
+
+  .site-project-shell #overview .site-panel-card {
+    padding: 14px;
+    gap: 12px;
+  }
+
   .site-project-shell .site-signal-column {
     gap: 0;
     padding-top: 8px;


### PR DESCRIPTION
﻿## Summary

- tighten the compact `#overview` project-pack section spacing and card padding so the first overview card fits fully after hash navigation on tiny phones
- keep the existing contributor and contact deep-link fixes untouched while leaving wider project-pack layouts unchanged

## Linked issues

- Closes #653

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
```

- Targeted mobile Playwright QA on `/project#overview` at `320x568` and `390x844`
- Regression spot-checks on `/project#contributors` and `/project#contact` at `320x568`
- After the fix:
  - `/project#overview` at `320x568` still landed at `scrollY = 1058`, with the first overview card moving to `328.23` to `567.20`
  - `/project#overview` at `390x844` kept the first overview card clean at `330.13` to `551.50`
  - `/project#contributors` at `320x568` kept the primary and secondary actions visible at `393.75` to `434.94` and `446.94` to `488.13`
  - `/project#contact` at `320x568` still landed correctly on the contact section heading

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Public frontend-only CSS adjustment. No auth or backend behavior changed.
- No infrastructure or runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship the frontend patch normally.
- Rollback: revert this PR to restore the prior compact overview spacing.

## Notes

- The change is isolated to the compact `#overview` section so the earlier contributor/contact deep-link fixes are not broadened or reordered.
