### PR TITLE
fix(web): guard decodeURIComponent in public report route

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -49,6 +49,16 @@ describe("resolvePublicSiteRoute", () => {
       kind: "report"
     });
   });
+
+  it("handles malformed percent-encoding in report routes", async () => {
+    setWindowUrl("http://127.0.0.1/");
+    const { resolvePublicSiteRoute } = await loadPublicSiteModule();
+
+    expect(resolvePublicSiteRoute("/reports/%")).toEqual({
+      benchmarkVersionId: "%",
+      kind: "report"
+    });
+  });
 });
 
 describe("PublicSite", () => {

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -326,9 +326,16 @@ export function resolvePublicSiteRoute(pathname: string) {
 
   if (pathname.startsWith(reportsRoutePrefix)) {
     const benchmarkVersionId = pathname.slice(reportsRoutePrefix.length).split("/")[0] ?? "";
+    let decodedBenchmarkVersionId = benchmarkVersionId;
+
+    try {
+      decodedBenchmarkVersionId = decodeURIComponent(benchmarkVersionId);
+    } catch {
+      decodedBenchmarkVersionId = benchmarkVersionId;
+    }
 
     return {
-      benchmarkVersionId: decodeURIComponent(benchmarkVersionId),
+      benchmarkVersionId: decodedBenchmarkVersionId,
       kind: "report" as const
     };
   }


### PR DESCRIPTION
### Motivation
- `resolvePublicSiteRoute` decoded the `/reports/:id` path segment with `decodeURIComponent` without validation, which throws on malformed percent-encoding and can break rendering.

### Description
- Guard the decode by wrapping `decodeURIComponent(benchmarkVersionId)` in a `try/catch` and falling back to the raw segment when decoding fails (`apps/web/src/routes/public-site.tsx`).
- Add a regression test that ensures `/reports/%` is handled and returns a `report` route with the raw `%` id (`apps/web/src/routes/public-site.test.js`).

### Testing
- Ran `bun test apps/web/src/routes/public-site.test.js`; the test run failed in this environment with an unmet runtime dependency (`Cannot find module 'react-dom/server'`).
- The new unit test targeting `resolvePublicSiteRoute` was added and the code change is locally committed; full test execution is expected to pass in CI when the project test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4d95e703483239b604a63f7496b28)