### PR TITLE
Harden state-changing routes against cross-site form posts

### DIFF
--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -33,6 +33,30 @@ function shouldAllowLocalhostCors() {
   return process.env.CORS_ALLOW_LOCALHOST === "true";
 }
 
+function isStateChangingMethod(method: string) {
+  return ["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+}
+
+function parseHeaderOrigin(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return normalizeOrigin(new URL(value).origin);
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedRequestOrigin(origin: string, allowedOrigins: string[]) {
+  if (allowedOrigins.includes(origin)) {
+    return true;
+  }
+
+  return shouldAllowLocalhostCors() && isAllowedLocalOrigin(origin);
+}
+
 export async function buildServer() {
   const app = Fastify({
     logger: true
@@ -64,6 +88,27 @@ export async function buildServer() {
     }
   });
   await app.register(formbody);
+
+  app.addHook("onRequest", async (request, reply) => {
+    if (!isStateChangingMethod(request.method)) {
+      return;
+    }
+
+    const originHeader = request.headers.origin;
+    const refererHeader = request.headers.referer;
+    const requestOrigin =
+      parseHeaderOrigin(originHeader) ?? parseHeaderOrigin(refererHeader);
+
+    if (!requestOrigin) {
+      return;
+    }
+
+    if (!isAllowedRequestOrigin(requestOrigin, allowedOrigins)) {
+      await reply.code(403).send({
+        error: "forbidden_origin"
+      });
+    }
+  });
 
   registerHealthRoute(app);
   registerPortalRoutes(app, db, requireAccess);


### PR DESCRIPTION
### Motivation
- The app registers `@fastify/formbody` globally which enables `application/x-www-form-urlencoded` submissions and reintroduced a CSRF vector for mutating endpoints that consume `request.body`.
- Add a minimal server-side origin gate for state-changing requests to mitigate cross-site form POSTs without altering existing CORS allowlist behavior.

### Description
- Added `isStateChangingMethod`, `parseHeaderOrigin`, and `isAllowedRequestOrigin` helpers to centralize method/origin checks. 
- Registered an `onRequest` hook that inspects `Origin` and `Referer` for `POST|PUT|PATCH|DELETE` requests and returns `403 { error: "forbidden_origin" }` for non-allowlisted origins. 
- Reused the existing `readAllowedCorsOrigins()` allowlist and the `CORS_ALLOW_LOCALHOST` toggle so runtime behavior remains aligned with current configuration.

### Testing
- Ran `bun install` to ensure dependencies installed successfully. 
- Ran `bun run build:shared` and `bun --cwd apps/api typecheck` and both completed without errors. 
- Ran `bun --cwd apps/api test` and the repository test(s) passed (1 test, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b387a45a748323b0de6e03cffd9041)