### PR TITLE
Fix partial report summary fit on small phones

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -65,7 +65,17 @@ describe("PublicSite", () => {
 
     expect(html).toContain("Problem 9 public release");
     expect(html).toContain("One release table, presented as calm mobile-safe rows.");
+    expect(html).not.toContain("site-benchmark-report-partial");
     expect(html).not.toContain("Measure frontier reasoning with reproducible proof workflows.");
+  });
+
+  it("marks partial release reports for compact-only layout tuning", async () => {
+    const html = await renderPublicSiteAt(
+      "http://127.0.0.1/reports/statement-formalization-pilot-v1"
+    );
+
+    expect(html).toContain("Statement formalization pilot release");
+    expect(html).toContain("site-benchmark-report-partial");
   });
 
   it("keeps the project pack route intact", async () => {

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -716,7 +716,11 @@ function PublicBenchmarkReport({
   }));
 
   return (
-    <main className="site-shell site-benchmark-shell site-benchmark-report-shell">
+    <main
+      className={`site-shell site-benchmark-shell site-benchmark-report-shell${
+        report.completeness === "partial" ? " site-benchmark-report-partial" : ""
+      }`}
+    >
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl(benchmarksRoute)} />
 
       <section className="site-hero">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -3566,4 +3566,18 @@ a.button-secondary {
   .site-shell.site-benchmark-report-shell .site-benchmark-mobile-value {
     font-size: 0.98rem;
   }
+
+  .site-shell.site-benchmark-report-shell.site-benchmark-report-partial .site-benchmark-mobile-summary {
+    gap: 5px;
+    padding-top: 4px;
+  }
+
+  .site-shell.site-benchmark-report-shell.site-benchmark-report-partial .site-benchmark-mobile-card {
+    gap: 3px;
+    padding: 9px;
+  }
+
+  .site-shell.site-benchmark-report-shell.site-benchmark-report-partial .site-benchmark-mobile-card p {
+    display: none;
+  }
 }


### PR DESCRIPTION
﻿## Summary
- mark partial public benchmark reports with a dedicated shell class for compact-only tuning
- tighten the smallest-phone partial release summary cards without changing the complete release layout
- add public-site coverage so the partial report marker stays wired

## Testing
- bun test apps/web/src/routes/public-site.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi
- targeted Playwright QA on /reports/statement-formalization-pilot-v1 and /reports/problem-9-v1 at 320x568 and 390x844

## Verification Notes
- before the fix, the partial statement-formalization summary bottom landed at y=594.94 on 320x568 while the complete Problem 9 summary landed at y=552.22
- after the fix, the partial statement-formalization summary bottom lands at y=531.05 on 320x568 and stays at y=776.75 on 390x844
- the complete Problem 9 summary remains healthy at y=552.22 on 320x568 and y=745.80 on 390x844

Closes #697
