### PR TITLE
Validate trusted-local auth mounts and reject hosted reuse

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -103,6 +103,7 @@ Trusted-local devbox wrapper:
 - use `node infra/scripts/run-problem9-trusted-local-attempt.mjs --benchmark-package-root <directory> --prompt-package-root <directory> --workspace <directory> --output <directory> --provider-model <model> [--model-snapshot-id <id>] [--print-docker-command]` to launch the worker attempt through the canonical local Docker/devbox wrapper
 - the repo-owned launcher defaults to `--image paretoproof-problem9-devbox:local`; pass `--image <docker-image>` only when you intentionally need a different local devbox tag
 - the wrapper resolves host `CODEX_HOME`, verifies the host `auth.json`, runs host `codex login status`, mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`, sets in-container `CODEX_HOME=/run/paretoproof/codex-home`, runs in-container `codex login status`, and only then starts `run-problem9-attempt`
+- the wrapper also sets `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json`; inside the devbox, trusted-local runs now reject malformed `auth.json`, a non-canonical `CODEX_HOME`, or any mount shape other than the single-file read-only `auth.json` contract
 - the wrapper does not mount the full host Codex home and does not silently fall back from `trusted_local_user` to `machine_api_key`
 - do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above
 - benchmark-package and prompt-package inputs are mounted read-only; workspace and output parents are mounted writable so the inner runner can safely clear and recreate the selected subdirectories
@@ -128,6 +129,7 @@ Hosted claim loop:
   - `API_BASE_URL`
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY` when `--auth-mode machine_api_key`
+- hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home/auth.json` path instead of silently attempting to reuse contributor auth material
 - the hosted loop only accepts `single_run` claims with machine auth, materializes the canonical benchmark and prompt packages from repo-owned sources, reuses the same `runProblem9Attempt` inner runner as local single-run execution, and submits heartbeats, execution events, artifact manifests, and terminal success or failure objects through the internal API
 - use `--max-jobs <n>` to bound a longer poller run, `--provider-model <model>` to override the provider model derived from `modelConfigId`, and `--worker-runtime` to choose the runtime label sent in claim requests
 - if the API reports `cancel_requested` or `expired` on a heartbeat before terminal submission, the loop exits that claim explicitly without sending a stale terminal finalize

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -5,10 +5,14 @@ import {
   parseWorkerRuntimeEnv
 } from "./runtime.js";
 import {
-  preflightProblem9AuthMode,
+  preflightProblem9AuthMode
+} from "./problem9-auth.js";
+import {
+  trustedLocalAuthMountMarkerEnvName,
+  trustedLocalAuthMountMarkerValue,
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
-} from "./problem9-auth.js";
+} from "./trusted-local-auth-contract.js";
 
 const benchmarkPackageContainerRoot = "/workdir/input/benchmark-package";
 const promptPackageContainerRoot = "/workdir/input/prompt-package";
@@ -194,6 +198,8 @@ export function buildTrustedLocalDevboxDockerArgs(
     "/app",
     "--env",
     `CODEX_HOME=${trustedLocalCodexContainerHome}`,
+    "--env",
+    `${trustedLocalAuthMountMarkerEnvName}=${trustedLocalAuthMountMarkerValue}`,
     "--mount",
     buildBindMountArg(
       options.authJsonPath,
@@ -286,6 +292,7 @@ function buildContainerShellCommands(options: {
   const commands = [
     "set -eu",
     `test "$CODEX_HOME" = ${shellQuote(trustedLocalCodexContainerHome)}`,
+    `test "$${trustedLocalAuthMountMarkerEnvName}" = ${shellQuote(trustedLocalAuthMountMarkerValue)}`,
     `test -r ${shellQuote(trustedLocalCodexContainerAuthJsonPath)}`,
     "codex login status"
   ];

--- a/apps/worker/src/lib/problem9-auth.ts
+++ b/apps/worker/src/lib/problem9-auth.ts
@@ -2,9 +2,10 @@ import { spawn } from "node:child_process";
 import {
   parseWorkerRuntimeEnv
 } from "./runtime.js";
-
-export const trustedLocalCodexContainerHome = "/run/paretoproof/codex-home";
-export const trustedLocalCodexContainerAuthJsonPath = `${trustedLocalCodexContainerHome}/auth.json`;
+import {
+  trustedLocalCodexContainerAuthJsonPath,
+  trustedLocalCodexContainerHome
+} from "./trusted-local-auth-contract.js";
 
 export const problem9AuthModes = [
   "trusted_local_user",

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -1,8 +1,14 @@
-import { access, constants } from "node:fs/promises";
+import { access, constants, readFile, readdir, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
 import type { Problem9AuthMode } from "./problem9-auth.js";
+import {
+  trustedLocalAuthMountMarkerEnvName,
+  trustedLocalAuthMountMarkerValue,
+  trustedLocalCodexContainerAuthJsonPath,
+  trustedLocalCodexContainerHome
+} from "./trusted-local-auth-contract.js";
 
 function normalizeOptionalEnvValue(value: unknown) {
   if (typeof value !== "string") {
@@ -25,6 +31,7 @@ const workerRawRuntimeEnvSchema = z.object({
   CODEX_API_KEY: trimmedOptionalStringSchema,
   CODEX_HOME: trimmedOptionalStringSchema,
   HOME: trimmedOptionalStringSchema,
+  [trustedLocalAuthMountMarkerEnvName]: trimmedOptionalStringSchema,
   R2_ACCESS_KEY_ID: trimmedOptionalStringSchema,
   R2_SECRET_ACCESS_KEY: trimmedOptionalStringSchema,
   USERPROFILE: trimmedOptionalStringSchema,
@@ -127,6 +134,123 @@ function resolveCodexHome(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
   return path.join(rawEnv.HOME ?? os.homedir(), ".codex");
 }
 
+function getTrustedLocalAuthMountMarker(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
+  return rawEnv[trustedLocalAuthMountMarkerEnvName];
+}
+
+function hasTrustedLocalContainerMount(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>
+) {
+  return (
+    getTrustedLocalAuthMountMarker(rawEnv) !== undefined ||
+    rawEnv.CODEX_HOME === trustedLocalCodexContainerHome
+  );
+}
+
+function rejectTrustedLocalContainerMount(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>,
+  commandFamily: WorkerRuntimeMode["commandFamily"]
+) {
+  if (!hasTrustedLocalContainerMount(rawEnv)) {
+    return;
+  }
+
+  throw new Error(
+    [
+      `Invalid worker runtime environment: ${trustedLocalAuthMountMarkerEnvName}: trusted-local auth mounts are not allowed for ${commandFamily}.`,
+      `Use machine auth for ${commandFamily}; only trusted_local_user and trusted_local_devbox may use ${trustedLocalCodexContainerAuthJsonPath}.`
+    ].join(" ")
+  );
+}
+
+async function validateTrustedLocalAuthJson(authJsonPath: string) {
+  const authJsonStats = await stat(authJsonPath).catch(() => null);
+
+  if (!authJsonStats?.isFile()) {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires a readable Codex auth.json.",
+        `Expected file at ${authJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  let parsedAuthJson: unknown;
+
+  try {
+    parsedAuthJson = JSON.parse(await readFile(authJsonPath, "utf8"));
+  } catch {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires auth.json to contain valid JSON.",
+        `Checked file at ${authJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  if (
+    typeof parsedAuthJson !== "object" ||
+    parsedAuthJson === null ||
+    Array.isArray(parsedAuthJson)
+  ) {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires auth.json to contain a JSON object.",
+        `Checked file at ${authJsonPath}.`
+      ].join(" ")
+    );
+  }
+}
+
+async function validateTrustedLocalContainerMount(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>,
+  trustedLocalCodexHome: string,
+  trustedLocalAuthJsonPath: string
+) {
+  const mountMarker = getTrustedLocalAuthMountMarker(rawEnv);
+
+  if (mountMarker === undefined && rawEnv.CODEX_HOME !== trustedLocalCodexContainerHome) {
+    return;
+  }
+
+  if (mountMarker !== trustedLocalAuthMountMarkerValue) {
+    throw new Error(
+      [
+        `Invalid worker runtime environment: ${trustedLocalAuthMountMarkerEnvName}: expected ${trustedLocalAuthMountMarkerValue}.`,
+        "Trusted-local devbox runs must use the repo-owned read-only auth.json mount contract."
+      ].join(" ")
+    );
+  }
+
+  if (rawEnv.CODEX_HOME !== trustedLocalCodexContainerHome) {
+    throw new Error(
+      [
+        `Invalid worker runtime environment: CODEX_HOME: expected ${trustedLocalCodexContainerHome}.`,
+        "Trusted-local devbox runs must mount auth.json at the canonical in-container path."
+      ].join(" ")
+    );
+  }
+
+  if (trustedLocalAuthJsonPath !== trustedLocalCodexContainerAuthJsonPath) {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires the canonical in-container auth.json path.",
+        `Expected file at ${trustedLocalCodexContainerAuthJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  const codexHomeEntries = await readdir(trustedLocalCodexHome);
+  if (codexHomeEntries.length !== 1 || codexHomeEntries[0] !== "auth.json") {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires a single-file auth.json mount.",
+        `Expected ${trustedLocalCodexHome} to contain only auth.json.`
+      ].join(" ")
+    );
+  }
+}
+
 async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
   const trustedLocalCodexHome = resolveCodexHome(rawEnv);
   const trustedLocalAuthJsonPath = path.join(trustedLocalCodexHome, "auth.json");
