### PR TITLE
Keep benchmark index project-pack CTA visible on tiny phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3090,6 +3090,13 @@ a.button-secondary {
     gap: 6px;
   }
 
+  .site-shell.site-benchmark-shell .button,
+  .site-shell.site-benchmark-shell a.button {
+    min-height: 2.34rem;
+    padding: 0.52rem 0.82rem;
+    font-size: 0.9rem;
+  }
+
   .site-shell.site-benchmark-shell .site-tagline,
   .site-shell.site-benchmark-shell .site-signal-column {
     display: none;
@@ -3101,7 +3108,7 @@ a.button-secondary {
   }
 
   .site-shell.site-benchmark-shell .hero-actions .button-secondary {
-    display: none;
+    display: inline-flex;
   }
 
   .site-shell.site-benchmark-report-shell .hero-actions .button-secondary {
@@ -3199,16 +3206,17 @@ a.button-secondary {
   }
 
   .site-shell.site-benchmark-shell .site-hero {
-    gap: 10px;
-    padding-top: 12px;
+    gap: 8px;
+    padding-top: 10px;
   }
 
   .site-shell.site-benchmark-shell .site-hero-copy h1 {
-    font-size: clamp(1.68rem, 8.7vw, 2.2rem);
+    font-size: clamp(1.58rem, 8.1vw, 2.02rem);
     line-height: 0.98;
   }
 
   .site-shell.site-benchmark-shell .site-lead {
-    font-size: 0.92rem;
+    font-size: 0.88rem;
+    line-height: 1.42;
   }
 }


### PR DESCRIPTION
﻿## Summary

- restore the benchmark index project-pack CTA on tiny phones by removing the overly broad secondary-button hide rule for the benchmark shell
- tighten the tiny-phone benchmark hero/button sizing so both hero CTAs stay visible without pushing the compact summary block below the fold
- leave wider benchmark layouts unchanged

## Linked issues

- Closes #663

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile Playwright QA on /benchmarks at 320x568 and 390x844
```

QA evidence:
- before the fix, `/benchmarks` at `320x568` hid `Read the project pack` entirely while `Open latest release` stayed visible
- after the fix, `/benchmarks` at `320x568` kept `Open latest release` visible at `y=377.13` and restored `Read the project pack` at `y=425.75`
- after the fix, the compact benchmark summary still started above the fold at `y=472.38` on `320x568`
- at `390x844`, both hero CTAs remained visible with the secondary CTA at `y=602.97`

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [ ] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- Not applicable. This is a public frontend-only CSS adjustment.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the normal web deployment.

Rollback plan:
- Revert the tiny-phone benchmark hero adjustment if it regresses the benchmark index hero fit.

## Notes

- The queue was empty at pickup, so this PR starts from a newly filed execution issue for the verified benchmark-index regression.
