### PR TITLE
docs(ops): backfill review traceability audit

### DIFF
--- a/infra/review-traceability-audit-2026-03-14.md
+++ b/infra/review-traceability-audit-2026-03-14.md
@@ -1,0 +1,39 @@
+# Review Traceability Audit 2026-03-14
+
+This note records the `#792` audit pass over the recent security-fix issues and the highest-comment closed PR threads.
+
+## Security-fix issue backfills
+
+- `#439`: core finalize CSRF fix landed in `#390`; related trusted-Origin hardening landed in `#450`
+- `#440`: implemented by `#450`
+- `#442`: broad mitigation landed in `#450`; route-specific regression proof landed in `#790`
+
+## High-comment PR audit
+
+No missing follow-up found:
+
+- `#287`
+- `#314`
+- `#366`
+- `#383`
+- `#395`
+- `#397`
+- `#400`
+- `#416`
+- `#420`
+- `#436`
+- `#513`
+
+Backfilled to the later resolution path:
+
+- `#295` -> later auth follow-on work in `#314`, `#287`, and live verification tail `#806`
+- `#510` -> worker lease follow-on work in `#783` / `#784`, implemented by `#745` / `#744`
+
+New follow-up issues opened from still-actionable review findings:
+
+- `#815` `[Frontend] Fix stale selection, refresh, and error-state bugs in portal admin workspaces`
+- `#816` `[Frontend] Harden portal benchmark-ops filters against malformed query and stale response state`
+
+## Current dead-end audit context
+
+`bun run report:dead-end-issues -- --limit 200` currently reports 14 recently closed issues with no GitHub issue, PR, or commit relationship signals. The next cleanup pass should use that output together with the comments backfilled from this audit.


### PR DESCRIPTION
## Summary
- add a durable repo-side note for the #792 traceability audit
- record the backfilled security-fix issues, resolved high-comment PR threads, and new frontend follow-up issues
- preserve the current dead-end audit context so the next cleanup pass has a concrete handoff

## Testing
- bun run check:bidi

Closes #792