### PR TITLE
Fix compact benchmark index first-fold ordering

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -3,22 +3,33 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 const originalWindow = globalThis.window;
 
-function setWindowUrl(url) {
-  globalThis.window = {
-    location: new URL(url)
+function createMatchMedia(width) {
+  return (query) => {
+    const maxWidthMatch = /\(max-width:\s*(\d+)px\)/.exec(query);
+    const maxWidth = maxWidthMatch ? Number(maxWidthMatch[1]) : Number.POSITIVE_INFINITY;
+
+    return {
+      addEventListener() {},
+      matches: width <= maxWidth,
+      media: query,
+      removeEventListener() {}
+    };
   };
 }
 
-function renderPublicSiteAt(url) {
-  setWindowUrl(url);
+function setWindow(url, width = 1280) {
+  globalThis.window = {
+    location: new URL(url),
+    matchMedia: createMatchMedia(width)
+  };
 }
 
 async function loadPublicSiteModule() {
   return import(`./public-site.tsx?test=${Date.now()}`);
 }
 
-async function renderPublicSiteAt(url) {
-  setWindowUrl(url);
+async function renderPublicSiteAt(url, width = 1280) {
+  setWindow(url, width);
   const { PublicSite } = await loadPublicSiteModule();
   return renderToStaticMarkup(PublicSite());
 }
@@ -34,14 +45,14 @@ afterEach(() => {
 
 describe("resolvePublicSiteRoute", () => {
   it("routes /benchmarks to the benchmark index", async () => {
-    setWindowUrl("http://127.0.0.1/");
+    setWindow("http://127.0.0.1/");
     const { resolvePublicSiteRoute } = await loadPublicSiteModule();
 
     expect(resolvePublicSiteRoute("/benchmarks")).toEqual({ kind: "benchmarks" });
   });
 
   it("routes /reports/:benchmarkVersionId to the release summary view", async () => {
-    setWindowUrl("http://127.0.0.1/");
+    setWindow("http://127.0.0.1/");
     const { resolvePublicSiteRoute } = await loadPublicSiteModule();
 
     expect(resolvePublicSiteRoute("/reports/problem-9-v1")).toEqual({
@@ -76,6 +87,22 @@ describe("PublicSite", () => {
 
     expect(html).toContain("Statement formalization pilot release");
     expect(html).toContain("site-benchmark-report-partial");
+  });
+
+  it("keeps compact benchmark index release cards ahead of the support summary", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/benchmarks", 320);
+
+    expect(html).toContain("site-benchmark-index-shell-compact");
+    expect(html.indexOf("Problem 9")).toBeLessThan(
+      html.indexOf("Benchmark status cues stay available after the released slices.")
+    );
+  });
+
+  it("keeps the wide benchmark index summary ahead of the release cards", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/benchmarks", 1280);
+
+    expect(html).not.toContain("site-benchmark-index-shell-compact");
+    expect(html.indexOf("Released slices")).toBeLessThan(html.indexOf("Problem 9"));
   });
 
   it("keeps the project pack route intact", async () => {

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -1,7 +1,7 @@
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { buildAuthUrl, buildPublicUrl } from "../lib/surface";
 import { useCompactLayout } from "../lib/use-compact-layout";
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
 
 const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discussions";
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
@@ -317,6 +317,10 @@ function formatReleaseStatus(status: string) {
   return status.replaceAll("_", " ");
 }
 
+export function getCompactBenchmarkIndexSectionOrder() {
+  return ["benchmarkCards", "summarySupport", "reportingRules"] as const;
+}
+
 export function resolvePublicSiteRoute(pathname: string) {
   if (pathname === projectRoute || pathname.startsWith(`${projectRoute}/`)) {
     return { kind: "project" as const };
@@ -610,8 +614,51 @@ function PublicBenchmarkIndex() {
     </section>
   );
 
+  const reportingRules = (
+    <section className="site-band-grid" aria-label="Reporting rules">
+      <article className="site-band">
+        <p className="section-tag">Release flow</p>
+        <h2>Public reporting stays release-centric.</h2>
+        <p>
+          Benchmark cards route into one release summary page with stable top-line metrics,
+          one visible notice block, and links to methodology rather than private evidence consoles.
+        </p>
+      </article>
+      <article className="site-band">
+        <p className="section-tag">What not to expect</p>
+        <h2>No public run drilldown.</h2>
+        <p>
+          Per-run evidence, artifact inspection, and operational rerun context remain in the
+          authenticated portal. The public site only shows released benchmark slices.
+        </p>
+      </article>
+    </section>
+  );
+
+  const summarySupport = showInFlowSummary ? (
+    <section className="site-project-section site-benchmark-index-summary-support">
+      <div className="site-section-copy">
+        <p className="section-tag">Index support</p>
+        <h2>Benchmark status cues stay available after the released slices.</h2>
+        <p className="site-lead">
+          The support summary still explains coverage, release posture, and data-quality framing
+          without displacing the actual benchmark entries from the first mobile viewport.
+        </p>
+      </div>
+      <PublicBenchmarkSummary
+        ariaLabel="Benchmark index summary"
+        cards={benchmarkIndexSummaryCards}
+        compact
+      />
+    </section>
+  ) : null;
+
   return (
-    <main className="site-shell site-benchmark-shell">
+    <main
+      className={`site-shell site-benchmark-shell${
+        showInFlowSummary ? " site-benchmark-index-shell-compact" : ""
+      }`}
+    >
       <PublicHeader currentPath={window.location.pathname} homeHref={buildPublicUrl("/")} />
 
       <section className="site-hero">
@@ -633,33 +680,31 @@ function PublicBenchmarkIndex() {
             </a>
           </div>
         </div>
-        <PublicBenchmarkSummary
-          ariaLabel="Benchmark index summary"
-          cards={benchmarkIndexSummaryCards}
-          compact={showInFlowSummary}
-        />
+        {!showInFlowSummary ? (
+          <PublicBenchmarkSummary
+            ariaLabel="Benchmark index summary"
+            cards={benchmarkIndexSummaryCards}
+            compact={false}
+          />
+        ) : null}
       </section>
 
-      {benchmarkCards}
+      {showInFlowSummary
+        ? getCompactBenchmarkIndexSectionOrder().map((sectionId) => {
+            const sections = {
+              benchmarkCards,
+              reportingRules,
+              summarySupport
+            };
 
-      <section className="site-band-grid" aria-label="Reporting rules">
-        <article className="site-band">
-          <p className="section-tag">Release flow</p>
-          <h2>Public reporting stays release-centric.</h2>
-          <p>
-            Benchmark cards route into one release summary page with stable top-line metrics,
-            one visible notice block, and links to methodology rather than private evidence consoles.
-          </p>
-        </article>
-        <article className="site-band">
-          <p className="section-tag">What not to expect</p>
-          <h2>No public run drilldown.</h2>
-          <p>
-            Per-run evidence, artifact inspection, and operational rerun context remain in the
-            authenticated portal. The public site only shows released benchmark slices.
-          </p>
-        </article>
-      </section>
+            return <Fragment key={sectionId}>{sections[sectionId]}</Fragment>;
+          })
+        : (
+            <>
+              {benchmarkCards}
+              {reportingRules}
+            </>
+          )}
 
       <PublicFooter isProjectRoute={false} />
     </main>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -476,6 +476,11 @@ a.button-secondary {
   gap: 6px;
 }
 
+.site-benchmark-index-summary-support .site-benchmark-mobile-summary {
+  padding-top: 0;
+  border-top: 0;
+}
+
 .site-footer {
   border: 1px solid var(--line);
   border-radius: 18px;


### PR DESCRIPTION
## Summary
- move the compact `/benchmarks` support summary below the released benchmark cards
- keep the wide benchmark index summary placement unchanged
- cover narrow-vs-wide ordering in `public-site` route tests

## Linked issues
- Closes #699

## Testing
- bun test apps/web/src/routes/public-site.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi