### PR TITLE
test(api): cover offline ingest trusted origins

### DIFF
--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -103,6 +103,40 @@ test("trusted mutation origin hook also protects admin role revocation mutations
   });
 });
 
+test("trusted mutation origin hook also protects portal-admin offline ingest mutations", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: ["https://portal.paretoproof.com"]
+    })
+  );
+
+  app.post("/portal/admin/offline-ingest/problem9-run-bundles", async () => ({ ok: true }));
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      bundle: {}
+    },
+    url: "/portal/admin/offline-ingest/problem9-run-bundles",
+    headers: {
+      origin: "https://evil.example"
+    }
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_not_allowed"
+  });
+});
+
 test("trusted mutation origin hook allows trusted portal origins and safe GET redirects", async (t) => {
   const app = Fastify();
 


### PR DESCRIPTION
﻿## Summary

- add offline-ingest coverage to the current trusted-mutation-origin test suite so the draft-PR-749 disposition is backed by current main behavior
- confirm the global `/portal/*` hook already covers contributor, admin, and portal-admin offline-ingest mutations on main
- leave `/internal/worker/*` outside this browser-origin boundary because those routes use explicit bearer-token machine auth rather than browser cookie flows

## Linked issues

- Closes #779
- Related: #749

## Verification

- [x] Commands run are listed below
- [x] Relevant logs, artifact paths, or screenshots are linked or described
- [x] New or changed contracts are wired through implementation, not only documented

```text
bun run test:api
bun run check:bidi
```

## Security and cost review

- [x] No new auth, CSRF, secret-handling, or data-exposure risk was introduced without mitigation or a linked follow-up issue
- [x] For security-sensitive changes, the threat boundary and mitigation are described below
- [x] Cost or rate-limit impact is described below when relevant

This PR adds regression coverage only. It confirms that the existing global trusted-mutation-origin hook already protects portal, admin, and portal-admin offline-ingest state-changing routes under `/portal/*`. Internal worker routes remain intentionally outside this browser-origin policy because they authenticate with explicit bearer tokens rather than ambient browser credentials.

## Rollout and rollback

- [x] Rollout plan is described or marked not applicable
- [x] Rollback plan is described or marked not applicable

Rollout: merge the coverage update, then close draft PR #749 with a disposition comment that points at the current hook plus the landed tests.

Rollback: revert only if this coverage proves to be asserting the wrong security boundary, then reopen #779 with the exact mismatch.

## Notes

- This intentionally does not revive the stale draft implementation in #749; it records why current main is sufficient for MVP and anchors that decision in current tests.
