### PR TITLE
Fix compact launch route next-step visibility

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -991,6 +991,9 @@ function PortalLaunchSurface({
   const modelConfig = loadState.data?.modelConfigs.find(
     (item) => item.modelConfigId === selection.modelConfigId
   );
+  const launchEvidenceHref = benchmark
+    ? buildRunDetailHref(benchmark.lastSeenRunId)
+    : buildPortalUrl("/runs");
 
   return (
     <section className="portal-workspace-grid">
@@ -1019,6 +1022,16 @@ function PortalLaunchSurface({
           />
         ) : null}
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
+        {isCompactLayout ? (
+          <div className="portal-launch-quick-actions" aria-label="Launch next steps">
+            <a className="button button-secondary" href={launchEvidenceHref}>
+              Open evidence
+            </a>
+            <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+              Review runs
+            </a>
+          </div>
+        ) : null}
         <div className="portal-form-grid">
           <label className="portal-field">
             <span>Benchmark package</span>
@@ -1121,7 +1134,7 @@ function PortalLaunchSurface({
           />
           <PortalLinkCard
             copy="Preflight is currently read-only; use the last seen run as the concrete evidence target."
-            href={benchmark ? buildRunDetailHref(benchmark.lastSeenRunId) : buildPortalUrl("/runs")}
+            href={launchEvidenceHref}
             title="Open current evidence"
           />
         </div>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1007,6 +1007,17 @@ a.button-secondary {
   padding-top: 12px;
 }
 
+.portal-launch-quick-actions {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.portal-launch-quick-actions .button,
+.portal-launch-quick-actions a.button {
+  min-height: 2.2rem;
+}
+
 .portal-launch-panel-compact .portal-form-grid {
   margin-top: -2px;
 }
@@ -2417,6 +2428,16 @@ a.button-secondary {
   .portal-overview-actions-compact .portal-action-copy,
   .portal-overview-actions-compact .portal-action-hint {
     display: none;
+  }
+
+  .portal-launch-quick-actions {
+    gap: 6px;
+  }
+
+  .portal-launch-quick-actions .button,
+  .portal-launch-quick-actions a.button {
+    min-height: 2.1rem;
+    padding: 0.38rem 0.6rem;
   }
 
   .site-shell:not(.site-project-shell) {


### PR DESCRIPTION
## Summary

- add compact in-flow launch quick actions so the launch route exposes concrete next steps before the long preflight content and stacked rail
- reuse the same evidence target href in both the compact quick-action row and the existing launch rail
- keep the wider launch layout unchanged while tightening the compact quick-action spacing

## Linked issues

- Closes #669

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile QA on /launch?surface=portal&access=approved&roles=collaborator&email=qa%40paretoproof.local at 320x568 and 390x844
```

QA notes:
- Before the fix, on `320x568` `Open last seen run` landed at `y=1126.81` and `Review runs` landed at `y=1722.56`.
- Before the fix, on `390x844` `Open last seen run` landed at `y=1110.69` and `Review runs` landed at `y=1681.44`.
- After the fix, on `320x568` `Open evidence` and `Review runs` both land at `y=461.08`.
- After the fix, on `390x844` `Open evidence` and `Review runs` both land at `y=469.75`.

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- UI-only portal launch layout change; no auth, API, session, or mutation behavior changed.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the next normal web deploy.

Rollback plan:
- Revert this PR to restore the previous compact launch layout if the route regresses.

## Notes

- The repo still does not have `codex` or `codex-automation` labels available, so they could not be applied.
