### PR TITLE
Keep auth exit action visible on compact phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2497,19 +2497,26 @@ a.button-secondary {
   }
 
   .auth-provider-panel {
-    padding: 16px;
-    gap: 10px;
+    padding: 14px;
+    gap: 8px;
+  }
+
+  .auth-provider-panel .section-tag,
+  .auth-provider-panel .auth-panel-copy,
+  .auth-provider-panel-notes,
+  .auth-card-footer p {
+    display: none;
   }
 
   .auth-provider-button {
-    grid-template-columns: 38px minmax(0, 1fr) 18px;
-    gap: 10px;
-    padding: 12px 0;
+    grid-template-columns: 36px minmax(0, 1fr) 16px;
+    gap: 8px;
+    padding: 10px 0;
   }
 
   .auth-provider-mark {
-    width: 38px;
-    height: 38px;
+    width: 36px;
+    height: 36px;
   }
 
   .auth-check-list {
@@ -2524,6 +2531,12 @@ a.button-secondary {
   .auth-check-mark {
     width: 28px;
     height: 28px;
+  }
+
+  .auth-card-footer {
+    padding-top: 10px;
+    gap: 10px;
+    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
﻿## Summary

- keep the compact auth-entry escape hatch visible on first load by collapsing nonessential footer and notes content at `<=420px`
- tighten the compact auth provider panel spacing so the GitHub, Google, and public-exit actions fit cleanly on small phones
- leave wider auth layouts unchanged

## Linked issues

- Closes #657

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile Playwright QA on /?surface=auth, /?surface=auth&handoff=retry, and /?surface=auth&handoff=failed at 320x568
Regression spot-check on /?surface=auth at 390x844
```

QA evidence:
- after the fix, `Back to paretoproof.com` landed at `y=553.5` on `/?surface=auth` at `320x568`
- after the fix, the same action landed at `y=510.6` on both `handoff=retry` and `handoff=failed` at `320x568`
- at `390x844`, the public-exit action stayed visible at `y=487.7` on the default state and `y=570.7` on the retry/failed states
- visual spot-check confirmed the compact retry state now shows both provider buttons plus the public-exit button in the initial viewport

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- Not applicable. This is a frontend-only CSS adjustment on the public auth entry.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the normal web deployment.

Rollback plan:
- Revert the compact auth CSS change if it regresses small-screen auth affordances.

## Notes

- The issue queue was empty at pickup, so this PR starts from a newly filed execution issue for the verified compact-auth regression.
