### PR TITLE
Fix compact workers evidence visibility

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -1192,6 +1192,7 @@ function PortalWorkersSurface({
 }: SurfaceProps<PortalWorkersViewResponse>) {
   const data = loadState.data;
   const isCompactLayout = useCompactLayout(480);
+  const compactEvidenceCards = buildWorkersCompactEvidenceCards(data);
   const freshnessCard = (
     <PortalFreshnessCard
       isRefreshing={loadState.isLoading}
@@ -1227,6 +1228,21 @@ function PortalWorkersSurface({
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
         {data ? (
           <>
+            {isCompactLayout && compactEvidenceCards.length ? (
+              <article className="portal-panel-table-flat portal-workers-quick-evidence">
+                <div className="portal-panel-header">
+                  <div>
+                    <p className="section-tag">Concrete evidence</p>
+                    <h2>Jump straight into the current worker-linked runs.</h2>
+                  </div>
+                </div>
+                <div className="portal-action-list">
+                  {compactEvidenceCards.map((card) => (
+                    <PortalLinkCard copy={card.copy} href={card.href} key={card.title} title={card.title} />
+                  ))}
+                </div>
+              </article>
+            ) : null}
             <div className="portal-summary-grid">
               <article className="portal-summary-card">
                 <span>Queued jobs</span>
@@ -1349,6 +1365,49 @@ function PortalLinkCard({
       </a>
     </article>
   );
+}
+
+function buildWorkersCompactEvidenceCards(data: PortalWorkersViewResponse | null) {
+  if (!data) {
+    return [];
+  }
+
+  const cards: Array<{ copy: string; href: string; title: string }> = [];
+  const seenHrefs = new Set<string>();
+
+  const pushCard = (title: string, copy: string, runId: string | null | undefined) => {
+    if (!runId) {
+      return;
+    }
+
+    const href = buildRunDetailHref(runId);
+    if (seenHrefs.has(href)) {
+      return;
+    }
+
+    seenHrefs.add(href);
+    cards.push({ copy, href, title });
+  };
+
+  const primaryLease = data.activeLeases[0];
+  pushCard(
+    primaryLease ? `${primaryLease.runId} lease` : "Active lease",
+    primaryLease
+      ? `${primaryLease.workerPool} on ${primaryLease.workerId} · ${primaryLease.health}`
+      : "Open the first active lease run detail.",
+    primaryLease?.runId ?? data.workerPools.find((pool) => pool.activeRunIds[0])?.activeRunIds[0]
+  );
+
+  const primaryIncident = data.incidents.find((incident) => incident.affectedRunIds[0]);
+  pushCard(
+    primaryIncident ? `${primaryIncident.affectedRunIds[0]} incident` : "Incident run",
+    primaryIncident
+      ? `${primaryIncident.severity} · ${primaryIncident.workerPool ?? "all pools"}`
+      : "Open the first incident-linked run detail.",
+    primaryIncident?.affectedRunIds[0]
+  );
+
+  return cards;
 }
 
 function PortalErrorState({ error }: { error: string }) {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1353,6 +1353,42 @@ a.button-secondary {
   gap: 8px;
 }
 
+.portal-workers-quick-evidence {
+  gap: 8px;
+}
+
+.portal-workers-quick-evidence .portal-action-list {
+  border-top: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.portal-workers-quick-evidence .portal-action-card,
+.portal-workers-quick-evidence .portal-action-card + .portal-action-card {
+  align-items: stretch;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  border-top: 0;
+}
+
+.portal-workers-quick-evidence .portal-action-title {
+  margin-bottom: 2px;
+  font-size: 0.94rem;
+  line-height: 1.18;
+}
+
+.portal-workers-quick-evidence .portal-action-copy {
+  font-size: 0.8rem;
+  line-height: 1.3;
+}
+
+.portal-workers-quick-evidence .portal-action-card .button,
+.portal-workers-quick-evidence .portal-action-card a.button {
+  min-height: 2.2rem;
+}
+
 .portal-workers-main-compact h2 {
   font-size: 1.08rem;
   line-height: 1.08;
@@ -2386,6 +2422,14 @@ a.button-secondary {
     min-height: 2.35rem;
     padding: 0.48rem 0.78rem;
   }
+
+  .portal-workers-quick-evidence .portal-action-title {
+    font-size: 0.9rem;
+  }
+
+  .portal-workers-quick-evidence .portal-action-copy {
+    font-size: 0.78rem;
+  }
 }
 
 @media (max-width: 420px) {
@@ -2458,6 +2502,25 @@ a.button-secondary {
 
   .portal-launch-quick-actions .button,
   .portal-launch-quick-actions a.button {
+    min-height: 2.1rem;
+    padding: 0.38rem 0.6rem;
+  }
+
+  .portal-workers-quick-evidence .portal-action-list {
+    gap: 6px;
+  }
+
+  .portal-workers-quick-evidence .portal-action-card,
+  .portal-workers-quick-evidence .portal-action-card + .portal-action-card {
+    gap: 6px;
+  }
+
+  .portal-workers-quick-evidence .portal-action-copy {
+    display: none;
+  }
+
+  .portal-workers-quick-evidence .portal-action-card .button,
+  .portal-workers-quick-evidence .portal-action-card a.button {
     min-height: 2.1rem;
     padding: 0.38rem 0.6rem;
   }


### PR DESCRIPTION
## Summary
- add a compact-only workers evidence panel that surfaces the first lease-linked and incident-linked run cards near the top of `/workers`
- keep the existing worker-pool, incidents, and lease rail flow intact for wider layouts
- tighten the compact evidence card styling so both actions stay inside the first phone viewport

## Verification
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted Playwright QA on `/workers?surface=portal&access=approved&roles=collaborator&email=qa%40paretoproof.local` at 320x568 and 390x844

Closes #677