### PR TITLE
Fix compact project pack overview fold

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -110,4 +110,28 @@ describe("PublicSite", () => {
 
     expect(html).toContain("One public pack for project context, contributor entry, and contact rules.");
   });
+
+  it("keeps compact project pack overview content ahead of the coverage summary", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/project", 320);
+
+    expect(html.indexOf("Explain the product without duplicating the whole methodology archive.")).toBeLessThan(
+      html.indexOf("Coverage summary stays available after the real overview.")
+    );
+  });
+
+  it("keeps realistic phone-width project pack overview content ahead of the coverage summary", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/project", 390);
+
+    expect(html.indexOf("Explain the product without duplicating the whole methodology archive.")).toBeLessThan(
+      html.indexOf("Coverage summary stays available after the real overview.")
+    );
+  });
+
+  it("keeps the wide project pack coverage summary in the hero ahead of the overview section", async () => {
+    const html = await renderPublicSiteAt("http://127.0.0.1/project", 1280);
+
+    expect(html.indexOf("Project overview")).toBeLessThan(
+      html.indexOf("Explain the product without duplicating the whole methodology archive.")
+    );
+  });
 });

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -856,7 +856,24 @@ function PublicBenchmarkReport({
 }
 
 function PublicProjectPack() {
-  const isCompactLayout = useCompactLayout(480);
+  const isCompactLayout = useCompactLayout(640);
+
+  const projectCoverageSummary = (
+    <aside
+      className="site-signal-column site-project-coverage-hero"
+      aria-label="Project pack coverage"
+    >
+      {packCoverage.map((item) => (
+        <article className="site-signal-row" key={item.label}>
+          <span className="site-signal-value">{item.value}</span>
+          <div>
+            <h2>{item.label}</h2>
+            <p>{item.detail}</p>
+          </div>
+        </article>
+      ))}
+    </aside>
+  );
 
   useEffect(() => {
     function scrollProjectHashIntoView() {
@@ -918,17 +935,7 @@ function PublicProjectPack() {
           </div>
         </div>
 
-        <aside className="site-signal-column" aria-label="Project pack coverage">
-          {packCoverage.map((item) => (
-            <article className="site-signal-row" key={item.label}>
-              <span className="site-signal-value">{item.value}</span>
-              <div>
-                <h2>{item.label}</h2>
-                <p>{item.detail}</p>
-              </div>
-            </article>
-          ))}
-        </aside>
+        {projectCoverageSummary}
       </section>
 
       <section className="site-section-stack" aria-label="Project pack sections">
@@ -956,6 +963,19 @@ function PublicProjectPack() {
               </article>
             ))}
           </div>
+        </article>
+
+        <article className="site-project-section site-project-section-support">
+          <div className="site-section-copy">
+            <p className="section-tag">Pack coverage</p>
+            <h2>Coverage summary stays available after the real overview.</h2>
+            <p className="site-lead">
+              The coverage summary still tells readers which parts of the pack exist
+              without displacing the actual project overview from the first compact
+              viewport.
+            </p>
+          </div>
+          {projectCoverageSummary}
         </article>
 
         <article className="site-project-section" id="contributors">

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -399,6 +399,15 @@ a.button-secondary {
   gap: 18px;
 }
 
+.site-project-section-support .site-signal-column {
+  border: 0;
+  padding: 0;
+}
+
+.site-project-section-support {
+  display: none;
+}
+
 .site-section-copy {
   display: grid;
   gap: 10px;
@@ -2332,6 +2341,14 @@ a.button-secondary {
     font-size: 0.94rem;
   }
 
+  .site-project-shell .site-project-coverage-hero {
+    display: none;
+  }
+
+  .site-project-shell .site-project-section-support {
+    display: grid;
+  }
+
   .portal-shell {
     padding: 8px;
   }
@@ -3275,6 +3292,19 @@ a.button-secondary {
     padding: 0.28rem 0.52rem;
     font-size: 0.74rem;
     text-align: center;
+  }
+
+  .site-project-shell .site-project-coverage-hero {
+    display: none;
+  }
+
+  .site-project-shell .site-project-section-support {
+    display: grid;
+    padding: 12px;
+  }
+
+  .site-project-shell .site-project-section-support .site-section-copy {
+    gap: 6px;
   }
 
   .site-project-shell #overview {


### PR DESCRIPTION
﻿## Summary
- move the project-pack coverage summary out of the hero on phone-sized widths so the real `#overview` section lands in the first viewport
- widen the compact project-pack breakpoint to cover realistic phone widths and keep the wide hero summary behavior intact
- add regression coverage for `320px`, `390px`, and wide project-pack ordering

## Testing
- bun test apps/web/src/routes/public-site.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi
- packaging-level Playwright check on built `apps/web/dist` with a local history-fallback server at `320x568`, `390x844`, and `1280x900`

Closes #701
