### PR TITLE
fix(worker): validate trusted-local overlap against mounted parents

### DIFF
--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -51,6 +51,8 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
   const outputRoot = options.preflightOnly
     ? null
     : await prepareWritableTarget(options.outputRoot, "Output root");
+  const workspaceMountRoot = workspaceRoot ? path.dirname(workspaceRoot) : null;
+  const outputMountRoot = outputRoot ? path.dirname(outputRoot) : null;
 
   if (!options.preflightOnly && !options.providerModel) {
     throw new Error(
@@ -58,39 +60,39 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
     );
   }
 
-  if (benchmarkPackageRoot && workspaceRoot) {
+  if (benchmarkPackageRoot && workspaceMountRoot) {
     assertNoHostPathOverlap(
       benchmarkPackageRoot,
-      workspaceRoot,
+      workspaceMountRoot,
       "Benchmark package root",
-      "Workspace root"
+      "Workspace mount parent"
     );
   }
 
-  if (promptPackageRoot && workspaceRoot) {
+  if (promptPackageRoot && workspaceMountRoot) {
     assertNoHostPathOverlap(
       promptPackageRoot,
-      workspaceRoot,
+      workspaceMountRoot,
       "Prompt package root",
-      "Workspace root"
+      "Workspace mount parent"
     );
   }
 
-  if (benchmarkPackageRoot && outputRoot) {
+  if (benchmarkPackageRoot && outputMountRoot) {
     assertNoHostPathOverlap(
       benchmarkPackageRoot,
-      outputRoot,
+      outputMountRoot,
       "Benchmark package root",
-      "Output root"
+      "Output mount parent"
     );
   }
 
-  if (promptPackageRoot && outputRoot) {
+  if (promptPackageRoot && outputMountRoot) {
     assertNoHostPathOverlap(
       promptPackageRoot,
-      outputRoot,
+      outputMountRoot,
       "Prompt package root",
-      "Output root"
+      "Output mount parent"
     );
   }
 
@@ -141,17 +143,17 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
     );
   }
 
-  if (workspaceRoot) {
+  if (workspaceMountRoot) {
     dockerArgs.push(
       "--mount",
-      buildBindMountArg(path.dirname(workspaceRoot), workspaceParentContainerRoot, false)
+      buildBindMountArg(workspaceMountRoot, workspaceParentContainerRoot, false)
     );
   }
 
-  if (outputRoot) {
+  if (outputMountRoot) {
     dockerArgs.push(
       "--mount",
-      buildBindMountArg(path.dirname(outputRoot), outputParentContainerRoot, false)
+      buildBindMountArg(outputMountRoot, outputParentContainerRoot, false)
     );
   }
 


### PR DESCRIPTION
### Motivation
- The trusted-local devbox wrapper mounts the parent directories of `workspaceRoot` and `outputRoot` read-write, which could expose sibling benchmark/prompt directories despite read-only mounts on the child paths, so overlap checks must consider the actual mounted parents.

### Description
- Compute `workspaceMountRoot` and `outputMountRoot` from the resolved writable targets and use them as the canonical mount parents.
- Perform `assertNoHostPathOverlap` checks against the mount-parent paths instead of the child `workspaceRoot`/`outputRoot` to prevent sibling-directory exposure.
- Reuse the computed mount-parent variables when constructing Docker bind mounts so validation and mount behavior remain aligned.
- Update the reported labels to indicate the overlap is against the mount parent for clarity.

### Testing
- Ran `npm --prefix apps/worker run -s typecheck`, which failed in this environment with `TS2688: Cannot find type definition file for 'node'` so project typechecking could not be validated here.
- Ran `npm --prefix apps/worker install`, which failed with `EUNSUPPORTEDPROTOCOL` due to `workspace:*` dependencies in this environment, preventing full dependency installation and further automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b412d0449c832391eae6aaae9e2562)