### PR TITLE
Freeze canonical run-control lifecycle enums

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,5 +1,12 @@
 import { relations, sql } from "drizzle-orm";
 import {
+  attemptLifecycleStates,
+  evaluationVerdictClasses,
+  jobLifecycleStates,
+  runKindValues,
+  runLifecycleStates
+} from "@paretoproof/shared";
+import {
   boolean,
   foreignKey,
   index,
@@ -56,46 +63,18 @@ export const auditSeverityEnum = pgEnum("audit_severity", [
   "critical"
 ]);
 
-export const runKindEnum = pgEnum("run_kind", [
-  "full_benchmark",
-  "benchmark_slice",
-  "single_run",
-  "repeated_n"
-]);
+export const runKindEnum = pgEnum("run_kind", runKindValues);
 
-export const runStateEnum = pgEnum("run_state", [
-  "created",
-  "queued",
-  "running",
-  "cancel_requested",
-  "succeeded",
-  "failed",
-  "cancelled"
-]);
+export const runStateEnum = pgEnum("run_state", runLifecycleStates);
 
-export const jobStateEnum = pgEnum("job_state", [
-  "queued",
-  "claimed",
-  "running",
-  "cancel_requested",
-  "completed",
-  "failed",
-  "cancelled"
-]);
+export const jobStateEnum = pgEnum("job_state", jobLifecycleStates);
 
-export const attemptStateEnum = pgEnum("attempt_state", [
-  "prepared",
-  "active",
-  "succeeded",
-  "failed",
-  "cancelled"
-]);
+export const attemptStateEnum = pgEnum("attempt_state", attemptLifecycleStates);
 
-export const evaluationVerdictClassEnum = pgEnum("evaluation_verdict_class", [
-  "pass",
-  "fail",
-  "invalid_result"
-]);
+export const evaluationVerdictClassEnum = pgEnum(
+  "evaluation_verdict_class",
+  evaluationVerdictClasses
+);
 
 export const artifactClassEnum = pgEnum("artifact_class", [
   "run_manifest",

--- a/apps/api/test/run-control-state-parity.test.ts
+++ b/apps/api/test/run-control-state-parity.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  attemptLifecycleCatalog,
+  attemptLifecycleStates,
+  jobLifecycleCatalog,
+  jobLifecycleStates,
+  offlineIngestAttemptLifecycleStates,
+  offlineIngestJobLifecycleStates,
+  offlineIngestRunLifecycleStates,
+  portalRunAttemptSummarySchema,
+  problem9OfflineIngestResponseSchema,
+  runKindCatalog,
+  runKindValues,
+  runLifecycleCatalog,
+  runLifecycleStates,
+  workerResultAttemptLifecycleStates,
+  workerResultJobLifecycleStates,
+  workerResultMessageResponseSchema,
+  workerResultRunLifecycleStates,
+  workerTerminalFailureAttemptLifecycleStates,
+  workerTerminalFailureJobLifecycleStates,
+  workerTerminalFailureResponseSchema,
+  workerTerminalFailureRunLifecycleStates
+} from "@paretoproof/shared";
+import {
+  attemptStateEnum,
+  jobStateEnum,
+  runKindEnum,
+  runStateEnum
+} from "../src/db/schema.ts";
+
+test("shared lifecycle catalogs, response schemas, and API Postgres enums stay in parity", () => {
+  assert.deepEqual(runKindCatalog.map((entry) => entry.id), [...runKindValues]);
+  assert.deepEqual(runLifecycleCatalog.map((entry) => entry.id), [...runLifecycleStates]);
+  assert.deepEqual(jobLifecycleCatalog.map((entry) => entry.id), [...jobLifecycleStates]);
+  assert.deepEqual(attemptLifecycleCatalog.map((entry) => entry.id), [...attemptLifecycleStates]);
+
+  for (const entry of runLifecycleCatalog) {
+    assert.ok(
+      entry.allowedNextStates.every((state) => runLifecycleStates.includes(state)),
+      `run lifecycle drift: ${entry.id}`
+    );
+  }
+
+  for (const entry of jobLifecycleCatalog) {
+    assert.ok(
+      entry.allowedNextStates.every((state) => jobLifecycleStates.includes(state)),
+      `job lifecycle drift: ${entry.id}`
+    );
+  }
+
+  for (const entry of attemptLifecycleCatalog) {
+    assert.ok(
+      entry.allowedNextStates.every((state) => attemptLifecycleStates.includes(state)),
+      `attempt lifecycle drift: ${entry.id}`
+    );
+  }
+
+  assert.deepEqual(runKindEnum.enumValues, [...runKindValues]);
+  assert.deepEqual(runStateEnum.enumValues, [...runLifecycleStates]);
+  assert.deepEqual(jobStateEnum.enumValues, [...jobLifecycleStates]);
+  assert.deepEqual(attemptStateEnum.enumValues, [...attemptLifecycleStates]);
+
+  assert.deepEqual(
+    portalRunAttemptSummarySchema.shape.state.options,
+    [...attemptLifecycleStates]
+  );
+
+  assert.deepEqual(
+    problem9OfflineIngestResponseSchema.shape.attempt.shape.state.options,
+    [...offlineIngestAttemptLifecycleStates]
+  );
+  assert.deepEqual(
+    problem9OfflineIngestResponseSchema.shape.job.shape.state.options,
+    [...offlineIngestJobLifecycleStates]
+  );
+  assert.deepEqual(
+    problem9OfflineIngestResponseSchema.shape.run.shape.state.options,
+    [...offlineIngestRunLifecycleStates]
+  );
+
+  assert.deepEqual(
+    workerResultMessageResponseSchema.shape.attemptState.options,
+    [...workerResultAttemptLifecycleStates]
+  );
+  assert.deepEqual(
+    workerResultMessageResponseSchema.shape.jobState.options,
+    [...workerResultJobLifecycleStates]
+  );
+  assert.deepEqual(
+    workerResultMessageResponseSchema.shape.runState.options,
+    [...workerResultRunLifecycleStates]
+  );
+
+  assert.deepEqual(
+    workerTerminalFailureResponseSchema.shape.attemptState.options,
+    [...workerTerminalFailureAttemptLifecycleStates]
+  );
+  assert.deepEqual(
+    workerTerminalFailureResponseSchema.shape.jobState.options,
+    [...workerTerminalFailureJobLifecycleStates]
+  );
+  assert.deepEqual(
+    workerTerminalFailureResponseSchema.shape.runState.options,
+    [...workerTerminalFailureRunLifecycleStates]
+  );
+});

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -25,6 +25,12 @@ This repo uses a small number of runtime rules.
 - Hosted runs must use machine auth only.
 - Offline ingest is a control-plane import path, not a worker-bootstrap-token flow.
 
+## Lifecycle Vocab
+
+- Canonical run, job, and attempt lifecycle exports live in `@paretoproof/shared` `run-control` exports.
+- Shared response contracts and the API Postgres enums must import those exports instead of re-declaring lifecycle strings locally.
+- `apps/api/test/run-control-state-parity.test.ts` is the drift gate for catalogs, shared schemas, and API DB enum parity.
+
 ## Main-Branch Promotion Gate
 
 Use the PR's `Pull Request CI / ci` run as the pre-merge promotion gate for worker, image, auth, and runtime slices.

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  attemptLifecycleStateSchema,
   evaluationVerdictClassSchema,
   jobLifecycleStateSchema,
   runKindSchema,
@@ -177,7 +178,7 @@ export const portalRunAttemptSummarySchema = z.object({
   jobId: z.string().nullable(),
   runId: z.string(),
   startedAt: timestampSchema,
-  state: z.enum(["prepared", "active", "succeeded", "failed", "cancelled"]),
+  state: attemptLifecycleStateSchema,
   stopReason: z.string(),
   verdictClass: evaluationVerdictClassSchema,
   verifierResult: z.string()

--- a/packages/shared/src/schemas/problem9-offline-ingest.ts
+++ b/packages/shared/src/schemas/problem9-offline-ingest.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import {
+  offlineIngestAttemptLifecycleStateSchema,
+  offlineIngestJobLifecycleStateSchema,
+  offlineIngestRunLifecycleStateSchema
+} from "./run-control.js";
+import {
   workerArtifactManifestEntrySchema,
   workerFailureClassificationSchema,
   workerFailureCodeSchema
@@ -220,17 +225,17 @@ export const problem9OfflineIngestResponseSchema = z.object({
   attempt: z.object({
     id: z.string().min(1),
     sourceAttemptId: z.string().min(1),
-    state: z.enum(["succeeded", "failed"]),
+    state: offlineIngestAttemptLifecycleStateSchema,
     verdictClass: z.enum(["pass", "fail"])
   }),
   job: z.object({
     id: z.string().min(1),
     sourceJobId: z.string().min(1).nullable(),
-    state: z.enum(["completed", "failed"])
+    state: offlineIngestJobLifecycleStateSchema
   }),
   run: z.object({
     id: z.string().min(1),
     sourceRunId: z.string().min(1),
-    state: z.enum(["succeeded", "failed"])
+    state: offlineIngestRunLifecycleStateSchema
   })
 });

--- a/packages/shared/src/schemas/run-control.ts
+++ b/packages/shared/src/schemas/run-control.ts
@@ -1,45 +1,66 @@
 import { z } from "zod";
+import {
+  attemptLifecycleStates,
+  evaluationVerdictClasses,
+  jobLifecycleStates,
+  offlineIngestAttemptLifecycleStates,
+  offlineIngestJobLifecycleStates,
+  offlineIngestRunLifecycleStates,
+  runKindValues,
+  runLifecycleStates,
+  workerResultAttemptLifecycleStates,
+  workerResultJobLifecycleStates,
+  workerResultRunLifecycleStates,
+  workerTerminalFailureAttemptLifecycleStates,
+  workerTerminalFailureJobLifecycleStates,
+  workerTerminalFailureRunLifecycleStates
+} from "../types/run-control.js";
 
-export const runKindSchema = z.enum([
-  "full_benchmark",
-  "benchmark_slice",
-  "single_run",
-  "repeated_n"
-]);
+export const runKindSchema = z.enum(runKindValues);
 
-export const runLifecycleStateSchema = z.enum([
-  "created",
-  "queued",
-  "running",
-  "cancel_requested",
-  "succeeded",
-  "failed",
-  "cancelled"
-]);
+export const runLifecycleStateSchema = z.enum(runLifecycleStates);
 
-export const jobLifecycleStateSchema = z.enum([
-  "queued",
-  "claimed",
-  "running",
-  "cancel_requested",
-  "completed",
-  "failed",
-  "cancelled"
-]);
+export const jobLifecycleStateSchema = z.enum(jobLifecycleStates);
 
-export const attemptLifecycleStateSchema = z.enum([
-  "prepared",
-  "active",
-  "succeeded",
-  "failed",
-  "cancelled"
-]);
+export const attemptLifecycleStateSchema = z.enum(attemptLifecycleStates);
 
-export const evaluationVerdictClassSchema = z.enum([
-  "pass",
-  "fail",
-  "invalid_result"
-]);
+export const evaluationVerdictClassSchema = z.enum(evaluationVerdictClasses);
+
+export const offlineIngestRunLifecycleStateSchema = z.enum(
+  offlineIngestRunLifecycleStates
+);
+
+export const offlineIngestJobLifecycleStateSchema = z.enum(
+  offlineIngestJobLifecycleStates
+);
+
+export const offlineIngestAttemptLifecycleStateSchema = z.enum(
+  offlineIngestAttemptLifecycleStates
+);
+
+export const workerResultRunLifecycleStateSchema = z.enum(
+  workerResultRunLifecycleStates
+);
+
+export const workerResultJobLifecycleStateSchema = z.enum(
+  workerResultJobLifecycleStates
+);
+
+export const workerResultAttemptLifecycleStateSchema = z.enum(
+  workerResultAttemptLifecycleStates
+);
+
+export const workerTerminalFailureRunLifecycleStateSchema = z.enum(
+  workerTerminalFailureRunLifecycleStates
+);
+
+export const workerTerminalFailureJobLifecycleStateSchema = z.enum(
+  workerTerminalFailureJobLifecycleStates
+);
+
+export const workerTerminalFailureAttemptLifecycleStateSchema = z.enum(
+  workerTerminalFailureAttemptLifecycleStates
+);
 
 export const runKindCatalogEntrySchema = z.object({
   description: z.string(),

--- a/packages/shared/src/schemas/worker-control.ts
+++ b/packages/shared/src/schemas/worker-control.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
-import { runKindSchema } from "./run-control.js";
+import {
+  runKindSchema,
+  workerResultAttemptLifecycleStateSchema,
+  workerResultJobLifecycleStateSchema,
+  workerResultRunLifecycleStateSchema,
+  workerTerminalFailureAttemptLifecycleStateSchema,
+  workerTerminalFailureJobLifecycleStateSchema,
+  workerTerminalFailureRunLifecycleStateSchema
+} from "./run-control.js";
 
 const timestampSchema = z.string().min(1);
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
@@ -347,9 +355,9 @@ export const workerResultMessageRequestSchema = z.object({
 
 export const workerResultMessageResponseSchema = z.object({
   acceptedAt: timestampSchema,
-  attemptState: z.literal("succeeded"),
-  jobState: z.literal("completed"),
-  runState: z.literal("succeeded")
+  attemptState: workerResultAttemptLifecycleStateSchema,
+  jobState: workerResultJobLifecycleStateSchema,
+  runState: workerResultRunLifecycleStateSchema
 });
 
 export const workerTerminalFailureRequestSchema = z.object({
@@ -364,16 +372,16 @@ export const workerTerminalFailureRequestSchema = z.object({
   leaseId: z.string().min(1),
   runId: z.string().min(1),
   summary: z.string().min(1),
-  terminalState: z.enum(["failed", "cancelled"]),
+  terminalState: workerTerminalFailureAttemptLifecycleStateSchema,
   verifierVerdict: workerVerifierVerdictSchema.nullable(),
   verdictDigest: sha256Schema.nullable()
 });
 
 export const workerTerminalFailureResponseSchema = z.object({
   acceptedAt: timestampSchema,
-  attemptState: z.enum(["failed", "cancelled"]),
-  jobState: z.enum(["failed", "cancelled"]),
-  runState: z.enum(["failed", "cancelled"])
+  attemptState: workerTerminalFailureAttemptLifecycleStateSchema,
+  jobState: workerTerminalFailureJobLifecycleStateSchema,
+  runState: workerTerminalFailureRunLifecycleStateSchema
 });
 
 export const workerExecutionEventCatalogEntrySchema = z.object({

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -1,4 +1,5 @@
 import type {
+  AttemptLifecycleState,
   EvaluationVerdictClass,
   JobLifecycleState,
   RunKind,
@@ -156,7 +157,7 @@ export type PortalRunAttemptSummary = {
   jobId: string | null;
   runId: string;
   startedAt: string;
-  state: "prepared" | "active" | "succeeded" | "failed" | "cancelled";
+  state: AttemptLifecycleState;
   stopReason: string;
   verdictClass: EvaluationVerdictClass;
   verifierResult: string;

--- a/packages/shared/src/types/problem9-offline-ingest.ts
+++ b/packages/shared/src/types/problem9-offline-ingest.ts
@@ -1,3 +1,9 @@
+import type {
+  OfflineIngestAttemptLifecycleState,
+  OfflineIngestJobLifecycleState,
+  OfflineIngestRunLifecycleState
+} from "./run-control.js";
+
 export type Problem9OfflineIngestRequest = {
   ingestRequestSchemaVersion: "1";
   bundle: Problem9OfflineIngestBundle;
@@ -23,18 +29,18 @@ export type Problem9OfflineIngestResponse = {
   attempt: {
     id: string;
     sourceAttemptId: string;
-    state: "succeeded" | "failed";
+    state: OfflineIngestAttemptLifecycleState;
     verdictClass: "pass" | "fail";
   };
   job: {
     id: string;
     sourceJobId: string | null;
-    state: "completed" | "failed";
+    state: OfflineIngestJobLifecycleState;
   };
   run: {
     id: string;
     sourceRunId: string;
-    state: "succeeded" | "failed";
+    state: OfflineIngestRunLifecycleState;
   };
 };
 

--- a/packages/shared/src/types/run-control.ts
+++ b/packages/shared/src/types/run-control.ts
@@ -1,35 +1,122 @@
-export type RunKind =
-  | "full_benchmark"
-  | "benchmark_slice"
-  | "single_run"
-  | "repeated_n";
+export const runKindValues = [
+  "full_benchmark",
+  "benchmark_slice",
+  "single_run",
+  "repeated_n"
+] as const;
 
-export type RunLifecycleState =
-  | "created"
-  | "queued"
-  | "running"
-  | "cancel_requested"
-  | "succeeded"
-  | "failed"
-  | "cancelled";
+export type RunKind = (typeof runKindValues)[number];
 
-export type JobLifecycleState =
-  | "queued"
-  | "claimed"
-  | "running"
-  | "cancel_requested"
-  | "completed"
-  | "failed"
-  | "cancelled";
+export const runLifecycleStates = [
+  "created",
+  "queued",
+  "running",
+  "cancel_requested",
+  "succeeded",
+  "failed",
+  "cancelled"
+] as const;
 
-export type AttemptLifecycleState =
-  | "prepared"
-  | "active"
-  | "succeeded"
-  | "failed"
-  | "cancelled";
+export type RunLifecycleState = (typeof runLifecycleStates)[number];
 
-export type EvaluationVerdictClass = "pass" | "fail" | "invalid_result";
+export const jobLifecycleStates = [
+  "queued",
+  "claimed",
+  "running",
+  "cancel_requested",
+  "completed",
+  "failed",
+  "cancelled"
+] as const;
+
+export type JobLifecycleState = (typeof jobLifecycleStates)[number];
+
+export const attemptLifecycleStates = [
+  "prepared",
+  "active",
+  "succeeded",
+  "failed",
+  "cancelled"
+] as const;
+
+export type AttemptLifecycleState = (typeof attemptLifecycleStates)[number];
+
+export const evaluationVerdictClasses = [
+  "pass",
+  "fail",
+  "invalid_result"
+] as const;
+
+export type EvaluationVerdictClass = (typeof evaluationVerdictClasses)[number];
+
+export const offlineIngestRunLifecycleStates = [
+  "succeeded",
+  "failed"
+] as const satisfies readonly RunLifecycleState[];
+
+export type OfflineIngestRunLifecycleState =
+  (typeof offlineIngestRunLifecycleStates)[number];
+
+export const offlineIngestJobLifecycleStates = [
+  "completed",
+  "failed"
+] as const satisfies readonly JobLifecycleState[];
+
+export type OfflineIngestJobLifecycleState =
+  (typeof offlineIngestJobLifecycleStates)[number];
+
+export const offlineIngestAttemptLifecycleStates = [
+  "succeeded",
+  "failed"
+] as const satisfies readonly AttemptLifecycleState[];
+
+export type OfflineIngestAttemptLifecycleState =
+  (typeof offlineIngestAttemptLifecycleStates)[number];
+
+export const workerResultRunLifecycleStates = [
+  "succeeded"
+] as const satisfies readonly RunLifecycleState[];
+
+export type WorkerResultRunLifecycleState =
+  (typeof workerResultRunLifecycleStates)[number];
+
+export const workerResultJobLifecycleStates = [
+  "completed"
+] as const satisfies readonly JobLifecycleState[];
+
+export type WorkerResultJobLifecycleState =
+  (typeof workerResultJobLifecycleStates)[number];
+
+export const workerResultAttemptLifecycleStates = [
+  "succeeded"
+] as const satisfies readonly AttemptLifecycleState[];
+
+export type WorkerResultAttemptLifecycleState =
+  (typeof workerResultAttemptLifecycleStates)[number];
+
+export const workerTerminalFailureRunLifecycleStates = [
+  "failed",
+  "cancelled"
+] as const satisfies readonly RunLifecycleState[];
+
+export type WorkerTerminalFailureRunLifecycleState =
+  (typeof workerTerminalFailureRunLifecycleStates)[number];
+
+export const workerTerminalFailureJobLifecycleStates = [
+  "failed",
+  "cancelled"
+] as const satisfies readonly JobLifecycleState[];
+
+export type WorkerTerminalFailureJobLifecycleState =
+  (typeof workerTerminalFailureJobLifecycleStates)[number];
+
+export const workerTerminalFailureAttemptLifecycleStates = [
+  "failed",
+  "cancelled"
+] as const satisfies readonly AttemptLifecycleState[];
+
+export type WorkerTerminalFailureAttemptLifecycleState =
+  (typeof workerTerminalFailureAttemptLifecycleStates)[number];
 
 export type RunKindCatalogEntry = {
   description: string;

--- a/packages/shared/src/types/worker-control.ts
+++ b/packages/shared/src/types/worker-control.ts
@@ -1,4 +1,12 @@
-import type { RunKind } from "./run-control.js";
+import type {
+  RunKind,
+  WorkerResultAttemptLifecycleState,
+  WorkerResultJobLifecycleState,
+  WorkerResultRunLifecycleState,
+  WorkerTerminalFailureAttemptLifecycleState,
+  WorkerTerminalFailureJobLifecycleState,
+  WorkerTerminalFailureRunLifecycleState
+} from "./run-control.js";
 
 export type WorkerControlEndpointId =
   | "internal.worker.claim"
@@ -317,9 +325,9 @@ export type WorkerResultMessageRequest = {
 
 export type WorkerResultMessageResponse = {
   acceptedAt: string;
-  attemptState: "succeeded";
-  jobState: "completed";
-  runState: "succeeded";
+  attemptState: WorkerResultAttemptLifecycleState;
+  jobState: WorkerResultJobLifecycleState;
+  runState: WorkerResultRunLifecycleState;
 };
 
 export type WorkerTerminalFailureRequest = {
@@ -334,16 +342,16 @@ export type WorkerTerminalFailureRequest = {
   leaseId: string;
   runId: string;
   summary: string;
-  terminalState: "failed" | "cancelled";
+  terminalState: WorkerTerminalFailureAttemptLifecycleState;
   verifierVerdict: WorkerVerifierVerdict | null;
   verdictDigest: string | null;
 };
 
 export type WorkerTerminalFailureResponse = {
   acceptedAt: string;
-  attemptState: "failed" | "cancelled";
-  jobState: "failed" | "cancelled";
-  runState: "failed" | "cancelled";
+  attemptState: WorkerTerminalFailureAttemptLifecycleState;
+  jobState: WorkerTerminalFailureJobLifecycleState;
+  runState: WorkerTerminalFailureRunLifecycleState;
 };
 
 export type WorkerExecutionEventCatalogEntry = {


### PR DESCRIPTION
## Summary
- export canonical run, job, and attempt lifecycle enum values from shared run-control and reuse them across shared schemas/types and API Postgres enums
- replace duplicated portal, worker, and offline-ingest lifecycle subsets with shared run-control exports
- add API parity coverage and implementer docs so lifecycle drift across catalogs, shared contracts, and DB enums fails fast

## Testing
- bun --cwd packages/shared build
- bun --cwd packages/shared typecheck
- bun --cwd apps/api typecheck
- bun --cwd apps/api test --test-name-pattern "shared lifecycle catalogs, response schemas, and API Postgres enums stay in parity|maps canonical passing bundles to terminal imported states|preserves failure metadata for canonical failing bundles|POST /internal/worker/jobs/:jobId/result accepts terminal success payloads|POST /internal/worker/jobs/:jobId/failure accepts terminal failure payloads"
- bun run check:bidi

Closes #757
