### PR TITLE
Fix Problem 9 execution image workspace runtime deps

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -72,9 +72,11 @@ ENV NODE_ENV=production
 COPY --from=problem9-app-build /app/node_modules ./node_modules
 COPY --from=problem9-app-build /app/package.json ./package.json
 COPY --from=problem9-app-build /app/apps/worker/package.json ./apps/worker/package.json
+COPY --from=problem9-app-build /app/apps/worker/node_modules ./apps/worker/node_modules
 COPY --from=problem9-app-build /app/apps/worker/dist ./apps/worker/dist
 COPY --from=problem9-app-build /app/apps/worker/prompts ./apps/worker/prompts
 COPY --from=problem9-app-build /app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=problem9-app-build /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=problem9-app-build /app/packages/shared/dist ./packages/shared/dist
 
 CMD ["node", "apps/worker/dist/index.js"]

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -13,6 +13,7 @@ Docker targets:
   - `problem9-devbox`
   - `paretoproof-worker`
 - `problem9-execution` is the canonical non-interactive verdict environment and includes the built worker runtime, prompt templates, and checked-in `benchmarks/firstproof/problem9` source tree at the repo-root paths the CLI materializers resolve at runtime
+- because Bun workspaces can install runtime packages under workspace-local `node_modules`, `problem9-execution` also needs the worker/shared workspace dependency trees instead of assuming every runtime package is hoisted into repo-root `node_modules`
 - `problem9-devbox` extends `problem9-execution` with Bun `1.3.10`, Python `3.11`, Codex CLI, and `lean-lsp-mcp` for trusted-local contributor workflows
 - `paretoproof-worker` remains the narrower hosted wrapper target and is published on `main` alongside the canonical `problem9-execution` image
 - published image names, local tags, and workflow ownership are tracked in [infra/problem9-image-policy.md](../../infra/problem9-image-policy.md) and [infra/docker/problem9-image-policy.json](../../infra/docker/problem9-image-policy.json)
@@ -21,7 +22,7 @@ Docker targets:
   - `bun run build:problem9-devbox` builds `problem9-devbox` and tags it as `paretoproof-problem9-devbox:local`
   - `bun run build:paretoproof-worker` builds `paretoproof-worker` and tags it as `paretoproof-worker:local`
 - root-level image verification commands for the publish-critical Problem 9 targets:
-  - `bun run verify:problem9-execution-image` verifies the built `paretoproof-problem9-execution:local` image contains the expected Lean toolchains, Node runtime, benchmark package, and built worker/shared artifacts
+  - `bun run verify:problem9-execution-image` verifies the built `paretoproof-problem9-execution:local` image contains the expected Lean toolchains, Node runtime, benchmark package, built worker/shared artifacts, and the workspace-local runtime dependency paths the worker actually resolves at runtime
   - `bun run verify:problem9-devbox-image` verifies the built `paretoproof-problem9-devbox:local` image contains the expected Lean toolchains plus Bun, Codex CLI, Python `3.11`, and `lean-lsp-mcp`
 - use `node infra/scripts/build-problem9-image.mjs --target <target> --dry-run` to print the exact `docker buildx build` command without executing it
 - if local Docker image loading is unavailable, export the target filesystem instead with `docker buildx build --file apps/worker/Dockerfile --target <target> --output type=local,dest=<directory> .` and then run `node infra/scripts/verify-problem9-image-toolchains.mjs --target <target> --rootfs <directory>`

