### PR TITLE
Backfill missing PR issue links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@
 ## Linked issues
 
 - Closes #
+- Replace the placeholder with real issue references before opening or merging.
+- Use literal markdown such as `Closes #123` or `Related: #456`; do not leave the placeholder blank and do not paste escaped `\n` text.
+- If there is intentionally no issue, say so explicitly here.
 
 ## Verification
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -59,6 +59,8 @@ Execution work should land through a pull request, not through direct pushes to 
 - Open a dedicated branch for the issue.
 - Open a PR against `main`.
 - Fill in the PR template with linked issues, exact verification commands, and any required security notes.
+- The PR body must contain real GitHub issue references such as `Closes #123` or `Related: #456` in normal markdown text. Do not leave the placeholder `Closes #` line empty, and do not paste escaped `\n` sequences that prevent GitHub from parsing the reference.
+- If a PR intentionally has no linked issue, say that explicitly in the PR body so the missing link is a conscious exception instead of silent drift.
 - Merge the PR into `main`.
 - Close the issue only after the relevant PR has merged into `main`.
 


### PR DESCRIPTION
## Summary
- backfill the missing issue links for the current benchmark-kernel / project-ops slice by repairing closed PR bodies that GitHub was not parsing correctly and by adding the missing linked-issue lines on the recent compact-layout PRs
- document the linked-issue rule in the project process and PR template so future merged PRs do not silently drift back to zero `closingIssuesReferences`
- leave a durable audit record on issue `#728` with the reviewed PR set and the before/after state

## Linked issues
- Closes #728

## Verification
- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
gh pr list --repo Tomodovodoo/ParetoProof --state closed --limit 200 --json number,title,closingIssuesReferences,mergedAt
bun run check:bidi
```

Audit notes:
- Before backfill, these merged PRs had zero linked issues: `#704`, `#702`, `#700`, `#595`, `#547`, `#457`, `#456`, `#452`, `#450`, `#428`, `#385`, `#383`, `#382`.
- Root cause split:
  - `#704`, `#702`, and `#700` never had linked-issue lines in the body.
  - the others had intended issue references, but their PR bodies contained literal escaped `\n` text, so GitHub did not parse the closing keywords.
- Backfill applied directly to those closed PRs:
  - restored issue links `#703`, `#701`, `#699`, `#594`, `#535`, `#448`, `#449`, `#447`, `#440`, `#442`, `#51`, `#43`, `#380`, and `#379`
  - preserved the multi-issue context on `#450` with `Related: #439`
- After backfill, the same 200-PR audit window returns no merged PRs with zero `closingIssuesReferences`.
- Durable audit record:
  - issue comment on `#728`: https://github.com/Tomodovodoo/ParetoProof/issues/728#issuecomment-4061219953

## Security and cost review
- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Security boundary:
- This change improves auditability only. The direct metadata backfill makes it harder to lose review or issue traceability across merged PR history.

Cost impact:
- Negligible beyond repository-maintenance time.

## Rollout and rollback
- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout:
- Merge the doc/template change; the PR metadata backfill is already live on the reviewed merged PRs.

Rollback:
- If the wording is unclear, refine the process text in place rather than removing the linkage rule.

## Notes
- The metadata backfill was intentionally done on the already-merged PRs themselves so the GitHub graph is corrected at the source instead of only being documented elsewhere.