### PR TITLE
docs(project-ops): normalize malformed feedback records

### DIFF
--- a/infra/review-traceability-audit-2026-03-14.md
+++ b/infra/review-traceability-audit-2026-03-14.md
@@ -37,3 +37,9 @@ New follow-up issues opened from still-actionable review findings:
 ## Current dead-end audit context
 
 `bun run report:dead-end-issues -- --limit 200` currently reports 14 recently closed issues with no GitHub issue, PR, or commit relationship signals. The next cleanup pass should use that output together with the comments backfilled from this audit.
+
+## Malformed feedback issue normalization
+
+- `#411` was a broad audit dump, not a durable scope. Its still-actionable findings now live in concrete follow-up records: docs drift in `#722`, worker/image smoke evidence in `#719`, `#720`, and `#796`, and surface-boundary cleanup in `#753` and `#754`. The earlier worker/internal-route gap is historical because the offline Problem 9 slice in `#377` landed and the API now registers `internal-worker` plus `offline-ingest`.
+- `#469` was a malformed placeholder for PR `#462` review output. The referenced worker findings are now historical: compile-failure bundle emission and workspace-overlap guards landed in PR `#462`, and the scenario-specific local-stub snapshot fix landed in PR `#518`.
+- `#474` was a superseded umbrella. Its missing-follow-up concerns are now backfilled by concrete records: runtime env validation in `#479` and `#755`, run-state parity in `#757`, image-graph follow-up in `#485` and `#719`, trusted-local wrapper/auth work in `#460`, deferred benchmark-ops IA in `#765` and `#766`, and public/portal surface cleanup in `#753` and `#754`.


### PR DESCRIPTION
﻿## Summary
- append the 2026-03-14 traceability audit note with the final normalization status for malformed feedback issues #411, #469, and #474
- backfill each malformed issue with a durable normalization comment that links its concrete replacement issue/PR records
- verify the dead-end issue audit reflects the new links so these threads stop showing up as untraceable

Closes #791

## Verification
- `bun run report:dead-end-issues -- --limit 200`
- `bun run check:bidi`
