### PR TITLE
feat(worker): standardize CLI failure contract

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -29,6 +29,19 @@ Runtime env guidance:
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
 - the checked-in `ingest-problem9-run-bundle` CLI is not a `WORKER_BOOTSTRAP_TOKEN` flow; offline ingest uses an explicit admin-authenticated control-plane handoff
 
+CLI contract:
+
+- `0`: success or `--help`
+- `2`: validation, unsupported-mode, usage, or local setup failures; non-ingest commands print `Validation error: ...` to stderr, while offline-ingest keeps its machine-readable rejected JSON on stderr for `setup_failure` and `local_validation`
+- `3`: runtime or remote failures after command setup; non-ingest commands print `Runtime error: ...` to stderr, while offline-ingest keeps its machine-readable rejected JSON on stderr for `remote_rejection`
+- `1`: unexpected internal failures; commands print `Internal error: ...` to stderr so the failure is still distinguishable from operator mistakes
+- use `bun --cwd apps/worker test:cli-contract` or the root alias `bun run test:worker:cli-contract` to verify the contract on representative command-entry paths
+- success JSON remains on stdout and pins the durable artifact/result locations:
+  - materializers print `outputRoot`
+  - `run-problem9-attempt` prints the emitted run-bundle `outputRoot`
+  - `run-worker-claim-loop` prints the overall loop summary while per-job outputs live under `<output-root>/<job-id>/`
+  - offline-ingest accepted output prints `bundleRoot` plus the target `endpoint`
+
 Package materialization:
 
 - use `bun --cwd apps/worker materialize:problem9-package -- --output <directory>` to

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,6 +8,7 @@
     "materialize:problem9-package": "tsx src/index.ts materialize-problem9-package",
     "materialize:problem9-prompt-package": "tsx src/index.ts materialize-problem9-prompt-package",
     "materialize:problem9-run-bundle": "tsx src/index.ts materialize-problem9-run-bundle",
+    "test:cli-contract": "bun --cwd ../../packages/shared build && node --import tsx --test test/worker-cli-contract.test.ts",
     "test:cli-smoke": "node --import tsx --test test/worker-cli-smoke.test.ts",
     "test:run-bundle": "node --import tsx --test src/lib/problem9-run-bundle.test.ts",
     "run:problem9-attempt": "tsx src/index.ts run-problem9-attempt",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,7 @@
 import { runProblem9AttemptCli } from "./lib/problem9-attempt-cli.js";
 import { runProblem9OfflineIngestCli } from "./lib/problem9-offline-ingest-cli.js";
 import { runProblem9AttemptInDevboxCli } from "./lib/problem9-attempt-devbox-cli.js";
+import { reportWorkerCliError, workerCliExitCodes } from "./lib/cli-contract.js";
 import { runProblem9PackageCli } from "./lib/problem9-package-cli.js";
 import { runProblem9PromptPackageCli } from "./lib/problem9-prompt-package-cli.js";
 import { runProblem9RunBundleCli } from "./lib/problem9-run-bundle-cli.js";
@@ -24,50 +25,29 @@ const showWorkerUsage = () => {
 
 if (!command || command === "--help") {
   showWorkerUsage();
-  process.exitCode = command === "--help" ? 0 : 1;
+  process.exitCode =
+    command === "--help" ? workerCliExitCodes.success : workerCliExitCodes.validation;
 } else if (command === "materialize-problem9-package") {
-  void runProblem9PackageCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9PackageCli, args);
 } else if (command === "materialize-problem9-prompt-package") {
-  void runProblem9PromptPackageCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9PromptPackageCli, args);
 } else if (command === "materialize-problem9-run-bundle") {
-  void runProblem9RunBundleCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9RunBundleCli, args);
 } else if (command === "run-problem9-attempt") {
-  void runProblem9AttemptCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9AttemptCli, args);
 } else if (command === "run-problem9-attempt-in-devbox") {
-  void runProblem9AttemptInDevboxCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9AttemptInDevboxCli, args);
 } else if (command === "ingest-problem9-run-bundle") {
-  void runProblem9OfflineIngestCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runProblem9OfflineIngestCli, args);
 } else if (command === "run-worker-claim-loop") {
-  void runWorkerClaimLoopCli(args).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  void runWorkerCliCommand(runWorkerClaimLoopCli, args);
 } else {
-  console.error(`Unknown worker command: ${command}`);
-  process.exitCode = 1;
+  process.exitCode = reportWorkerCliError(new Error(`Unknown worker command: ${command}`));
+  showWorkerUsage();
+}
+
+function runWorkerCliCommand(handler: (args: string[]) => Promise<void>, args: string[]) {
+  return handler(args).catch((error: unknown) => {
+    process.exitCode = reportWorkerCliError(error);
+  });
 }

