### PR TITLE
Keep profile identity actions visible on compact phones

### DIFF
--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -533,6 +533,8 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
           {profileForm}
         </article>
 
+        {identityPanel}
+
         <article className="portal-panel portal-profile-context-panel">
           <p className="portal-panel-muted">
             Update the supported contributor details and attach an extra GitHub or Google
@@ -540,8 +542,6 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
           </p>
           <PortalFreshnessCard lastUpdatedAt={lastUpdatedAt} routeId="portal.profile" />
         </article>
-
-        {identityPanel}
       </section>
     );
   }


### PR DESCRIPTION
## Summary
- move the compact linked-identity panel ahead of the profile context card
- keep the display-name form first while bringing identity management into the first viewport
- leave the wider profile layout unchanged

## Testing
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted Playwright QA on `/profile?surface=portal&access=approved&roles=helper&email=qa%40paretoproof.local` at `320x568` and `390x844`

Closes #683.