### PR TITLE
Add Problem 9 image publish policy manifest

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check trusted-local auth boundaries
         run: node infra/scripts/check-trusted-local-boundaries.mjs
 
+      - name: Check Problem 9 image policy
+        run: node infra/scripts/check-problem9-image-policy.mjs
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -15,6 +15,7 @@ Docker targets:
 - `problem9-execution` is the canonical non-interactive verdict environment and includes the built worker runtime, prompt templates, and checked-in `benchmarks/firstproof/problem9` source tree at the repo-root paths the CLI materializers resolve at runtime
 - `problem9-devbox` extends `problem9-execution` with Bun `1.3.10`, Python `3.11`, Codex CLI, and `lean-lsp-mcp` for trusted-local contributor workflows
 - `paretoproof-worker` remains the narrower hosted wrapper target and is published on `main` alongside the canonical `problem9-execution` image
+- published image names, local tags, and workflow ownership are tracked in [infra/problem9-image-policy.md](../../infra/problem9-image-policy.md) and [infra/docker/problem9-image-policy.json](../../infra/docker/problem9-image-policy.json)
 - root-level image build commands for the named runtime targets:
   - `bun run build:problem9-execution` builds `problem9-execution` and tags it as `paretoproof-problem9-execution:local`
   - `bun run build:problem9-devbox` builds `problem9-devbox` and tags it as `paretoproof-problem9-devbox:local`

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,4 +6,9 @@ Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
 - `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts. It does not scan issue bodies, PR bodies, comments, or other GitHub discussion text, so GitHub can still warn on pasted content even when this repo check passes.
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.
+- `infra/scripts/check-problem9-image-policy.mjs`: fails CI when the Problem 9 image manifest, publish workflows, root build scripts, or operator docs drift apart.
 - `infra/scripts/check-trusted-local-boundaries.mjs`: fails CI when repo ignore rules, worker Docker packaging, or trusted-local docs drift toward persisting Codex auth material in the repository or image build context.
+
+Problem 9 image policy:
+- `infra/docker/problem9-image-policy.json`: authoritative manifest for the repository-owned Problem 9 image targets, local tags, published GHCR names, and owning workflows.
+- `infra/problem9-image-policy.md`: operator-facing policy for mutable tags, immutable provenance tags, workflow ownership, and rollback by digest.

--- a/infra/docker/problem9-image-policy.json
+++ b/infra/docker/problem9-image-policy.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "registryHost": "ghcr.io",
+  "repositoryOwnerPlaceholder": "${{ github.repository_owner }}",
+  "mutableTag": "main",
+  "immutableTagPrefix": "sha-",
+  "images": [
+    {
+      "target": "problem9-execution",
+      "localTag": "paretoproof-problem9-execution:local",
+      "repository": "paretoproof-problem9-execution",
+      "publishedImage": "ghcr.io/${{ github.repository_owner }}/paretoproof-problem9-execution",
+      "localBuildScript": "build:problem9-execution",
+      "publishedByWorkflow": ".github/workflows/publish-worker-image.yml",
+      "ownership": "Infrastructure / Deployment",
+      "publishTrigger": "push to main for worker/build-graph changes or workflow_dispatch",
+      "notes": "Canonical non-interactive Problem 9 verdict environment."
+    },
+    {
+      "target": "problem9-devbox",
+      "localTag": "paretoproof-problem9-devbox:local",
+      "repository": "paretoproof-problem9-devbox",
+      "publishedImage": "ghcr.io/${{ github.repository_owner }}/paretoproof-problem9-devbox",
+      "localBuildScript": "build:problem9-devbox",
+      "publishedByWorkflow": ".github/workflows/publish-problem9-devbox-image.yml",
+      "ownership": "Infrastructure / Deployment",
+      "publishTrigger": "workflow_dispatch only",
+      "notes": "Trusted-local contributor/devbox image. Main may move only on an explicit operator publish."
+    },
+    {
+      "target": "paretoproof-worker",
+      "localTag": "paretoproof-worker:local",
+      "repository": "paretoproof-worker",
+      "publishedImage": "ghcr.io/${{ github.repository_owner }}/paretoproof-worker",
+      "localBuildScript": "build:paretoproof-worker",
+      "publishedByWorkflow": ".github/workflows/publish-worker-image.yml",
+      "ownership": "Infrastructure / Deployment",
+      "publishTrigger": "push to main for worker/build-graph changes or workflow_dispatch",
+      "notes": "Hosted worker wrapper image built from the same Dockerfile graph as problem9-execution."
+    }
+  ]
+}

--- a/infra/problem9-image-policy.md
+++ b/infra/problem9-image-policy.md
@@ -1,0 +1,51 @@
+# Problem 9 Image Policy
+
+The authoritative source of truth for the Problem 9 image graph is [`infra/docker/problem9-image-policy.json`](./docker/problem9-image-policy.json). Use this document for operator-facing guidance and use the manifest plus `node infra/scripts/check-problem9-image-policy.mjs` for drift checks.
+
+## Tag policy
+
+- Published images live under `ghcr.io/<repository-owner>/...`.
+- `main` is the only mutable publish tag. It may move only when the owning publish workflow completes successfully on the default branch or from an explicit manual publish for the devbox image.
+- `sha-<git sha>` tags are immutable provenance tags for the exact published commit.
+- Rollback and provenance review must use the digest recorded in the publish workflow summary artifact rather than assuming the mutable tag still points at the intended build.
+
+## Ownership matrix
+
+### `problem9-execution`
+
+- Docker target: `problem9-execution`
+- Local build script: `bun run build:problem9-execution`
+- Local tag: `paretoproof-problem9-execution:local`
+- Published image: `ghcr.io/<repository-owner>/paretoproof-problem9-execution`
+- Owning workflow: `.github/workflows/publish-worker-image.yml`
+- Publish trigger: push to `main` for worker/build-graph changes or `workflow_dispatch`
+- Digest evidence: `problem9-image-digests.md` workflow artifact and step summary entry
+- Purpose: canonical non-interactive Problem 9 verdict environment
+
+### `problem9-devbox`
+
+- Docker target: `problem9-devbox`
+- Local build script: `bun run build:problem9-devbox`
+- Local tag: `paretoproof-problem9-devbox:local`
+- Published image: `ghcr.io/<repository-owner>/paretoproof-problem9-devbox`
+- Owning workflow: `.github/workflows/publish-problem9-devbox-image.yml`
+- Publish trigger: `workflow_dispatch`
+- Digest evidence: `problem9-devbox-image-digest.md` workflow artifact and step summary entry
+- Purpose: trusted-local contributor/devbox image with Codex CLI and Lean support tools
+
+### `paretoproof-worker`
+
+- Docker target: `paretoproof-worker`
+- Local build script: `bun run build:paretoproof-worker`
+- Local tag: `paretoproof-worker:local`
+- Published image: `ghcr.io/<repository-owner>/paretoproof-worker`
+- Owning workflow: `.github/workflows/publish-worker-image.yml`
+- Publish trigger: push to `main` for worker/build-graph changes or `workflow_dispatch`
+- Digest evidence: `problem9-image-digests.md` workflow artifact and step summary entry
+- Purpose: hosted worker wrapper image built from the same Dockerfile graph as `problem9-execution`
+
+## Review and rollback
+
+- Before changing image names, tags, or workflow ownership, update the JSON manifest first and then update any coupled workflows or docs in the same change.
+- Use `node infra/scripts/check-problem9-image-policy.mjs` or `bun run check:problem9-image-policy` to confirm workflows, package scripts, and the worker/infra docs still match the manifest.
+- For rollback, identify the required digest from the workflow artifact, re-publish or deploy by digest, and record the chosen digest in the release evidence instead of relying on `main`.

--- a/infra/scripts/build-problem9-image.mjs
+++ b/infra/scripts/build-problem9-image.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const TARGET_IMAGE_TAGS = new Map([
-  ["problem9-execution", "paretoproof-problem9-execution:local"],
-  ["problem9-devbox", "paretoproof-problem9-devbox:local"],
-  ["paretoproof-worker", "paretoproof-worker:local"],
-]);
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const manifestPath = path.resolve(scriptDirectory, "..", "docker", "problem9-image-policy.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const TARGET_IMAGE_POLICIES = new Map(manifest.images.map((image) => [image.target, image]));
 
 const usage = `Usage: node infra/scripts/build-problem9-image.mjs --target <problem9-execution|problem9-devbox|paretoproof-worker> [options]
 