--- a/apps/worker/src/lib/cli-contract.ts
+++ b/apps/worker/src/lib/cli-contract.ts
@@ -1,0 +1,111 @@
+export const workerCliExitCodes = {
+  success: 0,
+  internal: 1,
+  validation: 2,
+  runtime: 3
+} as const;
+
+type WorkerCliExitCode =
+  (typeof workerCliExitCodes)[keyof typeof workerCliExitCodes];
+
+export type WorkerCliFailureKind = "internal" | "runtime" | "validation";
+
+export class WorkerCliError extends Error {
+  readonly exitCode: WorkerCliExitCode;
+  readonly kind: WorkerCliFailureKind;
+
+  constructor(kind: WorkerCliFailureKind, message: string) {
+    super(message);
+    this.name = "WorkerCliError";
+    this.kind = kind;
+    this.exitCode = workerCliExitCodes[kind];
+  }
+}
+
+const validationMessagePatterns = [
+  /^Invalid worker runtime environment:/u,
+  /^Missing required /u,
+  /^Unknown worker command:/u,
+  /^Unsupported /u,
+  /^Trusted-local Codex auth preflight failed\./u,
+  /^Trusted-local devbox runs currently support only provider-family /u,
+  /^Trusted-local devbox runs require --provider-model/u,
+  /^Failing bundles require --failure-classification <path>\./u,
+  /^Passing bundles may not include a failure classification\./u,
+  /requires a readable Codex auth\.json/u,
+  /may not be a top-level directory/u,
+  /must be an existing directory:/u,
+  /must be either true or false\./u,
+  /must not be a filesystem root:/u,
+  /overlaps .* on the host filesystem/u
+] as const;
+
+const runtimeMessagePatterns = [
+  /\bdocker run exited with code\b/u,
+  /\bcodex exec failed\b/ui,
+  /\bfetch failed\b/ui,
+  /\bECONNREFUSED\b/u,
+  /\btimed out\b/ui
+] as const;
+
+function isZodErrorLike(error: unknown): error is { issues: unknown[] } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "issues" in error &&
+    Array.isArray((error as { issues: unknown[] }).issues)
+  );
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export function classifyWorkerCliError(error: unknown): WorkerCliError {
+  if (error instanceof WorkerCliError) {
+    return error;
+  }
+
+  const message = normalizeErrorMessage(error);
+
+  if (
+    isZodErrorLike(error) ||
+    validationMessagePatterns.some((pattern) => pattern.test(message))
+  ) {
+    return new WorkerCliError("validation", message);
+  }
+
+  if (runtimeMessagePatterns.some((pattern) => pattern.test(message))) {
+    return new WorkerCliError("runtime", message);
+  }
+
+  return new WorkerCliError("internal", message);
+}
+
+export function formatWorkerCliError(error: unknown): string {
+  const failure = classifyWorkerCliError(error);
+  const label =
+    failure.kind === "validation"
+      ? "Validation error"
+      : failure.kind === "runtime"
+        ? "Runtime error"
+        : "Internal error";
+
+  return `${label}: ${failure.message}`;
+}
+
+export function reportWorkerCliError(error: unknown): WorkerCliExitCode {
+  const failure = classifyWorkerCliError(error);
+  console.error(formatWorkerCliError(failure));
+  return failure.exitCode;
+}
+
+export function rejectedOfflineIngestExitCode(stage: string) {
+  return stage === "remote_rejection"
+    ? workerCliExitCodes.runtime
+    : workerCliExitCodes.validation;
+}

