### PR TITLE
Add startup validation smoke coverage

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Smoke startup validation across runtime surfaces
+        run: bun run test:startup-validation
+
       - name: Build shared package
         run: bun run build:shared
 

--- a/apps/web/src/lib/api-base-url.ts
+++ b/apps/web/src/lib/api-base-url.ts
@@ -1,11 +1,12 @@
 import { isLocalDevelopmentLocation } from "./local-development";
+import { readWebRuntimeEnv } from "./runtime-env";
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
 }
 
 export function getApiBaseUrl() {
-  const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL;
+  const configuredBaseUrl = readWebRuntimeEnv().apiBaseUrl;
 
   if (configuredBaseUrl) {
     return trimTrailingSlash(configuredBaseUrl);

--- a/apps/web/src/lib/runtime-env.ts
+++ b/apps/web/src/lib/runtime-env.ts
@@ -1,0 +1,52 @@
+function normalizeOptionalEnvValue(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+function trimTrailingSlash(url: string) {
+  return url.replace(/\/+$/, "");
+}
+
+export type WebRuntimeEnv = {
+  apiBaseUrl?: string;
+};
+
+export function parseWebRuntimeEnv(
+  rawEnv: {
+    VITE_API_BASE_URL?: unknown;
+  } = import.meta.env as {
+    VITE_API_BASE_URL?: unknown;
+  }
+): WebRuntimeEnv {
+  const configuredBaseUrl = normalizeOptionalEnvValue(rawEnv.VITE_API_BASE_URL);
+
+  if (!configuredBaseUrl) {
+    return {};
+  }
+
+  let parsedBaseUrl: URL;
+
+  try {
+    parsedBaseUrl = new URL(configuredBaseUrl);
+  } catch {
+    throw new Error("Invalid web runtime environment: VITE_API_BASE_URL: must be a valid URL");
+  }
+
+  if (parsedBaseUrl.protocol !== "http:" && parsedBaseUrl.protocol !== "https:") {
+    throw new Error(
+      "Invalid web runtime environment: VITE_API_BASE_URL: must use http or https"
+    );
+  }
+
+  return {
+    apiBaseUrl: trimTrailingSlash(parsedBaseUrl.toString())
+  };
+}
+
+export function readWebRuntimeEnv() {
+  return parseWebRuntimeEnv(import.meta.env as { VITE_API_BASE_URL?: unknown });
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { readWebRuntimeEnv } from "./lib/runtime-env";
 import "./styles/app.css";
+
+readWebRuntimeEnv();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -111,6 +111,11 @@ type WorkerClaimLoopResolvedDependencies = {
   sleep: WorkerSleep;
 };
 
+const startupValidationOnlyEnabled = (() => {
+  const rawValue = process.env.PARETOPROOF_STARTUP_VALIDATION_ONLY?.trim().toLowerCase();
+  return rawValue === "1" || rawValue === "true";
+})();
+
 export type RunWorkerClaimLoopResult = {
   claimedJobs: number;
   completedJobs: number;
@@ -161,6 +166,15 @@ export async function runWorkerClaimLoop(
     authMode: options.authMode,
     commandFamily: "worker_claim_loop"
   }, dependencies.rawEnv);
+
+  if (startupValidationOnlyEnabled) {
+    return {
+      claimedJobs: 0,
+      completedJobs: 0,
+      idlePollCount: 0,
+      stoppedReason: "idle_once"
+    };
+  }
 
   let claimedJobs = 0;
   let completedJobs = 0;

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -12,6 +12,7 @@ If a mode is not listed here, do not infer support from a placeholder variable n
 - hosted secrets stay in the platform that runs the process, not in checked-in `.env` files
 - empty strings are treated as missing values by the runtime validators
 - required CLI flags such as `--access-jwt` are part of the operational checklist even when they are not environment variables
+- `bun run test:startup-validation` is the required smoke suite for startup env validation across the documented web, API, worker, and local Docker paths; update it when any checklist item changes
 
 ## Web modes
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -6,6 +6,7 @@ This repo uses a small number of runtime rules.
 
 - `apps/api/.env.example`, `apps/web/.env.example`, and `apps/worker/.env.example` are the local examples.
 - [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) is the operator-facing per-mode checklist for the supported local, hosted, and owner-only runtime paths.
+- `bun run test:startup-validation` is the executable smoke owner for startup env validation across the currently supported runtime surfaces.
 - Keep browser env separate from Pages function secrets and worker machine credentials.
 - Do not store short-lived access assertions, human session data, or local auth caches in committed env files.
 - Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.

--- a/infra/scripts/startup-validation-smoke.ts
+++ b/infra/scripts/startup-validation-smoke.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { parseApiRuntimeEnv } from "../../apps/api/src/config/runtime.ts";
+import { parseWebRuntimeEnv } from "../../apps/web/src/lib/runtime-env.ts";
+import { parseWorkerRuntimeEnv } from "../../apps/worker/src/lib/runtime.ts";
+
+const startupSmokeExecutionImage =
+  process.env.PARETOPROOF_STARTUP_SMOKE_EXECUTION_IMAGE ??
+  "paretoproof-problem9-execution:pr-smoke";
+const skipDockerStartupSmoke = (() => {
+  const rawValue = process.env.PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER?.trim().toLowerCase();
+  return rawValue === "1" || rawValue === "true";
+})();
+
+await expectPass("web startup accepts an omitted VITE_API_BASE_URL", () => {
+  assert.deepEqual(parseWebRuntimeEnv({}), {});
+});
+
+await expectFailure(
+  "web startup rejects malformed VITE_API_BASE_URL values",
+  () => parseWebRuntimeEnv({ VITE_API_BASE_URL: "not-a-url" }),
+  /VITE_API_BASE_URL: must be a valid URL/
+);
+
+await expectPass("API startup accepts the documented local runtime contract", () => {
+  assert.equal(
+    parseApiRuntimeEnv({
+      ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+      CF_ACCESS_PORTAL_AUD: "portal-audience",
+      CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+      DATABASE_URL: "postgres://localhost:5432/paretoproof",
+      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+    }).portalAccessAudience,
+    "portal-audience"
+  );
+});
+
+await expectFailure(
+  "API startup rejects missing required worker bootstrap auth",
+  () =>
+    parseApiRuntimeEnv({
+      ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+      CF_ACCESS_PORTAL_AUD: "portal-audience",
+      CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+      DATABASE_URL: "postgres://localhost:5432/paretoproof"
+    }),
+  /WORKER_BOOTSTRAP_TOKEN: is required/
+);
+
+await expectPass("worker local_stub startup keeps hosted env vars optional", async () => {
+  assert.deepEqual(
+    await parseWorkerRuntimeEnv(
+      {
+        authMode: "local_stub",
+        commandFamily: "problem9_attempt"
+      },
+      {}
+    ),
+    {}
+  );
+});
+
+await expectFailure(
+  "worker machine_api_key startup rejects a missing CODEX_API_KEY",
+  () =>
+    parseWorkerRuntimeEnv(
+      {
+        authMode: "machine_api_key",
+        commandFamily: "problem9_attempt"
+      },
+      {}
+    ),
+  /CODEX_API_KEY: is required/
+);
+
+if (skipDockerStartupSmoke) {
+  console.log("SKIP local Docker worker startup smoke because PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER is set.");
+} else {
+  expectCommandPass(
+    "local Docker worker startup accepts the hosted claim-loop runtime contract",
+    [
+      "run",
+      "--rm",
+      "--pull",
+      "never",
+      "--env",
+      "API_BASE_URL=https://api.paretoproof.com",
+      "--env",
+      "WORKER_BOOTSTRAP_TOKEN=worker-bootstrap-token",
+      "--env",
+      "CODEX_API_KEY=worker-api-key",
+      "--env",
+      "PARETOPROOF_STARTUP_VALIDATION_ONLY=1",
+      startupSmokeExecutionImage,
+      "node",
+      "apps/worker/dist/index.js",
+      "run-worker-claim-loop",
+      "--worker-id",
+      "startup-smoke-worker",
+      "--worker-pool",
+      "startup-smoke",
+      "--worker-version",
+      "startup-smoke-v1",
+      "--workspace-root",
+      "/tmp/worker-workspace",
+      "--output-root",
+      "/tmp/worker-output",
+      "--once"
+    ],
+    /"stoppedReason": "idle_once"/
+  );
+
+  expectCommandFailure(
+    "local Docker worker startup rejects a missing WORKER_BOOTSTRAP_TOKEN",
+    [
+      "run",
+      "--rm",
+      "--pull",
+      "never",
+      "--env",
+      "API_BASE_URL=https://api.paretoproof.com",
+      "--env",
+      "CODEX_API_KEY=worker-api-key",
+      "--env",
+      "PARETOPROOF_STARTUP_VALIDATION_ONLY=1",
+      startupSmokeExecutionImage,
+      "node",
+      "apps/worker/dist/index.js",
+      "run-worker-claim-loop",
+      "--worker-id",
+      "startup-smoke-worker",
+      "--worker-pool",
+      "startup-smoke",
+      "--worker-version",
+      "startup-smoke-v1",
+      "--workspace-root",
+      "/tmp/worker-workspace",
+      "--output-root",
+      "/tmp/worker-output",
+      "--once"
+    ],
+    /Validation error: Invalid worker runtime environment: WORKER_BOOTSTRAP_TOKEN: is required/
+  );
+}
+
+console.log(
+  skipDockerStartupSmoke
+    ? "Startup validation smoke coverage passed for web, API, and worker; local Docker was skipped."
+    : "Startup validation smoke coverage passed for web, API, worker, and local Docker."
+);
+
+async function expectPass(name: string, assertion: () => Promise<void> | void) {
+  await assertion();
+  console.log(`PASS ${name}`);
+}
+
+async function expectFailure(
+  name: string,
+  assertion: () => Promise<unknown> | unknown,
+  expectedMessage: RegExp
+) {
+  await assert.rejects(async () => await assertion(), expectedMessage);
+  console.log(`PASS ${name}`);
+}
+
+function expectCommandPass(name: string, commandArgs: string[], stdoutPattern: RegExp) {
+  const result = spawnSync(resolveDockerCommand(), commandArgs, {
+    encoding: "utf8",
+    timeout: 120000,
+    windowsHide: true
+  });
+
+  if (result.error) {
+    throw new Error(`Startup smoke "${name}" failed before completion: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Startup smoke "${name}" failed unexpectedly.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+
+  assert.match(result.stdout, stdoutPattern);
+  console.log(`PASS ${name}`);
+}
+
+function expectCommandFailure(name: string, commandArgs: string[], stderrPattern: RegExp) {
+  const result = spawnSync(resolveDockerCommand(), commandArgs, {
+    encoding: "utf8",
+    timeout: 120000,
+    windowsHide: true
+  });
+
+  if (result.error) {
+    throw new Error(`Startup smoke "${name}" failed before completion: ${result.error.message}`);
+  }
+
+  if (result.status === 0) {
+    throw new Error(`Startup smoke "${name}" unexpectedly passed.\nstdout:\n${result.stdout}`);
+  }
+
+  assert.match(result.stderr, stderrPattern);
+  console.log(`PASS ${name}`);
+}
+
+function resolveDockerCommand() {
+  return process.platform === "win32" ? "docker.exe" : "docker";
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
+    "test:startup-validation": "bun infra/scripts/startup-validation-smoke.ts",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",
     "test:problem9-image-toolchains": "node --test infra/scripts/verify-problem9-image-toolchains.test.mjs",
     "verify:problem9-execution-image": "node infra/scripts/verify-problem9-image-toolchains.mjs --target problem9-execution",


### PR DESCRIPTION
## Summary
- add explicit web runtime env validation and fail-fast startup parsing for malformed VITE_API_BASE_URL
- add a repo-level startup smoke runner that exercises pass/fail env validation across web, API, worker, and the execution image claim-loop entrypoint
- wire the smoke suite into PR CI and the runtime checklist docs as the required enforcement point

## Testing
- bun --cwd apps/web typecheck
- bun --cwd apps/web build
- bun --cwd apps/api typecheck
- bun --cwd apps/worker typecheck
- bun run build:worker
- bun run check:bidi
- $env:PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER='1'; bun run test:startup-validation (local Docker daemon was unresponsive, so the image-backed leg is left to PR CI)

Closes #755