### PR TITLE
Fix compact admin request queue first-fold layout

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.test.js
+++ b/apps/web/src/routes/portal-access-request-panel.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  getCompactAccessRequestSectionOrder,
   resolveSelectedAccessRequestId
 } from "./portal-access-request-panel.tsx";
 
@@ -31,5 +32,14 @@ describe("resolveSelectedAccessRequestId", () => {
 
   it("clears the selection when the current filter slice is empty", () => {
     expect(resolveSelectedAccessRequestId("request-pending", [])).toBeNull();
+  });
+});
+
+describe("getCompactAccessRequestSectionOrder", () => {
+  it("shows the review queue before filters on compact layouts", () => {
+    expect(getCompactAccessRequestSectionOrder()).toEqual([
+      "queueContent",
+      "filterFields"
+    ]);
   });
 });

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -6,7 +6,7 @@ import {
   type PortalAdminApprovedRole,
   type PortalIdentityProvider
 } from "@paretoproof/shared";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import {
   approvePortalAdminAccessRequest,
@@ -63,6 +63,10 @@ export function resolveSelectedAccessRequestId(
   }
 
   return filteredRequests[0]?.id ?? null;
+}
+
+export function getCompactAccessRequestSectionOrder() {
+  return ["queueContent", "filterFields"] as const;
 }
 
 export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProps) {
@@ -568,18 +572,33 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
   const layout = (
     <section className="portal-admin-layout">
       <article className="portal-panel portal-admin-list-panel">
-        <div className="portal-panel-header">
-          <div>
-            <p className="section-tag">Queue</p>
-            <h2>Scoped filters keep pending work visible.</h2>
+        {!isCompactLayout ? (
+          <div className="portal-panel-header">
+            <div>
+              <p className="section-tag">Queue</p>
+              <h2>Scoped filters keep pending work visible.</h2>
+            </div>
+            <span className="role-chip role-chip-tonal">
+              {filteredRequests.length} visible
+            </span>
           </div>
-          <span className="role-chip role-chip-tonal">
-            {filteredRequests.length} visible
-          </span>
-        </div>
+        ) : null}
 
-        {isCompactLayout ? filterFields : queueContent}
-        {isCompactLayout ? queueContent : filterFields}
+        {isCompactLayout
+          ? getCompactAccessRequestSectionOrder().map((sectionId) => {
+              const sections = {
+                filterFields,
+                queueContent
+              };
+
+              return <Fragment key={sectionId}>{sections[sectionId]}</Fragment>;
+            })
+          : (
+              <>
+                {queueContent}
+                {filterFields}
+              </>
+            )}
       </article>
 
       <article className="portal-panel portal-admin-detail-panel" ref={detailPanelRef}>


### PR DESCRIPTION
﻿## Summary
- keep the compact admin access-request route focused on the actual review queue by rendering the first request card ahead of the filter stack
- drop the redundant compact queue header so the first request object clears the smallest phone viewport
- preserve the existing wider admin access-request layout and add regression coverage for the compact ordering helper

## Linked Issues
- Closes #708

## Verification
- `bun test apps/web/src/routes/portal-access-request-panel.test.js`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- `bun run check:bidi`
- Playwright screenshot QA on `/admin/access-requests?surface=portal&access=approved&roles=helper,collaborator,admin&email=qa%40paretoproof.local` at `320x568` and `390x844`
