### PR TITLE
Pin publish-worker-image GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/publish-worker-image.yml
+++ b/.github/workflows/publish-worker-image.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Generate image metadata
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.WORKER_IMAGE }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and publish worker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: apps/worker/Dockerfile


### PR DESCRIPTION
### Motivation
- The publish job in `.github/workflows/publish-worker-image.yml` ran on `main` with `packages: write` and referenced third‑party actions by mutable tags, creating a CI supply‑chain risk. 
- The intent is to mitigate that risk by ensuring each `uses:` entry invokes an immutable commit SHA instead of a mutable tag.

### Description
- Replaced mutable action tags in `.github/workflows/publish-worker-image.yml` with the corresponding immutable commit SHAs for the actions used by the publish job. 
- The affected actions are `actions/checkout`, `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, and `docker/build-push-action`. 
- Major-version comments (e.g., `# v4`) were retained inline to indicate the original tag that determined the pinned SHA. 
- No runtime workflow logic, environment variables, or publish parameters were changed.

### Testing
- Resolved the current tag targets to commit SHAs using `git ls-remote` to ensure the pinned SHAs match the tags being replaced, and this command completed successfully. 
- Verified the workflow file `uses:` entries now reference full commit SHAs and no mutable tags remain. 
- Confirmed the repository diff and workspace status with `git diff` and `git status`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b382b0f8308323b84185cff5f0ff25)