### PR TITLE
Keep home signal cards fully visible on tiny phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3062,29 +3062,85 @@ a.button-secondary {
   }
 
   .site-shell.site-home-shell .site-header {
-    padding-bottom: 10px;
+    padding-bottom: 8px;
   }
 
   .site-shell.site-home-shell .site-hero {
-    gap: 8px;
-    padding-top: 10px;
+    gap: 4px;
+    padding-top: 6px;
   }
 
   .site-shell.site-home-shell .site-hero-copy {
-    gap: 8px;
+    gap: 5px;
   }
 
   .site-shell.site-home-shell .site-hero-copy h1 {
-    font-size: clamp(1.68rem, 8.7vw, 2.18rem);
+    font-size: clamp(1.5rem, 7.9vw, 1.92rem);
     line-height: 0.98;
   }
 
   .site-shell.site-home-shell .site-lead {
-    font-size: 0.9rem;
+    font-size: 0.84rem;
+    line-height: 1.44;
   }
 
   .site-shell.site-home-shell .hero-actions {
+    gap: 5px;
+  }
+
+  .site-shell.site-home-shell .site-brand {
     gap: 8px;
+  }
+
+  .site-shell.site-home-shell .site-brand-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  .site-shell.site-home-shell .site-primary-nav {
+    gap: 6px;
+  }
+
+  .site-shell.site-home-shell .site-nav-link {
+    min-height: 2rem;
+    padding: 0.35rem 0.68rem;
+  }
+
+  .site-shell.site-home-shell .button,
+  .site-shell.site-home-shell a.button {
+    min-height: 2.34rem;
+    padding: 0.52rem 0.82rem;
+    font-size: 0.9rem;
+  }
+
+  .site-shell.site-home-shell .site-signal-column {
+    gap: 6px;
+    padding-top: 4px;
+  }
+
+  .site-shell.site-home-shell .site-signal-row,
+  .site-shell.site-home-shell .site-signal-row + .site-signal-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+  }
+
+  .site-shell.site-home-shell .site-signal-row h2 {
+    font-size: 0.98rem;
+    line-height: 1.06;
+  }
+
+  .site-shell.site-home-shell .site-signal-row p {
+    font-size: 0.78rem;
+    line-height: 1.34;
+  }
+
+  .site-shell.site-home-shell .site-signal-value {
+    min-width: 0;
+    font-size: 0.92rem;
   }
 
   .site-shell.site-benchmark-shell .site-hero {


### PR DESCRIPTION
﻿## Summary

- keep the apex home route's first signal card fully visible on tiny phones by tightening the home-only header, hero, CTA, and signal-card sizing at `<=360px`
- preserve the existing home CTAs and top nav while compacting the signal rail into smaller card-like rows
- leave wider home layouts unchanged

## Linked issues

- Closes #659

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile Playwright QA on / at 320x568 and 390x844
```

QA evidence:
- before the fix, the first home signal row started at `y=540.92` and extended below the `320x568` viewport
- after the fix, the first home signal card moved to `y=453.22` with a height of `92.06`, fitting fully within the `320x568` viewport
- after the fix, `Open the project pack` stayed visible at `y=361.97` and the contributor sign-in CTA stayed visible at `y=405.59` on `320x568`
- at `390x844`, the home route remained healthy with the first signal row still visible at `y=702.59`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- Not applicable. This is a public frontend-only CSS adjustment.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the normal web deployment.

Rollback plan:
- Revert the compact home CSS adjustment if it regresses the apex hero or nav affordances.

## Notes

- The issue queue was empty at pickup, so this PR starts from a newly filed execution issue for the verified apex-home regression.
