### PR TITLE
Require promotion smoke evidence before main-branch signoff

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check Problem 9 image policy
         run: node infra/scripts/check-problem9-image-policy.mjs
 
+      - name: Check main-branch promotion gate docs
+        run: node infra/scripts/check-main-branch-promotion-gate.mjs
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -19,10 +19,18 @@ A scoping issue is only complete when it produces a clear implementation path. I
 
 - execution work should land through a PR, not a direct push to `main`
 - PRs should link the issue they implement with real issue references
+- a slice is not promotion-ready just because the PR is generally green; reviewers must check the specific promotion evidence listed in [runtime.md](./runtime.md) when worker, image, auth, or runtime surfaces move
 - if review uncovers more work than the current issue covers, open a follow-up issue instead of hiding it in comments
 - if a PR is superseded, preserve any still-actionable review findings in the replacement PR or a linked issue
 - if a PR reaches 5+ comments or attracts Codex/Aardvark findings, add one short feedback-disposition note on the linked issue before merge: resolved here, carried by PR #..., or followed up in issue #...
 - use `bun run report:dead-end-issues -- --limit 200` during cleanup passes to find closed issues that still have no issue, PR, or commit relationship signals on GitHub
+
+## Promotion Rule
+
+- treat `main` promotion as a kernel-evidence gate, not a generic "CI looks green" judgment
+- the required pre-merge evidence source is the `Pull Request CI` workflow on the exact PR head that will merge
+- when a slice touches worker execution, image packaging, auth handoff, or runtime validation, reviewers should read the named smoke and boundary steps listed in [runtime.md](./runtime.md) instead of inferring health from unrelated UI, build, or typecheck steps
+- post-merge publish workflows may add release evidence such as image digests, but they do not replace the pre-merge PR smoke gate
 
 ## Status rule
 

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -254,6 +254,16 @@ These names may appear in examples as commented placeholders, but they are not p
 
 ## Operator workflow summary
 
+- before treating a PR as promotion-ready for `main`, read the successful `Pull Request CI / ci` run on the exact merge head and confirm the named smoke evidence in [runtime.md](runtime.md):
+  - image smoke: `Build Problem 9 execution image smoke target`, `Verify Problem 9 execution image smoke target`, `Build Problem 9 devbox image smoke target`, and `Verify Problem 9 devbox image smoke target`
+  - worker smoke: `Run deterministic Problem 9 verifier smoke` and `Run deterministic Problem 9 local-stub attempt smoke`
+  - coupled auth/runtime gates when those surfaces changed: `Check runtime env examples`, `Check trusted-local auth boundaries`, `Test API auth handoff routes`, and `Test web auth relay functions`
+- do not sign off main-branch promotion from generic success signals alone such as typecheck, build, or unrelated frontend checks when the slice changes worker or runtime kernel paths
+- sample promotion path:
+  - review the PR and wait for `Pull Request CI / ci` on the final head
+  - confirm the named smoke evidence above for the touched surfaces
+  - merge to `main`
+  - if the merge triggers image publication, attach the `problem9-image-digests` or `problem9-devbox-image-digest` artifact from the publish workflow to the release packet as the post-merge digest record
 - use `apps/web/.env.example` only for local browser overrides
 - use `apps/api/.env.example` for local API startup and owner-only API operations
 - use `apps/worker/.env.example` for local worker modes that actually need environment variables

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -24,3 +24,32 @@ This repo uses a small number of runtime rules.
 - Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer.
 - Hosted runs must use machine auth only.
 - Offline ingest is a control-plane import path, not a worker-bootstrap-token flow.
+
+## Main-Branch Promotion Gate
+
+Use the PR's `Pull Request CI / ci` run as the pre-merge promotion gate for worker, image, auth, and runtime slices.
+
+Required kernel evidence comes from these named steps:
+
+- image-build smoke:
+  - `Build Problem 9 execution image smoke target`
+  - `Verify Problem 9 execution image smoke target`
+  - `Build Problem 9 devbox image smoke target`
+  - `Verify Problem 9 devbox image smoke target`
+- worker and verifier smoke:
+  - `Run deterministic Problem 9 verifier smoke`
+  - `Run deterministic Problem 9 local-stub attempt smoke`
+- directly coupled auth or runtime gates:
+  - `Check runtime env examples`
+  - `Check trusted-local auth boundaries`
+  - `Test API auth handoff routes`
+  - `Test web auth relay functions`
+
+`Typecheck workspace`, `Build workspace`, and unrelated UI checks still matter, but they do not substitute for the named kernel-proof steps above when deciding whether a slice is ready to promote through `main`.
+
+After merge, treat the main-branch publish workflows as release evidence only:
+
+- `Publish Problem 9 Execution and Worker Images` records the pushed image digests in the `problem9-image-digests` artifact and step summary
+- `Publish Problem 9 Devbox Image` records the pushed image digest in the `problem9-devbox-image-digest` artifact and step summary
+
+Those post-merge artifacts are what a release packet should cite for published-image identity. They do not waive the requirement that the PR already proved the corresponding smoke evidence before merge.

