### PR TITLE
fix(web): harden benchmark ops query state

### DIFF
--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -15,8 +15,25 @@ describe("parsePortalRunsQuery", () => {
     expect(query).toEqual({
       ...defaultPortalRunsQuery,
       providerFamily: "openai",
-      q: "PP-318"
+      q: "PP-318",
+      runLifecycle: ["queued"],
+      verdict: ["pass"]
     });
+  });
+
+  it("drops malformed csv fragments while preserving valid unique entries", () => {
+    const query = parsePortalRunsQuery(
+      "?verdict=invalid_result,pass,invalid_result,wrong&runLifecycle=running,,queued,broken,running"
+    );
+
+    expect(query.verdict).toEqual([
+      "invalid_result",
+      "pass"
+    ]);
+    expect(query.runLifecycle).toEqual([
+      "running",
+      "queued"
+    ]);
   });
 
   it("keeps valid enum and csv params when they parse cleanly", () => {

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1,4 +1,5 @@
 import {
+  evaluationVerdictClassSchema,
   portalLaunchViewResponseSchema,
   portalRunDetailResponseSchema,
   portalRunsLifecycleBuckets,
@@ -14,6 +15,7 @@ import {
   type PortalRunsSortId,
   type PortalWorkerIncidentSeverity,
   type PortalWorkersViewResponse,
+  runLifecycleStateSchema,
   runKindSchema,
   type RunLifecycleState
 } from "@paretoproof/shared";
@@ -712,6 +714,37 @@ function parseQueryField<TValue>(
   return result.success ? result.data : fallback;
 }
 
+function parseCsvEnumField<TValue extends string>(
+  parser: { safeParse: (value: unknown) => { success: true; data: TValue } | { success: false } },
+  value: string | null
+) {
+  if (!value) {
+    return [];
+  }
+
+  const items: TValue[] = [];
+  const seen = new Set<TValue>();
+
+  for (const candidate of value.split(",")) {
+    const normalizedCandidate = parseNullableParam(candidate);
+
+    if (!normalizedCandidate) {
+      continue;
+    }
+
+    const parsedCandidate = parser.safeParse(normalizedCandidate);
+
+    if (!parsedCandidate.success || seen.has(parsedCandidate.data)) {
+      continue;
+    }
+
+    seen.add(parsedCandidate.data);
+    items.push(parsedCandidate.data);
+  }
+
+  return items;
+}
+
 function createRunsListResponse(query: PortalRunsListQuery): PortalRunsListResponse {
   const filteredItems = sortPortalRuns(
     localRunItems.filter((item) => matchesPortalRunsQuery(item, query)),
@@ -910,19 +943,11 @@ export function parsePortalRunsQuery(search: string): PortalRunsListQuery {
       parseNullableParam(params.get("runKind")),
       defaultPortalRunsQuery.runKind
     ),
-    runLifecycle: parseQueryField(
-      portalRunsListQuerySchema.shape.runLifecycle,
-      params.get("runLifecycle") ?? undefined,
-      defaultPortalRunsQuery.runLifecycle
-    ),
+    runLifecycle: parseCsvEnumField(runLifecycleStateSchema, params.get("runLifecycle")),
     runMode: parseNullableParam(params.get("runMode")),
     sort,
     toolProfile: parseNullableParam(params.get("toolProfile")),
-    verdict: parseQueryField(
-      portalRunsListQuerySchema.shape.verdict,
-      params.get("verdict") ?? undefined,
-      defaultPortalRunsQuery.verdict
-    )
+    verdict: parseCsvEnumField(evaluationVerdictClassSchema, params.get("verdict"))
   } satisfies PortalRunsListQuery;
 
   const parsedQuery = portalRunsListQuerySchema.safeParse(candidateQuery);

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   buildRunDetailTargetPath,
   buildRunsIndexTargetPath,
-  getCompactRunsSectionOrder
+  getCompactRunsSectionOrder,
+  isCurrentBenchmarkOpsRequest
 } from "./portal-benchmark-ops-surfaces.tsx";
 
 describe("portal benchmark ops route targets", () => {
@@ -45,5 +46,15 @@ describe("portal benchmark ops route targets", () => {
       "resultsPanel",
       "supportPanel"
     ]);
+  });
+});
+
+describe("isCurrentBenchmarkOpsRequest", () => {
+  it("accepts the latest in-flight request id", () => {
+    expect(isCurrentBenchmarkOpsRequest(4, 4)).toBe(true);
+  });
+
+  it("rejects stale responses from older list or detail requests", () => {
+    expect(isCurrentBenchmarkOpsRequest(3, 4)).toBe(false);
   });
 });

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -126,6 +126,10 @@ export function getCompactRunsSectionOrder() {
   return ["runsSlice", "quickFilters", "resultsPanel", "supportPanel"] as const;
 }
 
+export function isCurrentBenchmarkOpsRequest(requestId: number, currentRequestId: number) {
+  return requestId === currentRequestId;
+}
+
 function updateRunsQuery(
   pathname: string,
   currentQuery: PortalRunsListQuery,
@@ -170,6 +174,7 @@ export function PortalBenchmarkOpsSurface({
   const [runDetailState, setRunDetailState] = useState<LoadState<PortalRunDetailResponse>>(createLoadState);
   const [launchState, setLaunchState] = useState<LoadState<PortalLaunchViewResponse>>(createLoadState);
   const [workersState, setWorkersState] = useState<LoadState<PortalWorkersViewResponse>>(createLoadState);
+  const runsRequestIdRef = useRef(0);
   const runDetailRequestIdRef = useRef(0);
   const [launchSelection, setLaunchSelection] = useState<LaunchSelectionState>({
     benchmarkVersionId: "",
@@ -179,8 +184,16 @@ export function PortalBenchmarkOpsSurface({
 
   const loadRuns = useCallback(async () => {
     setRunsState((current) => ({ ...current, error: null, isLoading: true }));
+    runsRequestIdRef.current += 1;
+    const requestId = runsRequestIdRef.current;
+
     try {
       const data = await fetchPortalRunsView(runsQuery);
+
+      if (!isCurrentBenchmarkOpsRequest(requestId, runsRequestIdRef.current)) {
+        return;
+      }
+
       setRunsState({
         data,
         error: null,
@@ -188,6 +201,10 @@ export function PortalBenchmarkOpsSurface({
         lastUpdatedAt: new Date().toISOString()
       });
     } catch (error) {
+      if (!isCurrentBenchmarkOpsRequest(requestId, runsRequestIdRef.current)) {
+        return;
+      }
+
       setRunsState((current) => ({
         ...current,
         error: toDisplayError(error),
@@ -208,7 +225,7 @@ export function PortalBenchmarkOpsSurface({
     try {
       const data = await fetchPortalRunDetail(activeRunId);
 
-      if (requestId !== runDetailRequestIdRef.current) {
+      if (!isCurrentBenchmarkOpsRequest(requestId, runDetailRequestIdRef.current)) {
         return;
       }
 
@@ -219,7 +236,7 @@ export function PortalBenchmarkOpsSurface({
         lastUpdatedAt: new Date().toISOString()
       });
     } catch (error) {
-      if (requestId !== runDetailRequestIdRef.current) {
+      if (!isCurrentBenchmarkOpsRequest(requestId, runDetailRequestIdRef.current)) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- make runs query parsing tolerate malformed csv enum params while preserving valid filter values
- guard runs-list responses so stale async fetches cannot overwrite newer filter state
- add regression coverage for tolerant query fallback and latest-request guards

## Testing
- bun test apps/web/src/lib/portal-benchmark-ops.test.js apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi

Closes #816