### PR TITLE
Enforce origin checks on portal access-request mutations to mitigate CSRF

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -97,6 +97,53 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
   return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Lax; Max-Age=0; Secure; HttpOnly`;
 }
 
+function normalizeOrigin(value: string) {
+  return value.replace(/\/+$/, "");
+}
+
+function isAllowedPortalMutationOrigin(origin: string) {
+  const allowLocalhostCors = process.env.CORS_ALLOW_LOCALHOST === "true";
+
+  if (allowLocalhostCors && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin)) {
+    return true;
+  }
+
+  const configuredOrigins = process.env.CORS_ALLOWED_ORIGINS?.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map(normalizeOrigin);
+
+  return ["https://portal.paretoproof.com", ...(configuredOrigins ?? [])].includes(origin);
+}
+
+function enforcePortalMutationOrigin(request: FastifyRequest, reply: FastifyReply) {
+  const originHeader =
+    typeof request.headers.origin === "string" ? normalizeOrigin(request.headers.origin) : null;
+  const refererHeader =
+    typeof request.headers.referer === "string" ? request.headers.referer : null;
+
+  const candidateOrigin =
+    originHeader ??
+    (refererHeader
+      ? (() => {
+          try {
+            return normalizeOrigin(new URL(refererHeader).origin);
+          } catch {
+            return null;
+          }
+        })()
+      : null);
+
+  if (!candidateOrigin || !isAllowedPortalMutationOrigin(candidateOrigin)) {
+    reply.code(403).send({
+      error: "invalid_mutation_origin"
+    });
+    return false;
+  }
+
+  return true;
+}
+
 function buildPortalAuthStartUrl(options: {
   provider: "cloudflare_github" | "cloudflare_google";
   redirectPath: string;
@@ -621,7 +668,17 @@ export function registerPortalRoutes(
   app.post(
     "/portal/access-requests",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        requireAccess("authenticated_access_identity"),
+        (request, reply, done) => {
+          if (!enforcePortalMutationOrigin(request, reply)) {
+            done();
+            return;
+          }
+
+          done();
+        }
+      ]
     },
     async (request, reply) => {
       const parsedBody = portalAccessRequestInputSchema.safeParse(request.body ?? {});

--- a/apps/api/test/portal-access-request-origin.test.ts
+++ b/apps/api/test/portal-access-request-origin.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+test("POST /portal/access-requests rejects requests without an allowed origin", async (t) => {
+  let mutationAttempted = false;
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      transaction: async () => {
+        mutationAttempted = true;
+        throw new Error("mutation should be blocked before db writes");
+      }
+    } as never,
+    () => (request, _reply, done) => {
+      (request as { accessIdentity?: { email: string; subject: string } }).accessIdentity = {
+        email: "user@example.com",
+        subject: "subject"
+      };
+      done();
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/access-requests",
+    payload: {
+      rationale: "I need access",
+      requestedRole: "helper"
+    }
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.equal(response.json().error, "invalid_mutation_origin");
+  assert.equal(mutationAttempted, false);
+});
+
+test("POST /portal/access-requests allows configured portal origin", async (t) => {
+  let mutationAttempted = false;
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      transaction: async () => {
+        mutationAttempted = true;
+        throw new Error("expected test database failure");
+      }
+    } as never,
+    () => (request, _reply, done) => {
+      (request as { accessIdentity?: { email: string; subject: string } }).accessIdentity = {
+        email: "user@example.com",
+        subject: "subject"
+      };
+      done();
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/access-requests",
+    headers: {
+      origin: "https://portal.paretoproof.com"
+    },
+    payload: {
+      rationale: "I need access",
+      requestedRole: "helper"
+    }
+  });
+
+  assert.equal(response.statusCode, 500);
+  assert.equal(mutationAttempted, true);
+});
+


### PR DESCRIPTION
### Motivation
- The POST `/portal/access-requests` endpoint performed authenticated state-changing writes without any CSRF/origin validation, which could allow cross-site request forgery to create or alter access requests.

### Description
- Add `normalizeOrigin`, `isAllowedPortalMutationOrigin`, and `enforcePortalMutationOrigin` helpers to validate `Origin` (with `Referer` fallback) against `https://portal.paretoproof.com`, configured `CORS_ALLOWED_ORIGINS`, and optional localhost when `CORS_ALLOW_LOCALHOST` is enabled. 
- Wire `enforcePortalMutationOrigin` as an additional `preHandler` for `POST /portal/access-requests` alongside the existing `requireAccess("authenticated_access_identity")` guard so mutations are blocked before database writes when the origin is untrusted. 
- Preserve existing request validation and transaction logic while returning `403` with `{ error: "invalid_mutation_origin" }` for blocked requests. 
- Add tests in `apps/api/test/portal-access-request-origin.test.ts` that verify untrusted origins are rejected and the trusted portal origin is allowed to reach mutation code.

### Testing
- Running the API tests initially failed due to a missing runner dependency (`tsx`) in the environment, which was resolved by installing dependencies (`bun install`) and building shared artifacts (`bun run build:shared`).
- After setup, the added origin tests and the existing portal finalize test were executed with `node --import tsx --test` from `apps/api` and all tests passed. 
- A production build of the API (`bun --cwd apps/api build`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b38818d6408323b69bef512ff74fcf)