### PR TITLE
Backfill benchmark-ops runs read-model facets

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -11,6 +11,7 @@ import {
   type PortalRunDetailResponse,
   type PortalRunFailureSummary,
   type PortalRunJobSummary,
+  type PortalRunsAvailableFilters,
   type PortalRunListItem,
   type PortalRunTimelineEntry,
   type PortalRunsLifecycleBucket,
@@ -44,6 +45,11 @@ export type PortalBenchmarkOpsReadModelService = {
   getRunsList(query: PortalRunsListQuery): Promise<PortalRunsListResponse>;
   getWorkersView(): Promise<PortalWorkersViewResponse>;
 };
+
+// This service is the authoritative read-model boundary for `/portal/runs`,
+// `/portal/runs/:runId`, `/portal/launch`, and `/portal/workers`. The portal UI
+// should consume explicit filter facets and detail fields from here rather than
+// inferring them from paginated rows.
 
 function toIso(value: Date | null) {
   return value ? value.toISOString() : null;
@@ -385,6 +391,72 @@ function buildRunOrderBy(sortId: PortalRunsListQuery["sort"]) {
   }
 }
 
+function buildEmptyRunsFilters(): PortalRunsAvailableFilters {
+  return {
+    modelConfigs: [],
+    providerFamilies: []
+  };
+}
+
+function buildEmptyRunsListResponse(query: PortalRunsListQuery): PortalRunsListResponse {
+  return {
+    filters: buildEmptyRunsFilters(),
+    items: [],
+    query,
+    summary: {
+      activeRuns: 0,
+      failedRuns: 0,
+      returnedCount: 0,
+      totalMatches: 0,
+      verdictCounts: {
+        fail: 0,
+        invalid_result: 0,
+        pass: 0
+      }
+    }
+  };
+}
+
+async function loadRunsFilters(
+  db: ReturnTypeOfCreateDbClient,
+  whereClause: ReturnType<typeof and> | undefined
+): Promise<PortalRunsAvailableFilters> {
+  const [providerRows, modelConfigRows] = await Promise.all([
+    db
+      .select({
+        count: count(),
+        providerFamily: runs.providerFamily
+      })
+      .from(runs)
+      .where(whereClause)
+      .groupBy(runs.providerFamily)
+      .orderBy(runs.providerFamily),
+    db
+      .select({
+        count: count(),
+        modelConfigId: runs.modelConfigId,
+        providerFamily: runs.providerFamily
+      })
+      .from(runs)
+      .where(whereClause)
+      .groupBy(runs.modelConfigId, runs.providerFamily)
+      .orderBy(runs.modelConfigId, runs.providerFamily)
+  ]);
+
+  return {
+    modelConfigs: modelConfigRows.map((row) => ({
+      count: row.count,
+      modelConfigId: row.modelConfigId,
+      modelConfigLabel: row.modelConfigId,
+      providerFamily: row.providerFamily
+    })),
+    providerFamilies: providerRows.map((row) => ({
+      count: row.count,
+      providerFamily: row.providerFamily
+    }))
+  };
+}
+
 export function createPortalBenchmarkOpsReadModelService(
   db: ReturnTypeOfCreateDbClient
 ): PortalBenchmarkOpsReadModelService {
@@ -462,21 +534,7 @@ export function createPortalBenchmarkOpsReadModelService(
         const jobRunIds = await loadRunIdsForSourceJobId(db, query.jobId);
 
         if (jobRunIds.length === 0) {
-          return {
-            items: [],
-            query,
-            summary: {
-              activeRuns: 0,
-              failedRuns: 0,
-              returnedCount: 0,
-              totalMatches: 0,
-              verdictCounts: {
-                fail: 0,
-                invalid_result: 0,
-                pass: 0
-              }
-            }
-          };
+          return buildEmptyRunsListResponse(query);
         }
 
         runConditions.push(inArray(runs.id, jobRunIds));
@@ -486,21 +544,7 @@ export function createPortalBenchmarkOpsReadModelService(
         const attemptRunIds = await loadRunIdsForSourceAttemptId(db, query.attemptId);
 
         if (attemptRunIds.length === 0) {
-          return {
-            items: [],
-            query,
-            summary: {
-              activeRuns: 0,
-              failedRuns: 0,
-              returnedCount: 0,
-              totalMatches: 0,
-              verdictCounts: {
-                fail: 0,
-                invalid_result: 0,
-                pass: 0
-              }
-            }
-          };
+          return buildEmptyRunsListResponse(query);
         }
 
         runConditions.push(inArray(runs.id, attemptRunIds));
@@ -525,18 +569,21 @@ export function createPortalBenchmarkOpsReadModelService(
       }
 
       const whereClause = runConditions.length > 0 ? and(...runConditions) : undefined;
-      const [{ total: totalMatches }] = await db
-        .select({
-          total: count()
-        })
-        .from(runs)
-        .where(whereClause);
-      const runRows = await db
-        .select()
-        .from(runs)
-        .where(whereClause)
-        .orderBy(...buildRunOrderBy(query.sort))
-        .limit(query.limit);
+      const [[{ total: totalMatches }], filters, runRows] = await Promise.all([
+        db
+          .select({
+            total: count()
+          })
+          .from(runs)
+          .where(whereClause),
+        loadRunsFilters(db, whereClause),
+        db
+          .select()
+          .from(runs)
+          .where(whereClause)
+          .orderBy(...buildRunOrderBy(query.sort))
+          .limit(query.limit)
+      ]);
       const runIds = runRows.map((runRow) => runRow.id);
       const jobRows = await loadJobsForRunIds(db, runIds);
       const attemptRows = await loadAttemptsForRunIds(db, runIds);
@@ -551,6 +598,7 @@ export function createPortalBenchmarkOpsReadModelService(
       );
 
       return {
+        filters,
         items,
         query,
         summary: {

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -8,6 +8,7 @@ import type {
   PortalRunsListResponse,
   PortalWorkersViewResponse
 } from "@paretoproof/shared";
+import { portalBenchmarkOpsReadModelsContract } from "@paretoproof/shared";
 import type { PortalBenchmarkOpsReadModelService } from "../src/lib/portal-benchmark-ops.ts";
 import { registerPortalRoutes } from "../src/routes/portal.ts";
 
@@ -51,6 +52,22 @@ function buildRunsListResponse(
   query: PortalRunsListQuery
 ): PortalRunsListResponse {
   return {
+    filters: {
+      modelConfigs: [
+        {
+          count: 1,
+          modelConfigId: "gpt-oss",
+          modelConfigLabel: "gpt-oss",
+          providerFamily: "openai"
+        }
+      ],
+      providerFamilies: [
+        {
+          count: 1,
+          providerFamily: "openai"
+        }
+      ]
+    },
     items: [
       {
         authMode: "machine_api_key",
@@ -298,6 +315,8 @@ test("GET /portal/runs parses canonical query state for approved helpers", async
   });
 
   assert.equal(response.statusCode, 200);
+  const payload = portalBenchmarkOpsReadModelsContract.runsListResponse.parse(response.json());
+
   assert.deepEqual(observedQuery, {
     attemptId: null,
     authMode: null,
@@ -320,6 +339,12 @@ test("GET /portal/runs parses canonical query state for approved helpers", async
     toolProfile: null,
     verdict: ["pass"]
   });
+  assert.deepEqual(payload.filters.providerFamilies, [
+    {
+      count: 1,
+      providerFamily: "openai"
+    }
+  ]);
 });
 
 test("GET /portal/runs rejects invalid benchmark-ops query params", async (t) => {
@@ -376,6 +401,33 @@ test("GET /portal/runs/:runId returns 404 when the run read model is missing", a
   assert.equal(response.json().error, "portal_run_not_found");
 });
 
+test("GET /portal/runs/:runId returns a contract-valid detail payload for approved helpers", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService(),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/runs/PP-318"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = portalBenchmarkOpsReadModelsContract.runDetailResponse.parse(response.json());
+  assert.equal(payload.item.runId, "PP-318");
+});
+
 test("GET /portal/launch requires collaborator-or-higher access", async (t) => {
   const helperApp = Fastify();
   const collaboratorApp = Fastify();
@@ -415,7 +467,10 @@ test("GET /portal/launch requires collaborator-or-higher access", async (t) => {
 
   assert.equal(deniedResponse.statusCode, 403);
   assert.equal(allowedResponse.statusCode, 200);
-  assert.equal(allowedResponse.json().submissionMode, "preflight_only");
+  const payload = portalBenchmarkOpsReadModelsContract.launchViewResponse.parse(
+    allowedResponse.json()
+  );
+  assert.equal(payload.submissionMode, "preflight_only");
 });
 
 test("GET /portal/workers returns the worker posture view for collaborators", async (t) => {
@@ -441,5 +496,8 @@ test("GET /portal/workers returns the worker posture view for collaborators", as
   });
 
   assert.equal(response.statusCode, 200);
-  assert.equal(response.json().queueSummary.queuedJobs, 1);
+  const payload = portalBenchmarkOpsReadModelsContract.workersViewResponse.parse(
+    response.json()
+  );
+  assert.equal(payload.queueSummary.queuedJobs, 1);
 });

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -40,14 +40,20 @@ describe("sanitizePortalRunsQueryString", () => {
 
 describe("runs filter option builders", () => {
   it("keeps the selected provider visible even when the current result set is empty", () => {
-    expect(buildRunsProviderOptions([], "openai")).toEqual(["openai"]);
+    expect(
+      buildRunsProviderOptions({ modelConfigs: [], providerFamilies: [] }, "openai")
+    ).toEqual(["openai"]);
   });
 
   it("keeps the selected model config visible even when the current result set is empty", () => {
-    expect(buildRunsModelOptions([], "openai-gpt-oss-high")).toEqual([
+    expect(
+      buildRunsModelOptions({ modelConfigs: [], providerFamilies: [] }, "openai-gpt-oss-high")
+    ).toEqual([
       {
+        count: 0,
         label: "openai-gpt-oss-high",
-        modelConfigId: "openai-gpt-oss-high"
+        modelConfigId: "openai-gpt-oss-high",
+        providerFamily: ""
       }
     ]);
   });

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -7,6 +7,9 @@ import {
   portalWorkersViewResponseSchema,
   type EvaluationVerdictClass,
   type PortalLaunchViewResponse,
+  type PortalRunsAvailableFilters,
+  type PortalRunsModelConfigFilterOption,
+  type PortalRunsProviderFilterOption,
   type PortalRunDetailResponse,
   type PortalRunListItem,
   type PortalRunsListQuery,
@@ -724,6 +727,10 @@ function createRunsListResponse(query: PortalRunsListQuery): PortalRunsListRespo
   const limitedItems = filteredItems.slice(0, query.limit);
 
   return {
+    filters: {
+      modelConfigs: buildRunsModelOptionsFromItems(filteredItems),
+      providerFamilies: buildRunsProviderOptionsFromItems(filteredItems)
+    },
     items: limitedItems,
     query,
     summary: {
@@ -1036,15 +1043,17 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
 }
 
 export type PortalRunsModelFilterOption = {
+  count: number;
   label: string;
   modelConfigId: string;
+  providerFamily: string;
 };
 
 export function buildRunsProviderOptions(
-  items: PortalRunListItem[],
+  filters: PortalRunsAvailableFilters,
   selectedProviderFamily: string | null
 ) {
-  const providerOptions = Array.from(new Set(items.map((item) => item.providerFamily)));
+  const providerOptions = filters.providerFamilies.map((entry) => entry.providerFamily);
 
   if (selectedProviderFamily && !providerOptions.includes(selectedProviderFamily)) {
     providerOptions.push(selectedProviderFamily);
@@ -1054,21 +1063,70 @@ export function buildRunsProviderOptions(
 }
 
 export function buildRunsModelOptions(
-  items: PortalRunListItem[],
+  filters: PortalRunsAvailableFilters,
   selectedModelConfigId: string | null
 ): PortalRunsModelFilterOption[] {
   const modelOptions = new Map(
-    items.map((item) => [item.modelConfigId, item.modelConfigLabel] as const)
+    filters.modelConfigs.map((entry) => [
+      entry.modelConfigId,
+      {
+        count: entry.count,
+        label: entry.modelConfigLabel,
+        modelConfigId: entry.modelConfigId,
+        providerFamily: entry.providerFamily
+      }
+    ] as const)
   );
 
   if (selectedModelConfigId && !modelOptions.has(selectedModelConfigId)) {
-    modelOptions.set(selectedModelConfigId, selectedModelConfigId);
+    modelOptions.set(selectedModelConfigId, {
+      count: 0,
+      label: selectedModelConfigId,
+      modelConfigId: selectedModelConfigId,
+      providerFamily: ""
+    });
   }
 
-  return Array.from(modelOptions, ([modelConfigId, label]) => ({
-    label,
-    modelConfigId
+  return Array.from(modelOptions.values());
+}
+
+function buildRunsProviderOptionsFromItems(
+  items: PortalRunListItem[]
+): PortalRunsProviderFilterOption[] {
+  const providerCounts = new Map<string, number>();
+
+  for (const item of items) {
+    providerCounts.set(item.providerFamily, (providerCounts.get(item.providerFamily) ?? 0) + 1);
+  }
+
+  return Array.from(providerCounts, ([providerFamily, count]) => ({
+    count,
+    providerFamily
   }));
+}
+
+function buildRunsModelOptionsFromItems(
+  items: PortalRunListItem[]
+): PortalRunsModelConfigFilterOption[] {
+  const modelOptions = new Map<string, PortalRunsModelConfigFilterOption>();
+
+  for (const item of items) {
+    const existing = modelOptions.get(item.modelConfigId);
+
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+
+    modelOptions.set(item.modelConfigId, {
+      count: 1,
+      modelConfigId: item.modelConfigId,
+      modelConfigLabel: item.modelConfigLabel,
+      providerFamily: item.providerFamily
+    });
+  }
+
+  return Array.from(modelOptions.values());
 }
 
 function escapeCsvValue(value: string) {

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -425,11 +425,11 @@ function PortalRunsSurface({
   search: string;
 }) {
   const providerOptions = buildRunsProviderOptions(
-    loadState.data?.items ?? [],
+    loadState.data?.filters ?? { modelConfigs: [], providerFamilies: [] },
     query.providerFamily
   );
   const modelOptions = buildRunsModelOptions(
-    loadState.data?.items ?? [],
+    loadState.data?.filters ?? { modelConfigs: [], providerFamilies: [] },
     query.modelConfigId
   );
   const isCompactLayout = useCompactLayout(480);

--- a/packages/shared/src/contracts/portal-benchmark-ops.ts
+++ b/packages/shared/src/contracts/portal-benchmark-ops.ts
@@ -71,6 +71,9 @@ export const portalRunsSortOptions = [
   }
 ] satisfies PortalRunsSortOption[];
 
+// Shared contract for the portal benchmark-ops read models consumed by the API
+// routes and the portal UI. Runs filter facets belong here so the UI does not
+// infer option catalogs from a paginated row slice.
 export const portalBenchmarkOpsReadModelsContract = {
   launchViewResponse: portalLaunchViewResponseSchema,
   runDetailResponse: portalRunDetailResponseSchema,

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -113,7 +113,25 @@ export const portalRunListItemSchema = z.object({
   verdictClass: evaluationVerdictClassSchema
 });
 
+export const portalRunsProviderFilterOptionSchema = z.object({
+  count: z.number().int().nonnegative(),
+  providerFamily: z.string()
+});
+
+export const portalRunsModelConfigFilterOptionSchema = z.object({
+  count: z.number().int().nonnegative(),
+  modelConfigId: z.string(),
+  modelConfigLabel: z.string(),
+  providerFamily: z.string()
+});
+
+export const portalRunsAvailableFiltersSchema = z.object({
+  modelConfigs: z.array(portalRunsModelConfigFilterOptionSchema),
+  providerFamilies: z.array(portalRunsProviderFilterOptionSchema)
+});
+
 export const portalRunsListResponseSchema = z.object({
+  filters: portalRunsAvailableFiltersSchema,
   items: z.array(portalRunListItemSchema),
   query: portalRunsListQuerySchema,
   summary: z.object({

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -33,6 +33,23 @@ export type PortalRunsSortOption = {
   label: string;
 };
 
+export type PortalRunsProviderFilterOption = {
+  count: number;
+  providerFamily: string;
+};
+
+export type PortalRunsModelConfigFilterOption = {
+  count: number;
+  modelConfigId: string;
+  modelConfigLabel: string;
+  providerFamily: string;
+};
+
+export type PortalRunsAvailableFilters = {
+  modelConfigs: PortalRunsModelConfigFilterOption[];
+  providerFamilies: PortalRunsProviderFilterOption[];
+};
+
 export type PortalRunsListQuery = {
   attemptId: string | null;
   authMode: string | null;
@@ -101,6 +118,7 @@ export type PortalRunListItem = {
 };
 
 export type PortalRunsListResponse = {
+  filters: PortalRunsAvailableFilters;
   items: PortalRunListItem[];
   query: PortalRunsListQuery;
   summary: {


### PR DESCRIPTION
## Summary
- add explicit provider and model-config filter facets to the portal benchmark-ops runs contract and API read model
- switch the portal runs UI to consume backend facets instead of inferring options from the paginated row slice
- validate the runs, run-detail, launch, and workers payloads against the shared benchmark-ops contract in API tests

## Verification
- bun run build:shared
- bun --cwd apps/api test
- bun --cwd apps/api typecheck
- bun test apps/web/src/lib/portal-benchmark-ops.test.js apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun run check:bidi