--- a/apps/worker/src/lib/problem9-offline-ingest-cli.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest-cli.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { rejectedOfflineIngestExitCode } from "./cli-contract.js";
 import { runProblem9OfflineIngest } from "./problem9-offline-ingest.js";
 
 export async function runProblem9OfflineIngestCli(args: string[]): Promise<void> {
@@ -47,7 +48,7 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
 
   if (parsedOptions.status === "rejected") {
     console.error(JSON.stringify(parsedOptions, null, 2));
-    process.exitCode = 1;
+    process.exitCode = rejectedOfflineIngestExitCode(parsedOptions.stage);
     return;
   }
 
@@ -58,7 +59,7 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
 
   if (result.status === "rejected") {
     console.error(JSON.stringify(result, null, 2));
-    process.exitCode = 1;
+    process.exitCode = rejectedOfflineIngestExitCode(result.stage);
     return;
   }
 

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -95,11 +95,11 @@ test("run-problem9-attempt rejects unsupported auth-mode values at the CLI bound
     }
   );
 
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 2);
   assert.match(
     result.stderr,
     new RegExp(
-      `Unsupported --auth-mode value "trusted_local_usr"\\. Expected one of: ${problem9AuthModes.join(", ")}\\.`
+      `^Validation error: Unsupported --auth-mode value "trusted_local_usr"\\. Expected one of: ${problem9AuthModes.join(", ")}\\.\r?\n$`
     )
   );
   assert.equal(result.stdout, "");

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -414,7 +414,7 @@ test("runProblem9OfflineIngestCli emits JSON setup failures for missing flags", 
   await runProblem9OfflineIngestCli(["--bundle-root", path.join(os.tmpdir(), "bundle-root")]);
 
   assert.equal(stdoutLines.length, 0);
-  assert.equal(process.exitCode, 1);
+  assert.equal(process.exitCode, 2);
   assert.deepEqual(JSON.parse(stderrLines.join("\n")), {
     bundleRoot: null,
     endpoint: null,
@@ -426,6 +426,66 @@ test("runProblem9OfflineIngestCli emits JSON setup failures for missing flags", 
       }
     ],
     stage: "setup_failure",
+    status: "rejected"
+  });
+});
+
+test("runProblem9OfflineIngestCli uses runtime exit code for remote rejections", async (t) => {
+  const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
+    result: "pass"
+  });
+  const originalExitCode = process.exitCode;
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const originalFetch = globalThis.fetch;
+  const originalApiBaseUrl = process.env.API_BASE_URL;
+  const stderrLines: string[] = [];
+  const stdoutLines: string[] = [];
+
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map(String).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map(String).join(" "));
+  };
+  globalThis.fetch = async () => {
+    throw new Error("connect ECONNREFUSED 127.0.0.1");
+  };
+  process.env.API_BASE_URL = "https://api.paretoproof.com";
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+    process.exitCode = originalExitCode;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    globalThis.fetch = originalFetch;
+    if (originalApiBaseUrl === undefined) {
+      delete process.env.API_BASE_URL;
+    } else {
+      process.env.API_BASE_URL = originalApiBaseUrl;
+    }
+  });
+
+  await runProblem9OfflineIngestCli([
+    "--bundle-root",
+    bundleRoot,
+    "--access-jwt",
+    "test-access-jwt"
+  ]);
+
+  assert.equal(stdoutLines.length, 0);
+  assert.equal(process.exitCode, 3);
+  assert.deepEqual(JSON.parse(stderrLines.join("\n")), {
+    bundleRoot,
+    endpoint: "https://api.paretoproof.com/portal/admin/offline-ingest/problem9-run-bundles",
+    error: "offline_ingest_transport_error",
+    issues: [
+      {
+        message: "connect ECONNREFUSED 127.0.0.1"
+      }
+    ],
+    stage: "remote_rejection",
     status: "rejected"
   });
 });

