### PR TITLE
Keep launch preflight visible on compact phones

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -1083,16 +1083,6 @@ function PortalLaunchSurface({
           />
         ) : null}
         {loadState.error ? <PortalErrorState error={loadState.error} /> : null}
-        {isCompactLayout ? (
-          <div className="portal-launch-quick-actions" aria-label="Launch next steps">
-            <a className="button button-secondary" href={launchEvidenceHref}>
-              Open evidence
-            </a>
-            <a className="button button-secondary" href={buildPortalUrl("/runs")}>
-              Review runs
-            </a>
-          </div>
-        ) : null}
         <div className="portal-form-grid">
           <label className="portal-field">
             <span>Benchmark package</span>
@@ -1152,6 +1142,16 @@ function PortalLaunchSurface({
             }}
             routeId={activeRouteId}
           />
+        ) : null}
+        {isCompactLayout ? (
+          <div className="portal-launch-quick-actions" aria-label="Launch next steps">
+            <a className="button button-secondary" href={launchEvidenceHref}>
+              Open evidence
+            </a>
+            <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+              Review runs
+            </a>
+          </div>
         ) : null}
         {benchmark && modelConfig ? (
           <div className="portal-results-contract-grid">


### PR DESCRIPTION
﻿## Summary
- move the compact `/launch` quick-action shortcuts below the preflight selector stack
- keep the launch route aligned with its preflight-first copy on the smallest phone viewport
- preserve the wider launch layout unchanged

## Testing
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- targeted Playwright QA on `/launch?surface=portal&access=approved&roles=collaborator&email=qa%40paretoproof.local` at `320x568`, `390x844`, and `1280x900`

## Issue
Closes #689
