### PR TITLE
Keep auth entry footer action visible on compact phones

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2749,6 +2749,40 @@ a.button-secondary {
 }
 
 @media (max-width: 360px) {
+  .auth-provider-layout {
+    gap: 0;
+  }
+
+  .auth-provider-panel {
+    padding: 12px;
+    gap: 6px;
+  }
+
+  .auth-provider-button {
+    padding: 7px 0;
+  }
+
+  .auth-provider-button strong {
+    font-size: 0.96rem;
+  }
+
+  .auth-provider-button small {
+    margin-top: 2px;
+    font-size: 0.74rem;
+    line-height: 1.3;
+  }
+
+  .auth-card-footer {
+    padding-top: 6px;
+    gap: 8px;
+  }
+
+  .auth-card-footer .button,
+  .auth-card-footer a.button {
+    min-height: 2.24rem;
+    padding: 0.5rem 0.82rem;
+  }
+
   .auth-access-request-card {
     gap: 10px;
   }


### PR DESCRIPTION
## Summary
- tighten the smallest auth-entry provider stack so the footer CTA stays in the first viewport
- reduce only the <=360px auth panel and footer spacing
- keep the wider auth entry and access-request surfaces unchanged

## Testing
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted Playwright QA on `/?surface=auth` at `320x568` and `390x844`

Closes #681.