--- a/apps/worker/test/worker-cli-contract.test.ts
+++ b/apps/worker/test/worker-cli-contract.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { materializeProblem9Package } from "../src/lib/problem9-package.ts";
+import {
+  getDefaultProblem9PromptPackageOptions,
+  materializeProblem9PromptPackage
+} from "../src/lib/problem9-prompt-package.ts";
+import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
+
+const workerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workerEntryPoint = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../src/index.ts"
+);
+const bunCommand = process.platform === "win32" ? "bun.exe" : "bun";
+
+test("worker entrypoint exits 2 and prefixes validation errors for unsupported auth-mode input", () => {
+  const result = spawnSync(
+    bunCommand,
+    [
+      workerEntryPoint,
+      "run-problem9-attempt",
+      "--benchmark-package-root",
+      "ignored-benchmark",
+      "--prompt-package-root",
+      "ignored-prompt",
+      "--workspace",
+      "ignored-workspace",
+      "--output",
+      "ignored-output",
+      "--auth-mode",
+      "trusted_local_usr"
+    ],
+    {
+      cwd: workerRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^Validation error: Unsupported --auth-mode value /u);
+  assert.equal(result.stdout, "");
+});
+
+test("worker entrypoint exits 2 for unknown commands and prints usage", () => {
+  const result = spawnSync(bunCommand, [workerEntryPoint, "totally-unknown-command"], {
+    cwd: workerRoot,
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /^Validation error: Unknown worker command: totally-unknown-command/u);
+  assert.match(result.stderr, /\nUsage:\n/u);
+  assert.equal(result.stdout, "");
+});
+
+test(
+  "worker entrypoint exits 3 and preserves machine-readable offline-ingest remote rejections",
+  { timeout: 120000 },
+  async (t) => {
+    const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot();
+
+    t.after(async () => {
+      await rm(tempRoot, { force: true, recursive: true });
+    });
+
+    const result = spawnSync(
+      bunCommand,
+      [
+        workerEntryPoint,
+        "ingest-problem9-run-bundle",
+        "--bundle-root",
+        bundleRoot,
+        "--access-jwt",
+        "worker-cli-contract-jwt"
+      ],
+      {
+        cwd: workerRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          API_BASE_URL: "http://127.0.0.1:9"
+        }
+      }
+    );
+
+    assert.equal(result.status, 3);
+    assert.equal(result.stdout, "");
+
+    const parsed = JSON.parse(result.stderr) as {
+      bundleRoot: string;
+      endpoint: string;
+      error: string;
+      issues: Array<{ message: string }>;
+      stage: string;
+      status: string;
+    };
+
+    assert.equal(parsed.status, "rejected");
+    assert.equal(parsed.stage, "remote_rejection");
+    assert.equal(parsed.error, "offline_ingest_transport_error");
+    assert.equal(parsed.bundleRoot, bundleRoot);
+    assert.equal(
+      parsed.endpoint,
+      "http://127.0.0.1:9/portal/admin/offline-ingest/problem9-run-bundles"
+    );
+    assert.match(parsed.issues[0]?.message ?? "", /.+/u);
+  }
+);
+
+async function buildOfflineIngestBundleRoot(): Promise<{
+  bundleRoot: string;
+  tempRoot: string;
+}> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-cli-contract-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const promptDefaults = getDefaultProblem9PromptPackageOptions();
+  const promptPackageRoot = (
+    await materializeProblem9PromptPackage({
+      attemptId: "attempt-cli-contract-001",
+      authMode: "local_stub",
+      benchmarkPackageRoot,
+      harnessRevision: "cli-contract-harness-rev",
+      jobId: null,
+      laneId: "lean422_exact",
+      modelConfigId: "local_stub/problem9_cli_contract.v1",
+      outputRoot: path.join(tempRoot, "prompt-package"),
+      passKCount: null,
+      passKIndex: null,
+      promptLayerVersions: promptDefaults.promptLayerVersions,
+      promptProtocolVersion: promptDefaults.promptProtocolVersion,
+      providerFamily: "openai",
+      runId: "run-cli-contract-001",
+      runMode: "single_pass_probe",
+      toolProfile: "workspace_edit_limited"
+    })
+  ).outputRoot;
+  const candidateSourcePath = path.join(tempRoot, "candidate.lean");
+  const compilerDiagnosticsPath = path.join(tempRoot, "compiler-diagnostics.json");
+  const compilerOutputPath = path.join(tempRoot, "compiler-output.txt");
+  const verifierOutputPath = path.join(tempRoot, "verifier-output.json");
+  const environmentInputPath = path.join(tempRoot, "environment-input.json");
+
+  await writeFile(
+    candidateSourcePath,
+    [
+      "import FirstProof.Problem9.Statement",
+      "",
+      "theorem candidate : True := by",
+      "  trivial",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  await writeFile(compilerDiagnosticsPath, JSON.stringify({ diagnostics: [] }, null, 2), "utf8");
+  await writeFile(compilerOutputPath, "No compiler output\n", "utf8");
+  await writeFile(
+    verifierOutputPath,
+    JSON.stringify({ checked: true, result: "pass" }, null, 2),
+    "utf8"
+  );
+  await writeFile(
+    environmentInputPath,
+    JSON.stringify(
+      {
+        environmentSchemaVersion: "1",
+        executionImageDigest: null,
+        executionTargetKind: "problem9-devbox",
+        lakeSnapshotId: "lake-snapshot-cli-contract",
+        leanVersion: "4.22.0",
+        localDevboxDigest: null,
+        metadata: {
+          source: "worker-cli-contract-test"
+        },
+        modelSnapshotId: "local_stub/problem9_cli_contract.v1",
+        os: {
+          arch: "x64",
+          platform: "linux",
+          release: "6.8.0"
+        },
+        runtime: {
+          bunVersion: null,
+          nodeVersion: process.version,
+          tsxVersion: null
+        },
+        verifierVersion: "problem9-verifier.v1"
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  return {
+    bundleRoot: (
+      await materializeProblem9RunBundle({
+        axiomCheck: "passed",
+        benchmarkPackageRoot,
+        candidateSourcePath,
+        compilerDiagnosticsPath,
+        compilerOutputPath,
+        containsAdmit: false,
+        containsSorry: false,
+        diagnosticGate: "passed",
+        environmentInputPath,
+        failureClassificationPath: null,
+        outputRoot: path.join(tempRoot, "run-bundle"),
+        promptPackageRoot,
+        result: "pass",
+        semanticEquality: "matched",
+        stopReason: "verification_complete",
+        surfaceEquality: "matched",
+        verifierOutputPath
+      })
+    ).outputRoot,
+    tempRoot
+  };
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "run:problem9-attempt": "bun --cwd apps/worker run:problem9-attempt",
     "run:problem9-attempt:trusted-local": "node infra/scripts/run-problem9-trusted-local-attempt.mjs",
     "run:worker-claim-loop": "bun --cwd apps/worker run:worker-claim-loop",
+    "test:worker:cli-contract": "bun --cwd apps/worker test:cli-contract",
+    "test:worker:cli-smoke": "bun --cwd apps/worker test:cli-smoke",
     "build:shared": "bun --cwd packages/shared build",
     "test:api": "bun run build:shared && bun --cwd apps/api test",
     "typecheck:web": "bun --cwd apps/web typecheck",


### PR DESCRIPTION
## Summary
- add a shared worker CLI contract for validation, runtime, and internal failures with stable exit codes and stderr prefixes
- make offline-ingest rejected results use the same contract while preserving machine-readable JSON on stderr
- add representative contract tests and document the success/output-location rules in the worker README

Closes #760

## Verification
- bun run test:worker:cli-contract
- bun --cwd apps/worker test
- bun run test:worker:cli-smoke
- bun --cwd apps/worker typecheck
- bun run check:bidi