### PR TITLE
Fix branded auth finalize handoff

### DIFF
--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -146,3 +146,42 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
     ok: true
   });
 });
+
+test("trusted mutation origin hook allows branded auth POSTs to the finalize submit handoff", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: [
+        "https://auth.paretoproof.com",
+        "https://github.auth.paretoproof.com",
+        "https://google.auth.paretoproof.com",
+        "https://portal.paretoproof.com"
+      ]
+    })
+  );
+
+  app.post("/portal/session/finalize/submit", async () => ({ ok: true }));
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      redirect: "/profile"
+    },
+    url: "/portal/session/finalize/submit",
+    headers: {
+      origin: "https://github.auth.paretoproof.com"
+    }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    ok: true
+  });
+});

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,5 +7,5 @@ Cloudflare Pages is configured around this app through the local Wrangler config
 Runtime env guidance:
 
 - use [docs/runtime-env-contract-baseline.md](../../docs/runtime-env-contract-baseline.md) as the authoritative source for browser build-time overrides versus Pages auth-entry runtime secrets
-- the Pages auth-entry runtime owns both the provider-start handlers and the finalize relay that forwards Access assertion plus auth cookies to the API server-side
+- the Pages auth-entry runtime owns the provider-start handlers and a legacy finalize compatibility route, while branded completion now posts into the API audience handoff at `/portal/session/finalize/submit`
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -1,39 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { handleAccessFinalize } from "./access-finalize";
 
