### PR TITLE
Fix expired lease handling in worker claim selection

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -156,6 +156,7 @@ function queuedJobWhereClause(): SQL {
 }
 
 async function selectNextClaimCandidate(tx: SelectExecutor): Promise<CandidateClaimRow | null> {
+  const now = new Date();
   const [candidate] = await tx
     .select({
       attemptId: attempts.sourceAttemptId,
@@ -174,7 +175,11 @@ async function selectNextClaimCandidate(tx: SelectExecutor): Promise<CandidateCl
     .innerJoin(attempts, eq(attempts.jobId, jobs.id))
     .leftJoin(
       workerJobLeases,
-      and(eq(workerJobLeases.jobId, jobs.id), isNull(workerJobLeases.revokedAt))
+      and(
+        eq(workerJobLeases.jobId, jobs.id),
+        isNull(workerJobLeases.revokedAt),
+        gt(workerJobLeases.leaseExpiresAt, now)
+      )
     )
     .where(
       and(


### PR DESCRIPTION
### Motivation
- Prevent expired but unrevoked worker leases from permanently blocking queued jobs and causing availability problems when a worker stops heartbeating.
- The previous claim selection only excluded leases with `revokedAt` set, so stale leases with past `leaseExpiresAt` still looked active.

### Description
- Add a `now` cutoff in `selectNextClaimCandidate` and restrict the `workerJobLeases` left join to only match leases where `leaseExpiresAt > now` in addition to `revokedAt IS NULL`.
- This makes expired leases no longer count as active blockers while preserving existing behavior for currently active leases. (File: `apps/api/src/lib/internal-worker-control.ts`)

### Testing
- Ran `bun run build:shared` and then `bun --cwd apps/api test`, and the full test suite passed (21/21 tests).
- An initial `node --import tsx --test` attempt failed due to missing `tsx`/built shared artifacts, which was resolved by `bun install` and `bun run build:shared` before the successful test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4396c95cc8323adb0040a20757574)