### PR TITLE
Fix compact admin users first-fold layout

### DIFF
--- a/apps/web/src/routes/portal-admin-users-panel.test.js
+++ b/apps/web/src/routes/portal-admin-users-panel.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  getCompactAdminUsersSectionOrder,
   resolveSelectedAdminUserId
 } from "./portal-admin-users-panel.tsx";
 
@@ -31,5 +32,14 @@ describe("resolveSelectedAdminUserId", () => {
 
   it("clears the selection when the current filter slice is empty", () => {
     expect(resolveSelectedAdminUserId("user-ada", [])).toBeNull();
+  });
+});
+
+describe("getCompactAdminUsersSectionOrder", () => {
+  it("shows the directory before filters on compact layouts", () => {
+    expect(getCompactAdminUsersSectionOrder()).toEqual([
+      "userList",
+      "filterFields"
+    ]);
   });
 });

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -1,5 +1,5 @@
 import type { PortalAdminUserListItem } from "@paretoproof/shared";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import {
@@ -38,6 +38,10 @@ export function resolveSelectedAdminUserId(
   }
 
   return visibleUsers[0]?.userId ?? null;
+}
+
+export function getCompactAdminUsersSectionOrder() {
+  return ["userList", "filterFields"] as const;
 }
 
 function formatTimestamp(timestamp: string | null) {
@@ -434,8 +438,21 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   const layout = (
     <section className="portal-admin-layout">
       <aside className="portal-admin-list-shell">
-        {isCompactLayout ? filterFields : userList}
-        {isCompactLayout ? userList : filterFields}
+        {isCompactLayout
+          ? getCompactAdminUsersSectionOrder().map((sectionId) => {
+              const sections = {
+                filterFields,
+                userList
+              };
+
+              return <Fragment key={sectionId}>{sections[sectionId]}</Fragment>;
+            })
+          : (
+              <>
+                {userList}
+                {filterFields}
+              </>
+            )}
       </aside>
 
       <section className="portal-admin-detail-shell" ref={detailShellRef}>


### PR DESCRIPTION
﻿## Summary
- keep the compact admin users route focused on the actual user directory by rendering the first user card before the filter controls
- preserve the existing wider admin users layout
- add regression coverage for the compact ordering helper

## Linked Issues
- Closes #706

## Verification
- `bun test apps/web/src/routes/portal-admin-users-panel.test.js`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- `bun run check:bidi`
- Playwright screenshot QA on `/admin/users?surface=portal&access=approved&roles=helper,collaborator,admin&email=qa%40paretoproof.local` at `320x568` and `390x844`
