### PR TITLE
fix(web): harden portal admin workspaces

### DIFF
--- a/apps/web/src/lib/portal-freshness.test.js
+++ b/apps/web/src/lib/portal-freshness.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { getPortalLiveViewFreshness } from "@paretoproof/shared";
+import {
+  canPortalRefreshOnDemand,
+  shouldPortalAutoPoll
+} from "./portal-freshness.ts";
+
+describe("portal freshness polling helpers", () => {
+  it("allows manual refresh for manual routes without enabling background polling", () => {
+    const policy = getPortalLiveViewFreshness("portal.admin.users");
+
+    expect(canPortalRefreshOnDemand(policy)).toBe(true);
+    expect(shouldPortalAutoPoll(policy)).toBe(false);
+  });
+
+  it("keeps polling routes eligible for both manual refresh and interval polling", () => {
+    const policy = getPortalLiveViewFreshness("portal.admin.access-requests");
+
+    expect(canPortalRefreshOnDemand(policy)).toBe(true);
+    expect(shouldPortalAutoPoll(policy)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/portal-freshness.ts
+++ b/apps/web/src/lib/portal-freshness.ts
@@ -12,6 +12,14 @@ type UsePortalPollingOptions = {
   routeId: string;
 };
 
+export function canPortalRefreshOnDemand(policy: PortalLiveViewFreshnessEntry | null) {
+  return policy !== null;
+}
+
+export function shouldPortalAutoPoll(policy: PortalLiveViewFreshnessEntry | null) {
+  return Boolean(policy && policy.mode === "polling" && policy.pollIntervalMs);
+}
+
 function formatDuration(ms: number) {
   if (ms < 1000) {
     return "under 1 second";
@@ -109,7 +117,7 @@ export function usePortalPolling({
   onPollRef.current = onPoll;
 
   async function pollNow() {
-    if (!policy || policy.mode !== "polling" || isPollingRef.current) {
+    if (!canPortalRefreshOnDemand(policy) || isPollingRef.current) {
       return;
     }
 
@@ -126,7 +134,13 @@ export function usePortalPolling({
   }
 
   useEffect(() => {
-    if (!enabled || !policy || policy.mode !== "polling" || !policy.pollIntervalMs) {
+    if (!enabled || !policy || !shouldPortalAutoPoll(policy)) {
+      return;
+    }
+
+    const pollIntervalMs = policy.pollIntervalMs;
+
+    if (!pollIntervalMs) {
       return;
     }
 
@@ -142,7 +156,7 @@ export function usePortalPolling({
       void pollNow().catch(() => {
         // The owning view already controls its error state.
       });
-    }, policy.pollIntervalMs);
+    }, pollIntervalMs);
 
     return () => {
       window.clearInterval(intervalId);

--- a/apps/web/src/routes/portal-access-request-panel.test.js
+++ b/apps/web/src/routes/portal-access-request-panel.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   getCompactAccessRequestSectionOrder,
+  isSelectedAccessRequestDetailCurrent,
+  sortAccessRequestsForDisplay,
   resolveSelectedAccessRequestId
 } from "./portal-access-request-panel.tsx";
 
@@ -10,6 +12,27 @@ const pendingRequest = {
 
 const rejectedRequest = {
   id: "request-rejected"
+};
+
+const approvedRequest = {
+  createdAt: "2026-03-13T09:00:00.000Z",
+  id: "request-approved",
+  reviewedAt: "2026-03-13T09:30:00.000Z",
+  status: "approved"
+};
+
+const olderPendingRequest = {
+  createdAt: "2026-03-12T09:00:00.000Z",
+  id: "request-pending-older",
+  reviewedAt: null,
+  status: "pending"
+};
+
+const newerPendingRequest = {
+  createdAt: "2026-03-14T09:00:00.000Z",
+  id: "request-pending-newer",
+  reviewedAt: null,
+  status: "pending"
 };
 
 describe("resolveSelectedAccessRequestId", () => {
@@ -41,5 +64,54 @@ describe("getCompactAccessRequestSectionOrder", () => {
       "queueContent",
       "filterFields"
     ]);
+  });
+});
+
+describe("sortAccessRequestsForDisplay", () => {
+  it("keeps pending work ahead of reviewed rows before applying date order", () => {
+    expect(
+      sortAccessRequestsForDisplay(
+        [
+          approvedRequest,
+          olderPendingRequest,
+          newerPendingRequest
+        ],
+        {
+          requestedRole: "all",
+          requestKind: "all",
+          reviewerState: "all",
+          sortOrder: "oldest",
+          status: "all"
+        }
+      ).map((item) => item.id)
+    ).toEqual([
+      "request-pending-older",
+      "request-pending-newer",
+      "request-approved"
+    ]);
+  });
+});
+
+describe("isSelectedAccessRequestDetailCurrent", () => {
+  it("returns false when the loaded detail does not match the current selection", () => {
+    expect(
+      isSelectedAccessRequestDetailCurrent(
+        {
+          id: "request-approved"
+        },
+        "request-pending"
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when the loaded detail matches the current selection", () => {
+    expect(
+      isSelectedAccessRequestDetailCurrent(
+        {
+          id: "request-pending"
+        },
+        "request-pending"
+      )
+    ).toBe(true);
   });
 });

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -51,6 +51,37 @@ const requestStatusPriority: Record<PortalAdminAccessRequestListItem["status"], 
   withdrawn: 3
 };
 
+export function sortAccessRequestsForDisplay(
+  items: PortalAdminAccessRequestListItem[],
+  filters: RequestFilterState
+) {
+  return [...items].sort((left, right) => {
+    const statusOrder =
+      requestStatusPriority[left.status] - requestStatusPriority[right.status];
+
+    if (statusOrder !== 0) {
+      return statusOrder;
+    }
+
+    if (filters.sortOrder === "newest") {
+      return right.createdAt.localeCompare(left.createdAt);
+    }
+
+    if (filters.sortOrder === "recently_reviewed") {
+      return (right.reviewedAt ?? "").localeCompare(left.reviewedAt ?? "");
+    }
+
+    return left.createdAt.localeCompare(right.createdAt);
+  });
+}
+
+export function isSelectedAccessRequestDetailCurrent(
+  detail: PortalAdminAccessRequestDetail | null,
+  selectedRequestId: string | null
+) {
+  return Boolean(detail && selectedRequestId && detail.id === selectedRequestId);
+}
+
 export function resolveSelectedAccessRequestId(
   selectedRequestId: string | null,
   filteredRequests: PortalAdminAccessRequestListItem[]
@@ -126,24 +157,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
       return true;
     });
 
-    return [...nextItems].sort((left, right) => {
-      const statusOrder =
-        requestStatusPriority[left.status] - requestStatusPriority[right.status];
-
-      if (statusOrder !== 0) {
-        return statusOrder;
-      }
-
-      if (filters.sortOrder === "newest") {
-        return right.createdAt.localeCompare(left.createdAt);
-      }
-
-      if (filters.sortOrder === "recently_reviewed") {
-        return (right.reviewedAt ?? "").localeCompare(left.reviewedAt ?? "");
-      }
-
-      return left.createdAt.localeCompare(right.createdAt);
-    });
+    return sortAccessRequestsForDisplay(nextItems, filters);
   }, [filters, requests]);
 
   const selectedRequest = useMemo(
@@ -300,12 +314,13 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
 
   async function refreshWorkspace() {
     const nextRequests = await loadPortalAdminAccessRequests(apiBaseUrl);
+    const detailRequestId = selectedRequestId;
 
     applyRequests(nextRequests);
     markUpdated();
 
-    if (selectedRequestId) {
-      const nextDetail = await loadPortalAdminAccessRequestDetail(apiBaseUrl, selectedRequestId);
+    if (detailRequestId) {
+      const nextDetail = await loadPortalAdminAccessRequestDetail(apiBaseUrl, detailRequestId);
       setDetail(nextDetail);
     }
   }
@@ -360,7 +375,15 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
         return;
       }
 
-      await refreshWorkspace();
+      try {
+        await refreshWorkspace();
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "The admin request queue could not be refreshed."
+        );
+      }
     } finally {
       setIsMutatingId(null);
     }
@@ -602,47 +625,63 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
       </article>
 
       <article className="portal-panel portal-admin-detail-panel" ref={detailPanelRef}>
-        {!selectedRequest ? (
-          <div className="portal-admin-empty-state">
-            <p className="section-tag">Selection</p>
-            <h2>Choose a request to inspect the full workflow context.</h2>
-            <p>
-              Request review stays local to this route, so the queue and the evidence
-              stay visible together.
-            </p>
-          </div>
-        ) : isDetailLoading || !detail ? (
-          <div className="portal-admin-empty-state">
-            <p className="section-tag">Selection</p>
-            <h2>Loading request detail</h2>
-            <p>Pulling linked identities, related history, and audit echoes.</p>
-          </div>
-        ) : (
-          <AccessRequestDetailCard
-            detail={detail}
-            draft={
-              drafts[detail.id] ?? {
-                approvedRole:
-                  detail.requestedRole === "collaborator" ? "collaborator" : "helper",
-                decisionNote: detail.decisionNote ?? ""
+        {(() => {
+          const currentDetail = isSelectedAccessRequestDetailCurrent(detail, selectedRequestId)
+            ? detail
+            : null;
+
+          if (!selectedRequest) {
+            return (
+              <div className="portal-admin-empty-state">
+                <p className="section-tag">Selection</p>
+                <h2>Choose a request to inspect the full workflow context.</h2>
+                <p>
+                  Request review stays local to this route, so the queue and the evidence
+                  stay visible together.
+                </p>
+              </div>
+            );
+          }
+
+          if (isDetailLoading || !currentDetail) {
+            return (
+              <div className="portal-admin-empty-state">
+                <p className="section-tag">Selection</p>
+                <h2>Loading request detail</h2>
+                <p>Pulling linked identities, related history, and audit echoes.</p>
+              </div>
+            );
+          }
+
+          return (
+            <AccessRequestDetailCard
+              detail={currentDetail}
+              draft={
+                drafts[currentDetail.id] ?? {
+                  approvedRole:
+                    currentDetail.requestedRole === "collaborator"
+                      ? "collaborator"
+                      : "helper",
+                  decisionNote: currentDetail.decisionNote ?? ""
+                }
               }
-            }
-            isMutating={isMutatingId === detail.id}
-            onApprove={() => {
-              void handleDecision("approve");
-            }}
-            onChangeDraft={(nextDraft) => {
-              setDrafts((current) => ({
-                ...current,
-                [detail.id]: nextDraft
-              }));
-            }}
-            onReject={() => {
-              void handleDecision("reject");
-            }}
-            actionSectionRef={detailActionRef}
-          />
-        )}
+              isMutating={isMutatingId === currentDetail.id}
+              onApprove={() => {
+                void handleDecision("approve");
+              }}
+              onChangeDraft={(nextDraft) => {
+                setDrafts((current) => ({
+                  ...current,
+                  [currentDetail.id]: nextDraft
+                }));
+              }}
+              onReject={() => {
+                void handleDecision("reject");
+              }}
+              actionSectionRef={detailActionRef}
+            />
+          );
+        })()}
       </article>
     </section>
   );

--- a/apps/web/src/routes/portal-admin-users-panel.test.js
+++ b/apps/web/src/routes/portal-admin-users-panel.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   getCompactAdminUsersSectionOrder,
+  isSelectedAdminUserDetailCurrent,
   resolveSelectedAdminUserId
 } from "./portal-admin-users-panel.tsx";
 
@@ -41,5 +42,29 @@ describe("getCompactAdminUsersSectionOrder", () => {
       "userList",
       "filterFields"
     ]);
+  });
+});
+
+describe("isSelectedAdminUserDetailCurrent", () => {
+  it("returns false when the currently loaded detail belongs to a different user", () => {
+    expect(
+      isSelectedAdminUserDetailCurrent(
+        {
+          userId: "user-ada"
+        },
+        "user-lin"
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when the loaded detail matches the active selection", () => {
+    expect(
+      isSelectedAdminUserDetailCurrent(
+        {
+          userId: "user-ada"
+        },
+        "user-ada"
+      )
+    ).toBe(true);
   });
 });

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -22,6 +22,13 @@ type UserFilters = {
   search: string;
 };
 
+type UserActionFeedback =
+  | {
+      message: string;
+      tone: "error" | "success";
+    }
+  | null;
+
 const initialFilters: UserFilters = {
   accessPosture: "all",
   activeRole: "all",
@@ -42,6 +49,13 @@ export function resolveSelectedAdminUserId(
 
 export function getCompactAdminUsersSectionOrder() {
   return ["userList", "filterFields"] as const;
+}
+
+export function isSelectedAdminUserDetailCurrent(
+  detailItem: Awaited<ReturnType<typeof loadPortalAdminUserDetail>> | null,
+  selectedUserId: string | null
+) {
+  return Boolean(detailItem && selectedUserId && detailItem.userId === selectedUserId);
 }
 
 function formatTimestamp(timestamp: string | null) {
@@ -84,7 +98,7 @@ function filterUsers(items: PortalAdminUserListItem[], filters: UserFilters) {
 }
 
 export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
-  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<UserActionFeedback>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [detailItem, setDetailItem] = useState<Awaited<
     ReturnType<typeof loadPortalAdminUserDetail>
@@ -203,10 +217,22 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
       setUsers(nextItems);
       setListError(null);
       markUpdated();
+
+      if (selectedUserId) {
+        const nextDetail = await loadPortalAdminUserDetail(apiBaseUrl, selectedUserId);
+        setDetailItem(nextDetail);
+        setDetailError(null);
+      }
     } catch (error) {
-      setListError(
-        error instanceof Error ? error.message : "The admin user directory could not be loaded."
-      );
+      const message =
+        error instanceof Error ? error.message : "The admin user directory could not be loaded.";
+
+      if (selectedUserId) {
+        setDetailItem(null);
+        setDetailError(message);
+      } else {
+        setListError(message);
+      }
     } finally {
       if (initialLoad) {
         setIsLoading(false);
@@ -230,28 +256,34 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     }
 
     try {
-      setActionMessage(null);
+      setActionFeedback(null);
       setIsMutating(true);
       const result = await revokePortalAdminUserRole(apiBaseUrl, detailItem.userId, {
         reason: revocationReason
       });
 
       if (!result.ok) {
-        setActionMessage(result.message);
+        setActionFeedback({
+          message: result.message,
+          tone: "error"
+        });
         return;
       }
 
       await refreshUsers();
-      const nextDetail = await loadPortalAdminUserDetail(apiBaseUrl, detailItem.userId);
-      setDetailItem(nextDetail);
       setRevocationReason("");
-      setActionMessage("Active contributor role revoked and current sessions cleared.");
+      setActionFeedback({
+        message: "Active contributor role revoked and current sessions cleared.",
+        tone: "success"
+      });
     } catch (error) {
-      setActionMessage(
-        error instanceof Error
-          ? error.message
-          : "The role revocation could not be completed."
-      );
+      setActionFeedback({
+        message:
+          error instanceof Error
+            ? error.message
+            : "The role revocation could not be completed.",
+        tone: "error"
+      });
     } finally {
       setIsMutating(false);
     }
@@ -402,7 +434,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               key={item.userId}
               onClick={() => {
                 revealSelectedUserDetail(item.userId);
-                setActionMessage(null);
+                setActionFeedback(null);
               }}
               type="button"
             >
@@ -461,6 +493,11 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
             <h3>User detail unavailable</h3>
             <p>{detailError}</p>
           </article>
+        ) : isDetailLoading || !isSelectedAdminUserDetailCurrent(detailItem, selectedUserId) ? (
+          <article className="portal-admin-card portal-admin-card-empty">
+            <h3>Loading user detail</h3>
+            <p>Pulling account posture, linked identities, and corrective-action context.</p>
+          </article>
         ) : detailItem ? (
           <>
             <article className="portal-admin-card">
@@ -484,15 +521,11 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
                   Latest session expiry {formatTimestamp(detailItem.sessionPosture.latestSessionExpiresAt)}
                 </span>
               </div>
-              {actionMessage ? (
+              {actionFeedback ? (
                 <p
-                  className={`portal-admin-feedback ${
-                    actionMessage.includes("could not") || actionMessage.includes("no active")
-                      ? "portal-admin-feedback-error"
-                      : "portal-admin-feedback-success"
-                  }`}
+                  className={`portal-admin-feedback portal-admin-feedback-${actionFeedback.tone}`}
                 >
-                  {actionMessage}
+                  {actionFeedback.message}
                 </p>
               ) : null}
             </article>


### PR DESCRIPTION
## Summary
- prevent stale admin detail panes from rendering against a newly selected request or user
- make the access-request queue ordering explicit, refresh manual admin-user views correctly, and reload selected detail on refresh
- surface admin mutation outcomes with explicit success/error state and add regression tests for the new helpers

## Testing
- bun test apps/web/src/routes/portal-access-request-panel.test.js apps/web/src/routes/portal-admin-users-panel.test.js apps/web/src/lib/portal-freshness.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build

Closes #815