@@ -141,6 +265,13 @@ async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEn
       ].join(" ")
     );
   }
+
+  await validateTrustedLocalAuthJson(trustedLocalAuthJsonPath);
+  await validateTrustedLocalContainerMount(
+    rawEnv,
+    trustedLocalCodexHome,
+    trustedLocalAuthJsonPath
+  );
 
   return {
     trustedLocalAuthJsonPath,
@@ -162,16 +293,20 @@ export async function parseWorkerRuntimeEnv(
 
   switch (mode.commandFamily) {
     case "materializer":
+      rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
       return {};
     case "problem9_attempt":
       switch (mode.authMode) {
         case "local_stub":
+          rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
           return {};
         case "machine_api_key":
+          rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
           return {
             codexApiKey: resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY)
           };
         case "machine_oauth":
+          rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
           return {};
         case "trusted_local_user":
           return resolveTrustedLocalEnv(parsed.data);
@@ -179,6 +314,7 @@ export async function parseWorkerRuntimeEnv(
     case "trusted_local_devbox":
       return resolveTrustedLocalEnv(parsed.data);
     case "worker_claim_loop":
+      rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
       assertRequiredFields([
         ["API_BASE_URL", parsed.data.API_BASE_URL],
         ["WORKER_BOOTSTRAP_TOKEN", parsed.data.WORKER_BOOTSTRAP_TOKEN],
@@ -199,6 +335,7 @@ export async function parseWorkerRuntimeEnv(
         )
       };
     case "offline_ingest_cli":
+      rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
       return {
         apiBaseUrl: resolveRequiredField("API_BASE_URL", parsed.data.API_BASE_URL)
       };

--- a/apps/worker/src/lib/trusted-local-auth-contract.ts
+++ b/apps/worker/src/lib/trusted-local-auth-contract.ts
@@ -1,0 +1,4 @@
+export const trustedLocalCodexContainerHome = "/run/paretoproof/codex-home";
+export const trustedLocalCodexContainerAuthJsonPath = `${trustedLocalCodexContainerHome}/auth.json`;
+export const trustedLocalAuthMountMarkerEnvName = "PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT";
+export const trustedLocalAuthMountMarkerValue = "readonly_auth_json";

--- a/apps/worker/test/problem9-attempt-devbox-cli.test.ts
+++ b/apps/worker/test/problem9-attempt-devbox-cli.test.ts
@@ -4,9 +4,11 @@ import {
   buildTrustedLocalDevboxDockerArgs
 } from "../src/lib/problem9-attempt-devbox-cli.ts";
 import {
+  trustedLocalAuthMountMarkerEnvName,
+  trustedLocalAuthMountMarkerValue,
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
-} from "../src/lib/problem9-auth.ts";
+} from "../src/lib/trusted-local-auth-contract.ts";
 
 test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Codex home", () => {
   const authJsonPath = "/host/.codex/auth.json";
@@ -28,6 +30,11 @@ test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Code
   );
 
   assert.ok(dockerArgs.includes(`CODEX_HOME=${trustedLocalCodexContainerHome}`));
+  assert.ok(
+    dockerArgs.includes(
+      `${trustedLocalAuthMountMarkerEnvName}=${trustedLocalAuthMountMarkerValue}`
+    )
+  );
   assert.ok(
     mountArgs.includes(
       `type=bind,src=${authJsonPath},dst=${trustedLocalCodexContainerAuthJsonPath},readonly`
@@ -59,5 +66,14 @@ test("buildTrustedLocalDevboxDockerArgs keeps preflight-only runs free of writab
   );
 
   assert.equal(mountArgs.length, 1);
+  assert.ok(
+    dockerArgs.includes(
+      `${trustedLocalAuthMountMarkerEnvName}=${trustedLocalAuthMountMarkerValue}`
+    )
+  );
+  assert.match(
+    dockerArgs[dockerArgs.length - 1] ?? "",
+    new RegExp(`\\$${trustedLocalAuthMountMarkerEnvName}`)
+  );
   assert.match(dockerArgs[dockerArgs.length - 1] ?? "", /codex login status/);
 });

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { parseWorkerRuntimeEnv } from "../src/lib/runtime.ts";
+import {
+  trustedLocalAuthMountMarkerEnvName,
+  trustedLocalAuthMountMarkerValue
+} from "../src/lib/trusted-local-auth-contract.ts";
 
 test("parseWorkerRuntimeEnv keeps materializer mode env-free", async () => {
   const runtimeEnv = await parseWorkerRuntimeEnv(
@@ -87,6 +91,27 @@ test("parseWorkerRuntimeEnv requires readable trusted-local auth for trusted_loc
   assert.equal(runtimeEnv.trustedLocalAuthJsonPath, path.join(codexHome, "auth.json"));
 });
 
+test("parseWorkerRuntimeEnv rejects malformed trusted-local auth json", async () => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-runtime-malformed-"));
+
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(path.join(codexHome, "auth.json"), "{not-json", "utf8");
+
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "trusted_local_user",
+          commandFamily: "problem9_attempt"
+        },
+        {
+          CODEX_HOME: codexHome
+        }
+      ),
+    /trusted_local_user requires auth\.json to contain valid JSON/
+  );
+});
+
 test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop machine auth", async () => {
   await assert.rejects(
     () =>
@@ -119,6 +144,25 @@ test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop mac
     codexApiKey: "worker-api-key",
     workerBootstrapToken: "bootstrap-token"
   });