--- a/infra/problem9-image-policy.md
+++ b/infra/problem9-image-policy.md
@@ -50,6 +50,7 @@ The authoritative source of truth for the Problem 9 image graph is [`infra/docke
 - Use `node infra/scripts/check-problem9-image-policy.mjs` or `bun run check:problem9-image-policy` to confirm workflows, package scripts, and the worker/infra docs still match the manifest.
 - Use `bun run verify:problem9-execution-image` after `bun run build:problem9-execution` and `bun run verify:problem9-devbox-image` after `bun run build:problem9-devbox` when local image loading is available.
 - If a local image-store issue blocks `--load`, export the target filesystem instead with `docker buildx build --file apps/worker/Dockerfile --target <target> --output type=local,dest=<directory> .` and pass `--rootfs <directory>` to `infra/scripts/verify-problem9-image-toolchains.mjs`.
+- The verifier also checks the worker/shared workspace-local runtime dependency paths because Bun may keep packages such as `@paretoproof/shared` and `zod` under those workspace trees instead of hoisting them into repo-root `node_modules`.
 - The publish workflows now build a local rootfs export and run `infra/scripts/verify-problem9-image-toolchains.mjs` before they push mutable or immutable tags, so a toolchain mismatch fails the publish path before new tags move.
 - For rollback, identify the required digest from the workflow artifact, re-publish or deploy by digest, and record the chosen digest in the release evidence instead of relying on `main`.
 

--- a/infra/scripts/verify-problem9-image-toolchains.mjs
+++ b/infra/scripts/verify-problem9-image-toolchains.mjs
@@ -183,6 +183,26 @@ function verifyRootfsJsonVersion(basePath, label, relativePath, expectedVersion)
   console.log(`Verified ${label}: ${parsed.version}`);
 }
 
+function verifyRootfsPackage(basePath, label, relativePath, expectedVersion = null) {
+  const absolutePath = rootfsPath(basePath, ...relativePath);
+
+  if (!existsSync(absolutePath)) {
+    fail(`${label} expected ${absolutePath} to exist.`);
+  }
+
+  if (expectedVersion === null) {
+    console.log(`Verified ${label}: ${absolutePath}`);
+    return;
+  }
+
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8"));
+  if (parsed.version !== expectedVersion) {
+    fail(`${label} expected version ${expectedVersion} but found ${parsed.version}.`);
+  }
+
+  console.log(`Verified ${label}: ${parsed.version}`);
+}
+
 function runDocker(image, entrypoint, args) {
   const result = spawnSync("docker", ["run", "--rm", "--entrypoint", entrypoint, image, ...args], {
     cwd: repoRoot,
@@ -279,6 +299,9 @@ if (options.rootfs) {
   verifyRootfsExists(rootfs, "benchmark package manifest", "app", "benchmarks", "firstproof", "problem9", "benchmark-package.json");
   verifyRootfsExists(rootfs, "worker runtime entry", "app", "apps", "worker", "dist", "index.js");
   verifyRootfsExists(rootfs, "shared runtime entry", "app", "packages", "shared", "dist", "index.js");
+  verifyRootfsPackage(rootfs, "worker runtime workspace link", ["app", "apps", "worker", "node_modules", "@paretoproof", "shared", "package.json"]);
+  verifyRootfsPackage(rootfs, "worker runtime zod dependency", ["app", "apps", "worker", "node_modules", "zod", "package.json"], "3.25.76");
+  verifyRootfsPackage(rootfs, "shared runtime zod dependency", ["app", "packages", "shared", "node_modules", "zod", "package.json"], "3.25.76");
 
   if (options.target === "problem9-devbox") {
     verifyRootfsExists(rootfs, "Bun runtime", "usr", "local", "bin", "bun");
@@ -310,6 +333,9 @@ if (options.rootfs) {
   verifyFileExists(image, "benchmark package manifest", "/app/benchmarks/firstproof/problem9/benchmark-package.json");
   verifyFileExists(image, "worker runtime entry", "/app/apps/worker/dist/index.js");
   verifyFileExists(image, "shared runtime entry", "/app/packages/shared/dist/index.js");
+  verifyFileExists(image, "worker runtime workspace link", "/app/apps/worker/node_modules/@paretoproof/shared/package.json");
+  verifyFileExists(image, "worker runtime zod dependency", "/app/apps/worker/node_modules/zod/package.json");
+  verifyFileExists(image, "shared runtime zod dependency", "/app/packages/shared/node_modules/zod/package.json");
 
   if (options.target === "problem9-devbox") {
     verifySemverCommand(image, "Bun runtime", "bun", ["--version"], expectedBunVersion);

--- a/infra/scripts/verify-problem9-image-toolchains.test.mjs
+++ b/infra/scripts/verify-problem9-image-toolchains.test.mjs
@@ -34,7 +34,10 @@ function makeFixtureRootfs() {
   fs.mkdirSync(path.join(rootfs, "usr", "bin"), { recursive: true });
   fs.mkdirSync(path.join(rootfs, "app", "benchmarks", "firstproof", "problem9"), { recursive: true });
   fs.mkdirSync(path.join(rootfs, "app", "apps", "worker", "dist"), { recursive: true });
+  fs.mkdirSync(path.join(rootfs, "app", "apps", "worker", "node_modules", "@paretoproof", "shared"), { recursive: true });
+  fs.mkdirSync(path.join(rootfs, "app", "apps", "worker", "node_modules", "zod"), { recursive: true });
   fs.mkdirSync(path.join(rootfs, "app", "packages", "shared", "dist"), { recursive: true });
+  fs.mkdirSync(path.join(rootfs, "app", "packages", "shared", "node_modules", "zod"), { recursive: true });
   fs.mkdirSync(path.join(rootfs, "usr", "lib", "node_modules", "@openai", "codex"), { recursive: true });
   fs.mkdirSync(
     path.join(
@@ -54,7 +57,10 @@ function makeFixtureRootfs() {
   fs.writeFileSync(path.join(rootfs, "usr", "bin", "python3.11"), "");
   fs.writeFileSync(path.join(rootfs, "app", "benchmarks", "firstproof", "problem9", "benchmark-package.json"), "{}");
   fs.writeFileSync(path.join(rootfs, "app", "apps", "worker", "dist", "index.js"), "");
+  fs.writeFileSync(path.join(rootfs, "app", "apps", "worker", "node_modules", "@paretoproof", "shared", "package.json"), JSON.stringify({ name: "@paretoproof/shared" }));
+  fs.writeFileSync(path.join(rootfs, "app", "apps", "worker", "node_modules", "zod", "package.json"), JSON.stringify({ version: "3.25.76" }));
   fs.writeFileSync(path.join(rootfs, "app", "packages", "shared", "dist", "index.js"), "");
+  fs.writeFileSync(path.join(rootfs, "app", "packages", "shared", "node_modules", "zod", "package.json"), JSON.stringify({ version: "3.25.76" }));
   fs.writeFileSync(
     path.join(rootfs, "usr", "lib", "node_modules", "@openai", "codex", "package.json"),
     JSON.stringify({ version: args.get("CODEX_CLI_VERSION") }),
@@ -97,4 +103,13 @@ test("verifier fails closed on a synthetic Codex version mismatch", () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /expected version 0\.0\.0 but found/);
+});
+
+test("verifier fails closed when worker runtime dependencies are missing from the rootfs", () => {
+  const { rootfs } = makeFixtureRootfs();
+  fs.rmSync(path.join(rootfs, "app", "apps", "worker", "node_modules", "zod"), { recursive: true, force: true });
+  const result = runVerifier("problem9-execution", rootfs);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /worker runtime zod dependency expected .* to exist/);
 });


### PR DESCRIPTION
## Summary\n- copy the worker and shared workspace-local node_modules trees into the execution image\n- extend the Problem 9 image verifier to require those runtime dependency paths in images and rootfs exports\n- document the Bun workspace packaging constraint for the execution image\n\n## Verification\n- node --test infra/scripts/verify-problem9-image-toolchains.test.mjs\n- node infra/scripts/check-problem9-image-policy.mjs\n- bun run check:bidi\n\n## Notes\n- local Docker/rootfs builds remain constrained by disk pressure on this workstation, so the publish workflow verifier is the authoritative runtime-image check\n\nCloses #833