### PR TITLE
Fix tiny-phone portal overview viewport fit

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2834,6 +2834,39 @@ a.button-secondary {
     font-size: 0.74rem;
   }
 
+  .portal-shell-overview-active .portal-metric-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portal-shell-overview-active .portal-metric-cell {
+    gap: 2px;
+    padding: 10px 10px 12px;
+  }
+
+  .portal-shell-overview-active .portal-metric-cell + .portal-metric-cell {
+    border-top: 0;
+    border-left: 1px solid var(--line);
+  }
+
+  .portal-shell-overview-active .portal-metric-cell:nth-child(3),
+  .portal-shell-overview-active .portal-metric-cell:nth-child(4) {
+    border-top: 1px solid var(--line);
+  }
+
+  .portal-shell-overview-active .portal-metric-cell:nth-child(3) {
+    border-left: 0;
+  }
+
+  .portal-shell-overview-active .portal-metric-cell span,
+  .portal-shell-overview-active .portal-metric-cell small {
+    font-size: 0.72rem;
+    line-height: 1.24;
+  }
+
+  .portal-shell-overview-active .portal-metric-cell strong {
+    font-size: 1.3rem;
+  }
+
   .portal-shell-profile-active .portal-nav {
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 5px;


### PR DESCRIPTION
## Summary

- keep the compact portal overview metrics in a 2x2 grid on tiny phones so the first workflow action stays in the initial viewport
- tighten the tiny-phone overview metric spacing and type sizing without changing wider portal layouts

## Linked issues

- Closes #667

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile QA on /?surface=portal&access=approved&roles=helper&email=qa%40paretoproof.local at 320x568 and 390x844
```

QA notes:
- Before the fix, on `320x568` the first overview action (`Review runs`) landed at `y=692.47` and its `Open` button was below the initial viewport.
- After the fix, on `320x568` `Review runs` lands at `y=458.06` and the `Open` button lands at `y=481.34`, both fully visible.
- On `390x844`, the first overview action remains visible at `y=753.09` and the `Open` button at `y=776.38`.

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- CSS-only portal layout change; no auth, API, session, or secret-handling behavior changed.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the next normal web deploy.

Rollback plan:
- Revert this PR to restore the previous tiny-phone portal overview metric layout if the compact landing view regresses.

## Notes

- The repo still does not have `codex` or `codex-automation` labels available, so they could not be applied.
