### PR TITLE
fix(web): harden portal admin workspace state

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.test.js
+++ b/apps/web/src/routes/portal-access-request-panel.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   getCompactAccessRequestSectionOrder,
+  getVisibleAccessRequests,
+  hasCurrentAccessRequestDetail,
   resolveSelectedAccessRequestId
 } from "./portal-access-request-panel.tsx";
 
@@ -41,5 +43,74 @@ describe("getCompactAccessRequestSectionOrder", () => {
       "queueContent",
       "filterFields"
     ]);
+  });
+});
+
+describe("getVisibleAccessRequests", () => {
+  it("keeps pending requests ahead of reviewed rows before timestamp sorting", () => {
+    const visibleIds = getVisibleAccessRequests(
+      [
+        {
+          createdAt: "2026-03-14T12:00:00.000Z",
+          id: "approved-newer",
+          requestKind: "access_request",
+          requestedRole: "helper",
+          reviewedAt: "2026-03-14T12:05:00.000Z",
+          reviewer: {
+            label: "Admin"
+          },
+          status: "approved"
+        },
+        {
+          createdAt: "2026-03-14T09:00:00.000Z",
+          id: "pending-older",
+          requestKind: "access_request",
+          requestedRole: "helper",
+          reviewedAt: null,
+          reviewer: null,
+          status: "pending"
+        },
+        {
+          createdAt: "2026-03-14T10:00:00.000Z",
+          id: "pending-newer",
+          requestKind: "access_request",
+          requestedRole: "helper",
+          reviewedAt: null,
+          reviewer: null,
+          status: "pending"
+        }
+      ],
+      {
+        requestKind: "all",
+        requestedRole: "all",
+        reviewerState: "all",
+        sortOrder: "oldest",
+        status: "all"
+      }
+    ).map((item) => item.id);
+
+    expect(visibleIds).toEqual([
+      "pending-older",
+      "pending-newer",
+      "approved-newer"
+    ]);
+  });
+});
+
+describe("hasCurrentAccessRequestDetail", () => {
+  it("rejects stale request detail payloads after selection changes", () => {
+    expect(
+      hasCurrentAccessRequestDetail("request-pending", {
+        id: "request-rejected"
+      })
+    ).toBe(false);
+  });
+
+  it("accepts detail payloads that match the selected request", () => {
+    expect(
+      hasCurrentAccessRequestDetail("request-pending", {
+        id: "request-pending"
+      })
+    ).toBe(true);
   });
 });

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -69,6 +69,67 @@ export function getCompactAccessRequestSectionOrder() {
   return ["queueContent", "filterFields"] as const;
 }
 
