### PR TITLE
Fix local access-request redirect loop

### DIFF
--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -66,4 +66,21 @@ describe("resolvePortalRouteRedirect", () => {
     expect(redirect.searchParams.get("email")).toBe("ada@paretoproof.local");
     expect(redirect.searchParams.has("roles")).toBe(false);
   });
+
+  it("does not self-redirect denied access-request routes when query param order differs", () => {
+    setWindowUrl(
+      "http://localhost/access-request?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local"
+    );
+
+    expect(
+      resolvePortalRouteRedirect({
+        pathname: "/access-request",
+        reason: "access_request_required",
+        roles: [],
+        search:
+          "?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local",
+        status: "denied"
+      })
+    ).toBeNull();
+  });
 });

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -133,6 +133,13 @@ function readRouteDeniedReason(
   return undefined;
 }
 
+function normalizeSearch(search = "") {
+  const params = new URLSearchParams(search);
+  params.sort();
+  const normalizedSearch = params.toString();
+  return normalizedSearch ? `?${normalizedSearch}` : "";
+}
+
 function isCurrentRedirectTarget(
   targetPath: string,
   context: PortalRouteAccessContext
@@ -140,7 +147,7 @@ function isCurrentRedirectTarget(
   const targetUrl = new URL(targetPath, window.location.origin);
   return (
     targetUrl.pathname === context.pathname &&
-    targetUrl.search === (context.search ?? "")
+    normalizeSearch(targetUrl.search) === normalizeSearch(context.search ?? "")
   );
 }
 


### PR DESCRIPTION
﻿## Summary
- normalize local portal redirect target comparison by sorting query params before checking whether the current route is already canonical
- add regression coverage for the denied `/access-request` route when the live search string orders `reason` and `email` differently
- verify the previously blank compact access-request screen now renders correctly again on `320x568` and `390x844`

## Verification
- bun test apps/web/src/lib/portal-route-access.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi
- npx -y playwright@latest screenshot --browser=chromium --viewport-size="320,568" "http://127.0.0.1:4371/access-request?surface=portal&access=denied&reason=access_request_required&email=qa%40paretoproof.local" ".codex-shots/access-request-320-fixed.png"
- npx -y playwright@latest screenshot --browser=chromium --viewport-size="390,844" "http://127.0.0.1:4371/access-request?surface=portal&access=denied&reason=access_request_required&email=qa%40paretoproof.local" ".codex-shots/access-request-390-fixed.png"

Closes #712