@@ -65,11 +67,11 @@ if (!target) {
   fail(`Missing required --target argument.\n\n${usage}`);
 }
 
-if (!TARGET_IMAGE_TAGS.has(target)) {
-  fail(`Unsupported target "${target}". Expected one of: ${Array.from(TARGET_IMAGE_TAGS.keys()).join(", ")}.`);
+if (!TARGET_IMAGE_POLICIES.has(target)) {
+  fail(`Unsupported target "${target}". Expected one of: ${Array.from(TARGET_IMAGE_POLICIES.keys()).join(", ")}.`);
 }
 
-const resolvedTag = tag ?? TARGET_IMAGE_TAGS.get(target);
+const resolvedTag = tag ?? TARGET_IMAGE_POLICIES.get(target).localTag;
 const loadOrPushFlag = push ? "--push" : "--load";
 const command = [
   "docker",

--- a/infra/scripts/check-problem9-image-policy.mjs
+++ b/infra/scripts/check-problem9-image-policy.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..", "..");
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`Problem 9 image policy check failed: ${message}`);
+  process.exit(1);
+}
+
+const manifestPath = "infra/docker/problem9-image-policy.json";
+const policyDocPath = "infra/problem9-image-policy.md";
+const workerReadmePath = "apps/worker/README.md";
+const infraReadmePath = "infra/README.md";
+const packageJsonPath = "package.json";
+
+const manifest = JSON.parse(readText(manifestPath));
+const policyDoc = readText(policyDocPath);
+const workerReadme = readText(workerReadmePath);
+const infraReadme = readText(infraReadmePath);
+const packageJson = JSON.parse(readText(packageJsonPath));
+
+if (manifest.mutableTag !== "main") {
+  fail(`expected mutableTag to be "main" but found "${manifest.mutableTag}"`);
+}
+
+if (manifest.immutableTagPrefix !== "sha-") {
+  fail(`expected immutableTagPrefix to be "sha-" but found "${manifest.immutableTagPrefix}"`);
+}
+
+const uniqueTargets = new Set();
+const uniquePublishedImages = new Set();
+const workflowContents = new Map();
+
+for (const image of manifest.images) {
+  if (uniqueTargets.has(image.target)) {
+    fail(`duplicate target "${image.target}" in ${manifestPath}`);
+  }
+
+  if (uniquePublishedImages.has(image.publishedImage)) {
+    fail(`duplicate published image "${image.publishedImage}" in ${manifestPath}`);
+  }
+
+  uniqueTargets.add(image.target);
+  uniquePublishedImages.add(image.publishedImage);
+
+  const workflowPath = image.publishedByWorkflow;
+  if (!workflowContents.has(workflowPath)) {
+    workflowContents.set(workflowPath, readText(workflowPath));
+  }
+
+  const workflowContent = workflowContents.get(workflowPath);
+
+  if (!workflowContent.includes(image.publishedImage)) {
+    fail(`${workflowPath} does not reference published image ${image.publishedImage}`);
+  }
+
+  if (!workflowContent.includes(`target: ${image.target}`)) {
+    fail(`${workflowPath} does not build docker target ${image.target}`);
+  }
+
+  if (!workflowContent.includes("type=raw,value=main")) {
+    fail(`${workflowPath} is missing the mutable main tag rule`);
+  }
+
+  if (!workflowContent.includes("type=sha,prefix=sha-")) {
+    fail(`${workflowPath} is missing the immutable sha tag rule`);
+  }
+
+  const buildScript = packageJson.scripts?.[image.localBuildScript];
+  if (!buildScript) {
+    fail(`package.json is missing script ${image.localBuildScript}`);
+  }
+
+  if (!buildScript.includes(`--target ${image.target}`)) {
+    fail(`package.json script ${image.localBuildScript} does not target ${image.target}`);
+  }
+
+  const requiredPolicySnippets = [
+    image.target,
+    image.localTag,
+    image.publishedImage.replace("${{ github.repository_owner }}", "<repository-owner>"),
+    image.localBuildScript,
+    image.publishedByWorkflow,
+  ];
+
+  for (const snippet of requiredPolicySnippets) {
+    if (!policyDoc.includes(snippet)) {
+      fail(`${policyDocPath} is missing required snippet "${snippet}"`);
+    }
+  }
+
+  const requiredWorkerReadmeSnippets = [
+    image.target,
+    image.localTag,
+  ];
+
+  for (const snippet of requiredWorkerReadmeSnippets) {
+    if (!workerReadme.includes(snippet)) {
+      fail(`${workerReadmePath} is missing required snippet "${snippet}"`);
+    }
+  }
+}
+
+if (!/`main`\s+is the only mutable publish tag/i.test(policyDoc)) {
+  fail(`${policyDocPath} must document the mutable main tag rule`);
+}
+
+if (!/`sha-<git sha>`\s+tags are immutable provenance tags/i.test(policyDoc)) {
+  fail(`${policyDocPath} must document the immutable sha tag rule`);
+}
+
+if (!workerReadme.includes("../../infra/problem9-image-policy.md")) {
+  fail(`${workerReadmePath} must link to the image policy document`);
+}
+
+if (!infraReadme.includes("check-problem9-image-policy.mjs")) {
+  fail(`${infraReadmePath} must mention the image policy check script`);
+}
+
+if (!infraReadme.includes("problem9-image-policy.json")) {
+  fail(`${infraReadmePath} must mention the image policy manifest`);
+}
+
+console.log("Problem 9 image policy check passed.");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
+    "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",
     "report:dead-end-issues": "node infra/scripts/report-dead-end-issues.mjs",
     "test:bidi": "node --test infra/scripts/check-bidi-chars.test.mjs",


### PR DESCRIPTION
## Summary
- add a manifest-backed Problem 9 image publication policy covering local tags, GHCR repositories, ownership, and rollback by digest
- make the local image build helper read the manifest and add a drift check that verifies workflows, scripts, and docs stay aligned
- enforce the new policy in pull-request CI and point the worker/infra docs at the source of truth

Closes #761

## Verification
- node infra/scripts/check-problem9-image-policy.mjs
- bun run check:problem9-image-policy
- node infra/scripts/build-problem9-image.mjs --target problem9-execution --dry-run
- node infra/scripts/build-problem9-image.mjs --target problem9-devbox --dry-run
- node infra/scripts/build-problem9-image.mjs --target paretoproof-worker --dry-run
- bun run check:bidi