### PR TITLE
Fix compact run detail evidence visibility

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -887,6 +887,7 @@ function PortalRunDetailSurface({
   const detail = loadState.data;
   const runsIndexHref = buildRunsIndexHref(search);
   const isCompactLayout = useCompactLayout(480);
+  const latestTimelineEntry = detail?.timeline.at(-1) ?? null;
   const freshnessCard = (
     <PortalFreshnessCard
       isRefreshing={loadState.isLoading}
@@ -922,6 +923,24 @@ function PortalRunDetailSurface({
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
         {detail ? (
           <>
+            {isCompactLayout && latestTimelineEntry ? (
+              <article className="portal-panel-table-flat portal-run-detail-quick-evidence">
+                <div className="portal-panel-header">
+                  <div>
+                    <p className="section-tag">Current evidence</p>
+                    <h2>Latest run signal stays in the first viewport.</h2>
+                  </div>
+                </div>
+                <article className="portal-timeline-item portal-run-detail-highlight">
+                  <strong>{latestTimelineEntry.label}</strong>
+                  <p>
+                    {latestTimelineEntry.scope}
+                    {latestTimelineEntry.sourceId ? ` - ${latestTimelineEntry.sourceId}` : ""}
+                  </p>
+                  <small>{formatTimestamp(latestTimelineEntry.occurredAt)}</small>
+                </article>
+              </article>
+            ) : null}
             <div className="portal-summary-grid">
               <article className="portal-summary-card">
                 <span>Benchmark</span>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1313,6 +1313,25 @@ a.button-secondary {
   line-height: 1.08;
 }
 
+.portal-run-detail-quick-evidence {
+  gap: 8px;
+}
+
+.portal-run-detail-highlight {
+  gap: 4px;
+  padding: 12px;
+}
+
+.portal-run-detail-highlight p {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.portal-run-detail-highlight small {
+  font-size: 0.76rem;
+}
+
 .portal-run-detail-main-compact .portal-summary-grid {
   gap: 8px;
 }
@@ -2415,6 +2434,11 @@ a.button-secondary {
   .portal-run-detail-main-compact .portal-panel-header a.button {
     min-height: 2.35rem;
     padding: 0.48rem 0.78rem;
+  }
+
+  .portal-run-detail-quick-evidence h2 {
+    font-size: 1.02rem;
+    line-height: 1.08;
   }
 
   .portal-workers-main-compact .portal-panel-header .button,


### PR DESCRIPTION
## Summary
- surface the latest run-detail evidence entry at the top of compact `/runs/:runId` views
- keep the existing summary cards and full timeline lower on the route
- tighten the compact evidence card typography without changing wider layouts

## Testing
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted Playwright QA on `/runs/PP-319?surface=portal&access=approved&roles=collaborator&email=qa%40paretoproof.local` at `320x568`, `390x844`, and desktop `1280x900`

Closes #679.