### PR TITLE
Preserve superseded PR review handoffs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,3 +33,4 @@
 ## Notes
 
 - 
+- If this PR supersedes or duplicates another PR, link that PR here and summarize any carried-forward review findings.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -68,6 +68,15 @@ If a branch or PR contains work for multiple issues, do not close those issues e
 
 Security-sensitive PRs should not merge with unresolved review comments that identify real auth, CSRF, secret-handling, or data-exposure risk. If a fix does not land in the same PR, the PR must link the follow-up issue explicitly and describe the accepted temporary risk.
 
+If a PR is closed as a duplicate or superseded by another PR, do not let actionable review findings disappear with that closure.
+
+- Before closing the old PR, leave a closing comment on that same PR with a short review-finding handoff.
+- For each still-relevant review finding, say whether it is:
+  - resolved in the replacement PR, with the replacement PR or commit linked directly, or
+  - still open, with a properly formed follow-up issue linked directly.
+- This applies to Codex review comments as well as human review comments.
+- Do not create malformed placeholder issues just to preserve review feedback. The durable record should live on the superseded PR itself, and any remaining work should move into a normal execution issue.
+
 The repository also enforces a hidden-Unicode gate in PR CI. Source changes should not introduce bidirectional control characters unless there is a documented and reviewed exception.
 
 That CI gate only scans tracked repository files. GitHub can still show a hidden-Unicode warning on issue bodies, PR bodies, comments, or other pasted text that never becomes a tracked file. When that happens, treat the GitHub banner as a content warning on the discussion text itself, not as evidence that `infra/scripts/check-bidi-chars.mjs` missed a tracked-file change.


### PR DESCRIPTION
## Summary
- document the required handoff behavior when a duplicate or superseded PR is closed so actionable Codex review findings are not lost with the old thread
- add a small PR-template reminder that superseding PRs must link the older PR and summarize any carried-forward review findings
- attach a real repository example using superseded PR `#470`, historical placeholder issue `#469`, and new follow-up issue `#752`

## Linked issues
- Closes #727

## Verification
- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun run check:bidi
```

Concrete example used for this process update:
- superseded PR handoff comment: https://github.com/Tomodovodoo/ParetoProof/pull/470#issuecomment-4061244922
- historical placeholder issue note: https://github.com/Tomodovodoo/ParetoProof/issues/469#issuecomment-4061244907
- properly formed carried-forward follow-up issue: #752

## Security and cost review
- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

Security boundary:
- This is a review-traceability guardrail. It reduces the risk of losing actionable security findings when duplicate or superseded PRs are closed.

Cost impact:
- Negligible beyond project-maintenance time.

## Rollout and rollback
- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout:
- Merge the process update. The example metadata updates on `#470`, `#469`, and `#752` are already live.

Rollback:
- If the wording is unclear, refine it in place rather than removing the handoff rule.

## Notes
- The durable place for a superseded PR's finding handoff is the superseded PR itself; malformed placeholder issues are now explicitly discouraged.