### PR TITLE
test(web): add route ownership regression checks

### DIFF
--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -83,4 +83,54 @@ describe("resolvePortalRouteRedirect", () => {
       })
     ).toBeNull();
   });
+
+  it("keeps unauthenticated users on the portal surface for non-public portal routes", () => {
+    setWindowUrl("http://localhost/profile?surface=portal");
+
+    const redirect = new URL(
+      resolvePortalRouteRedirect({
+        pathname: "/profile",
+        roles: [],
+        search: "?surface=portal",
+        status: "unauthenticated"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/");
+    expect(redirect.searchParams.get("surface")).toBe("portal");
+  });
+
+  it("sends unauthenticated users to the public apex only for portal routes that explicitly allow it", () => {
+    setWindowUrl("http://localhost/?surface=portal");
+
+    expect(
+      resolvePortalRouteRedirect({
+        pathname: "/",
+        roles: [],
+        search: "?surface=portal",
+        status: "unauthenticated"
+      })
+    ).toBe("http://localhost/");
+  });
+
+  it("sends approved helpers without collaborator access to the denied surface for collaborator routes", () => {
+    setWindowUrl(
+      "http://localhost/launch?surface=portal&access=approved&roles=helper&email=lin@paretoproof.local"
+    );
+
+    const redirect = new URL(
+      resolvePortalRouteRedirect({
+        pathname: "/launch",
+        roles: ["helper"],
+        search: "?surface=portal&access=approved&roles=helper&email=lin@paretoproof.local",
+        status: "approved"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/denied");
+    expect(redirect.searchParams.get("surface")).toBe("portal");
+    expect(redirect.searchParams.get("reason")).toBe("insufficient_role");
+  });
 });

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -1,7 +1,6 @@
 import {
-  appRouteAccessMatrix,
   type AppRouteMatrixEntry,
-  type RouteRedirectTarget
+  findAppRouteBySurface
 } from "@paretoproof/shared";
 import { buildPublicUrl, copyLocalPortalState, isLocalHostname } from "./surface";
 
@@ -20,31 +19,8 @@ type PortalRouteAccessContext = {
   status: PortalAccessStatus;
 };
 
-function matchesRoutePath(routePath: string, pathname: string) {
-  if (routePath === pathname) {
-    return true;
-  }
-
-  const routeSegments = routePath.split("/").filter(Boolean);
-  const pathSegments = pathname.split("/").filter(Boolean);
-
-  if (routeSegments.length !== pathSegments.length) {
-    return false;
-  }
-
-  return routeSegments.every((segment, index) => {
-    if (segment.startsWith(":")) {
-      return pathSegments[index].length > 0;
-    }
-
-    return segment === pathSegments[index];
-  });
-}
-
 function findPortalRoute(pathname: string) {
-  return appRouteAccessMatrix.find(
-    (entry) => entry.surface === "portal" && matchesRoutePath(entry.path, pathname)
-  );
+  return findAppRouteBySurface("portal", pathname);
 }
 
 function hasRole(roles: string[], role: "admin" | "collaborator" | "helper") {

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { buildAccessFinalizeUrl, buildPortalUrl } from "./surface.ts";
+import {
+  buildAccessFinalizeUrl,
+  buildAuthUrl,
+  buildPortalUrl,
+  buildPublicUrl,
+  readPortalRedirectTarget,
+  resolveWebSurface
+} from "./surface.ts";
 
 const originalWindow = globalThis.window;
 
@@ -77,5 +84,64 @@ describe("buildPortalUrl", () => {
     expect(buildAccessFinalizeUrl("/profile")).toBe(
       "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile"
     );
+  });
+});
+
+describe("surface ownership helpers", () => {
+  it("classifies apex, auth, provider auth, portal, and local surfaces", () => {
+    setWindowUrl("http://localhost/");
+
+    expect(resolveWebSurface("paretoproof.com")).toBe("public");
+    expect(resolveWebSurface("auth.paretoproof.com")).toBe("auth");
+    expect(resolveWebSurface("github.auth.paretoproof.com")).toBe("auth");
+    expect(resolveWebSurface("portal.paretoproof.com")).toBe("portal");
+    expect(resolveWebSurface("localhost")).toBe("public");
+  });
+
+  it("allows only public-site owned routes when building public URLs", () => {
+    setWindowUrl("https://paretoproof.com/");
+
+    expect(buildPublicUrl("/project")).toBe("https://paretoproof.com/project");
+    expect(buildPublicUrl("/reports/problem-9-v1?view=table#scores")).toBe(
+      "https://paretoproof.com/reports/problem-9-v1?view=table#scores"
+    );
+    expect(buildPublicUrl("/profile")).toBe("https://paretoproof.com/");
+  });
+
+  it("preserves only portal-owned redirect targets for auth URLs", () => {
+    setWindowUrl("https://paretoproof.com/");
+
+    expect(buildAuthUrl("/runs/run-123?tab=events#trace")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace"
+    );
+    expect(buildAuthUrl("/benchmarks")).toBe("https://auth.paretoproof.com/");
+  });
+
+  it("preserves only portal-owned redirect targets for finalize URLs", () => {
+    setWindowUrl("https://github.auth.paretoproof.com/");
+
+    expect(buildAccessFinalizeUrl("/admin/users?tab=review")).toBe(
+      "https://github.auth.paretoproof.com/api/access/finalize?redirect=%2Fadmin%2Fusers%3Ftab%3Dreview"
+    );
+    expect(buildAccessFinalizeUrl("/project")).toBe(
+      "https://github.auth.paretoproof.com/api/access/finalize"
+    );
+  });
+
+  it("rejects public-site and external redirect targets when reading auth redirect state", () => {
+    expect(readPortalRedirectTarget("?redirect=%2Fprofile%3Ftab%3Ddetails")).toBe(
+      "/profile?tab=details"
+    );
+    expect(readPortalRedirectTarget("?redirect=%2Fbenchmarks")).toBe("/");
+    expect(readPortalRedirectTarget("?redirect=https%3A%2F%2Fparetoproof.com%2Fprofile")).toBe(
+      "/"
+    );
+  });
+
+  it("rejects public-site targets when building portal URLs", () => {
+    setWindowUrl("https://portal.paretoproof.com/");
+
+    expect(buildPortalUrl("/workers")).toBe("https://portal.paretoproof.com/workers");
+    expect(buildPortalUrl("/project")).toBe("https://portal.paretoproof.com/");
   });
 });

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -1,3 +1,4 @@
+import { findAppRouteBySurface } from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
 import { isLocalDevelopmentLocation } from "./local-development";
 
@@ -62,18 +63,18 @@ function normalizeTargetPath(targetPath: string) {
   return targetPath.startsWith("/") ? targetPath : `/${targetPath}`;
 }
 
-function sanitizePortalTargetPath(targetPath: string) {
+function sanitizeSurfaceTargetPath(
+  surface: "public_site" | "portal",
+  targetPath: string
+) {
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetPath) || targetPath.startsWith("//")) {
     return "/";
   }
 
   try {
-    const candidateUrl = new URL(
-      normalizeTargetPath(targetPath),
-      productionPortalOrigin
-    );
+    const candidateUrl = new URL(normalizeTargetPath(targetPath), productionPortalOrigin);
 
-    if (candidateUrl.origin !== productionPortalOrigin) {
+    if (!findAppRouteBySurface(surface, candidateUrl.pathname)) {
       return "/";
     }
 
@@ -81,6 +82,14 @@ function sanitizePortalTargetPath(targetPath: string) {
   } catch {
     return "/";
   }
+}
+
+function sanitizePortalTargetPath(targetPath: string) {
+  return sanitizeSurfaceTargetPath("portal", targetPath);
+}
+
+function sanitizePublicTargetPath(targetPath: string) {
+  return sanitizeSurfaceTargetPath("public_site", targetPath);
 }
 
 export function readPortalRedirectTarget(search = window.location.search) {
@@ -189,7 +198,7 @@ export function buildAccessRequestUrl(hostname = window.location.hostname) {
 }
 
 export function buildPublicUrl(targetPath = "/", hostname = window.location.hostname) {
-  const normalizedTargetPath = normalizeTargetPath(targetPath);
+  const normalizedTargetPath = sanitizePublicTargetPath(targetPath);
 
   if (isLocalOrigin(hostname)) {
     return new URL(normalizedTargetPath, window.location.origin).toString();

--- a/packages/shared/src/contracts/route-access.ts
+++ b/packages/shared/src/contracts/route-access.ts
@@ -1,4 +1,5 @@
 import type { AppRouteMatrixEntry } from "../types/route-access.js";
+import type { AppSurface } from "../types/route-access.js";
 
 export const appRouteAccessMatrix = [
   {
@@ -9,6 +10,15 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "public_site",
     summary: "Marketing home and public project overview."
+  },
+  {
+    access: "public",
+    host: "paretoproof.com",
+    id: "public.project",
+    path: "/project",
+    redirectIfDenied: "public_home",
+    surface: "public_site",
+    summary: "Compact project pack for mission, contributor path, and contact rules."
   },
   {
     access: "public",
@@ -128,3 +138,32 @@ export const appRouteAccessMatrix = [
     summary: "Role management and contributor state inspection for admins."
   }
 ] satisfies AppRouteMatrixEntry[];
+
+export function matchesAppRoutePath(routePath: string, pathname: string) {
+  if (routePath === pathname) {
+    return true;
+  }
+
+  const routeSegments = routePath.split("/").filter(Boolean);
+  const pathSegments = pathname.split("/").filter(Boolean);
+
+  if (routeSegments.length !== pathSegments.length) {
+    return false;
+  }
+
+  return routeSegments.every((segment, index) => {
+    if (segment.startsWith(":")) {
+      return pathSegments[index].length > 0;
+    }
+
+    return segment === pathSegments[index];
+  });
+}
+
+export function findAppRouteBySurface(surface: AppSurface, pathname: string) {
+  return (
+    appRouteAccessMatrix.find(
+      (entry) => entry.surface === surface && matchesAppRoutePath(entry.path, pathname)
+    ) ?? null
+  );
+}

--- a/packages/shared/test/route-access.test.js
+++ b/packages/shared/test/route-access.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import {
+  findAppRouteBySurface,
+  matchesAppRoutePath
+} from "../dist/index.js";
+
+describe("route ownership matrix helpers", () => {
+  it("matches exact and parameterized route paths without allowing deeper unmatched paths", () => {
+    expect(matchesAppRoutePath("/project", "/project")).toBe(true);
+    expect(matchesAppRoutePath("/reports/:benchmarkVersionId", "/reports/problem-9-v1")).toBe(
+      true
+    );
+    expect(matchesAppRoutePath("/reports/:benchmarkVersionId", "/reports/problem-9-v1/files")).toBe(
+      false
+    );
+  });
+
+  it("finds only routes owned by the requested surface", () => {
+    expect(findAppRouteBySurface("public_site", "/project")?.id).toBe("public.project");
+    expect(findAppRouteBySurface("public_site", "/reports/problem-9-v1")?.id).toBe(
+      "public.benchmark-report"
+    );
+    expect(findAppRouteBySurface("public_site", "/profile")).toBeNull();
+    expect(findAppRouteBySurface("portal", "/runs/run-123")?.id).toBe(
+      "portal.run-detail"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical shared route-matrix matching helpers and include the apex `/project` route in the public ownership matrix
- make public/auth/portal surface URL helpers reject cross-surface redirect targets instead of only checking origin shape
- add regression coverage for shared route ownership, surface redirect sanitization, and portal unauthenticated/insufficient-role redirects

## Verification
- bun --cwd packages/shared build
- bun --cwd packages/shared typecheck
- bun --cwd apps/web typecheck
- bun test packages/shared/test/route-access.test.js
- bun test apps/web/src/lib/surface.test.js
- bun test apps/web/src/lib/portal-route-access.test.js apps/web/src/routes/portal-bootstrap.test.js
- bun run check:bidi

Closes #754