-const originalFetch = globalThis.fetch;
-
 describe("handleAccessFinalize", () => {
-  beforeEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("relays a successful finalize response back to the portal and forwards cookies", async () => {
-    globalThis.fetch = async (input, init) => {
-      expect(input).toBe("https://api.paretoproof.com/portal/session/finalize");
-      expect(init?.method).toBe("POST");
-      expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBe("assertion-1");
-      expect((init?.headers as Headers).get("cookie")).toContain("PortalAccessProvider=");
-      expect(init?.redirect).toBe("manual");
-      expect(init?.body).toBe(JSON.stringify({ redirect: "/profile" }));
-
-      return new Response(JSON.stringify({
-        redirectTo: "https://portal.paretoproof.com/profile"
-      }), {
-        headers: [
-          ["set-cookie", "PortalAccessProvider=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"],
-          ["set-cookie", "PortalLinkIntent=; Domain=.paretoproof.com; Path=/; Max-Age=0; Secure; HttpOnly"]
-        ],
-        status: 200
-      });
-    };
-
+  it("redirects the legacy finalize relay to the API finalize submit handoff", async () => {
     const response = await handleAccessFinalize(
-      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile", {
         body: new URLSearchParams({
           redirect: "/profile"
         }),
@@ -46,25 +17,16 @@ describe("handleAccessFinalize", () => {
       })
     );
 
-    expect(response.status).toBe(303);
-    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/profile");
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile"
+    );
     expect(response.headers.get("cache-control")).toBe("no-store");
-    const setCookies = (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
-    expect(setCookies).toHaveLength(2);
-    expect(setCookies[0]).toContain("PortalAccessProvider=signed");
-    expect(setCookies[1]).toContain("PortalLinkIntent=");
   });
 
-  it("redirects back to the branded retry surface when the API finalize call fails", async () => {
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify({
-        error: "access_assertion_required"
-      }), {
-        status: 401
-      });
-
+  it("keeps local branded-host finalize handoffs on the local API origin", async () => {
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("http://github.auth.paretoproof.com:4371/api/access/finalize?redirect=%2Fprofile", {
         body: new URLSearchParams({
           redirect: "/profile"
         }),
@@ -75,9 +37,9 @@ describe("handleAccessFinalize", () => {
       })
     );
 
-    expect(response.status).toBe(303);
+    expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
     );
   });
 });

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,9 +1,16 @@
-const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
 }
+
+const brandedHosts = new Set([
+  "paretoproof.com",
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com",
+  "portal.paretoproof.com"
+]);
 
 function isLocalHostname(hostname: string) {
   return (
@@ -39,19 +46,17 @@ function sanitizeRedirectPath(rawRedirectPath: string | null) {
   }
 }
 
-function buildAuthRetryUrl(redirectPath: string) {
-  const authUrl = new URL(authOrigin);
-
-  if (redirectPath !== "/") {
-    authUrl.searchParams.set("redirect", redirectPath);
+function resolveApiBaseUrl(requestUrl: URL) {
+  if (
+    requestUrl.protocol === "http:" &&
+    requestUrl.port !== "" &&
+    brandedHosts.has(requestUrl.hostname)
+  ) {
+    const localApiUrl = new URL(requestUrl.origin);
+    localApiUrl.port = "3000";
+    return trimTrailingSlash(localApiUrl.origin);
   }
 
-  authUrl.searchParams.set("handoff", "retry");
-
-  return authUrl.toString();
-}
-
-function resolveApiBaseUrl(requestUrl: URL) {
   if (
     requestUrl.hostname === "paretoproof.com" ||
     requestUrl.hostname.endsWith(".paretoproof.com")
@@ -69,40 +74,14 @@ function resolveApiBaseUrl(requestUrl: URL) {
   return "https://api.paretoproof.com";
 }
 
-function resolvePortalRedirectTarget(rawRedirectTarget: unknown, fallbackRedirectPath: string) {
-  if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
-    return new URL(fallbackRedirectPath, portalOrigin).toString();
+function buildFinalizeSubmitUrl(requestUrl: URL, redirectPath: string) {
+  const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
+
+  if (redirectPath !== "/") {
+    apiUrl.searchParams.set("redirect", redirectPath);
   }
 
-  try {
-    const targetUrl = new URL(rawRedirectTarget);
-
-    if (targetUrl.origin !== portalOrigin) {
-      return null;
-    }
-
-    return targetUrl.toString();
-  } catch {
-    return null;
-  }
-}
-
-function readSetCookieHeaders(headers: Headers) {
-  const cookieHeaders = headers as Headers & {
-    getAll?: (name: string) => string[];
-    getSetCookie?: () => string[];
-  };
-
-  if (typeof cookieHeaders.getSetCookie === "function") {
-    return cookieHeaders.getSetCookie();
-  }
-
-  if (typeof cookieHeaders.getAll === "function") {
-    return cookieHeaders.getAll("set-cookie");
-  }
-
-  const singleCookieHeader = headers.get("set-cookie");
-  return singleCookieHeader ? [singleCookieHeader] : [];
+  return apiUrl.toString();
 }
 
 async function readRedirectPath(request: Request) {
@@ -130,81 +109,24 @@ async function readRedirectPath(request: Request) {
   );
 }
 
-function buildRedirectResponse(targetUrl: string, responseHeaders?: Headers) {
+function buildRedirectResponse(targetUrl: string, status = 303) {
   const headers = new Headers({
     "cache-control": "no-store",
     location: targetUrl
   });
 
-  for (const cookieValue of responseHeaders ? readSetCookieHeaders(responseHeaders) : []) {
-    headers.append("set-cookie", cookieValue);
-  }
-
   return new Response(null, {
     headers,
-    status: 303
+    status
   });
 }
 
 export async function handleAccessFinalize(request: Request) {
   const redirectPath = await readRedirectPath(request);
-  const retryUrl = buildAuthRetryUrl(redirectPath);
   const requestUrl = new URL(request.url);
-  const apiUrl = new URL("/portal/session/finalize", resolveApiBaseUrl(requestUrl));
-  const forwardedHeaders = new Headers({
-    accept: "application/json",
-    "content-type": "application/json"
-  });
-  const accessAssertion = request.headers.get("cf-access-jwt-assertion");
-  const cookieHeader = request.headers.get("cookie");
+  const submitUrl = buildFinalizeSubmitUrl(requestUrl, redirectPath);
 
-  if (accessAssertion) {
-    forwardedHeaders.set("cf-access-jwt-assertion", accessAssertion);
-  }
-
-  if (cookieHeader) {
-    forwardedHeaders.set("cookie", cookieHeader);
-  }
-
-  let finalizeResponse: Response;
-
-  try {
-    finalizeResponse = await fetch(apiUrl.toString(), {
-      body: JSON.stringify(
-        redirectPath === "/"
-          ? {}
-          : {
-              redirect: redirectPath
-            }
-      ),
-      headers: forwardedHeaders,
-      method: "POST",
-      redirect: "manual"
-    });
-  } catch {
-    return buildRedirectResponse(retryUrl);
-  }
-
-  if (!finalizeResponse.ok) {
-    return buildRedirectResponse(retryUrl);
-  }
-
-  let responseBody: unknown;
-
-  try {
-    responseBody = await finalizeResponse.json();
-  } catch {
-    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
-  }
-
-  const redirectTarget = resolvePortalRedirectTarget(
-    (responseBody as { redirectTo?: unknown }).redirectTo,
-    redirectPath
-  );
-
-  if (!redirectTarget) {
-    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
-  }
-
-  return buildRedirectResponse(redirectTarget, finalizeResponse.headers);
+  // Preserve the browser's form POST so the API audience can establish its own
+  // Access session instead of completing the handoff only on the auth Pages runtime.
+  return buildRedirectResponse(submitUrl, 307);
 }

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -67,7 +67,15 @@ describe("buildPortalUrl", () => {
     setWindowUrl("http://github.auth.paretoproof.com:4371/");
 
     expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize?redirect=%2Fprofile"
+      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
+    );
+  });
+
+  it("uses the protected API finalize submit endpoint on branded auth hosts", () => {
+    setWindowUrl("https://google.auth.paretoproof.com/");
+
+    expect(buildAccessFinalizeUrl("/profile")).toBe(
+      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile"
     );
   });
 });

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -240,18 +240,7 @@ export function buildAccessStartUrl(
 
 export function buildAccessFinalizeUrl(targetPath = "/") {
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
-
-  if (isLocalOrigin()) {
-    const completionUrl = new URL("/portal/session/finalize", getApiBaseUrl());
-
-    if (normalizedTargetPath !== "/") {
-      completionUrl.searchParams.set("redirect", normalizedTargetPath);
-    }
-
-    return completionUrl.toString();
-  }
-
-  const completionUrl = new URL("/api/access/finalize", window.location.origin);
+  const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
 
   if (normalizedTargetPath !== "/") {
     completionUrl.searchParams.set("redirect", normalizedTargetPath);


### PR DESCRIPTION
## Summary
- send branded auth completion directly to the API audience handoff at `/portal/session/finalize/submit` so the browser can establish the API Access audience instead of completing the flow only inside the Pages relay
- turn the old Pages `/api/access/finalize` endpoint into a compatibility redirect that preserves the browser POST and lands stale completion pages on the same API finalize path
- add regression coverage for the branded finalize URL, the legacy compatibility redirect, and the auth-origin finalize POST allowance

## Linked issues
- Closes #726

## Verification
- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun install
bun run build:shared
bun run typecheck:web
bun run typecheck:api
bun run test:api
bun test apps/web/functions/_shared/access-finalize.test.ts apps/web/src/lib/surface.test.js apps/api/test/trusted-mutation-origin.test.ts
bun --cwd apps/web build
bun run check:bidi
```

Browser QA notes:
- Production-like local harness served the built auth app on `http://github.auth.paretoproof.com/` and `http://google.auth.paretoproof.com/` with host-resolution overrides.
- Intercepted the branded completion POST to `https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile` and fulfilled it into a branded `portal.paretoproof.com` success landing.
- For both providers, the completion page issued a `POST` to the API finalize submit URL, reached the portal landing, and never touched `https://auth.paretoproof.com/?handoff=retry...`.
- Screenshot artifacts:
  - `C:\Users\Tom\.codex\worktrees\4abc\ParetoProof\.codex-shots\github-auth-finalize-fixed.png`
  - `C:\Users\Tom\.codex\worktrees\4abc\ParetoProof\.codex-shots\google-auth-finalize-fixed.png`
- Harness limitation:
  - the local browser proof used `http` branded hosts to avoid local TLS setup, so it verifies the redirect chain and final landing but not secure cookie attachment semantics; those remain covered by the route-level and origin-allowance tests.

## Security and cost review
- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Security boundary:
- The finalize mutation remains POST-oriented.
- The API handoff stays behind the trusted-origin hook and explicit Access enforcement.
- The old Pages finalize path no longer tries to complete login server-side with a mismatched audience state; it only forwards the browser into the protected API handoff.

Cost impact:
- Negligible.

## Rollout and rollback
- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout:
- Deploy the updated web bundle and Pages function together so branded completion pages and the legacy compatibility path both target the API finalize submit route.

Rollback:
- Revert this PR if the deployed branded handoff regresses, restoring the prior Pages relay while the Access audience boundary is rechecked.

## Notes
- This aligns the runtime behavior with the shared API contract, which already describes `/portal/session/finalize/submit` as the canonical branded finalize handoff route.