### PR TITLE
Keep overview actions visible for collaborator and admin phones

### DIFF
--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -462,6 +462,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
 
         {activeSection?.id === "overview" ? (
           <>
+            {compactLayout ? overviewActionRail : null}
             <section className="portal-metric-strip" aria-label="Portal metrics">
               {overviewMetrics.map((metric) => (
                 <article className="portal-metric-cell" key={metric.label}>
@@ -471,7 +472,6 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                 </article>
               ))}
             </section>
-            {compactLayout ? overviewActionRail : null}
 
             <section className="portal-overview-grid">
               <article className="portal-panel portal-overview-lead">


### PR DESCRIPTION
## Summary
- render the compact overview action rail before the metric strip
- keep role-aware actions above the fold for helper, collaborator, and admin phones
- leave the wider overview layout unchanged

## Testing
- bun --cwd apps/web build
- bun --cwd apps/web typecheck
- bun run check:bidi
- targeted Playwright QA on `/?surface=portal&access=approved&roles=helper|collaborator|admin&email=qa%40paretoproof.local` at `320x568` and `390x844`

Closes #685.