+});
+
+test("parseWorkerRuntimeEnv rejects trusted-local mount markers for hosted claim loops", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "machine_api_key",
+          commandFamily: "worker_claim_loop"
+        },
+        {
+          API_BASE_URL: "https://api.paretoproof.com",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token",
+          [trustedLocalAuthMountMarkerEnvName]: trustedLocalAuthMountMarkerValue
+        }
+      ),
+    /trusted-local auth mounts are not allowed for worker_claim_loop/
+  );
 });
 
 test("parseWorkerRuntimeEnv requires API base URL for offline ingest", async () => {

--- a/apps/worker/test/worker-cli-contract.test.ts
+++ b/apps/worker/test/worker-cli-contract.test.ts
@@ -59,6 +59,45 @@ test("worker entrypoint exits 2 for unknown commands and prints usage", () => {
   assert.equal(result.stdout, "");
 });
 
+test("worker entrypoint exits 2 when hosted claim-loop env includes trusted-local mount markers", () => {
+  const result = spawnSync(
+    bunCommand,
+    [
+      workerEntryPoint,
+      "run-worker-claim-loop",
+      "--worker-id",
+      "worker-contract-test",
+      "--worker-pool",
+      "modal-dev",
+      "--worker-version",
+      "worker-smoke-1",
+      "--workspace-root",
+      path.join(os.tmpdir(), "worker-workspace"),
+      "--output-root",
+      path.join(os.tmpdir(), "worker-output"),
+      "--once"
+    ],
+    {
+      cwd: workerRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        API_BASE_URL: "https://api.paretoproof.com",
+        CODEX_API_KEY: "worker-api-key",
+        PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: "readonly_auth_json",
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+      }
+    }
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(
+    result.stderr,
+    /^Validation error: Invalid worker runtime environment: PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: trusted-local auth mounts are not allowed for worker_claim_loop\./u
+  );
+  assert.equal(result.stdout, "");
+});
+
 test(
   "worker entrypoint exits 3 and preserves machine-readable offline-ingest remote rejections",
   { timeout: 120000 },

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -186,6 +186,7 @@ Use this mode for `run-problem9-attempt --auth-mode trusted_local_user`.
 - Notes:
   - on Windows, the default inferred path is `%USERPROFILE%\\.codex\\auth.json`
   - on non-Windows hosts, the default inferred path is `$HOME/.codex/auth.json`
+  - malformed `auth.json` content is treated as a setup failure, not a runtime fallback
   - this is a trusted-local path only; do not reuse it for hosted worker modes
 
 ### Trusted-local devbox wrapper
@@ -206,6 +207,7 @@ Use this mode for:
 - Secret env: none
 - Notes:
   - this wrapper mounts the auth file into the container read-only
+  - the wrapper also sets `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json` and expects `CODEX_HOME=/run/paretoproof/codex-home` inside the devbox
   - do not move trusted-local auth into `apps/worker/.env`
 
 ### Offline ingest CLI
@@ -242,6 +244,7 @@ Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key 
   - `CODEX_API_KEY`
 - Notes:
   - this is the fully documented hosted worker path in the repository today
+  - hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT` or point `CODEX_HOME` at `/run/paretoproof/codex-home`
   - the command also accepts `--auth-mode machine_oauth`, but this checklist does not treat that as a complete hosted-provider workflow until a follow-up issue documents and exercises it end to end
 
 ## Reserved later-scope variables

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -23,7 +23,9 @@ This repo uses a small number of runtime rules.
 
 - Local trusted runs may use host-mounted auth material where explicitly supported.
 - Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer.
+- The trusted-local devbox path uses the single-file mount contract `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json` plus `CODEX_HOME=/run/paretoproof/codex-home`; malformed auth JSON or any other mount shape must fail closed.
 - Hosted runs must use machine auth only.
+- Hosted or packaged worker modes must reject the trusted-local mount contract instead of silently reusing mounted contributor auth material.
 - Offline ingest is a control-plane import path, not a worker-bootstrap-token flow.
 
 ## Main-Branch Promotion Gate

--- a/infra/scripts/check-trusted-local-boundaries.mjs
+++ b/infra/scripts/check-trusted-local-boundaries.mjs
@@ -7,15 +7,20 @@ const requiredGitignoreSnippets = [".codex/"];
 const requiredDockerignoreSnippets = [".codex", ".codex/**"];
 const requiredRuntimeDocSnippets = [
   "Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.",
-  "Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer."
+  "Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer.",
+  "PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json",
+  "Hosted or packaged worker modes must reject the trusted-local mount contract instead of silently reusing mounted contributor auth material."
 ];
 const requiredWorkerReadmeSnippets = [
   "mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`",
-  "do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above"
+  "PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json",
+  "do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above",
+  "hosted and packaged modes reject the trusted-local mount marker"
 ];
 const requiredChecklistSnippets = [
   "do not move trusted-local auth into `apps/worker/.env`",
-  "this wrapper mounts the auth file into the container read-only"
+  "this wrapper mounts the auth file into the container read-only",
+  "hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT`"
 ];
 const forbiddenDockerfileSnippets = [
   "COPY . .",


### PR DESCRIPTION
## Summary
- add an explicit trusted-local auth mount contract for the devbox path, including a canonical marker env and stricter auth.json validation
- reject trusted-local mount signals in hosted/non-trusted worker modes instead of silently ignoring them
- document and test the mount-shape contract across worker runtime, CLI, and boundary checks

## Testing
- bun run build:shared
- bun --cwd apps/worker typecheck
- bun --cwd apps/worker test
- bun run check:trusted-local-boundary
- bun run check:bidi

Closes #763