### PR TITLE
test(auth): backfill branded finalize follow-up coverage

### DIFF
--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -22,3 +22,13 @@ test("readAccessJwtAssertion prefers the Access header over the cookie fallback"
 
   assert.equal(assertion, "header-assertion");
 });
+
+test("readAccessJwtAssertion returns null when no usable Access assertion is present", () => {
+  const assertion = readAccessJwtAssertion({
+    headers: {
+      cookie: "PortalAccessProvider=signed"
+    }
+  } as never);
+
+  assert.equal(assertion, null);
+});

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -188,3 +188,80 @@ test("POST /portal/session/finalize/submit still returns JSON auth errors for no
   assert.equal(response.statusCode, 401);
   assert.equal(response.json().error, "access_assertion_required");
 });
+
+test("POST /portal/session/finalize/submit completes a pending-user handoff from cookie-backed branded access", async (t) => {
+  const app = Fastify();
+  const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
+
+  t.after(async () => {
+    process.env.ACCESS_PROVIDER_STATE_SECRET = originalSecret;
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      transaction: async () => {
+        throw new Error("pending sign-in finalize submit should not hit the identity-link mutation path");
+      }
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      resolvePortalAccess: async (request) => {
+        assert.equal(request.headers["cf-access-jwt-assertion"], undefined);
+        assert.match(
+          String(request.headers.cookie),
+          /CF_Authorization=session-cookie/
+        );
+        request.accessIdentity = {
+          email: "pending@example.com",
+          issuer: "https://paretoproof.cloudflareaccess.com",
+          provider: "cloudflare_google",
+          subject: "subject-pending"
+        };
+        request.accessRbacContext = {
+          email: "pending@example.com",
+          identityId: "identity-pending",
+          roles: [],
+          status: "pending",
+          subject: "subject-pending",
+          userId: "user-pending"
+        };
+
+        return request.accessRbacContext;
+      }
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit?redirect=/access-request",
+    headers: {
+      accept: "text/html",
+      cookie: [
+        "CF_Authorization=session-cookie",
+        buildSignedAccessCookie(
+          "PortalAccessProvider",
+          "cloudflare_google|subject-pending"
+        )
+      ].join("; "),
+      origin: "https://google.auth.paretoproof.com",
+      referer: "https://google.auth.paretoproof.com/"
+    }
+  });
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(
+    response.headers.location,
+    "https://portal.paretoproof.com/access-request"
+  );
+
+  const setCookies = response.headers["set-cookie"];
+  assert.ok(Array.isArray(setCookies));
+  assert.equal(setCookies.length, 2);
+  assert.match(setCookies[0], /^PortalAccessProvider=/);
+  assert.match(setCookies[1], /^PortalLinkIntent=;/);
+});

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,5 +8,5 @@ Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline for browser env versus hosted auth-entry secrets
 - use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages auth-entry runtime checklists
-- the Pages auth-entry runtime owns the provider-start handlers and a legacy finalize compatibility route, while branded completion now posts into the API audience handoff at `/portal/session/finalize/submit`
+- the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production completion stays on `/api/access/finalize`, while local loopback-branded previews can still use the local API finalize route directly
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -124,6 +124,26 @@ describe("handleAccessFinalize", () => {
     );
   });
 
+  it("redirects back to the branded retry surface when branded state cookies exist without a usable Access session", async () => {
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          cookie: "PortalAccessProvider=signed; PortalLinkIntent=intent-1",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    );
+  });
+
   it("redirects back to the branded retry surface when the API finalize call fails", async () => {
     globalThis.fetch = async () =>
       new Response(

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -63,19 +63,19 @@ describe("buildPortalUrl", () => {
     expect(portalUrl.searchParams.has("roles")).toBe(false);
   });
 
-  it("uses the local finalize endpoint on loopback-mapped branded auth hosts", () => {
+  it("uses the local API finalize endpoint on loopback-mapped branded auth hosts", () => {
     setWindowUrl("http://github.auth.paretoproof.com:4371/");
 
     expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
+      "http://github.auth.paretoproof.com:3000/portal/session/finalize?redirect=%2Fprofile"
     );
   });
 
-  it("uses the protected API finalize submit endpoint on branded auth hosts", () => {
+  it("uses the branded finalize relay endpoint on branded auth hosts", () => {
     setWindowUrl("https://google.auth.paretoproof.com/");
 
     expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile"
+      "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile"
     );
   });
 });


### PR DESCRIPTION
## Summary
- keep the new branded finalize relay covered for pending-user completion, unusable branded state cookies, and null Access-cookie fallback
- align stale web surface tests with the current branded finalize boundary now on `main`
- correct the web runtime note so it matches the Pages relay path instead of the old direct API finalize wording

## Context
- `main` already carries the functional relay fix from #808.
- This PR is the follow-up coverage and doc alignment that still remained after that merge.

## Testing
- bun test apps/web/functions/_shared/access-finalize.test.ts apps/web/src/lib/surface.test.js apps/api/test/portal-session-finalize.test.ts apps/api/test/cloudflare-access.test.ts
- bun --cwd apps/web typecheck
- bun --cwd apps/api typecheck
- bun run check:bidi

Related: #806