### PR TITLE
fix(api): rotate worker job token on heartbeat renewal

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -1150,10 +1150,12 @@ export function createInternalWorkerControlService(db: DbClient) {
 
         const nextLeaseExpiresAt = addSeconds(now, lease.heartbeatTimeoutSeconds);
         const nextJobTokenExpiresAt = addSeconds(now, lease.heartbeatTimeoutSeconds);
+        const nextJobToken = issueJobToken();
 
         const renewedLeases = await tx
           .update(workerJobLeases)
           .set({
+            jobTokenHash: nextJobToken.tokenHash,
             jobTokenExpiresAt: nextJobTokenExpiresAt,
             lastEventSequence: acknowledgedEventSequence,
             lastHeartbeatAt: now,
@@ -1186,7 +1188,7 @@ export function createInternalWorkerControlService(db: DbClient) {
         return {
           acknowledgedEventSequence,
           cancelRequested: false,
-          jobToken: authContext.jobToken,
+          jobToken: nextJobToken.token,
           jobTokenExpiresAt: nextJobTokenExpiresAt.toISOString(),
           leaseExpiresAt: nextLeaseExpiresAt.toISOString(),
           leaseStatus: "active"

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -853,7 +853,7 @@ test("stale-lease recovery does not downgrade a run while another job is still a
   assert.equal(updateCalls[2].state, "claimed");
 });
 
-test("heartbeat preserves the current job token while extending the lease", async () => {
+test("heartbeat rotates the job token while extending the lease", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
@@ -916,9 +916,10 @@ test("heartbeat preserves the current job token while extending the lease", asyn
   const response = await control.heartbeat(buildHeartbeatRequest(), buildJobAuthContext());
 
   assert.equal(response.cancelRequested, false);
-  assert.equal(response.jobToken, "job-token-1");
+  assert.ok(typeof response.jobToken === "string" && response.jobToken.length > 0);
+  assert.notEqual(response.jobToken, "job-token-1");
   assert.ok(response.jobTokenExpiresAt);
-  assert.equal(updateCalls[0].jobTokenHash, undefined);
+  assert.equal(typeof updateCalls[0].jobTokenHash, "string");
   assert.equal(updateCalls[1].state, "running");
   assert.equal(updateCalls[2].state, "active");
   assert.equal(updateCalls[3].state, "running");


### PR DESCRIPTION
### Motivation
- Heartbeat renewal previously extended `jobTokenExpiresAt` and returned the existing token, which allowed a leaked job token to be replayed and the lease extended indefinitely; this change restores token rotation on heartbeat to limit replay window.

### Description
- Issue a fresh job token via `issueJobToken()` during heartbeat renewal and persist its hash to `workerJobLeases.jobTokenHash` when updating the lease.
- Return the rotated token (`nextJobToken.token`) and the renewed expiry in the `WorkerHeartbeatResponse` instead of reusing `authContext.jobToken`.
- Update the unit test in `apps/api/test/internal-worker.test.ts` to assert that the token is rotated and that `jobTokenHash` is stored.
- Files changed: `apps/api/src/lib/internal-worker-control.ts`, `apps/api/test/internal-worker.test.ts`.

### Testing
- Ran `bun install`, which completed successfully.
- Built the shared package with `bun run build:shared` and then executed the heartbeat unit tests with `cd apps/api && node --import tsx --test test/internal-worker.test.ts`, which passed (all internal-worker tests passed).
- Observed `bun --cwd apps/api test` initially fail due to the shared package not being built, and confirmed the focused test run succeeded after building the shared package.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b449b95a688323a2d9b54461421a15)