### PR TITLE
fix(web): neutralize CSV formula injection in run exports

### DIFF
--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -975,11 +975,13 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
 }
 
 function escapeCsvValue(value: string) {
-  if (/[",\n]/.test(value)) {
-    return `"${value.replaceAll('"', '""')}"`;
+  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+
+  if (/[",\n]/.test(safeValue)) {
+    return `"${safeValue.replaceAll('"', '""')}"`;
   }
 
-  return value;
+  return safeValue;
 }
 
 export function getWorkerIncidentTone(severity: PortalWorkerIncidentSeverity) {


### PR DESCRIPTION
### Motivation
- Prevent CSV injection by neutralizing spreadsheet-formula-leading characters in run metadata exported to CSV.

### Description
- Update `escapeCsvValue` in `apps/web/src/lib/portal-benchmark-ops.ts` to prefix a single quote for values starting with `=`, `+`, `-`, or `@` before applying the existing quote/newline escaping, preserving current CSV formatting semantics.

### Testing
- Ran `bun test apps/web/functions/_shared/access-finalize.test.ts` which passed, and ran `bun run --cwd apps/web typecheck` which failed due to pre-existing module-resolution/type errors unrelated to this change (no type errors introduced by the fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48ac1218c8323bea4fe62482528ec)