### PR TITLE
test(worker): add CLI smoke matrix

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -51,6 +51,10 @@ Package materialization:
 - use `bun --cwd apps/worker materialize:problem9-run-bundle -- --output <directory> --benchmark-package-root <directory> --prompt-package-root <directory> --candidate-source <file> --compiler-diagnostics <file> --compiler-output <file> --verifier-output <file> --environment-input <file> --result <pass|fail> --semantic-equality <matched|mismatched|not_evaluated> --surface-equality <matched|drifted|not_evaluated> --contains-sorry <true|false> --contains-admit <true|false> --axiom-check <passed|failed|not_evaluated> --diagnostic-gate <passed|failed> --stop-reason <reason> [--failure-classification <file>]` to emit `problem9-run-bundle/` with the canonical manifests, copied package and prompt references, candidate source, verification artifacts, environment snapshot, and deterministic digests
 - the run-bundle command is a supported standalone materializer for fixture generation and later offline-ingest prep; it derives run identity from the prompt package `run-envelope.json`, writes `package/package-ref.json`, `verification/verdict.json`, `artifact-manifest.json`, and `run-bundle.json`, and rejects output roots that overlap the benchmark package, prompt package, or any bundle input file
 - use `bun --cwd apps/worker test:run-bundle` to run the fixture-backed standalone verification path, which materializes canonical benchmark and prompt inputs, runs the bundle CLI twice on identical fixture evidence, and checks that the resulting digests and root manifests are identical
+- use `bun --cwd apps/worker test:cli-smoke` to run the env-free worker CLI smoke matrix locally or in CI; it covers the package, prompt-package, and run-bundle materializers directly, plus the clear-failure command-entry paths for the trusted-local devbox wrapper and hosted claim loop
+- the remaining credential-gated CLI paths stay covered by their targeted suites:
+  - `apps/worker/test/problem9-attempt.test.ts` covers the local-attempt CLI boundary for invalid auth-mode input
+  - `apps/worker/test/problem9-offline-ingest.test.ts` covers offline-ingest CLI setup failure output for missing `--access-jwt`
 
 Offline ingest:
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,6 +8,7 @@
     "materialize:problem9-package": "tsx src/index.ts materialize-problem9-package",
     "materialize:problem9-prompt-package": "tsx src/index.ts materialize-problem9-prompt-package",
     "materialize:problem9-run-bundle": "tsx src/index.ts materialize-problem9-run-bundle",
+    "test:cli-smoke": "node --import tsx --test test/worker-cli-smoke.test.ts",
     "test:run-bundle": "node --import tsx --test src/lib/problem9-run-bundle.test.ts",
     "run:problem9-attempt": "tsx src/index.ts run-problem9-attempt",
     "ingest:problem9-run-bundle": "tsx src/index.ts ingest-problem9-run-bundle",

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -36,11 +36,10 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
     return;
   }
 
+  const options = parseDevboxWrapperOptions(args);
   await parseWorkerRuntimeEnv({
     commandFamily: "trusted_local_devbox"
   });
