### PR TITLE
docs(ops): publish runtime env mode checklists

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -5,6 +5,7 @@
 Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline
+- use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local API, Railway, migration, and owner-bootstrap checklists
 - use [`.env.example`](./.env.example) only as the local developer-facing example for routine startup and owner ops
 
 ## Offline Problem 9 ingest

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,5 +7,6 @@ Cloudflare Pages is configured around this app through the local Wrangler config
 Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline for browser env versus hosted auth-entry secrets
+- use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages auth-entry runtime checklists
 - the Pages auth-entry runtime owns the provider-start handlers and a legacy finalize compatibility route, while branded completion now posts into the API audience handoff at `/portal/session/finalize/submit`
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -24,9 +24,10 @@ Docker targets:
 Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline
+- use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete materializer, trusted-local, offline-ingest, and hosted claim-loop checklists
 - use [`.env.example`](./.env.example) only as the local developer-facing example
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
-- the future `ingest-problem9-run-bundle` CLI is not a `WORKER_BOOTSTRAP_TOKEN` flow; offline ingest uses an explicit admin-authenticated control-plane handoff
+- the checked-in `ingest-problem9-run-bundle` CLI is not a `WORKER_BOOTSTRAP_TOKEN` flow; offline ingest uses an explicit admin-authenticated control-plane handoff
 
 Package materialization:
 
@@ -37,11 +38,16 @@ Package materialization:
   digest-filled `benchmark-package.json`
 - use `bun --cwd apps/worker materialize:problem9-prompt-package -- --output <directory> --benchmark-package-root <directory> --run-id <id> --attempt-id <id> --lane-id <id> --run-mode <mode> --tool-profile <profile> --provider-family <family> --auth-mode <mode> --model-config-id <id> --harness-revision <revision>` to emit the canonical prompt package for one Problem 9 attempt
 - the prompt package writes `prompt-package.json` plus the reviewable raw prompt layers `system.md`, `benchmark.md`, `item.md`, and `run-envelope.json`
-- supported prompt and local-run auth modes now follow the MVP provider contract:
+- supported prompt-package auth modes follow the MVP provider contract:
   - `trusted_local_user`
   - `machine_api_key`
   - `machine_oauth`
   - `local_stub`
+- the checked-in `run-problem9-attempt` execution path currently documents and exercises:
+  - `trusted_local_user`
+  - `machine_api_key`
+  - `local_stub`
+- treat `machine_oauth` as a prompt-package contract value until a follow-up issue documents and exercises the local execution path end to end
 - use `bun --cwd apps/worker materialize:problem9-run-bundle -- --output <directory> --benchmark-package-root <directory> --prompt-package-root <directory> --candidate-source <file> --compiler-diagnostics <file> --compiler-output <file> --verifier-output <file> --environment-input <file> --result <pass|fail> --semantic-equality <matched|mismatched|not_evaluated> --surface-equality <matched|drifted|not_evaluated> --contains-sorry <true|false> --contains-admit <true|false> --axiom-check <passed|failed|not_evaluated> --diagnostic-gate <passed|failed> --stop-reason <reason> [--failure-classification <file>]` to emit `problem9-run-bundle/` with the canonical manifests, copied package and prompt references, candidate source, verification artifacts, environment snapshot, and deterministic digests
 - the run-bundle command is a supported standalone materializer for fixture generation and later offline-ingest prep; it derives run identity from the prompt package `run-envelope.json`, writes `package/package-ref.json`, `verification/verdict.json`, `artifact-manifest.json`, and `run-bundle.json`, and rejects output roots that overlap the benchmark package, prompt package, or any bundle input file
 - use `bun --cwd apps/worker test:run-bundle` to run the fixture-backed standalone verification path, which materializes canonical benchmark and prompt inputs, runs the bundle CLI twice on identical fixture evidence, and checks that the resulting digests and root manifests are identical

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use these files:
 - [architecture.md](./architecture.md) for the product and system shape
 - [benchmarks.md](./benchmarks.md) for the current benchmark scope
 - [runtime.md](./runtime.md) for environment, deploy, and worker runtime rules
