### PR TITLE
fix(web): harden benchmark ops runs state

### DIFF
--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -3,47 +3,51 @@ import {
   buildRunsModelOptions,
   buildRunsProviderOptions,
   defaultPortalRunsQuery,
-  parsePortalRunsQuery
+  extractPortalRunsQueryString,
+  parsePortalRunsQuery,
+  sanitizePortalRunsQueryString
 } from "./portal-benchmark-ops.ts";
 
 describe("parsePortalRunsQuery", () => {
-  it("falls back on malformed query params without discarding valid filters", () => {
-    const query = parsePortalRunsQuery(
-      "?providerFamily=openai&q=%20PP-318%20&limit=9999&sort=bad&runKind=nope&verdict=pass,wrong&runLifecycle=queued,broken"
-    );
-
-    expect(query).toEqual({
-      ...defaultPortalRunsQuery,
-      providerFamily: "openai",
-      q: "PP-318"
-    });
-  });
-
-  it("keeps valid enum and csv params when they parse cleanly", () => {
-    const query = parsePortalRunsQuery(
-      "?limit=50&sort=duration_desc&runKind=single_run&verdict=pass,fail&runLifecycle=queued,running"
-    );
-
-    expect(query.limit).toBe(50);
-    expect(query.sort).toBe("duration_desc");
-    expect(query.runKind).toBe("single_run");
-    expect(query.verdict).toEqual(["pass", "fail"]);
-    expect(query.runLifecycle).toEqual(["queued", "running"]);
+  it("falls back safely when the runs query contains invalid or outdated param values", () => {
+    expect(
+      parsePortalRunsQuery(
+        "?surface=portal&sort=bogus&lifecycleBucket=not_real&verdict=pass,broken&limit=9999"
+      )
+    ).toEqual(defaultPortalRunsQuery);
   });
 });
 
-describe("buildRunsProviderOptions", () => {
-  it("preserves the active provider when the current result set is empty", () => {
-    expect(buildRunsProviderOptions([], "google")).toEqual(["google"]);
+describe("extractPortalRunsQueryString", () => {
+  it("keeps only recognized runs query params when local portal state is present", () => {
+    expect(
+      extractPortalRunsQueryString(
+        "?surface=portal&access=approved&roles=admin&providerFamily=openai&sort=bogus"
+      )
+    ).toBe("providerFamily=openai&sort=bogus");
   });
 });
 
-describe("buildRunsModelOptions", () => {
-  it("preserves the active model config when the current result set is empty", () => {
-    expect(buildRunsModelOptions([], "google-gemini-pro")).toEqual([
+describe("sanitizePortalRunsQueryString", () => {
+  it("drops malformed runs query params while preserving valid filter state", () => {
+    expect(
+      sanitizePortalRunsQueryString(
+        "?surface=portal&providerFamily=openai&sort=bogus&verdict=pass,broken"
+      )
+    ).toBe("providerFamily=openai");
+  });
+});
+
+describe("runs filter option builders", () => {
+  it("keeps the selected provider visible even when the current result set is empty", () => {
+    expect(buildRunsProviderOptions([], "openai")).toEqual(["openai"]);
+  });
+
+  it("keeps the selected model config visible even when the current result set is empty", () => {
+    expect(buildRunsModelOptions([], "openai-gpt-oss-high")).toEqual([
       {
-        label: "google-gemini-pro",
-        modelConfigId: "google-gemini-pro"
+        label: "openai-gpt-oss-high",
+        modelConfigId: "openai-gpt-oss-high"
       }
     ]);
   });

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -67,6 +67,10 @@ export const defaultPortalRunsQuery: PortalRunsListQuery = {
   verdict: []
 };
 
+const portalRunsQueryParamKeys = Object.keys(defaultPortalRunsQuery) as Array<
+  keyof PortalRunsListQuery
+>;
+
 const localRunItems: PortalRunListItem[] = [
   {
     authMode: "oidc",
@@ -927,6 +931,33 @@ export function parsePortalRunsQuery(search: string): PortalRunsListQuery {
 
   const parsedQuery = portalRunsListQuerySchema.safeParse(candidateQuery);
   return parsedQuery.success ? parsedQuery.data : defaultPortalRunsQuery;
+}
+
+export function extractPortalRunsQueryString(search: string) {
+  const sourceParams = new URLSearchParams(search);
+  const runsParams = new URLSearchParams();
+
+  for (const key of portalRunsQueryParamKeys) {
+    const rawValue = sourceParams.get(key);
+
+    if (rawValue === null) {
+      continue;
+    }
+
+    const trimmedValue = rawValue.trim();
+
+    if (!trimmedValue) {
+      continue;
+    }
+
+    runsParams.set(key, trimmedValue);
+  }
+
+  return runsParams.toString();
+}
+
+export function sanitizePortalRunsQueryString(search: string) {
+  return buildPortalRunsQueryString(parsePortalRunsQuery(search));
 }
 
 export function buildPortalRunsQueryString(query: PortalRunsListQuery) {

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   buildRunDetailTargetPath,
   buildRunsIndexTargetPath,
-  getCompactRunsSectionOrder
+  getCompactRunsSectionOrder,
+  isCurrentPortalRequest
 } from "./portal-benchmark-ops-surfaces.tsx";
 
 describe("portal benchmark ops route targets", () => {
@@ -45,5 +46,10 @@ describe("portal benchmark ops route targets", () => {
       "resultsPanel",
       "supportPanel"
     ]);
+  });
+
+  it("uses the same current-request guard for list and detail async responses", () => {
+    expect(isCurrentPortalRequest(2, 2)).toBe(true);
+    expect(isCurrentPortalRequest(1, 2)).toBe(false);
   });
 });

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -27,12 +27,14 @@ import {
   buildRunsProviderOptions,
   buildRunsCsv,
   defaultPortalRunsQuery,
+  extractPortalRunsQueryString,
   fetchPortalLaunchView,
   fetchPortalRunDetail,
   fetchPortalRunsView,
   fetchPortalWorkersView,
   getWorkerIncidentTone,
-  parsePortalRunsQuery
+  parsePortalRunsQuery,
+  sanitizePortalRunsQueryString
 } from "../lib/portal-benchmark-ops";
 import { usePortalPolling } from "../lib/portal-freshness";
 import { evaluationVerdictLabels, runLifecycleStateLabels } from "../lib/results-state";
@@ -126,6 +128,10 @@ export function getCompactRunsSectionOrder() {
   return ["runsSlice", "quickFilters", "resultsPanel", "supportPanel"] as const;
 }
 
+export function isCurrentPortalRequest(requestId: number, latestRequestId: number) {
+  return requestId === latestRequestId;
+}
+
 function updateRunsQuery(
   pathname: string,
   currentQuery: PortalRunsListQuery,
@@ -170,17 +176,30 @@ export function PortalBenchmarkOpsSurface({
   const [runDetailState, setRunDetailState] = useState<LoadState<PortalRunDetailResponse>>(createLoadState);
   const [launchState, setLaunchState] = useState<LoadState<PortalLaunchViewResponse>>(createLoadState);
   const [workersState, setWorkersState] = useState<LoadState<PortalWorkersViewResponse>>(createLoadState);
+  const runsListRequestIdRef = useRef(0);
   const runDetailRequestIdRef = useRef(0);
   const [launchSelection, setLaunchSelection] = useState<LaunchSelectionState>({
     benchmarkVersionId: "",
     modelConfigId: "",
     runKind: "single_run"
   });
+  const sanitizedRunsQueryString = useMemo(
+    () => sanitizePortalRunsQueryString(search),
+    [search]
+  );
 
   const loadRuns = useCallback(async () => {
     setRunsState((current) => ({ ...current, error: null, isLoading: true }));
+    runsListRequestIdRef.current += 1;
+    const requestId = runsListRequestIdRef.current;
+
     try {
       const data = await fetchPortalRunsView(runsQuery);
+
+      if (!isCurrentPortalRequest(requestId, runsListRequestIdRef.current)) {
+        return;
+      }
+
       setRunsState({
         data,
         error: null,
@@ -188,6 +207,10 @@ export function PortalBenchmarkOpsSurface({
         lastUpdatedAt: new Date().toISOString()
       });
     } catch (error) {
+      if (!isCurrentPortalRequest(requestId, runsListRequestIdRef.current)) {
+        return;
+      }
+
       setRunsState((current) => ({
         ...current,
         error: toDisplayError(error),
@@ -208,7 +231,7 @@ export function PortalBenchmarkOpsSurface({
     try {
       const data = await fetchPortalRunDetail(activeRunId);
 
-      if (requestId !== runDetailRequestIdRef.current) {
+      if (!isCurrentPortalRequest(requestId, runDetailRequestIdRef.current)) {
         return;
       }
 
@@ -219,7 +242,7 @@ export function PortalBenchmarkOpsSurface({
         lastUpdatedAt: new Date().toISOString()
       });
     } catch (error) {
-      if (requestId !== runDetailRequestIdRef.current) {
+      if (!isCurrentPortalRequest(requestId, runDetailRequestIdRef.current)) {
         return;
       }
 
@@ -290,6 +313,21 @@ export function PortalBenchmarkOpsSurface({
     onPoll: pollCurrentView,
     routeId: activeRouteId
   });
+
+  useEffect(() => {
+    if (activeSectionId !== "runs") {
+      return;
+    }
+
+    if (extractPortalRunsQueryString(search) === sanitizedRunsQueryString) {
+      return;
+    }
+
+    onReplaceLocation(
+      pathname,
+      sanitizedRunsQueryString ? `?${sanitizedRunsQueryString}` : ""
+    );
+  }, [activeSectionId, onReplaceLocation, pathname, sanitizedRunsQueryString, search]);
 
   useEffect(() => {
     if (activeSectionId === "runs" && activeRunId) {


### PR DESCRIPTION
## Summary
- sanitize malformed runs query params back to the canonical supported subset before the surface keeps using them
- guard runs-list async responses with the same request-token logic already used by run detail so stale fetches cannot overwrite newer filter state
- add regressions for malformed query fallback, filter-option retention on empty result sets, and the shared request-current guard

## Testing
- bun test apps/web/src/lib/portal-benchmark-ops.test.js apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi

Closes #816