### PR TITLE
fix(worker): verify pinned elan installer in Docker build

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -6,6 +6,8 @@ ARG CODEX_CLI_VERSION=0.114.0
 ARG LEAN_LSP_MCP_VERSION=0.24.0
 ARG LEAN422_TOOLCHAIN=leanprover/lean4:v4.22.0
 ARG LEAN424_TOOLCHAIN=leanprover/lean4:v4.24.0
+ARG ELAN_INIT_COMMIT=917c18d0ad52f649c2603dc8b973f5b9fa5f8f43
+ARG ELAN_INIT_SHA256=4bacca9502cb89736fe63d2685abc2947cfbf34dc87673504f1bb4c43eda9264
 
 FROM ${NODE_IMAGE} AS problem9-os-base
 
@@ -25,12 +27,16 @@ FROM problem9-os-base AS problem9-toolchain-base
 
 ARG LEAN422_TOOLCHAIN
 ARG LEAN424_TOOLCHAIN
+ARG ELAN_INIT_COMMIT
+ARG ELAN_INIT_SHA256
 
 ENV ELAN_HOME=/opt/elan
 ENV PATH=${ELAN_HOME}/bin:${PATH}
 
-RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf \
-  | sh -s -- -y --default-toolchain none \
+RUN curl -fsSL -o /tmp/elan-init.sh https://raw.githubusercontent.com/leanprover/elan/${ELAN_INIT_COMMIT}/elan-init.sh \
+  && echo "${ELAN_INIT_SHA256}  /tmp/elan-init.sh" | sha256sum -c - \
+  && sh /tmp/elan-init.sh -y --default-toolchain none \
+  && rm /tmp/elan-init.sh \
   && elan toolchain install ${LEAN422_TOOLCHAIN} \
   && elan toolchain install ${LEAN424_TOOLCHAIN}
 


### PR DESCRIPTION
### Motivation
- The Dockerfile previously executed a remote `elan-init.sh` via `curl | sh` from a mutable `master` URL, creating a supply-chain execution risk during image builds. 
- The change pins the installer to a specific commit and verifies its integrity to remove the `curl | sh` attack vector.

### Description
- Added build args `ELAN_INIT_COMMIT` and `ELAN_INIT_SHA256` to make the installer commit and expected checksum explicit. 
- Replaced `curl | sh` with a download to `/tmp/elan-init.sh`, SHA-256 verification using `sha256sum -c`, execution via `sh /tmp/elan-init.sh`, and removal of the temporary file. 
- Kept existing behavior of installing the two Lean toolchains (`elan toolchain install ${LEAN422_TOOLCHAIN}` and `${LEAN424_TOOLCHAIN}`) so runtime functionality is preserved.

### Testing
- Ran `git diff --check` which reported no issues. 
- Verified the pinned installer commit and checksum by fetching the commit (`git ls-remote`) and comparing the downloaded script checksum with `sha256sum`, which matched the pinned `ELAN_INIT_COMMIT`. 
- Attempted to run `docker --version` but Docker is not available in this environment, so an image build could not be run locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b452e1214c8323b0e81ee7c4626d1a)