+- [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) for supported-mode env and operator checklists
 - [project-management.md](./project-management.md) for issue and scope workflow
 
 Everything else should live in code, tests, READMEs, or GitHub issues and PRs.

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -1,0 +1,260 @@
+# Runtime Env Mode Checklists
+
+This document is the operator-facing companion to [runtime.md](runtime.md).
+
+Use it when you need to answer a narrower question: "What do I actually need to set for this exact supported command or runtime?"
+
+If a mode is not listed here, do not infer support from a placeholder variable name or an aspirational issue. This checklist covers only the currently supported web, API, and worker modes that exist in the repository today.
+
+## Shared rules
+
+- checked-in `.env.example` files are local examples only
+- hosted secrets stay in the platform that runs the process, not in checked-in `.env` files
+- empty strings are treated as missing values by the runtime validators
+- required CLI flags such as `--access-jwt` are part of the operational checklist even when they are not environment variables
+
+## Web modes
+
+### Local browser build or dev server
+
+Use this mode for `bun run dev:web` and `bun run build:web`.
+
+- Example file: `apps/web/.env.example`
+- Required env: none
+- Optional env:
+  - `VITE_API_BASE_URL`
+- Secret env: none
+- Runtime behavior:
+  - when `VITE_API_BASE_URL` is unset, the app derives `https://api.paretoproof.com` on branded `paretoproof.com` hosts
+  - when `VITE_API_BASE_URL` is unset on local origins, the app derives the same origin on port `3000`
+- Do not set here:
+  - `ACCESS_PROVIDER_STATE_SECRET`
+
+### Pages auth-entry runtime
+
+Use this mode for the Pages-managed auth provider-start handlers and the legacy finalize compatibility route.
+
+- Checked-in example file: none by design
+- Required env:
+  - `ACCESS_PROVIDER_STATE_SECRET`
+- Optional env: none
+- Secret env:
+  - `ACCESS_PROVIDER_STATE_SECRET`
+- Platform owner:
+  - Cloudflare Pages runtime, not the browser bundle
+- Do not set here:
+  - `VITE_API_BASE_URL` as a secret substitute
+
+## API modes
+
+### Local API startup
+
+Use this mode for `bun run dev:api`, `bun run build:api`, and direct local server startup.
+
+- Example file: `apps/api/.env.example`
+- Required env:
+  - `DATABASE_URL`
+  - `ACCESS_PROVIDER_STATE_SECRET`
+  - `CF_ACCESS_TEAM_DOMAIN`
+  - one of `CF_ACCESS_PORTAL_AUD` or `CF_ACCESS_AUD`
+  - `WORKER_BOOTSTRAP_TOKEN`
+- Optional env:
+  - `HOST`
+  - `PORT`
+  - `NODE_ENV`
+  - `CF_ACCESS_INTERNAL_AUD`
+  - `CORS_ALLOWED_ORIGINS`
+  - `CORS_ALLOW_LOCALHOST`
+- Secret env:
+  - `DATABASE_URL`
+  - `ACCESS_PROVIDER_STATE_SECRET`
+  - `WORKER_BOOTSTRAP_TOKEN`
+- Notes:
+  - `CF_ACCESS_INTERNAL_AUD` falls back to the portal audience when omitted
+  - `HOST` defaults to `0.0.0.0`
+  - `PORT` defaults to `3000`
+
+### Railway API runtime
+
+Use this mode for the hosted `api.paretoproof.com` control plane.
+
+- Checked-in example file: none; use Railway service variables
+- Required env:
+  - `DATABASE_URL`
+  - `ACCESS_PROVIDER_STATE_SECRET`
+  - `CF_ACCESS_TEAM_DOMAIN`
+  - one of `CF_ACCESS_PORTAL_AUD` or `CF_ACCESS_AUD`
+  - `WORKER_BOOTSTRAP_TOKEN`
+- Optional env:
+  - `HOST`
+  - `PORT`
+  - `NODE_ENV`
+  - `CF_ACCESS_INTERNAL_AUD`
+  - `CORS_ALLOWED_ORIGINS`
+  - `CORS_ALLOW_LOCALHOST`
+- Secret env:
+  - `DATABASE_URL`
+  - `ACCESS_PROVIDER_STATE_SECRET`
+  - `WORKER_BOOTSTRAP_TOKEN`
+- Platform notes:
+  - Railway normally supplies `PORT`
+  - keep migration credentials out of the live service runtime
+
+### API migration mode
+
+Use this mode for `bun run db:migrate:api`.
+
+- Example file: `apps/api/.env.example`
+- Required env:
+  - `MIGRATION_DATABASE_URL` or `DATABASE_URL`
+- Optional env: none
+- Secret env:
+  - `MIGRATION_DATABASE_URL` when used
+  - `DATABASE_URL` when used as the fallback
+- Do not assume:
+  - Cloudflare platform tokens are needed just to run migrations
+
+### API owner bootstrap mode
+
+Use this mode for `bun run bootstrap:owner-admin:api` and related owner-only setup work.
+
+- Example file: `apps/api/.env.example`
+- Required env:
+  - `MIGRATION_DATABASE_URL` or `DATABASE_URL`
+  - `OWNER_EMAIL`
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - either `CLOUDFLARE_API_TOKEN`, or `CLOUDFLARE_EMAIL` together with `CLOUDFLARE_GLOBAL_API_KEY`
+- Optional env: none
+- Secret env:
+  - database credential used for the bootstrap
+  - Cloudflare credential used for the bootstrap
+- Do not treat as normal startup:
+  - these owner-only values are not required for routine API serving
+
+## Worker modes
+
+### Artifact materializers
+
+Use this mode for:
+
+- `bun run materialize:problem9-package`
+- `bun run materialize:problem9-prompt-package`
+- `bun run materialize:problem9-run-bundle`
+
+- Example file: `apps/worker/.env.example`
+- Required env: none
+- Optional env: none
+- Secret env: none
+- Notes:
+  - these commands are intentionally file-driven
+  - do not inject `API_BASE_URL`, `WORKER_BOOTSTRAP_TOKEN`, or provider keys just because they exist in the worker example file
+
+### Local Problem 9 attempt with `local_stub`
+
+Use this mode for deterministic local dry runs of `run-problem9-attempt`.
+
+- Example file: `apps/worker/.env.example`
+- Required env: none
+- Optional env: none
+- Secret env: none
+
+### Local Problem 9 attempt with `machine_api_key`
+
+Use this mode for `run-problem9-attempt --auth-mode machine_api_key`.
+
+- Example file: `apps/worker/.env.example`
+- Required env:
+  - `CODEX_API_KEY`
+- Optional env: none
+- Secret env:
+  - `CODEX_API_KEY`
+
+### Local Problem 9 attempt with `trusted_local_user`
+
+Use this mode for `run-problem9-attempt --auth-mode trusted_local_user`.
+
+- Example file: none by design
+- Required env:
+  - none if the default Codex home is correct
+- Optional env:
+  - `CODEX_HOME` when the local auth cache is not under the default home directory
+- Required local file/state:
+  - a readable `auth.json` under `CODEX_HOME` or the inferred home directory
+  - a passing `codex login status`
+- Secret env: none
+- Notes:
+  - on Windows, the default inferred path is `%USERPROFILE%\\.codex\\auth.json`
+  - on non-Windows hosts, the default inferred path is `$HOME/.codex/auth.json`
+  - this is a trusted-local path only; do not reuse it for hosted worker modes
+
+### Trusted-local devbox wrapper
+
+Use this mode for:
+
+- `node infra/scripts/run-problem9-trusted-local-attempt.mjs --preflight-only`
+- `bun run run:problem9-attempt:trusted-local`
+
+- Example file: none by design
+- Required env:
+  - none if the default Codex home is correct
+- Optional env:
+  - `CODEX_HOME` when the local auth cache is not under the default home directory
+- Required local file/state:
+  - a readable `auth.json` under `CODEX_HOME` or the inferred home directory
+  - a passing host `codex login status`
+- Secret env: none
+- Notes:
+  - this wrapper mounts the auth file into the container read-only
+  - do not move trusted-local auth into `apps/worker/.env`
+
+### Offline ingest CLI
+
+Use this mode for `bun run ingest:problem9-run-bundle -- --bundle-root <directory> --access-jwt <token>`.
+
+- Example file: `apps/worker/.env.example`
+- Required env:
+  - `API_BASE_URL`
+- Optional env: none
+- Required CLI inputs:
+  - `--bundle-root`
+  - `--access-jwt`
+- Secret env: none
+- Secret CLI input:
+  - `--access-jwt`
+- Do not set here:
+  - `WORKER_BOOTSTRAP_TOKEN`
+  - `CODEX_API_KEY`
+  - trusted-local `CODEX_HOME/auth.json`
+
+### Hosted claim loop with `machine_api_key`
+
+Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key ...`.
+
+- Example file: `apps/worker/.env.example`
+- Required env:
+  - `API_BASE_URL`
+  - `WORKER_BOOTSTRAP_TOKEN`
+  - `CODEX_API_KEY`
+- Optional env: none
+- Secret env:
+  - `WORKER_BOOTSTRAP_TOKEN`
+  - `CODEX_API_KEY`
+- Notes:
+  - this is the fully documented hosted worker path in the repository today
+  - the command also accepts `--auth-mode machine_oauth`, but this checklist does not treat that as a complete hosted-provider workflow until a follow-up issue documents and exercises it end to end
+
+## Reserved later-scope variables
+
+These names may appear in examples as commented placeholders, but they are not part of the required checklist for any currently supported mode above:
+
+- `CF_INTERNAL_API_SERVICE_TOKEN_ID`
+- `CF_INTERNAL_API_SERVICE_TOKEN_SECRET`
+- `R2_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY`
+
+## Operator workflow summary
+
+- use `apps/web/.env.example` only for local browser overrides
+- use `apps/api/.env.example` for local API startup and owner-only API operations
+- use `apps/worker/.env.example` for local worker modes that actually need environment variables
+- keep Pages, Railway, and Modal hosted secrets in those platforms rather than inventing checked-in hosted `.env` files

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -5,6 +5,7 @@ This repo uses a small number of runtime rules.
 ## Environment
 
 - `apps/api/.env.example`, `apps/web/.env.example`, and `apps/worker/.env.example` are the local examples.
+- [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) is the operator-facing per-mode checklist for the supported local, hosted, and owner-only runtime paths.
 - Keep browser env separate from Pages function secrets and worker machine credentials.
 - Do not store short-lived access assertions, human session data, or local auth caches in committed env files.
 

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -74,6 +74,7 @@ const readmeChecks = [
     file: "apps/api/README.md",
     requiredSnippets: [
       "docs/runtime.md",
+      "docs/runtime-env-mode-checklists.md",
       "`.env.example`"
     ]
   },
@@ -81,6 +82,7 @@ const readmeChecks = [
     file: "apps/web/README.md",
     requiredSnippets: [
       "docs/runtime.md",
+      "docs/runtime-env-mode-checklists.md",
       "`.env.example`"
     ]
   },
@@ -88,7 +90,41 @@ const readmeChecks = [
     file: "apps/worker/README.md",
     requiredSnippets: [
       "docs/runtime.md",
+      "docs/runtime-env-mode-checklists.md",
       "`.env.example`"
+    ]
+  }
+];
+
+const docsChecks = [
+  {
+    file: "docs/README.md",
+    requiredSnippets: [
+      "runtime.md",
+      "runtime-env-mode-checklists.md"
+    ]
+  },
+  {
+    file: "docs/runtime.md",
+    requiredSnippets: ["runtime-env-mode-checklists.md"]
+  },
+  {
+    file: "docs/runtime-env-mode-checklists.md",
+    requiredSnippets: [
+      "# Runtime Env Mode Checklists",
+      "### Local browser build or dev server",
+      "### Pages auth-entry runtime",
+      "### Local API startup",
+      "### Railway API runtime",
+      "### API migration mode",
+      "### API owner bootstrap mode",
+      "### Artifact materializers",
+      "### Local Problem 9 attempt with `local_stub`",
+      "### Local Problem 9 attempt with `machine_api_key`",
+      "### Local Problem 9 attempt with `trusted_local_user`",
+      "### Trusted-local devbox wrapper",
+      "### Offline ingest CLI",
+      "### Hosted claim loop with `machine_api_key`"
     ]
   }
 ];
@@ -152,6 +188,17 @@ for (const check of checks) {
 }
 
 for (const check of readmeChecks) {
+  const contents = readRepoFile(check.file);
+
+  for (const requiredSnippet of check.requiredSnippets) {
+    assert(
+      contents.includes(requiredSnippet),
+      `${check.file} must reference ${requiredSnippet}.`
+    );
+  }
+}
+
+for (const check of docsChecks) {
   const contents = readRepoFile(check.file);
 
   for (const requiredSnippet of check.requiredSnippets) {


### PR DESCRIPTION
﻿## Summary

- add an operator-facing runtime env checklist doc for every currently supported web, API, and worker mode
- sync the existing runtime env and worker runtime baseline docs to the checked-in implementation instead of future-only wording
- extend the env example checker so README and docs links to the new checklist cannot drift silently

## Linked issues

- Closes #756

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun run check:env-contract
bun run check:bidi
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

This PR changes documentation and repo-side doc consistency checks only. It narrows auth/runtime wording to the currently implemented modes and does not change live runtime behavior or secret handling. Cost impact is negligible beyond the two local validation commands above.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout: merge the docs and checker update together so the new checklist and README pointers land atomically.

Rollback: revert this PR if the checklist or checker pins the wrong supported mode, then reopen #756 with the specific mismatch.

## Notes

- No screenshots were needed because the change is docs plus a repo-side consistency check.
