### PR TITLE
Fix compact runs filter visibility

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -481,7 +481,47 @@ function PortalRunsSurface({
       <section className="portal-grid portal-grid-stack">
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
 
-        {runsSlice}
+        <article className="portal-panel portal-runs-quick-filter-panel">
+          <div className="portal-panel-header">
+            <div>
+              <p className="section-tag">Quick filters</p>
+              <h2>Refine the slice before dropping into the full list.</h2>
+            </div>
+          </div>
+          <div className="portal-form-grid portal-runs-quick-filter-grid">
+            <label className="portal-field">
+              <span>Search</span>
+              <input
+                className="input"
+                onChange={(event) => {
+                  updateRunsQuery(pathname, query, onReplaceLocation, { q: event.target.value || null });
+                }}
+                placeholder="run id, package, model, failure"
+                type="search"
+                value={query.q ?? ""}
+              />
+            </label>
+            <label className="portal-field">
+              <span>Lifecycle bucket</span>
+              <select
+                className="input"
+                onChange={(event) => {
+                  updateRunsQuery(pathname, query, onReplaceLocation, {
+                    lifecycleBucket: (event.target.value || null) as PortalRunsLifecycleBucket | null
+                  });
+                }}
+                value={query.lifecycleBucket ?? ""}
+              >
+                <option value="">All buckets</option>
+                {portalRunsLifecycleBuckets.map((bucket) => (
+                  <option key={bucket.id} value={bucket.id}>
+                    {bucket.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </article>
 
         <article className="portal-panel portal-results-panel portal-results-panel-compact">
           <div className="portal-panel-header">
@@ -653,10 +693,12 @@ function PortalRunsSurface({
               }}
               type="button"
             >
-              Reset filters
-            </button>
-          </div>
-        </article>
+            Reset filters
+          </button>
+        </div>
+      </article>
+
+        {runsSlice}
       </section>
     );
   }

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1233,6 +1233,15 @@ a.button-secondary {
   gap: 10px;
 }
 
+.portal-runs-quick-filter-panel {
+  gap: 10px;
+}
+
+.portal-runs-quick-filter-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
 .portal-run-card-list {
   display: grid;
   gap: 10px;
@@ -2347,6 +2356,19 @@ a.button-secondary {
   .portal-results-panel-compact .portal-toolbar .button,
   .portal-results-panel-compact .portal-toolbar a.button {
     min-height: 2.45rem;
+  }
+
+  .portal-runs-quick-filter-panel {
+    gap: 8px;
+  }
+
+  .portal-runs-quick-filter-panel h2 {
+    font-size: 1.02rem;
+    line-height: 1.08;
+  }
+
+  .portal-runs-quick-filter-grid {
+    gap: 8px;
   }
 
   .portal-run-card-timestamp {


### PR DESCRIPTION
## Summary

- add a compact quick-filter panel to `/runs` so search and lifecycle filters appear in the first viewport on phones
- keep the fuller advanced runs support panel lower on the page and leave the wider runs layout unchanged
- preserve the canonical runs detail navigation while making the route act like a filtered index on compact devices

## Linked issues

- Closes #675

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun --cwd apps/web build
bun --cwd apps/web typecheck
bun run check:bidi
Targeted mobile QA on /runs?surface=portal&access=approved&roles=collaborator&email=qa%40paretoproof.local at 320x568 and 390x844
```

QA notes:
- Before the fix, on `320x568` `Search` landed at `y=1626.86` and `Lifecycle bucket` at `y=1690.86`.
- Before the fix, on `390x844` `Search` landed at `y=1576.61` and `Lifecycle bucket` at `y=1640.61`.
- After the fix, on `320x568` `Search` lands at `y=403.27` and `Lifecycle bucket` at `y=463.27`.
- After the fix, on `390x844` `Search` lands at `y=450.33` and `Lifecycle bucket` at `y=510.33`.

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Threat boundary / mitigation:
- UI-only runs layout change; no auth, API, filtering semantics, or run detail behavior changed.

Cost / rate-limit impact:
- None.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout plan:
- Ship with the next normal web deploy.

Rollback plan:
- Revert this PR to restore the previous compact runs layout if the route regresses.

## Notes

- The repo still does not have `codex` or `codex-automation` labels available, so they could not be applied.
