### PR TITLE
Add PR-CI Docker smoke for Problem 9 images

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Check for hidden Unicode control characters
         run: node infra/scripts/check-bidi-chars.mjs
 
@@ -33,6 +36,37 @@ jobs:
 
       - name: Check Problem 9 image policy
         run: node infra/scripts/check-problem9-image-policy.mjs
+
+      - name: Build execution rootfs for PR image smoke
+        run: >-
+          docker buildx build
+          --file apps/worker/Dockerfile
+          --target problem9-execution
+          --output type=local,dest=.tmp/problem9-execution-rootfs
+          --cache-from type=gha,scope=problem9-execution
+          .
+
+      - name: Verify execution image toolchains in PR smoke
+        run: >-
+          node infra/scripts/verify-problem9-image-toolchains.mjs
+          --target problem9-execution
+          --rootfs .tmp/problem9-execution-rootfs
+
+      - name: Build devbox rootfs for PR image smoke
+        run: >-
+          docker buildx build
+          --file apps/worker/Dockerfile
+          --target problem9-devbox
+          --output type=local,dest=.tmp/problem9-devbox-rootfs
+          --cache-from type=gha,scope=problem9-execution
+          --cache-from type=gha,scope=problem9-devbox
+          .
+
+      - name: Verify devbox image toolchains in PR smoke
+        run: >-
+          node infra/scripts/verify-problem9-image-toolchains.mjs
+          --target problem9-devbox
+          --rootfs .tmp/problem9-devbox-rootfs
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -24,6 +24,7 @@ Docker targets:
 - root-level image verification commands for the publish-critical Problem 9 targets:
   - `bun run verify:problem9-execution-image` verifies the built `paretoproof-problem9-execution:local` image contains the expected Lean toolchains, Node runtime, benchmark package, built worker/shared artifacts, and the workspace-local runtime dependency paths the worker actually resolves at runtime
   - `bun run verify:problem9-devbox-image` verifies the built `paretoproof-problem9-devbox:local` image contains the expected Lean toolchains plus Bun, Codex CLI, Python `3.11`, and `lean-lsp-mcp`
+- `.github/workflows/pull-request-ci.yml` is the authoritative pre-merge image-smoke gate: it builds rootfs exports for both targets and runs `infra/scripts/verify-problem9-image-toolchains.mjs` against each export before the rest of the workspace build passes reviewers a green PR
 - use `node infra/scripts/build-problem9-image.mjs --target <target> --dry-run` to print the exact `docker buildx build` command without executing it
 - if local Docker image loading is unavailable, export the target filesystem instead with `docker buildx build --file apps/worker/Dockerfile --target <target> --output type=local,dest=<directory> .` and then run `node infra/scripts/verify-problem9-image-toolchains.mjs --target <target> --rootfs <directory>`
 - use `node infra/scripts/verify-problem9-image-toolchains.mjs --target problem9-devbox --expected-codex-cli-version 0.0.0` to force a synthetic mismatch and confirm the verifier fails closed when expected tool versions drift

--- a/infra/problem9-image-policy.md
+++ b/infra/problem9-image-policy.md
@@ -48,6 +48,8 @@ The authoritative source of truth for the Problem 9 image graph is [`infra/docke
 
 - Before changing image names, tags, or workflow ownership, update the JSON manifest first and then update any coupled workflows or docs in the same change.
 - Use `node infra/scripts/check-problem9-image-policy.mjs` or `bun run check:problem9-image-policy` to confirm workflows, package scripts, and the worker/infra docs still match the manifest.
+- Pull requests that touch the worker image graph now use `.github/workflows/pull-request-ci.yml` to build local rootfs exports for `problem9-execution` and `problem9-devbox` and then run `infra/scripts/verify-problem9-image-toolchains.mjs` against both exports before merge.
+- Treat those PR-CI rootfs build plus verify steps as the authoritative pre-merge evidence that the image graph still builds and exposes the required Lean, Node, Bun, Codex CLI, and `lean-lsp-mcp` toolchains.
 - Use `bun run verify:problem9-execution-image` after `bun run build:problem9-execution` and `bun run verify:problem9-devbox-image` after `bun run build:problem9-devbox` when local image loading is available.
 - If a local image-store issue blocks `--load`, export the target filesystem instead with `docker buildx build --file apps/worker/Dockerfile --target <target> --output type=local,dest=<directory> .` and pass `--rootfs <directory>` to `infra/scripts/verify-problem9-image-toolchains.mjs`.
 - The verifier also checks the worker/shared workspace-local runtime dependency paths because Bun may keep packages such as `@paretoproof/shared` and `zod` under those workspace trees instead of hoisting them into repo-root `node_modules`.


### PR DESCRIPTION
Closes #719

## Summary
- add pull-request CI rootfs smoke builds for `problem9-execution` and `problem9-devbox`
- verify both exported root filesystems with `infra/scripts/verify-problem9-image-toolchains.mjs`
- document pull-request CI as the authoritative pre-merge image-smoke gate

## Verification
- `node infra/scripts/check-problem9-image-policy.mjs`
- `node infra/scripts/build-problem9-image.mjs --target problem9-execution --dry-run`
- `node infra/scripts/build-problem9-image.mjs --target problem9-devbox --dry-run`

## Local note
- full local rootfs exports were not reliable on this workstation because Docker became unresponsive and `C:` only had about `598 MB` free; the real image-smoke proof for this change is the PR CI run added here