### PR TITLE
Clarify GitHub hidden Unicode warning boundary

### DIFF
--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -68,6 +68,8 @@ Security-sensitive PRs should not merge with unresolved review comments that ide
 
 The repository also enforces a hidden-Unicode gate in PR CI. Source changes should not introduce bidirectional control characters unless there is a documented and reviewed exception.
 
+That CI gate only scans tracked repository files. GitHub can still show a hidden-Unicode warning on issue bodies, PR bodies, comments, or other pasted text that never becomes a tracked file. When that happens, treat the GitHub banner as a content warning on the discussion text itself, not as evidence that `infra/scripts/check-bidi-chars.mjs` missed a tracked-file change.
+
 ## Status Rules
 
 Execution boards use the same status vocabulary:

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,5 +4,5 @@
 
 Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
-- `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts.
+- `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts. It does not scan issue bodies, PR bodies, comments, or other GitHub discussion text, so GitHub can still warn on pasted content even when this repo check passes.
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.

--- a/infra/scripts/check-bidi-chars.test.mjs
+++ b/infra/scripts/check-bidi-chars.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { formatOffender, scanTrackedFiles } from "./check-bidi-chars.mjs";
+import { findForbiddenCodePoints, formatOffender, scanTrackedFiles } from "./check-bidi-chars.mjs";
 
 const fixturesRoot = resolve(fileURLToPath(new URL("./fixtures/check-bidi-chars", import.meta.url)));
 const allowedFixtures = JSON.parse(readFileSync(resolve(fixturesRoot, "allowed.json"), "utf8"));
@@ -94,4 +94,8 @@ test("CLI exits nonzero for a tracked file with GitHub warning-class hidden Unic
   } finally {
     disposeTempRepo(repoRoot);
   }
+});
+
+test("findForbiddenCodePoints detects the BOM GitHub warns about in issue and PR bodies", () => {
+  assert.deepEqual(findForbiddenCodePoints("\uFEFF## Summary"), [0xFEFF]);
 });


### PR DESCRIPTION
## Summary
- add a focused bidi-check regression proving the checker flags the same leading BOM code point GitHub warns about when that character is present in text
- document the real boundary in workflow docs: `check-bidi-chars` scans tracked repository files only, while GitHub can also warn on issue bodies, PR bodies, comments, and other pasted discussion text
- capture the live reproduction used for this investigation so maintainers have one truthful explanation for why GitHub may warn while CI still passes

## Linked issues
- Closes #723

## Verification
- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
node infra/scripts/check-bidi-chars.mjs
node --test infra/scripts/check-bidi-chars.test.mjs
gh pr view 715 --json body --jq .body | node -e "process.stdin.setEncoding('utf8'); let data=''; process.stdin.on('data', (chunk) => data += chunk); process.stdin.on('end', () => { const chars = [...data].slice(0, 3).map((char) => char.codePointAt(0)); console.log(chars.join(',')); });"
```

Reproduction note:
- The live PR-body probe above returns `65279,35,35`, meaning PR `#715` begins with `U+FEFF` followed by `##`.
- `node infra/scripts/check-bidi-chars.mjs` still passes because that BOM is in GitHub PR body content, not in a tracked repository file.

## Security and cost review
- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Security boundary:
- This change makes the hidden-Unicode review boundary explicit so maintainers do not misread a GitHub discussion warning as a tracked-file CI false negative.

Cost impact:
- Negligible.

## Rollout and rollback
- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout:
- Not applicable beyond merging the docs and test update.

Rollback:
- Revert this branch if the wording proves misleading, but keep the reproduction note so the boundary remains documented somewhere.

## Notes
- The tracked issue and PR templates in `.github/` are clean on disk; the investigated warning comes from rendered GitHub body content, not from the checked-in template files.