+export function getVisibleAccessRequests(
+  requests: PortalAdminAccessRequestListItem[],
+  filters: RequestFilterState
+) {
+  const nextItems = requests.filter((requestItem) => {
+    if (filters.status !== "all" && requestItem.status !== filters.status) {
+      return false;
+    }
+
+    if (
+      filters.requestKind !== "all" &&
+      requestItem.requestKind !== filters.requestKind
+    ) {
+      return false;
+    }
+
+    if (
+      filters.requestedRole !== "all" &&
+      requestItem.requestedRole !== filters.requestedRole
+    ) {
+      return false;
+    }
+
+    if (filters.reviewerState === "reviewed" && requestItem.reviewer === null) {
+      return false;
+    }
+
+    if (filters.reviewerState === "unreviewed" && requestItem.reviewer !== null) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return [...nextItems].sort((left, right) => {
+    const statusOrder =
+      requestStatusPriority[left.status] - requestStatusPriority[right.status];
+
+    if (statusOrder !== 0) {
+      return statusOrder;
+    }
+
+    if (filters.sortOrder === "newest") {
+      return right.createdAt.localeCompare(left.createdAt);
+    }
+
+    if (filters.sortOrder === "recently_reviewed") {
+      return (right.reviewedAt ?? "").localeCompare(left.reviewedAt ?? "");
+    }
+
+    return left.createdAt.localeCompare(right.createdAt);
+  });
+}
+
+export function hasCurrentAccessRequestDetail(
+  selectedRequestId: string | null,
+  detail: PortalAdminAccessRequestDetail | null
+) {
+  return Boolean(selectedRequestId && detail?.id === selectedRequestId);
+}
+
 export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProps) {
   const [detail, setDetail] = useState<PortalAdminAccessRequestDetail | null>(null);
   const [drafts, setDrafts] = useState<Record<string, RequestDraftState>>({});
@@ -79,72 +140,31 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
   const [isMutatingId, setIsMutatingId] = useState<string | null>(null);
   const [requests, setRequests] = useState<PortalAdminAccessRequestListItem[]>([]);
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
+  const detailRequestIdRef = useRef(0);
   const detailPanelRef = useRef<HTMLElement | null>(null);
   const detailActionRef = useRef<HTMLElement | null>(null);
   const pendingCompactRevealRequestIdRef = useRef<string | null>(null);
+  const selectedRequestIdRef = useRef<string | null>(null);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const isCompactLayout = useCompactLayout();
   const {
     isPolling,
     lastUpdatedAt,
-    markUpdated,
-    pollNow
+    markUpdated
   } = usePortalPolling({
     enabled: !isLoading && !isDetailLoading && isMutatingId === null,
     onPoll: refreshWorkspace,
     routeId: "portal.admin.access-requests"
   });
 
-  const filteredRequests = useMemo(() => {
-    const nextItems = requests.filter((requestItem) => {
-      if (filters.status !== "all" && requestItem.status !== filters.status) {
-        return false;
-      }
+  const filteredRequests = useMemo(
+    () => getVisibleAccessRequests(requests, filters),
+    [filters, requests]
+  );
+  const hasSelectedDetail = hasCurrentAccessRequestDetail(selectedRequestId, detail);
+  const selectedDetail = hasSelectedDetail ? detail : null;
 
-      if (
-        filters.requestKind !== "all" &&
-        requestItem.requestKind !== filters.requestKind
-      ) {
-        return false;
-      }
-
-      if (
-        filters.requestedRole !== "all" &&
-        requestItem.requestedRole !== filters.requestedRole
-      ) {
-        return false;
-      }
-
-      if (filters.reviewerState === "reviewed" && requestItem.reviewer === null) {
-        return false;
-      }
-
-      if (filters.reviewerState === "unreviewed" && requestItem.reviewer !== null) {
-        return false;
-      }
-
-      return true;
-    });
-
-    return [...nextItems].sort((left, right) => {
-      const statusOrder =
-        requestStatusPriority[left.status] - requestStatusPriority[right.status];
-
-      if (statusOrder !== 0) {
-        return statusOrder;
-      }
-
-      if (filters.sortOrder === "newest") {
-        return right.createdAt.localeCompare(left.createdAt);
-      }
-
-      if (filters.sortOrder === "recently_reviewed") {
-        return (right.reviewedAt ?? "").localeCompare(left.reviewedAt ?? "");
-      }
-
-      return left.createdAt.localeCompare(right.createdAt);
-    });
-  }, [filters, requests]);
+  selectedRequestIdRef.current = selectedRequestId;
 
   const selectedRequest = useMemo(
     () =>
@@ -204,54 +224,53 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
 
   useEffect(() => {
     if (!selectedRequestId) {
+      detailRequestIdRef.current += 1;
       setDetail(null);
       setIsDetailLoading(false);
       return;
     }
 
-    let cancelled = false;
+    setErrorMessage(null);
+    void loadSelectedRequestDetail(selectedRequestId, true);
+  }, [apiBaseUrl, selectedRequestId]);
+
+  async function loadSelectedRequestDetail(requestId: string, clearCurrentDetail = false) {
+    const loadId = detailRequestIdRef.current + 1;
+    detailRequestIdRef.current = loadId;
     setIsDetailLoading(true);
 
-    async function loadDetail() {
-      const currentRequestId = selectedRequestId;
-
-      if (!currentRequestId) {
-        return;
-      }
-
-      try {
-        const nextDetail = await loadPortalAdminAccessRequestDetail(apiBaseUrl, currentRequestId);
-
-        if (cancelled) {
-          return;
-        }
-
-        setDetail(nextDetail);
-        setErrorMessage(null);
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
-        setDetail(null);
-        setErrorMessage(
-          error instanceof Error
-            ? error.message
-            : "The selected request could not be loaded."
-        );
-      } finally {
-        if (!cancelled) {
-          setIsDetailLoading(false);
-        }
-      }
+    if (clearCurrentDetail) {
+      setDetail(null);
     }
 
-    void loadDetail();
+    try {
+      const nextDetail = await loadPortalAdminAccessRequestDetail(apiBaseUrl, requestId);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [apiBaseUrl, selectedRequestId]);
+      if (detailRequestIdRef.current !== loadId || selectedRequestIdRef.current !== requestId) {
+        return false;
+      }
+
+      setDetail(nextDetail);
+      setErrorMessage(null);
+      return true;
+    } catch (error) {
+      if (detailRequestIdRef.current !== loadId || selectedRequestIdRef.current !== requestId) {
+        return false;
+      }
+
+      setDetail(null);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "The selected request could not be loaded."
+      );
+      return false;
+    } finally {
+      if (detailRequestIdRef.current === loadId && selectedRequestIdRef.current === requestId) {
+        setIsDetailLoading(false);
+      }
+    }
+  }
 
   useEffect(() => {
     if (
@@ -300,14 +319,27 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
 
   async function refreshWorkspace() {
     const nextRequests = await loadPortalAdminAccessRequests(apiBaseUrl);
+    const nextSelectedRequestId = resolveSelectedAccessRequestId(
+      selectedRequestIdRef.current,
+      getVisibleAccessRequests(nextRequests, filters)
+    );
 
     applyRequests(nextRequests);
     markUpdated();
 
-    if (selectedRequestId) {
-      const nextDetail = await loadPortalAdminAccessRequestDetail(apiBaseUrl, selectedRequestId);
-      setDetail(nextDetail);
+    if (nextSelectedRequestId !== selectedRequestIdRef.current) {
+      setSelectedRequestId(nextSelectedRequestId);
+      return;
     }
+
+    if (nextSelectedRequestId) {
+      await loadSelectedRequestDetail(nextSelectedRequestId);
+      return;
+    }
+
+    detailRequestIdRef.current += 1;
+    setDetail(null);
+    setIsDetailLoading(false);
   }
 
   async function handleDecision(action: "approve" | "reject") {
@@ -361,6 +393,12 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
       }
 
       await refreshWorkspace();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "The admin request action could not be completed."
+      );
     } finally {
       setIsMutatingId(null);
     }
@@ -404,7 +442,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
         isRefreshing={isPolling || isDetailLoading || isMutatingId !== null}
         lastUpdatedAt={lastUpdatedAt}
         onRefresh={() => {
-          void pollNow().catch(() => {
+          void refreshWorkspace().catch(() => {
             setErrorMessage("The admin request queue could not be refreshed.");
           });
         }}
@@ -611,7 +649,7 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
               stay visible together.
             </p>
           </div>
-        ) : isDetailLoading || !detail ? (
+        ) : isDetailLoading || !selectedDetail ? (
           <div className="portal-admin-empty-state">
             <p className="section-tag">Selection</p>
             <h2>Loading request detail</h2>
@@ -619,22 +657,22 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
           </div>
         ) : (
           <AccessRequestDetailCard
-            detail={detail}
+            detail={selectedDetail}
             draft={
-              drafts[detail.id] ?? {
+              drafts[selectedDetail.id] ?? {
                 approvedRole:
-                  detail.requestedRole === "collaborator" ? "collaborator" : "helper",
-                decisionNote: detail.decisionNote ?? ""
+                  selectedDetail.requestedRole === "collaborator" ? "collaborator" : "helper",
+                decisionNote: selectedDetail.decisionNote ?? ""
               }
             }
-            isMutating={isMutatingId === detail.id}
+            isMutating={isMutatingId === selectedDetail.id}
             onApprove={() => {
               void handleDecision("approve");
             }}
             onChangeDraft={(nextDraft) => {
               setDrafts((current) => ({
                 ...current,
-                [detail.id]: nextDraft
+                [selectedDetail.id]: nextDraft
               }));
             }}
             onReject={() => {

--- a/apps/web/src/routes/portal-admin-users-panel.test.js
+++ b/apps/web/src/routes/portal-admin-users-panel.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   getCompactAdminUsersSectionOrder,
+  hasCurrentAdminUserDetail,
   resolveSelectedAdminUserId
 } from "./portal-admin-users-panel.tsx";
 
@@ -41,5 +42,23 @@ describe("getCompactAdminUsersSectionOrder", () => {
       "userList",
       "filterFields"
     ]);
+  });
+});
+
+describe("hasCurrentAdminUserDetail", () => {
+  it("rejects stale detail cards after the selection changes", () => {
+    expect(
+      hasCurrentAdminUserDetail("user-lin", {
+        userId: "user-ada"
+      })
+    ).toBe(false);
+  });
+
+  it("accepts detail payloads that match the current selection", () => {
+    expect(
+      hasCurrentAdminUserDetail("user-ada", {
+        userId: "user-ada"
+      })
+    ).toBe(true);
   });
 });

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -1,4 +1,4 @@
-import type { PortalAdminUserListItem } from "@paretoproof/shared";
+import type { PortalAdminUserDetail, PortalAdminUserListItem } from "@paretoproof/shared";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { getApiBaseUrl } from "../lib/api-base-url";
@@ -22,6 +22,11 @@ type UserFilters = {
   search: string;
 };
 
+type ActionFeedback = {
+  message: string;
+  tone: "error" | "success";
+};
+
 const initialFilters: UserFilters = {
   accessPosture: "all",
   activeRole: "all",
@@ -42,6 +47,13 @@ export function resolveSelectedAdminUserId(
 
 export function getCompactAdminUsersSectionOrder() {
   return ["userList", "filterFields"] as const;
+}
+
+export function hasCurrentAdminUserDetail(
+  selectedUserId: string | null,
+  detailItem: PortalAdminUserDetail | null
+) {
+  return Boolean(selectedUserId && detailItem?.userId === selectedUserId);
 }
 
 function formatTimestamp(timestamp: string | null) {
@@ -84,7 +96,7 @@ function filterUsers(items: PortalAdminUserListItem[], filters: UserFilters) {
 }
 
 export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
-  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionFeedback, setActionFeedback] = useState<ActionFeedback | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [detailItem, setDetailItem] = useState<Awaited<
     ReturnType<typeof loadPortalAdminUserDetail>
@@ -97,22 +109,28 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   const [revocationReason, setRevocationReason] = useState("");
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [users, setUsers] = useState<PortalAdminUserListItem[]>([]);
+  const detailRequestIdRef = useRef(0);
   const detailShellRef = useRef<HTMLElement | null>(null);
   const correctiveActionRef = useRef<HTMLElement | null>(null);
   const pendingCompactRevealUserIdRef = useRef<string | null>(null);
+  const selectedUserIdRef = useRef<string | null>(null);
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const isCompactLayout = useCompactLayout();
   const {
     isPolling,
     lastUpdatedAt,
-    markUpdated,
-    pollNow
+    markUpdated
   } = usePortalPolling({
     enabled: !isLoading && !isMutating,
-    onPoll: refreshUsers,
+    onPoll: async () => {
+      await refreshUsers();
+    },
     routeId: "portal.admin.users"
   });
   const visibleUsers = useMemo(() => filterUsers(users, filters), [filters, users]);
+  const hasSelectedDetail = hasCurrentAdminUserDetail(selectedUserId, detailItem);
+
+  selectedUserIdRef.current = selectedUserId;
 
   useEffect(() => {
     void refreshUsers(true);
@@ -120,54 +138,54 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
 
   useEffect(() => {
     if (!selectedUserId) {
+      detailRequestIdRef.current += 1;
       setDetailItem(null);
       setDetailError(null);
       setIsDetailLoading(false);
+      setActionFeedback(null);
       return;
     }
 
-    let cancelled = false;
-    setDetailItem(null);
+    setActionFeedback(null);
+    void loadSelectedUserDetail(selectedUserId, true);
+  }, [apiBaseUrl, selectedUserId]);
+
+  async function loadSelectedUserDetail(userId: string, clearCurrentDetail = false) {
+    const requestId = detailRequestIdRef.current + 1;
+    detailRequestIdRef.current = requestId;
     setDetailError(null);
     setRevocationReason("");
     setIsDetailLoading(true);
 
-    async function loadDetail() {
-      const currentUserId = selectedUserId;
-
-      if (!currentUserId) {
-        return;
-      }
-
-      try {
-        const nextDetail = await loadPortalAdminUserDetail(apiBaseUrl, currentUserId);
-
-        if (cancelled) {
-          return;
-        }
-
-        setDetailError(null);
-        setDetailItem(nextDetail);
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
-        setDetailItem(null);
-        setDetailError(error instanceof Error ? error.message : "The user detail could not be loaded.");
-      } finally {
-        if (!cancelled) {
-          setIsDetailLoading(false);
-        }
-      }
+    if (clearCurrentDetail) {
+      setDetailItem(null);
     }
 
-    void loadDetail();
+    try {
+      const nextDetail = await loadPortalAdminUserDetail(apiBaseUrl, userId);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [apiBaseUrl, selectedUserId]);
+      if (detailRequestIdRef.current !== requestId || selectedUserIdRef.current !== userId) {
+        return false;
+      }
+
+      setDetailItem(nextDetail);
+      return true;
+    } catch (error) {
+      if (detailRequestIdRef.current !== requestId || selectedUserIdRef.current !== userId) {
+        return false;
+      }
+
+      setDetailItem(null);
+      setDetailError(
+        error instanceof Error ? error.message : "The user detail could not be loaded."
+      );
+      return false;
+    } finally {
+      if (detailRequestIdRef.current === requestId && selectedUserIdRef.current === userId) {
+        setIsDetailLoading(false);
+      }
+    }
+  }
 
   useEffect(() => {
     if (
@@ -200,13 +218,35 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
   async function refreshUsers(initialLoad = false) {
     try {
       const nextItems = await loadPortalAdminUsers(apiBaseUrl);
+      const nextVisibleUsers = filterUsers(nextItems, filters);
+      const nextSelectedUserId = resolveSelectedAdminUserId(
+        selectedUserIdRef.current,
+        nextVisibleUsers
+      );
+
       setUsers(nextItems);
       setListError(null);
       markUpdated();
+
+      if (nextSelectedUserId !== selectedUserIdRef.current) {
+        setSelectedUserId(nextSelectedUserId);
+        return true;
+      }
+
+      if (nextSelectedUserId) {
+        return await loadSelectedUserDetail(nextSelectedUserId);
+      }
+
+      detailRequestIdRef.current += 1;
+      setDetailItem(null);
+      setDetailError(null);
+      setIsDetailLoading(false);
+      return true;
     } catch (error) {
       setListError(
         error instanceof Error ? error.message : "The admin user directory could not be loaded."
       );
+      return false;
     } finally {
       if (initialLoad) {
         setIsLoading(false);
@@ -230,28 +270,42 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
     }
 
     try {
-      setActionMessage(null);
+      setActionFeedback(null);
       setIsMutating(true);
       const result = await revokePortalAdminUserRole(apiBaseUrl, detailItem.userId, {
         reason: revocationReason
       });
 
       if (!result.ok) {
-        setActionMessage(result.message);
+        setActionFeedback({
+          message: result.message,
+          tone: "error"
+        });
         return;
       }
 
-      await refreshUsers();
-      const nextDetail = await loadPortalAdminUserDetail(apiBaseUrl, detailItem.userId);
-      setDetailItem(nextDetail);
-      setRevocationReason("");
-      setActionMessage("Active contributor role revoked and current sessions cleared.");
+      const refreshSucceeded = await refreshUsers();
+
+      if (!refreshSucceeded) {
+        setActionFeedback({
+          message: "The role was revoked, but the refreshed user data could not be loaded.",
+          tone: "error"
+        });
+        return;
+      }
+
+      setActionFeedback({
+        message: "Active contributor role revoked and current sessions cleared.",
+        tone: "success"
+      });
     } catch (error) {
-      setActionMessage(
-        error instanceof Error
-          ? error.message
-          : "The role revocation could not be completed."
-      );
+      setActionFeedback({
+        message:
+          error instanceof Error
+            ? error.message
+            : "The role revocation could not be completed.",
+        tone: "error"
+      });
     } finally {
       setIsMutating(false);
     }
@@ -295,7 +349,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
         isRefreshing={isPolling || isMutating}
         lastUpdatedAt={lastUpdatedAt}
         onRefresh={() => {
-          void pollNow().catch(() => {
+          void refreshUsers().catch(() => {
             // refreshUsers already exposes the visible error state.
           });
         }}
@@ -402,7 +456,7 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
               key={item.userId}
               onClick={() => {
                 revealSelectedUserDetail(item.userId);
-                setActionMessage(null);
+                setActionFeedback(null);
               }}
               type="button"
             >
@@ -456,7 +510,12 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
       </aside>
 
       <section className="portal-admin-detail-shell" ref={detailShellRef}>
-        {detailError ? (
+        {selectedUserId && (isDetailLoading || !hasSelectedDetail) ? (
+          <article className="portal-admin-card portal-admin-card-empty">
+            <h3>Loading user detail</h3>
+            <p>Fetching account posture, linked identities, and recent admin activity.</p>
+          </article>
+        ) : detailError ? (
           <article className="portal-admin-card portal-admin-card-empty">
             <h3>User detail unavailable</h3>
             <p>{detailError}</p>
@@ -484,15 +543,11 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
                   Latest session expiry {formatTimestamp(detailItem.sessionPosture.latestSessionExpiresAt)}
                 </span>
               </div>
-              {actionMessage ? (
+              {actionFeedback ? (
                 <p
-                  className={`portal-admin-feedback ${
-                    actionMessage.includes("could not") || actionMessage.includes("no active")
-                      ? "portal-admin-feedback-error"
-                      : "portal-admin-feedback-success"
-                  }`}
+                  className={`portal-admin-feedback portal-admin-feedback-${actionFeedback.tone}`}
                 >
-                  {actionMessage}
+                  {actionFeedback.message}
                 </p>
               ) : null}
             </article>


### PR DESCRIPTION
## Summary
- guard both admin workspaces against stale detail payloads after selection changes
- make manual refresh reload current admin workspace data and keep pending requests prioritized ahead of reviewed rows
- surface admin mutation transport failures cleanly and replace substring-based success/error styling with explicit feedback state

## Testing
- bun test apps/web/src/routes/portal-admin-users-panel.test.js apps/web/src/routes/portal-access-request-panel.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi

Closes #815