### PR TITLE
fix(auth): relay branded finalize via trusted origin

### DIFF
--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readAccessJwtAssertion } from "../src/auth/cloudflare-access.ts";
+
+test("readAccessJwtAssertion falls back to CF_Authorization when the Access header is absent", () => {
+  const assertion = readAccessJwtAssertion({
+    headers: {
+      cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed"
+    }
+  } as never);
+
+  assert.equal(assertion, "session-cookie");
+});
+
+test("readAccessJwtAssertion prefers the Access header over the cookie fallback", () => {
+  const assertion = readAccessJwtAssertion({
+    headers: {
+      "cf-access-jwt-assertion": "header-assertion",
+      cookie: "CF_Authorization=session-cookie"
+    }
+  } as never);
+
+  assert.equal(assertion, "header-assertion");
+});

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -181,7 +181,7 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
   });
 });
 
-test("trusted mutation origin hook allows branded auth POSTs to the finalize submit handoff", async (t) => {
+test("trusted mutation origin hook allows branded auth POSTs to the finalize relay and finalize submit handoff", async (t) => {
   const app = Fastify();
 
   t.after(async () => {
@@ -201,9 +201,21 @@ test("trusted mutation origin hook allows branded auth POSTs to the finalize sub
     })
   );
 
+  app.post("/portal/session/finalize", async () => ({ ok: true }));
   app.post("/portal/session/finalize/submit", async () => ({ ok: true }));
 
-  const response = await app.inject({
+  const finalizeResponse = await app.inject({
+    method: "POST",
+    payload: {
+      redirect: "/profile"
+    },
+    url: "/portal/session/finalize",
+    headers: {
+      origin: "https://github.auth.paretoproof.com"
+    }
+  });
+
+  const submitResponse = await app.inject({
     method: "POST",
     payload: {
       redirect: "/profile"
@@ -214,8 +226,12 @@ test("trusted mutation origin hook allows branded auth POSTs to the finalize sub
     }
   });
 
-  assert.equal(response.statusCode, 200);
-  assert.deepEqual(response.json(), {
+  assert.equal(finalizeResponse.statusCode, 200);
+  assert.deepEqual(finalizeResponse.json(), {
+    ok: true
+  });
+  assert.equal(submitResponse.statusCode, 200);
+  assert.deepEqual(submitResponse.json(), {
     ok: true
   });
 });

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -18,6 +18,7 @@ describe("handleAccessFinalize", () => {
       expect(init?.method).toBe("POST");
       expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBe("assertion-1");
       expect((init?.headers as Headers).get("cookie")).toContain("PortalAccessProvider=");
+      expect((init?.headers as Headers).get("origin")).toBe("https://google.auth.paretoproof.com");
       expect(init?.redirect).toBe("manual");
       expect(init?.body).toBe(JSON.stringify({ redirect: "/profile" }));
 
@@ -65,7 +66,46 @@ describe("handleAccessFinalize", () => {
     expect(setCookies[1]).toContain("PortalLinkIntent=");
   });
 
-  it("redirects back to the branded retry surface when the branded handoff lacks an Access assertion", async () => {
+  it("relays a cookie-only branded Access session back to the API finalize boundary", async () => {
+    globalThis.fetch = async (_input, init) => {
+      expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBeNull();
+      expect((init?.headers as Headers).get("cookie")).toContain("CF_Authorization=session-cookie");
+      expect((init?.headers as Headers).get("origin")).toBe("https://github.auth.paretoproof.com");
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/access-request"
+        }),
+        {
+          headers: [
+            [
+              "set-cookie",
+              "PortalAccessProvider=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
+            ]
+          ],
+          status: 200
+        }
+      );
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/access-request"
+        }),
+        headers: {
+          cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/access-request");
+  });
+
+  it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {
     const response = await handleAccessFinalize(
       new Request("https://github.auth.paretoproof.com/api/access/finalize", {
         body: new URLSearchParams({

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -5,6 +5,22 @@ function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
 }
 
+function readCookieValue(cookieHeader: string | null, name: string) {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...valueParts] = part.trim().split("=");
+
+    if (rawName === name) {
+      return valueParts.join("=") || null;
+    }
+  }
+
+  return null;
+}
+
 const brandedHosts = new Set([
   "paretoproof.com",
   "auth.paretoproof.com",
@@ -171,16 +187,20 @@ export async function handleAccessFinalize(request: Request) {
   const apiUrl = new URL("/portal/session/finalize", resolveApiBaseUrl(requestUrl));
   const forwardedHeaders = new Headers({
     accept: "application/json",
-    "content-type": "application/json"
+    "content-type": "application/json",
+    origin: requestUrl.origin
   });
   const accessAssertion = request.headers.get("cf-access-jwt-assertion");
   const cookieHeader = request.headers.get("cookie");
+  const accessSessionCookie = readCookieValue(cookieHeader, "CF_Authorization");
 
-  if (!accessAssertion) {
+  if (!accessAssertion && !accessSessionCookie) {
     return buildRedirectResponse(retryUrl);
   }
 
-  forwardedHeaders.set("cf-access-jwt-assertion", accessAssertion);
+  if (accessAssertion) {
+    forwardedHeaders.set("cf-access-jwt-assertion", accessAssertion);
+  }
 
   if (cookieHeader) {
     forwardedHeaders.set("cookie", cookieHeader);


### PR DESCRIPTION
## Summary
- forward the branded auth origin into the server-side finalize relay so the protected API finalize POST no longer trips the trusted-origin hook and falls back to `?handoff=retry`
- accept cookie-only `CF_Authorization` branded sessions in the relay instead of requiring `cf-access-jwt-assertion` up front
- backfill relay/origin/cookie regression coverage across the web auth function and API auth helpers

## Verification
- bun test apps/web/functions/_shared/access-finalize.test.ts
- bun test apps/api/test/cloudflare-access.test.ts apps/api/test/trusted-mutation-origin.test.ts apps/api/test/portal-session-finalize.test.ts apps/web/functions/_shared/access-finalize.test.ts
- bun run test:api
- bun run build:web
- bun run check:bidi

## Issue
- Related: #806

## Notes
- I could open the live branded auth surface with Playwright, but I could not complete the real Google/GitHub callback path in this automation context because there are no reusable approved-provider test credentials or authenticated session state available here. Live post-deploy verification for `#806` still needs to be attached before that issue should be considered fully done.