### PR TITLE
Harden portal link-state cookies against CSRF

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -98,7 +98,7 @@ function sanitizePortalRedirectPath(rawRedirectPath: string | null) {
 }
 
 function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkIntent") {
-  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Lax; Max-Age=0; Secure; HttpOnly`;
+  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Strict; Max-Age=0; Secure; HttpOnly`;
 }
 
 function buildPortalAuthStartUrl(options: {
@@ -293,7 +293,7 @@ export function registerPortalRoutes(
         buildSignedAccessCookie(
           "PortalAccessProvider",
           `${providerHint}|${identity.subject}`,
-          { maxAgeSeconds: 24 * 60 * 60, sameSite: "Lax" }
+          { maxAgeSeconds: 24 * 60 * 60 }
         )
       );
     } else {
@@ -651,9 +651,7 @@ export function registerPortalRoutes(
 
       reply.header(
         "set-cookie",
-        buildSignedAccessCookie("PortalLinkIntent", intent.id, {
-          sameSite: "Lax"
-        })
+        buildSignedAccessCookie("PortalLinkIntent", intent.id)
       );
 
       return {

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -76,7 +76,7 @@ async function buildProviderHintCookie(env: AccessStartEnv, provider: Provider) 
     `PortalAccessProvider=${value}`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Lax",
+    "SameSite=Strict",
     "Max-Age=600",
     "Secure",
     "HttpOnly"
@@ -88,7 +88,7 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
     `${name}=`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Lax",
+    "SameSite=Strict",
     "Max-Age=0",
     "Secure",
     "HttpOnly"


### PR DESCRIPTION
### Motivation
- A recent change relaxed `SameSite` for the `PortalAccessProvider` and `PortalLinkIntent` signed cookies to `Lax`, which permits cross-site top-level navigations to include those cookies and enables CSRF-like identity-linking actions that are implemented as GET/top-level navigations.
- The intent of this PR is to restore the stricter cookie policy to prevent cross-site delivery of these stateful link cookies and preserve the previous CSRF protection.

### Description
- Reverted cookie clearing in the API to `SameSite=Strict` for `PortalAccessProvider` and `PortalLinkIntent` in `apps/api/src/routes/portal.ts`.
- Removed explicit `sameSite: "Lax"` overrides when issuing `PortalAccessProvider` and `PortalLinkIntent` so `buildSignedAccessCookie` default (`Strict`) is used again in `apps/api/src/routes/portal.ts`.
- Updated the web edge helper in `apps/web/functions/_shared/access-start.ts` to set `SameSite=Strict` for provider hint issuance and clearing to keep behavior consistent across edge and API.
- Preserved other cookie attributes (`Domain=.paretoproof.com`, `Path=/`, `Secure`, `HttpOnly`, and intended `Max-Age`) to keep functionality unchanged except for `SameSite`.

### Testing
- Ran repository typechecks: `bun run typecheck:api` failed due to missing `node` type definitions in this environment and `bun run typecheck:web` failed due to missing `vite/client` type definitions, so full TypeScript validation could not be completed here. 
- Performed targeted searches for `SameSite=Lax` and `sameSite: "Lax"` in the modified files and confirmed no `Lax` overrides remain in the touched files, which succeeded.
- No runtime or integration tests were executed in this environment due to missing platform dependencies; changes are intentionally minimal to reduce risk to existing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b385eed8548323908bb4fd1460abe6)