### PR TITLE
Tighten project contact deep-link spacing on mobile

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2949,6 +2949,23 @@ a.button-secondary {
     gap: 12px;
   }
 
+  .site-project-shell #contact {
+    padding: 12px;
+  }
+
+  .site-project-shell #contact .site-section-copy {
+    gap: 6px;
+  }
+
+  .site-project-shell #contact .site-card-grid {
+    gap: 10px;
+  }
+
+  .site-project-shell #contact .site-panel-card {
+    padding: 14px;
+    gap: 12px;
+  }
+
   .site-project-shell .site-signal-column {
     gap: 0;
     padding-top: 8px;


### PR DESCRIPTION
﻿## Summary

- tighten the compact `#contact` project-pack section spacing and card padding so the first contact card fits fully after hash navigation on tiny phones
- keep the existing overview and contributor deep-link fixes untouched while leaving wider project-pack layouts unchanged

## Linked issues

- Closes #655

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
```

- Targeted mobile Playwright QA on `/project#contact` at `320x568` and `390x844`
- Regression spot-checks on `/project#overview` and `/project#contributors` at `320x568`
- After the fix:
  - `/project#contact` at `320x568` still landed correctly, with the first `GitHub Discussions` card moving to `296.28` to `560.84`
  - `/project#contact` at `390x844` kept the first card clean at `270.94` to `517.91`
  - `/project#overview` at `320x568` kept the first card fitting at `328.23` to `567.20`
  - `/project#contributors` at `320x568` kept the primary and secondary actions visible at `393.75` to `434.94` and `446.94` to `488.13`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

- Public frontend-only CSS adjustment. No auth or backend behavior changed.
- No infrastructure or runtime cost impact.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

- Rollout: ship the frontend patch normally.
- Rollback: revert this PR to restore the prior compact contact-section spacing.

## Notes

- The change is isolated to the compact `#contact` section so the earlier overview and contributor deep-link fixes remain independent.
