### PR TITLE
Add trusted-local auth leakage regressions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ node_modules
 dist
 **/dist
 coverage
+.codex
+.codex/**
 .env
 .env.*
 .DS_Store

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check runtime env examples
         run: node infra/scripts/check-runtime-env-examples.mjs
 
+      - name: Check trusted-local auth boundaries
+        run: node infra/scripts/check-trusted-local-boundaries.mjs
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ Thumbs.db
 dist/
 coverage/
 node_modules/
+.codex/
 .codex-*.pid
 *.tsbuildinfo

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -81,6 +81,7 @@ Trusted-local devbox wrapper:
 - the repo-owned launcher defaults to `--image paretoproof-problem9-devbox:local`; pass `--image <docker-image>` only when you intentionally need a different local devbox tag
 - the wrapper resolves host `CODEX_HOME`, verifies the host `auth.json`, runs host `codex login status`, mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`, sets in-container `CODEX_HOME=/run/paretoproof/codex-home`, runs in-container `codex login status`, and only then starts `run-problem9-attempt`
 - the wrapper does not mount the full host Codex home and does not silently fall back from `trusted_local_user` to `machine_api_key`
+- do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above
 - benchmark-package and prompt-package inputs are mounted read-only; workspace and output parents are mounted writable so the inner runner can safely clear and recreate the selected subdirectories
 - the supplied Docker image must already include the Codex CLI and the worker runtime; if it cannot run `codex login status`, trusted-local preflight fails before any attempt starts
 

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -28,6 +28,21 @@ type DevboxWrapperOptions = {
   workspaceRoot?: string;
 };
 
+type TrustedLocalDevboxDockerArgsOptions = {
+  authJsonPath: string;
+  benchmarkPackageRoot: string | null;
+  image: string;
+  modelSnapshotId?: string;
+  outputMountRoot: string | null;
+  outputRoot: string | null;
+  preflightOnly: boolean;
+  promptPackageRoot: string | null;
+  providerFamily: "openai";
+  providerModel?: string;
+  workspaceMountRoot: string | null;
+  workspaceRoot: string | null;
+};
+
 export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<void> {
   if (args.includes("--help")) {
     console.error(
@@ -113,64 +128,20 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
     assertNoHostPathOverlap(workspaceRoot, outputRoot, "Workspace root", "Output root");
   }
 
-  const workspaceContainerRoot = workspaceRoot
-    ? path.posix.join(workspaceParentContainerRoot, path.basename(workspaceRoot))
-    : null;
-  const outputContainerRoot = outputRoot
-    ? path.posix.join(outputParentContainerRoot, path.basename(outputRoot))
-    : null;
-  const shellCommands = buildContainerShellCommands({
-    benchmarkPackageContainerRoot,
+  const dockerArgs = buildTrustedLocalDevboxDockerArgs({
+    authJsonPath: authPreflight.authJsonPath,
+    benchmarkPackageRoot,
+    image: options.image,
     modelSnapshotId: options.modelSnapshotId,
-    outputContainerRoot,
+    outputMountRoot,
+    outputRoot,
     preflightOnly: options.preflightOnly,
-    promptPackageContainerRoot,
+    promptPackageRoot,
     providerFamily: options.providerFamily ?? "openai",
     providerModel: options.providerModel,
-    workspaceContainerRoot
+    workspaceMountRoot,
+    workspaceRoot
   });
-  const dockerArgs = [
-    "run",
-    "--rm",
-    "--entrypoint",
-    "sh",
-    "--workdir",
-    "/app",
-    "--env",
-    `CODEX_HOME=${trustedLocalCodexContainerHome}`,
-    "--mount",
-    buildBindMountArg(authPreflight.authJsonPath, trustedLocalCodexContainerAuthJsonPath, true)
-  ];
-
-  if (benchmarkPackageRoot) {
-    dockerArgs.push(
-      "--mount",
-      buildBindMountArg(benchmarkPackageRoot, benchmarkPackageContainerRoot, true)
-    );
-  }
-
-  if (promptPackageRoot) {
-    dockerArgs.push(
-      "--mount",
-      buildBindMountArg(promptPackageRoot, promptPackageContainerRoot, true)
-    );
-  }
-
-  if (workspaceMountRoot) {
-    dockerArgs.push(
-      "--mount",
-      buildBindMountArg(workspaceMountRoot, workspaceParentContainerRoot, false)
-    );
-  }
-
-  if (outputMountRoot) {
-    dockerArgs.push(
-      "--mount",
-      buildBindMountArg(outputMountRoot, outputParentContainerRoot, false)
-    );
-  }
-
-  dockerArgs.push(options.image, "-lc", shellCommands.join(" && "));
 
   if (options.printDockerCommand) {
     console.error(formatDockerCommand(dockerArgs));
@@ -193,6 +164,75 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
       )
     );
   }
+}
+
+export function buildTrustedLocalDevboxDockerArgs(
+  options: TrustedLocalDevboxDockerArgsOptions
+): string[] {
+  const workspaceContainerRoot = options.workspaceRoot
+    ? path.posix.join(workspaceParentContainerRoot, path.basename(options.workspaceRoot))
+    : null;
+  const outputContainerRoot = options.outputRoot
+    ? path.posix.join(outputParentContainerRoot, path.basename(options.outputRoot))
+    : null;
+  const shellCommands = buildContainerShellCommands({
+    benchmarkPackageContainerRoot,
+    modelSnapshotId: options.modelSnapshotId,
+    outputContainerRoot,
+    preflightOnly: options.preflightOnly,
+    promptPackageContainerRoot,
+    providerFamily: options.providerFamily,
+    providerModel: options.providerModel,
+    workspaceContainerRoot
+  });
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "--entrypoint",
+    "sh",
+    "--workdir",
+    "/app",
+    "--env",
+    `CODEX_HOME=${trustedLocalCodexContainerHome}`,
+    "--mount",
+    buildBindMountArg(
+      options.authJsonPath,
+      trustedLocalCodexContainerAuthJsonPath,
+      true
+    )
+  ];
+
+  if (options.benchmarkPackageRoot) {
+    dockerArgs.push(
+      "--mount",
+      buildBindMountArg(options.benchmarkPackageRoot, benchmarkPackageContainerRoot, true)
+    );
+  }
+
+  if (options.promptPackageRoot) {
+    dockerArgs.push(
+      "--mount",
+      buildBindMountArg(options.promptPackageRoot, promptPackageContainerRoot, true)
+    );
+  }
+
+  if (options.workspaceMountRoot) {
+    dockerArgs.push(
+      "--mount",
+      buildBindMountArg(options.workspaceMountRoot, workspaceParentContainerRoot, false)
+    );
+  }
+
+  if (options.outputMountRoot) {
+    dockerArgs.push(
+      "--mount",
+      buildBindMountArg(options.outputMountRoot, outputParentContainerRoot, false)
+    );
+  }
+
+  dockerArgs.push(options.image, "-lc", shellCommands.join(" && "));
+
+  return dockerArgs;
 }
 
 function parseDevboxWrapperOptions(args: string[]): DevboxWrapperOptions {

--- a/apps/worker/test/problem9-attempt-devbox-cli.test.ts
+++ b/apps/worker/test/problem9-attempt-devbox-cli.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildTrustedLocalDevboxDockerArgs
+} from "../src/lib/problem9-attempt-devbox-cli.ts";
+import {
+  trustedLocalCodexContainerAuthJsonPath,
+  trustedLocalCodexContainerHome
+} from "../src/lib/problem9-auth.ts";
+
+test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Codex home", () => {
+  const authJsonPath = "/host/.codex/auth.json";
+  const dockerArgs = buildTrustedLocalDevboxDockerArgs({
+    authJsonPath,
+    benchmarkPackageRoot: "/host/benchmark",
+    image: "paretoproof-problem9-devbox:local",
+    outputMountRoot: "/host/outputs",
+    outputRoot: "/host/outputs/output-run",
+    preflightOnly: false,
+    promptPackageRoot: "/host/prompt",
+    providerFamily: "openai",
+    providerModel: "gpt-5-codex",
+    workspaceMountRoot: "/host/workspaces",
+    workspaceRoot: "/host/workspaces/workspace-run"
+  });
+  const mountArgs = dockerArgs.flatMap((argument, index) =>
+    dockerArgs[index - 1] === "--mount" ? [argument] : []
+  );
+
+  assert.ok(dockerArgs.includes(`CODEX_HOME=${trustedLocalCodexContainerHome}`));
+  assert.ok(
+    mountArgs.includes(
+      `type=bind,src=${authJsonPath},dst=${trustedLocalCodexContainerAuthJsonPath},readonly`
+    )
+  );
+  assert.ok(
+    !mountArgs.includes(
+      `type=bind,src=/host/.codex,dst=${trustedLocalCodexContainerHome},readonly`
+    )
+  );
+  assert.ok(!mountArgs.some((argument) => argument.includes("src=/host/.codex,dst=")));
+});
+
+test("buildTrustedLocalDevboxDockerArgs keeps preflight-only runs free of writable work mounts", () => {
+  const dockerArgs = buildTrustedLocalDevboxDockerArgs({
+    authJsonPath: "/host/.codex/auth.json",
+    benchmarkPackageRoot: null,
+    image: "paretoproof-problem9-devbox:local",
+    outputMountRoot: null,
+    outputRoot: null,
+    preflightOnly: true,
+    promptPackageRoot: null,
+    providerFamily: "openai",
+    workspaceMountRoot: null,
+    workspaceRoot: null
+  });
+  const mountArgs = dockerArgs.flatMap((argument, index) =>
+    dockerArgs[index - 1] === "--mount" ? [argument] : []
+  );
+
+  assert.equal(mountArgs.length, 1);
+  assert.match(dockerArgs[dockerArgs.length - 1] ?? "", /codex login status/);
+});

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -8,6 +8,7 @@ This repo uses a small number of runtime rules.
 - [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) is the operator-facing per-mode checklist for the supported local, hosted, and owner-only runtime paths.
 - Keep browser env separate from Pages function secrets and worker machine credentials.
 - Do not store short-lived access assertions, human session data, or local auth caches in committed env files.
+- Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.
 
 ## Deploy surfaces
 
@@ -20,5 +21,6 @@ This repo uses a small number of runtime rules.
 ## Worker rules
 
 - Local trusted runs may use host-mounted auth material where explicitly supported.
+- Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer.
 - Hosted runs must use machine auth only.
 - Offline ingest is a control-plane import path, not a worker-bootstrap-token flow.

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,3 +6,4 @@ Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
 - `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts. It does not scan issue bodies, PR bodies, comments, or other GitHub discussion text, so GitHub can still warn on pasted content even when this repo check passes.
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.
+- `infra/scripts/check-trusted-local-boundaries.mjs`: fails CI when repo ignore rules, worker Docker packaging, or trusted-local docs drift toward persisting Codex auth material in the repository or image build context.

--- a/infra/scripts/check-trusted-local-boundaries.mjs
+++ b/infra/scripts/check-trusted-local-boundaries.mjs
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+const requiredGitignoreSnippets = [".codex/"];
+const requiredDockerignoreSnippets = [".codex", ".codex/**"];
+const requiredRuntimeDocSnippets = [
+  "Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.",
+  "Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer."
+];
+const requiredWorkerReadmeSnippets = [
+  "mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`",
+  "do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above"
+];
+const requiredChecklistSnippets = [
+  "do not move trusted-local auth into `apps/worker/.env`",
+  "this wrapper mounts the auth file into the container read-only"
+];
+const forbiddenDockerfileSnippets = [
+  "COPY . .",
+  "COPY . ./",
+  "ADD . .",
+  "ADD . ./",
+  ".codex",
+  "auth.json"
+];
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertContainsAll(contents, snippets, file) {
+  for (const snippet of snippets) {
+    assert(contents.includes(snippet), `${file} is missing required snippet: ${snippet}`);
+  }
+}
+
+const gitignore = readRepoFile(".gitignore");
+assertContainsAll(gitignore, requiredGitignoreSnippets, ".gitignore");
+
+const dockerignore = readRepoFile(".dockerignore");
+assertContainsAll(dockerignore, requiredDockerignoreSnippets, ".dockerignore");
+
+const dockerfile = readRepoFile("apps/worker/Dockerfile");
+for (const snippet of forbiddenDockerfileSnippets) {
+  assert(
+    !dockerfile.includes(snippet),
+    `apps/worker/Dockerfile must not include trusted-local packaging drift: ${snippet}`
+  );
+}
+
+assertContainsAll(readRepoFile("docs/runtime.md"), requiredRuntimeDocSnippets, "docs/runtime.md");
+assertContainsAll(
+  readRepoFile("apps/worker/README.md"),
+  requiredWorkerReadmeSnippets,
+  "apps/worker/README.md"
+);
+assertContainsAll(
+  readRepoFile("docs/runtime-env-mode-checklists.md"),
+  requiredChecklistSnippets,
+  "docs/runtime-env-mode-checklists.md"
+);
+
+console.log("Trusted-local auth boundaries are enforced across ignore rules, Docker packaging, and docs.");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
+    "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",
     "report:dead-end-issues": "node infra/scripts/report-dead-end-issues.mjs",
     "test:bidi": "node --test infra/scripts/check-bidi-chars.test.mjs",
     "build": "bun run build:shared && bun run build:web && bun run build:api && bun run build:worker",


### PR DESCRIPTION
## Summary
- add a repo-owned trusted-local boundary check for git/docker ignore rules, Docker packaging, and worker docs
- pin the devbox wrapper to a unit-tested auth-file mount contract so only `auth.json` is mounted read-only
- run the new boundary check in pull-request CI and document the no-in-repo-auth rule explicitly

## Verification
- node infra/scripts/check-trusted-local-boundaries.mjs
- bun --cwd apps/worker test
- bun --cwd apps/worker typecheck
- bun run check:bidi
- bun run check:env-contract
- bun run build:shared
- bun run build:worker

Closes #764