--- a/infra/scripts/check-main-branch-promotion-gate.mjs
+++ b/infra/scripts/check-main-branch-promotion-gate.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..", "..");
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`Main-branch promotion gate check failed: ${message}`);
+  process.exit(1);
+}
+
+const runtimeDocPath = "docs/runtime.md";
+const checklistDocPath = "docs/runtime-env-mode-checklists.md";
+const projectManagementDocPath = "docs/project-management.md";
+const prCiWorkflowPath = ".github/workflows/pull-request-ci.yml";
+const publishWorkerWorkflowPath = ".github/workflows/publish-worker-image.yml";
+const publishDevboxWorkflowPath = ".github/workflows/publish-problem9-devbox-image.yml";
+const packageJsonPath = "package.json";
+
+const runtimeDoc = readText(runtimeDocPath);
+const checklistDoc = readText(checklistDocPath);
+const projectManagementDoc = readText(projectManagementDocPath);
+const prCiWorkflow = readText(prCiWorkflowPath);
+const publishWorkerWorkflow = readText(publishWorkerWorkflowPath);
+const publishDevboxWorkflow = readText(publishDevboxWorkflowPath);
+const packageJson = JSON.parse(readText(packageJsonPath));
+
+const requiredPrCiSteps = [
+  "Build Problem 9 execution image smoke target",
+  "Verify Problem 9 execution image smoke target",
+  "Build Problem 9 devbox image smoke target",
+  "Verify Problem 9 devbox image smoke target",
+  "Run deterministic Problem 9 verifier smoke",
+  "Run deterministic Problem 9 local-stub attempt smoke",
+  "Check runtime env examples",
+  "Check trusted-local auth boundaries",
+  "Test API auth handoff routes",
+  "Test web auth relay functions"
+];
+
+for (const stepName of requiredPrCiSteps) {
+  if (!prCiWorkflow.includes(stepName)) {
+    fail(`${prCiWorkflowPath} is missing required PR CI step "${stepName}"`);
+  }
+
+  if (!runtimeDoc.includes(stepName)) {
+    fail(`${runtimeDocPath} is missing required promotion-evidence step "${stepName}"`);
+  }
+
+  if (!checklistDoc.includes(stepName)) {
+    fail(`${checklistDocPath} is missing required promotion-evidence step "${stepName}"`);
+  }
+}
+
+const requiredRuntimeDocSnippets = [
+  "Pull Request CI / ci",
+  "do not substitute for the named kernel-proof steps",
+  "problem9-image-digests",
+  "problem9-devbox-image-digest"
+];
+
+for (const snippet of requiredRuntimeDocSnippets) {
+  if (!runtimeDoc.includes(snippet)) {
+    fail(`${runtimeDocPath} is missing required snippet "${snippet}"`);
+  }
+}
+
+const requiredChecklistSnippets = [
+  "sample promotion path",
+  "do not sign off main-branch promotion from generic success signals alone",
+  "problem9-image-digests",
+  "problem9-devbox-image-digest"
+];
+
+for (const snippet of requiredChecklistSnippets) {
+  if (!checklistDoc.includes(snippet)) {
+    fail(`${checklistDocPath} is missing required snippet "${snippet}"`);
+  }
+}
+
+const requiredProjectManagementSnippets = [
+  "a slice is not promotion-ready just because the PR is generally green",
+  "the required pre-merge evidence source is the `Pull Request CI` workflow",
+  "they do not replace the pre-merge PR smoke gate"
+];
+
+for (const snippet of requiredProjectManagementSnippets) {
+  if (!projectManagementDoc.includes(snippet)) {
+    fail(`${projectManagementDocPath} is missing required snippet "${snippet}"`);
+  }
+}
+
+if (!publishWorkerWorkflow.includes("problem9-image-digests")) {
+  fail(`${publishWorkerWorkflowPath} must upload the problem9-image-digests artifact`);
+}
+
+if (!publishDevboxWorkflow.includes("problem9-devbox-image-digest")) {
+  fail(`${publishDevboxWorkflowPath} must upload the problem9-devbox-image-digest artifact`);
+}
+
+const packageScript = packageJson.scripts?.["check:main-branch-promotion-gate"];
+if (packageScript !== "node infra/scripts/check-main-branch-promotion-gate.mjs") {
+  fail(`${packageJsonPath} is missing script check:main-branch-promotion-gate`);
+}
+
+console.log("Main-branch promotion gate check passed.");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
+    "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",
     "test:problem9-image-toolchains": "node --test infra/scripts/verify-problem9-image-toolchains.test.mjs",


### PR DESCRIPTION
Closes #796

## Summary
- define a main-branch promotion rule that requires named PR CI smoke evidence for image, worker/verifier, and directly-coupled auth/runtime surfaces
- add an operator checklist and sample promotion path for where that evidence is checked before merge and where post-merge image-digest artifacts belong in the release packet
- add a lightweight repo check that pins the promotion-gate docs to the real PR CI step names and publish-artifact names, then run that check in pull-request CI

## Verification
- `node infra/scripts/check-main-branch-promotion-gate.mjs`
- `node infra/scripts/check-problem9-image-policy.mjs`
- `bun run check:bidi`