### PR TITLE
Fix branded auth finalize handoff when stale auth bundles post directly to the API

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -140,6 +140,58 @@ function buildPortalAuthRetryUrl(redirectPath: string) {
   return authUrl.toString();
 }
 
+const brandedAuthHosts = new Set([
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com"
+]);
+
+function readTrustedBrandedAuthOrigin(request: FastifyRequest) {
+  const originHeader =
+    typeof request.headers.origin === "string" ? request.headers.origin : null;
+
+  if (originHeader) {
+    try {
+      const originUrl = new URL(originHeader);
+
+      if (originUrl.protocol === "https:" && brandedAuthHosts.has(originUrl.hostname)) {
+        return originUrl.origin;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const refererHeader =
+    typeof request.headers.referer === "string" ? request.headers.referer : null;
+
+  if (!refererHeader) {
+    return null;
+  }
+
+  try {
+    const refererUrl = new URL(refererHeader);
+
+    if (refererUrl.protocol === "https:" && brandedAuthHosts.has(refererUrl.hostname)) {
+      return refererUrl.origin;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function buildBrandedFinalizeRelayUrl(origin: string, redirectPath: string) {
+  const relayUrl = new URL("/api/access/finalize", origin);
+
+  if (redirectPath !== "/") {
+    relayUrl.searchParams.set("redirect", redirectPath);
+  }
+
+  return relayUrl.toString();
+}
+
 function toPortalProfile(options: {
   currentSubject: string;
   fallbackEmail: string | null;
@@ -360,6 +412,63 @@ export function registerPortalRoutes(
     return handlePortalSessionCompletion(request, reply);
   };
 
+  const handlePortalSessionFinalizeSubmit = async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => {
+    const parsedBody =
+      typeof request.body === "object" && request.body !== null
+        ? (request.body as { redirect?: string })
+        : undefined;
+    const redirectPath = sanitizePortalRedirectPath(
+      parsedBody?.redirect ??
+        (request.query as { redirect?: string } | undefined)?.redirect ??
+        null
+    );
+
+    try {
+      const accessContext = await resolvePortalAccess(request);
+
+      if (!accessContext) {
+        const brandedOrigin = readTrustedBrandedAuthOrigin(request);
+
+        if (brandedOrigin) {
+          reply.code(307).header(
+            "location",
+            buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath)
+          );
+          return reply.send();
+        }
+
+        reply.code(401).send({
+          error: "access_assertion_required"
+        });
+        return;
+      }
+    } catch (error) {
+      if (isAccessAssertionVerificationError(error)) {
+        const brandedOrigin = readTrustedBrandedAuthOrigin(request);
+
+        if (brandedOrigin) {
+          reply.code(307).header(
+            "location",
+            buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath)
+          );
+          return reply.send();
+        }
+
+        reply.code(401).send({
+          error: "invalid_access_assertion"
+        });
+        return;
+      }
+
+      throw error;
+    }
+
+    return handlePortalSessionCompletion(request, reply);
+  };
+
   app.get(
     "/portal/me",
     {
@@ -395,10 +504,7 @@ export function registerPortalRoutes(
 
   app.post(
     "/portal/session/finalize/submit",
-    {
-      preHandler: requireAccess("authenticated_access_identity")
-    },
-    handlePortalSessionCompletion
+    handlePortalSessionFinalizeSubmit
   );
 
   app.get(

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -123,3 +123,68 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   assert.match(setCookies[0], /^PortalAccessProvider=/);
   assert.match(setCookies[1], /^PortalLinkIntent=;/);
 });
+
+test("POST /portal/session/finalize/submit bounces stale direct browser handoffs back to the branded auth relay", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit?redirect=/profile",
+    headers: {
+      accept: "text/html",
+      origin: "https://google.auth.paretoproof.com",
+      referer: "https://google.auth.paretoproof.com/"
+    }
+  });
+
+  assert.equal(response.statusCode, 307);
+  assert.equal(
+    response.headers.location,
+    "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile"
+  );
+});
+
+test("POST /portal/session/finalize/submit still returns JSON auth errors for non-branded callers without access", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit",
+    headers: {
+      accept: "application/json"
+    }
+  });
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(response.json().error, "access_assertion_required");
+});

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -1,10 +1,48 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { handleAccessFinalize } from "./access-finalize";
 
+const originalFetch = globalThis.fetch;
+
 describe("handleAccessFinalize", () => {
-  it("redirects the legacy finalize relay to the API finalize submit handoff", async () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("relays a successful finalize response back to the portal and forwards cookies", async () => {
+    globalThis.fetch = async (input, init) => {
+      expect(input).toBe("https://api.paretoproof.com/portal/session/finalize");
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBe("assertion-1");
+      expect((init?.headers as Headers).get("cookie")).toContain("PortalAccessProvider=");
+      expect(init?.redirect).toBe("manual");
+      expect(init?.body).toBe(JSON.stringify({ redirect: "/profile" }));
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/profile"
+        }),
+        {
+          headers: [
+            [
+              "set-cookie",
+              "PortalAccessProvider=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
+            ],
+            [
+              "set-cookie",
+              "PortalLinkIntent=; Domain=.paretoproof.com; Path=/; Max-Age=0; Secure; HttpOnly"
+            ]
+          ],
+          status: 200
+        }
+      );
+    };
+
     const response = await handleAccessFinalize(
-      new Request("https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile", {
+      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
         body: new URLSearchParams({
           redirect: "/profile"
         }),
@@ -17,16 +55,19 @@ describe("handleAccessFinalize", () => {
       })
     );
 
-    expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe(
-      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile"
-    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/profile");
     expect(response.headers.get("cache-control")).toBe("no-store");
+    const setCookies =
+      (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain("PortalAccessProvider=signed");
+    expect(setCookies[1]).toContain("PortalLinkIntent=");
   });
 
-  it("keeps local branded-host finalize handoffs on the local API origin", async () => {
+  it("redirects back to the branded retry surface when the branded handoff lacks an Access assertion", async () => {
     const response = await handleAccessFinalize(
-      new Request("http://github.auth.paretoproof.com:4371/api/access/finalize?redirect=%2Fprofile", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
         body: new URLSearchParams({
           redirect: "/profile"
         }),
@@ -37,9 +78,39 @@ describe("handleAccessFinalize", () => {
       })
     );
 
-    expect(response.status).toBe(307);
+    expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
+      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    );
+  });
+
+  it("redirects back to the branded retry surface when the API finalize call fails", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          error: "access_assertion_required"
+        }),
+        {
+          status: 401
+        }
+      );
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-2",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
     );
   });
 });

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,3 +1,4 @@
+const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
 
 function trimTrailingSlash(url: string) {
@@ -46,6 +47,18 @@ function sanitizeRedirectPath(rawRedirectPath: string | null) {
   }
 }
 
+function buildAuthRetryUrl(redirectPath: string) {
+  const authUrl = new URL(authOrigin);
+
+  if (redirectPath !== "/") {
+    authUrl.searchParams.set("redirect", redirectPath);
+  }
+
+  authUrl.searchParams.set("handoff", "retry");
+
+  return authUrl.toString();
+}
+
 function resolveApiBaseUrl(requestUrl: URL) {
   if (
     requestUrl.protocol === "http:" &&
@@ -74,14 +87,40 @@ function resolveApiBaseUrl(requestUrl: URL) {
   return "https://api.paretoproof.com";
 }
 
-function buildFinalizeSubmitUrl(requestUrl: URL, redirectPath: string) {
-  const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
-
-  if (redirectPath !== "/") {
-    apiUrl.searchParams.set("redirect", redirectPath);
+function resolvePortalRedirectTarget(rawRedirectTarget: unknown, fallbackRedirectPath: string) {
+  if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
+    return new URL(fallbackRedirectPath, portalOrigin).toString();
   }
 
-  return apiUrl.toString();
+  try {
+    const targetUrl = new URL(rawRedirectTarget);
+
+    if (targetUrl.origin !== portalOrigin) {
+      return null;
+    }
+
+    return targetUrl.toString();
+  } catch {
+    return null;
+  }
+}
+
+function readSetCookieHeaders(headers: Headers) {
+  const cookieHeaders = headers as Headers & {
+    getAll?: (name: string) => string[];
+    getSetCookie?: () => string[];
+  };
+
+  if (typeof cookieHeaders.getSetCookie === "function") {
+    return cookieHeaders.getSetCookie();
+  }
+
+  if (typeof cookieHeaders.getAll === "function") {
+    return cookieHeaders.getAll("set-cookie");
+  }
+
+  const singleCookieHeader = headers.get("set-cookie");
+  return singleCookieHeader ? [singleCookieHeader] : [];
 }
 
 async function readRedirectPath(request: Request) {
@@ -109,24 +148,83 @@ async function readRedirectPath(request: Request) {
   );
 }
 
-function buildRedirectResponse(targetUrl: string, status = 303) {
+function buildRedirectResponse(targetUrl: string, responseHeaders?: Headers) {
   const headers = new Headers({
     "cache-control": "no-store",
     location: targetUrl
   });
 
+  for (const cookieValue of responseHeaders ? readSetCookieHeaders(responseHeaders) : []) {
+    headers.append("set-cookie", cookieValue);
+  }
+
   return new Response(null, {
     headers,
-    status
+    status: 303
   });
 }
 
 export async function handleAccessFinalize(request: Request) {
   const redirectPath = await readRedirectPath(request);
+  const retryUrl = buildAuthRetryUrl(redirectPath);
   const requestUrl = new URL(request.url);
-  const submitUrl = buildFinalizeSubmitUrl(requestUrl, redirectPath);
+  const apiUrl = new URL("/portal/session/finalize", resolveApiBaseUrl(requestUrl));
+  const forwardedHeaders = new Headers({
+    accept: "application/json",
+    "content-type": "application/json"
+  });
+  const accessAssertion = request.headers.get("cf-access-jwt-assertion");
+  const cookieHeader = request.headers.get("cookie");
 
-  // Preserve the browser's form POST so the API audience can establish its own
-  // Access session instead of completing the handoff only on the auth Pages runtime.
-  return buildRedirectResponse(submitUrl, 307);
+  if (!accessAssertion) {
+    return buildRedirectResponse(retryUrl);
+  }
+
+  forwardedHeaders.set("cf-access-jwt-assertion", accessAssertion);
+
+  if (cookieHeader) {
+    forwardedHeaders.set("cookie", cookieHeader);
+  }
+
+  let finalizeResponse: Response;
+
+  try {
+    finalizeResponse = await fetch(apiUrl.toString(), {
+      body: JSON.stringify(
+        redirectPath === "/"
+          ? {}
+          : {
+              redirect: redirectPath
+            }
+      ),
+      headers: forwardedHeaders,
+      method: "POST",
+      redirect: "manual"
+    });
+  } catch {
+    return buildRedirectResponse(retryUrl);
+  }
+
+  if (!finalizeResponse.ok) {
+    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
+  }
+
+  let responseBody: unknown;
+
+  try {
+    responseBody = await finalizeResponse.json();
+  } catch {
+    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
+  }
+
+  const redirectTarget = resolvePortalRedirectTarget(
+    (responseBody as { redirectTo?: unknown }).redirectTo,
+    redirectPath
+  );
+
+  if (!redirectTarget) {
+    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
+  }
+
+  return buildRedirectResponse(redirectTarget, finalizeResponse.headers);
 }

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -184,6 +184,10 @@ export function buildAuthUrl(targetPath = "/", hostname = window.location.hostna
   return authUrl.toString();
 }
 
+export function buildAccessRequestUrl(hostname = window.location.hostname) {
+  return buildAuthUrl("/access-request", hostname);
+}
+
 export function buildPublicUrl(targetPath = "/", hostname = window.location.hostname) {
   const normalizedTargetPath = normalizeTargetPath(targetPath);
 
@@ -240,7 +244,18 @@ export function buildAccessStartUrl(
 
 export function buildAccessFinalizeUrl(targetPath = "/") {
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
-  const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
+
+  if (isLocalOrigin()) {
+    const completionUrl = new URL("/portal/session/finalize", getApiBaseUrl());
+
+    if (normalizedTargetPath !== "/") {
+      completionUrl.searchParams.set("redirect", normalizedTargetPath);
+    }
+
+    return completionUrl.toString();
+  }
+
+  const completionUrl = new URL("/api/access/finalize", window.location.origin);
 
   if (normalizedTargetPath !== "/") {
     completionUrl.searchParams.set("redirect", normalizedTargetPath);


### PR DESCRIPTION
## Summary

Closes #726.

This PR fixes the live auth failure where the branded GitHub/Google auth surfaces still end up POSTing directly to:

- `https://api.paretoproof.com/portal/session/finalize/submit`

without an Access assertion, which currently returns:

- `{error:access_assertion_required}`

That failure mode matches the production traces exactly.

## Root cause

There are two paths in the system today:

1. the intended path: branded auth finishes through the same-origin Pages relay at `/api/access/finalize`
2. the stale path still seen in production: the branded auth surface posts directly to the API finalize submit route

When the stale direct POST hits the API, it arrives without the API Access assertion that `requireAccess(...)` expects, so the API returns `401 access_assertion_required` before the handoff can complete.

## What this PR changes

### API compatibility bridge

`apps/api/src/routes/portal.ts`

- stops treating `/portal/session/finalize/submit` as a hard preHandler-only route
- detects branded auth origins and referers from the trusted auth hosts
- if the request is a stale branded direct submit without access attached, returns a `307` back to the branded Pages relay at `/api/access/finalize`
- keeps returning normal JSON auth errors for non-branded callers

This means old auth bundles are rescued instead of failing with raw JSON.

### Branded Pages relay

`apps/web/functions/_shared/access-finalize.ts`

- no longer forwards the browser directly to `/portal/session/finalize/submit`
- forwards the Access assertion and cookies server-side to `/portal/session/finalize`
- preserves returned cookies
- redirects into the portal on success
- redirects back to the branded retry flow on missing assertion or failed finalize

### Web surface helper

`apps/web/src/lib/surface.ts`

- keeps production finalize on the branded relay path `/api/access/finalize`
- preserves the local direct-API flow for local development
- restores `buildAccessRequestUrl(...)` so the web typecheck stays consistent with current route usage

## Tests

This PR adds regression coverage for:

- stale branded direct POSTs to `/portal/session/finalize/submit`
- non-branded unauthenticated callers still getting JSON auth errors
- successful Pages relay finalize behavior
- retry redirects when the assertion is missing or the API finalize call fails

## Why this should merge now

This is not a cosmetic auth cleanup. It fixes the concrete live failure users are seeing right now in production, and it also makes the system tolerant of stale branded auth bundles instead of assuming every client already runs the new relay path.