-
-  const options = parseDevboxWrapperOptions(args);
   const authPreflight = await preflightProblem9AuthMode("trusted_local_user");
 
   if (authPreflight.authMode !== "trusted_local_user") {

--- a/apps/worker/test/worker-cli-smoke.test.ts
+++ b/apps/worker/test/worker-cli-smoke.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runProblem9AttemptInDevboxCli } from "../src/lib/problem9-attempt-devbox-cli.ts";
+import { runProblem9PackageCli } from "../src/lib/problem9-package-cli.ts";
+import { materializeProblem9Package } from "../src/lib/problem9-package.ts";
+import { runProblem9PromptPackageCli } from "../src/lib/problem9-prompt-package-cli.ts";
+import {
+  getDefaultProblem9PromptPackageOptions,
+  materializeProblem9PromptPackage
+} from "../src/lib/problem9-prompt-package.ts";
+import { runProblem9RunBundleCli } from "../src/lib/problem9-run-bundle-cli.ts";
+import { runWorkerClaimLoopCli } from "../src/lib/worker-claim-loop-cli.ts";
+
+test("runProblem9PackageCli materializes the canonical package and prints JSON output", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-cli-package-"));
+  const captured = captureConsole(t);
+  const outputRoot = path.join(tempRoot, "package-output");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  await runProblem9PackageCli(["--output", outputRoot]);
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 1);
+
+  const payload = JSON.parse(captured.stdoutLines[0] ?? "{}") as {
+    outputRoot: string;
+    packageDigest: string;
+    packageId: string;
+    packageVersion: string;
+  };
+  const manifest = JSON.parse(
+    await readFile(path.join(payload.outputRoot, "benchmark-package.json"), "utf8")
+  ) as {
+    packageDigest: string;
+    packageId: string;
+    packageVersion: string;
+  };
+
+  assert.equal(payload.outputRoot, path.join(outputRoot, "firstproof", "Problem9"));
+  assert.match(payload.packageDigest, /^[a-f0-9]{64}$/);
+  assert.equal(payload.packageId, "firstproof/Problem9");
+  assert.equal(payload.packageDigest, manifest.packageDigest);
+  assert.equal(payload.packageVersion, manifest.packageVersion);
+});
+
+test("runProblem9PromptPackageCli materializes a prompt package and prints its digest", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-cli-prompt-"));
+  const captured = captureConsole(t);
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const outputRoot = path.join(tempRoot, "prompt-package");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  await runProblem9PromptPackageCli([
+    "--output",
+    outputRoot,
+    "--benchmark-package-root",
+    benchmarkPackageRoot,
+    "--run-id",
+    "run-cli-smoke-001",
+    "--attempt-id",
+    "attempt-cli-smoke-001",
+    "--lane-id",
+    "lean422_exact",
+    "--run-mode",
+    "single_pass_probe",
+    "--tool-profile",
+    "workspace_edit_limited",
+    "--provider-family",
+    "openai",
+    "--auth-mode",
+    "local_stub",
+    "--model-config-id",
+    "local_stub/problem9_fixture.v1",
+    "--harness-revision",
+    "smoke-harness-rev"
+  ]);
+
+  assert.equal(captured.stderrLines.length, 0);
+  const payload = JSON.parse(captured.stdoutLines[0] ?? "{}") as {
+    outputRoot: string;
+    promptPackageDigest: string;
+  };
+  const promptPackage = JSON.parse(
+    await readFile(path.join(payload.outputRoot, "prompt-package.json"), "utf8")
+  ) as {
+    promptPackageDigest: string;
+  };
+
+  assert.equal(payload.outputRoot, outputRoot);
+  assert.match(payload.promptPackageDigest, /^[a-f0-9]{64}$/);
+  assert.equal(payload.promptPackageDigest, promptPackage.promptPackageDigest);
+});
+
+test("runProblem9RunBundleCli materializes a canonical run bundle and prints digest output", async (t) => {
+  const fixture = await createRunBundleFixture();
+  const captured = captureConsole(t);
+
+  t.after(async () => {
+    await rm(fixture.tempRoot, { force: true, recursive: true });
+  });
+
+  await runProblem9RunBundleCli([
+    "--output",
+    fixture.outputRoot,
+    "--benchmark-package-root",
+    fixture.benchmarkPackageRoot,
+    "--prompt-package-root",
+    fixture.promptPackageRoot,
+    "--candidate-source",
+    fixture.candidateSourcePath,
+    "--compiler-diagnostics",
+    fixture.compilerDiagnosticsPath,
+    "--compiler-output",
+    fixture.compilerOutputPath,
+    "--verifier-output",
+    fixture.verifierOutputPath,
+    "--environment-input",
+    fixture.environmentInputPath,
+    "--result",
+    "pass",
+    "--semantic-equality",
+    "matched",
+    "--surface-equality",
+    "matched",
+    "--contains-sorry",
+    "false",
+    "--contains-admit",
+    "false",
+    "--axiom-check",
+    "passed",
+    "--diagnostic-gate",
+    "passed",
+    "--stop-reason",
+    "verification_complete"
+  ]);
+
+  assert.equal(captured.stderrLines.length, 0);
+  const payload = JSON.parse(captured.stdoutLines[0] ?? "{}") as {
+    artifactManifestDigest: string;
+    bundleDigest: string;
+    outputRoot: string;
+    promptPackageDigest: string;
+    verdictDigest: string;
+  };
+  const bundle = JSON.parse(
+    await readFile(path.join(payload.outputRoot, "run-bundle.json"), "utf8")
+  ) as {
+    bundleDigest: string;
+    outputRoot?: string;
+  };
+
+  assert.equal(payload.outputRoot, path.join(fixture.outputRoot, "problem9-run-bundle"));
+  assert.match(payload.bundleDigest, /^[a-f0-9]{64}$/);
+  assert.match(payload.artifactManifestDigest, /^[a-f0-9]{64}$/);
+  assert.match(payload.promptPackageDigest, /^[a-f0-9]{64}$/);
+  assert.match(payload.verdictDigest, /^[a-f0-9]{64}$/);
+  assert.equal(payload.bundleDigest, bundle.bundleDigest);
+});
+
+test("runWorkerClaimLoopCli fails clearly when required worker identity flags are missing", async () => {
+  await assert.rejects(
+    () =>
+      runWorkerClaimLoopCli([
+        "--worker-pool",
+        "modal-dev",
+        "--worker-version",
+        "worker-smoke-1",
+        "--workspace-root",
+        path.join(os.tmpdir(), "worker-workspace"),
+        "--output-root",
+        path.join(os.tmpdir(), "worker-output"),
+        "--once"
+      ]),
+    /Missing required --worker-id <value> argument\./
+  );
+});
+
+test("runProblem9AttemptInDevboxCli rejects unsupported provider families before env preflight", async () => {
+  await assert.rejects(
+    () =>
+      runProblem9AttemptInDevboxCli([
+        "--image",
+        "paretoproof-problem9-devbox:local",
+        "--provider-family",
+        "anthropic"
+      ]),
+    /Trusted-local devbox runs currently support only provider-family openai, received anthropic\./
+  );
+});
+
+function captureConsole(t: test.TestContext) {
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const stderrLines: string[] = [];
+  const stdoutLines: string[] = [];
+
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map(String).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map(String).join(" "));
+  };
+
+  t.after(() => {
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+
+  return {
+    stderrLines,
+    stdoutLines
+  };
+}
+
+async function createRunBundleFixture(): Promise<{
+  benchmarkPackageRoot: string;
+  candidateSourcePath: string;
+  compilerDiagnosticsPath: string;
+  compilerOutputPath: string;
+  environmentInputPath: string;
+  outputRoot: string;
+  promptPackageRoot: string;
+  tempRoot: string;
+  verifierOutputPath: string;
+}> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-cli-bundle-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const promptDefaults = getDefaultProblem9PromptPackageOptions();
+  const promptPackageRoot = (
+    await materializeProblem9PromptPackage({
+      attemptId: "attempt-cli-run-bundle-001",
+      authMode: "local_stub",
+      benchmarkPackageRoot,
+      harnessRevision: "cli-smoke-harness-rev",
+      jobId: null,
+      laneId: "lean422_exact",
+      modelConfigId: "local_stub/problem9_fixture.v1",
+      outputRoot: path.join(tempRoot, "prompt-package"),
+      passKCount: null,
+      passKIndex: null,
+      promptLayerVersions: promptDefaults.promptLayerVersions,
+      promptProtocolVersion: promptDefaults.promptProtocolVersion,
+      providerFamily: "openai",
+      runId: "run-cli-run-bundle-001",
+      runMode: "single_pass_probe",
+      toolProfile: "workspace_edit_limited"
+    })
+  ).outputRoot;
+  const candidateSourcePath = path.join(tempRoot, "candidate.lean");
+  const compilerDiagnosticsPath = path.join(tempRoot, "compiler-diagnostics.json");
+  const compilerOutputPath = path.join(tempRoot, "compiler-output.txt");
+  const verifierOutputPath = path.join(tempRoot, "verifier-output.json");
+  const environmentInputPath = path.join(tempRoot, "environment-input.json");
+
+  await writeFile(
+    candidateSourcePath,
+    [
+      "import FirstProof.Problem9.Statement",
+      "",
+      "theorem candidate : True := by",
+      "  trivial",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  await writeFile(compilerDiagnosticsPath, JSON.stringify({ diagnostics: [] }, null, 2), "utf8");
+  await writeFile(compilerOutputPath, "No compiler output\n", "utf8");
+  await writeFile(
+    verifierOutputPath,
+    JSON.stringify({ checked: true, result: "pass" }, null, 2),
+    "utf8"
+  );
+  await writeFile(
+    environmentInputPath,
+    JSON.stringify(
+      {
+        environmentSchemaVersion: "1",
+        executionImageDigest: null,
+        executionTargetKind: "problem9-devbox",
+        lakeSnapshotId: "lake-snapshot-cli-smoke",
+        leanVersion: "4.22.0",
+        localDevboxDigest: null,
+        metadata: {
+          source: "worker-cli-smoke-test"
+        },
+        modelSnapshotId: "local_stub/problem9_fixture.v1",
+        os: {
+          arch: "x64",
+          platform: "linux",
+          release: "6.8.0"
+        },
+        runtime: {
+          bunVersion: null,
+          nodeVersion: process.version,
+          tsxVersion: null
+        },
+        verifierVersion: "problem9-verifier.v1"
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  return {
+    benchmarkPackageRoot,
+    candidateSourcePath,
+    compilerDiagnosticsPath,
+    compilerOutputPath,
+    environmentInputPath,
+    outputRoot: path.join(tempRoot, "run-bundle"),
+    promptPackageRoot,
+    tempRoot,
+    verifierOutputPath
+  };
+}


### PR DESCRIPTION
﻿## Summary
- add a dedicated worker CLI smoke matrix that exercises the package, prompt-package, and run-bundle materializers through their real command-entry functions
- cover the remaining non-credential command-entry failures for the hosted claim loop and trusted-local devbox wrapper so unsupported or incomplete invocations fail clearly
- document the smoke suite in the worker README and expose it as `bun --cwd apps/worker test:cli-smoke` for local and CI use

Closes #759

## Verification
- `bun run build:shared`
- `bun --cwd apps/worker test:cli-smoke`
- `bun --cwd apps/worker test`
- `bun --cwd apps/worker typecheck`
- `bun run check:bidi`
