### PR TITLE
Remove compact overflow from admin access requests

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2826,10 +2826,21 @@ a.button-secondary {
   .portal-grid-admin-workspace .portal-admin-list-panel {
     gap: 6px;
     padding-top: 6px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel > * {
+    min-width: 0;
   }
 
   .portal-grid-admin-workspace .portal-admin-list-panel .portal-panel-header {
+    flex-wrap: wrap;
     gap: 8px;
+  }
+
+  .portal-grid-admin-workspace .portal-admin-list-panel .portal-panel-header > div {
+    min-width: 0;
+    flex: 1 1 11rem;
   }
 
   .portal-grid-admin-workspace .portal-admin-list-panel .section-tag {


### PR DESCRIPTION
﻿## Summary
- remove compact horizontal overflow from `/admin/access-requests`
- keep the access-request queue panel on a real single-column track on the smallest screens
- let the queue header wrap instead of widening the route

## Testing
- `bun --cwd apps/web build`
- `bun --cwd apps/web typecheck`
- `bun run check:bidi`
- targeted Playwright QA on `/admin/access-requests?surface=portal&access=approved&roles=admin&email=qa%40paretoproof.local` at `320x568`, `390x844`, and `1280x900`

## Issue
Closes #691
