### PR TITLE
ci: pin upload artifact in worker image publish workflow

### DIFF
--- a/.github/workflows/publish-worker-image.yml
+++ b/.github/workflows/publish-worker-image.yml
@@ -112,7 +112,7 @@ jobs:
           } | tee problem9-image-digests.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload image digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: problem9-image-digests
           path: problem9-image-digests.md


### PR DESCRIPTION
## Summary
- pin the remaining mutable `actions/upload-artifact@v4` step in `.github/workflows/publish-worker-image.yml` to immutable SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (`v4.6.2`)
- keep the rest of the already-pinned worker-image publish workflow unchanged
- validate the workflow on the branch via `workflow_dispatch`

## Validation
- `bun run check:bidi`
- successful workflow dispatch: https://github.com/Tomodovodoo/ParetoProof/actions/runs/23096473260

## Notes
- The dispatch succeeded end to end, including both image build/push steps and the final `problem9-image-digests` artifact upload.
- That run still emits the known Node 20 deprecation annotation for several pinned actions. That is separate runtime-upgrade work tracked by #729, not a regression from this immutable-pin fix.

Closes #788