### PR TITLE
test(api): cover portal access request trusted origins

### DIFF
--- a/apps/api/test/portal-access-request-origin.test.ts
+++ b/apps/api/test/portal-access-request-origin.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+import { createTrustedMutationOriginHook } from "../src/server/trusted-mutation-origin.ts";
+
+function createAuthenticatedAccessGuard() {
+  return () => (
+    request: {
+      accessIdentity?: {
+        email: string;
+        provider: "cloudflare_google";
+        subject: string;
+      };
+    },
+    _reply: unknown,
+    done: () => void
+  ) => {
+    request.accessIdentity = {
+      email: "person@example.com",
+      provider: "cloudflare_google",
+      subject: "subject-1"
+    };
+    done();
+  };
+}
+
+function createMutationTrackingDb(onMutationAttempt: () => void) {
+  return {
+    transaction: async () => {
+      onMutationAttempt();
+      throw new Error("expected test database failure");
+    }
+  } as never;
+}
+
+function registerPortalAccessRequestTestApp(options: {
+  allowLocalhostOrigins?: boolean;
+  allowedOrigins?: string[];
+  onMutationAttempt: () => void;
+}) {
+  const app = Fastify();
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: options.allowLocalhostOrigins ?? false,
+      allowedOrigins: options.allowedOrigins ?? ["https://portal.paretoproof.com"]
+    })
+  );
+
+  registerPortalRoutes(
+    app,
+    createMutationTrackingDb(options.onMutationAttempt),
+    createAuthenticatedAccessGuard(),
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  return app;
+}
+
+test("POST /portal/access-requests rejects requests without an Origin header before mutation work runs", async (t) => {
+  let mutationAttempted = false;
+  const app = registerPortalAccessRequestTestApp({
+    onMutationAttempt: () => {
+      mutationAttempted = true;
+    }
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need contributor access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests"
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_required"
+  });
+  assert.equal(mutationAttempted, false);
+});
+
+test("POST /portal/access-requests rejects untrusted origins before mutation work runs", async (t) => {
+  let mutationAttempted = false;
+  const app = registerPortalAccessRequestTestApp({
+    onMutationAttempt: () => {
+      mutationAttempted = true;
+    }
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need contributor access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests",
+    headers: {
+      origin: "https://evil.example"
+    }
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_not_allowed"
+  });
+  assert.equal(mutationAttempted, false);
+});
+
+test("POST /portal/access-requests allows the trusted portal origin to reach mutation work", async (t) => {
+  let mutationAttempted = false;
+  const app = registerPortalAccessRequestTestApp({
+    onMutationAttempt: () => {
+      mutationAttempted = true;
+    }
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need contributor access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests",
+    headers: {
+      origin: "https://portal.paretoproof.com"
+    }
+  });
+
+  assert.equal(response.statusCode, 500);
+  assert.equal(mutationAttempted, true);
+});


### PR DESCRIPTION
﻿## Summary

- add focused API coverage that wires the real `/portal/access-requests` route through the current global trusted-mutation-origin hook
- prove missing and untrusted origins are rejected before `db.transaction(...)` is reached
- prove the trusted portal origin is still allowed through to mutation work under the current route registration shape

## Linked issues

- Closes #778
- Related: #750

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun install
bun run test:api
bun run check:bidi
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

This PR adds regression coverage only. It does not widen route access or origin policy; it proves that the current global trusted-origin hook blocks cross-site writes to `/portal/access-requests` before mutation work runs. Runtime cost impact is negligible.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout: merge the test backfill and then close draft PR #750 as superseded by the current hook plus this route-level coverage.

Rollback: revert this PR only if the new test proves to be architecturally wrong about the current hook boundary, then reopen #778 with the exact mismatch.

## Notes

- This intentionally supersedes the stale route-local guard approach in draft PR #750 instead of reviving that branch.
