### PR TITLE
Validate trusted-local auth mount contract

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -91,6 +91,7 @@ Local attempt execution:
 - use `bun --cwd apps/worker run:problem9-attempt -- --benchmark-package-root <directory> --prompt-package-root <directory> --workspace <directory> --output <directory> [--provider-family <family>] [--auth-mode <mode>] [--provider-model <model>] [--model-snapshot-id <id>] [--stub-scenario exact_canonical|compile_failure]` to execute one local Problem 9 attempt and emit the canonical `problem9-run-bundle/`
 - the command copies the immutable benchmark package into a clean writable workspace, writes the candidate as `FirstProof/Problem9/Candidate.lean`, runs the authoritative Lean compile gate, runs theorem and axiom verification, and finalizes through the existing run-bundle materializer instead of inventing a second output shape
 - `trusted_local_user` runs fail fast if the resolved `CODEX_HOME/auth.json` is missing or unreadable or if `codex login status` fails; the command does not silently downgrade to machine auth
+- when `trusted_local_user` runs execute inside a container, the auth file must be mounted at `/run/paretoproof/codex-home/auth.json`; copied or image-baked auth files fail closed before execution
 - `machine_api_key` runs require `CODEX_API_KEY`
 - `local_stub` is the deterministic offline verification path for local dry runs and fixture generation
 - use `bun --cwd apps/worker test:attempt-smoke` or the root alias `bun run test:worker:attempt-smoke` for the deterministic local-stub worker smoke gate; it proves one exact-canonical pass path and one compile-failure path without any interactive auth or paid provider traffic
@@ -104,6 +105,7 @@ Trusted-local devbox wrapper:
 - the repo-owned launcher defaults to `--image paretoproof-problem9-devbox:local`; pass `--image <docker-image>` only when you intentionally need a different local devbox tag
 - the wrapper resolves host `CODEX_HOME`, verifies the host `auth.json`, runs host `codex login status`, mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`, sets in-container `CODEX_HOME=/run/paretoproof/codex-home`, runs in-container `codex login status`, and only then starts `run-problem9-attempt`
 - the wrapper does not mount the full host Codex home and does not silently fall back from `trusted_local_user` to `machine_api_key`
+- the wrapper itself is host-only; starting it from inside a containerized or image-baked worker environment now fails closed instead of trying to re-use unsupported local auth state
 - do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above
 - benchmark-package and prompt-package inputs are mounted read-only; workspace and output parents are mounted writable so the inner runner can safely clear and recreate the selected subdirectories
 - the supplied Docker image must already include the Codex CLI and the worker runtime; if it cannot run `codex login status`, trusted-local preflight fails before any attempt starts

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -5,10 +5,12 @@ import {
   parseWorkerRuntimeEnv
 } from "./runtime.js";
 import {
-  preflightProblem9AuthMode,
+  preflightProblem9AuthMode
+} from "./problem9-auth.js";
+import {
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
-} from "./problem9-auth.js";
+} from "./trusted-local-codex.js";
 
 const benchmarkPackageContainerRoot = "/workdir/input/benchmark-package";
 const promptPackageContainerRoot = "/workdir/input/prompt-package";
@@ -194,6 +196,8 @@ export function buildTrustedLocalDevboxDockerArgs(
     "/app",
     "--env",
     `CODEX_HOME=${trustedLocalCodexContainerHome}`,
+    "--env",
+    "PARETOPROOF_RUNTIME_CONTEXT=container",
     "--mount",
     buildBindMountArg(
       options.authJsonPath,

--- a/apps/worker/src/lib/problem9-auth.ts
+++ b/apps/worker/src/lib/problem9-auth.ts
@@ -2,9 +2,10 @@ import { spawn } from "node:child_process";
 import {
   parseWorkerRuntimeEnv
 } from "./runtime.js";
-
-export const trustedLocalCodexContainerHome = "/run/paretoproof/codex-home";
-export const trustedLocalCodexContainerAuthJsonPath = `${trustedLocalCodexContainerHome}/auth.json`;
+import {
+  trustedLocalCodexContainerAuthJsonPath,
+  trustedLocalCodexContainerHome
+} from "./trusted-local-codex.js";
 
 export const problem9AuthModes = [
   "trusted_local_user",

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -1,8 +1,13 @@
-import { access, constants } from "node:fs/promises";
+import { access, constants, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
 import type { Problem9AuthMode } from "./problem9-auth.js";
+import {
+  linuxMountInfoListsMountPoint,
+  trustedLocalCodexContainerAuthJsonPath,
+  trustedLocalCodexContainerHome
+} from "./trusted-local-codex.js";
 
 function normalizeOptionalEnvValue(value: unknown) {
   if (typeof value !== "string") {
@@ -25,11 +30,19 @@ const workerRawRuntimeEnvSchema = z.object({
   CODEX_API_KEY: trimmedOptionalStringSchema,
   CODEX_HOME: trimmedOptionalStringSchema,
   HOME: trimmedOptionalStringSchema,
+  PARETOPROOF_RUNTIME_CONTEXT: z.enum(["container", "host"]).optional(),
   R2_ACCESS_KEY_ID: trimmedOptionalStringSchema,
   R2_SECRET_ACCESS_KEY: trimmedOptionalStringSchema,
   USERPROFILE: trimmedOptionalStringSchema,
   WORKER_BOOTSTRAP_TOKEN: trimmedOptionalStringSchema
 });
+
+type TrustedLocalRuntimeContext = "container" | "host";
+
+type WorkerRuntimeInspection = {
+  readLinuxMountInfo?: () => Promise<string | null>;
+  runtimeContext?: TrustedLocalRuntimeContext;
+};
 
 export type WorkerRuntimeMode =
   | {
@@ -127,7 +140,14 @@ function resolveCodexHome(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
   return path.join(rawEnv.HOME ?? os.homedir(), ".codex");
 }
 
-async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
+async function resolveTrustedLocalEnv(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>,
+  inspection: WorkerRuntimeInspection
+) {
+  if ((await resolveTrustedLocalRuntimeContext(rawEnv, inspection)) === "container") {
+    return resolveTrustedLocalContainerEnv(rawEnv, inspection);
+  }
+
   const trustedLocalCodexHome = resolveCodexHome(rawEnv);
   const trustedLocalAuthJsonPath = path.join(trustedLocalCodexHome, "auth.json");
 
@@ -148,9 +168,115 @@ async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEn
   } satisfies Pick<WorkerRuntimeEnv, "trustedLocalAuthJsonPath" | "trustedLocalCodexHome">;
 }
 
+async function resolveTrustedLocalContainerEnv(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>,
+  inspection: WorkerRuntimeInspection
+) {
+  const trustedLocalCodexHome = resolveCodexHome(rawEnv);
+
+  if (trustedLocalCodexHome !== trustedLocalCodexContainerHome) {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user inside a container is supported only through the trusted-local devbox auth mount.",
+        `Expected CODEX_HOME=${trustedLocalCodexContainerHome}, received ${trustedLocalCodexHome}.`
+      ].join(" ")
+    );
+  }
+
+  const mountInfo = await (inspection.readLinuxMountInfo?.() ?? readLinuxMountInfo());
+
+  if (
+    mountInfo === null ||
+    !linuxMountInfoListsMountPoint(mountInfo, trustedLocalCodexContainerAuthJsonPath)
+  ) {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user inside a container requires a mounted auth.json, not a baked or copied file.",
+        `Expected a mount entry for ${trustedLocalCodexContainerAuthJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  try {
+    await access(trustedLocalCodexContainerAuthJsonPath, constants.R_OK);
+  } catch {
+    throw new Error(
+      [
+        "Invalid worker runtime environment: trusted_local_user requires a readable Codex auth.json.",
+        `Expected file at ${trustedLocalCodexContainerAuthJsonPath}.`
+      ].join(" ")
+    );
+  }
+
+  return {
+    trustedLocalAuthJsonPath: trustedLocalCodexContainerAuthJsonPath,
+    trustedLocalCodexHome: trustedLocalCodexContainerHome
+  } satisfies Pick<WorkerRuntimeEnv, "trustedLocalAuthJsonPath" | "trustedLocalCodexHome">;
+}
+
+async function resolveTrustedLocalRuntimeContext(
+  rawEnv: z.output<typeof workerRawRuntimeEnvSchema>,
+  inspection: WorkerRuntimeInspection
+): Promise<TrustedLocalRuntimeContext> {
+  if (inspection.runtimeContext) {
+    return inspection.runtimeContext;
+  }
+
+  if (rawEnv.PARETOPROOF_RUNTIME_CONTEXT) {
+    return rawEnv.PARETOPROOF_RUNTIME_CONTEXT;
+  }
+
+  return (await isContainerizedRuntime()) ? "container" : "host";
+}
+
+async function isContainerizedRuntime(): Promise<boolean> {
+  if (process.platform === "win32") {
+    return false;
+  }
+
+  if (
+    typeof process.env.container === "string" ||
+    typeof process.env.KUBERNETES_SERVICE_HOST === "string"
+  ) {
+    return true;
+  }
+
+  for (const markerPath of ["/.dockerenv", "/run/.containerenv"]) {
+    try {
+      await access(markerPath, constants.F_OK);
+      return true;
+    } catch {}
+  }
+
+  for (const cgroupPath of ["/proc/1/cgroup", "/proc/self/cgroup"]) {
+    try {
+      const cgroupText = await readFile(cgroupPath, "utf8");
+
+      if (/(docker|containerd|kubepods|podman|libpod)/iu.test(cgroupText)) {
+        return true;
+      }
+    } catch {}
+  }
+
+  return false;
+}
+
+async function readLinuxMountInfo(): Promise<string | null> {
+  if (process.platform === "win32") {
+    return null;
+  }
+
+  try {
+    return await readFile("/proc/self/mountinfo", "utf8");
+  } catch {
+    return null;
+  }
+}
+
 export async function parseWorkerRuntimeEnv(
   mode: WorkerRuntimeMode,
-  rawEnv: Partial<Record<string, string | undefined>> = process.env
+  rawEnv: Partial<Record<string, string | undefined>> = process.env,
+  inspection: WorkerRuntimeInspection = {}
 ): Promise<WorkerRuntimeEnv> {
   const parsed = workerRawRuntimeEnvSchema.safeParse(rawEnv);
 
@@ -174,10 +300,16 @@ export async function parseWorkerRuntimeEnv(
         case "machine_oauth":
           return {};
         case "trusted_local_user":
-          return resolveTrustedLocalEnv(parsed.data);
+          return resolveTrustedLocalEnv(parsed.data, inspection);
       }
     case "trusted_local_devbox":
-      return resolveTrustedLocalEnv(parsed.data);
+      if ((await resolveTrustedLocalRuntimeContext(parsed.data, inspection)) === "container") {
+        throw new Error(
+          "Invalid worker runtime environment: trusted_local_devbox must start on the host, not from inside a containerized or image-baked worker environment."
+        );
+      }
+
+      return resolveTrustedLocalEnv(parsed.data, inspection);
     case "worker_claim_loop":
       assertRequiredFields([
         ["API_BASE_URL", parsed.data.API_BASE_URL],

--- a/apps/worker/src/lib/trusted-local-codex.ts
+++ b/apps/worker/src/lib/trusted-local-codex.ts
@@ -1,0 +1,34 @@
+export const trustedLocalCodexContainerHome = "/run/paretoproof/codex-home";
+export const trustedLocalCodexContainerAuthJsonPath = `${trustedLocalCodexContainerHome}/auth.json`;
+
+export function linuxMountInfoListsMountPoint(
+  mountInfoText: string,
+  mountPoint: string
+): boolean {
+  return mountInfoText
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .some((line) => {
+      const separatorIndex = line.indexOf(" - ");
+
+      if (separatorIndex === -1) {
+        return false;
+      }
+
+      const leftFields = line.slice(0, separatorIndex).split(" ");
+      const encodedMountPoint = leftFields[4];
+
+      if (!encodedMountPoint) {
+        return false;
+      }
+
+      return decodeLinuxMountInfoField(encodedMountPoint) === mountPoint;
+    });
+}
+
+function decodeLinuxMountInfoField(value: string): string {
+  return value.replace(/\\([0-7]{3})/gu, (_match, octalDigits: string) =>
+    String.fromCharCode(Number.parseInt(octalDigits, 8))
+  );
+}

--- a/apps/worker/test/problem9-attempt-devbox-cli.test.ts
+++ b/apps/worker/test/problem9-attempt-devbox-cli.test.ts
@@ -6,7 +6,7 @@ import {
 import {
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
-} from "../src/lib/problem9-auth.ts";
+} from "../src/lib/trusted-local-codex.ts";
 
 test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Codex home", () => {
   const authJsonPath = "/host/.codex/auth.json";
@@ -28,6 +28,7 @@ test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Code
   );
 
   assert.ok(dockerArgs.includes(`CODEX_HOME=${trustedLocalCodexContainerHome}`));
+  assert.ok(dockerArgs.includes("PARETOPROOF_RUNTIME_CONTEXT=container"));
   assert.ok(
     mountArgs.includes(
       `type=bind,src=${authJsonPath},dst=${trustedLocalCodexContainerAuthJsonPath},readonly`
@@ -59,5 +60,6 @@ test("buildTrustedLocalDevboxDockerArgs keeps preflight-only runs free of writab
   );
 
   assert.equal(mountArgs.length, 1);
+  assert.ok(dockerArgs.includes("PARETOPROOF_RUNTIME_CONTEXT=container"));
   assert.match(dockerArgs[dockerArgs.length - 1] ?? "", /codex login status/);
 });

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -4,6 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { parseWorkerRuntimeEnv } from "../src/lib/runtime.ts";
+import {
+  trustedLocalCodexContainerHome
+} from "../src/lib/trusted-local-codex.ts";
 
 test("parseWorkerRuntimeEnv keeps materializer mode env-free", async () => {
   const runtimeEnv = await parseWorkerRuntimeEnv(
@@ -85,6 +88,64 @@ test("parseWorkerRuntimeEnv requires readable trusted-local auth for trusted_loc
 
   assert.equal(runtimeEnv.trustedLocalCodexHome, codexHome);
   assert.equal(runtimeEnv.trustedLocalAuthJsonPath, path.join(codexHome, "auth.json"));
+});
+
+test("parseWorkerRuntimeEnv rejects containerized trusted_local_user paths outside the devbox mount", async () => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-runtime-container-"));
+  await writeFile(path.join(codexHome, "auth.json"), "{}", "utf8");
+
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "trusted_local_user",
+          commandFamily: "problem9_attempt"
+        },
+        {
+          CODEX_HOME: codexHome,
+          PARETOPROOF_RUNTIME_CONTEXT: "container"
+        }
+      ),
+    new RegExp(
+      `trusted_local_user inside a container is supported only through the trusted-local devbox auth mount\\..*Expected CODEX_HOME=${trustedLocalCodexContainerHome.replace(/\//g, "\\/")}`
+    )
+  );
+});
+
+test("parseWorkerRuntimeEnv rejects containerized trusted_local_user when the expected auth mount is not mounted", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "trusted_local_user",
+          commandFamily: "problem9_attempt"
+        },
+        {
+          CODEX_HOME: trustedLocalCodexContainerHome,
+          PARETOPROOF_RUNTIME_CONTEXT: "container"
+        },
+        {
+          readLinuxMountInfo: async () => "",
+          runtimeContext: "container"
+        }
+      ),
+    /trusted_local_user inside a container requires a mounted auth\.json, not a baked or copied file/
+  );
+});
+
+test("parseWorkerRuntimeEnv rejects trusted_local_devbox startup inside a container context", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          commandFamily: "trusted_local_devbox"
+        },
+        {
+          PARETOPROOF_RUNTIME_CONTEXT: "container"
+        }
+      ),
+    /trusted_local_devbox must start on the host/
+  );
 });
 
 test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop machine auth", async () => {

--- a/apps/worker/test/trusted-local-codex.test.ts
+++ b/apps/worker/test/trusted-local-codex.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  linuxMountInfoListsMountPoint,
+  trustedLocalCodexContainerAuthJsonPath
+} from "../src/lib/trusted-local-codex.ts";
+
+test("linuxMountInfoListsMountPoint matches the trusted-local auth file mount point", () => {
+  const mountInfo = [
+    "185 35 0:68 / / rw,relatime - overlay overlay rw",
+    `212 185 0:71 /host/auth.json ${trustedLocalCodexContainerAuthJsonPath} ro,relatime - ext4 /dev/sda ro`
+  ].join("\n");
+
+  assert.equal(
+    linuxMountInfoListsMountPoint(mountInfo, trustedLocalCodexContainerAuthJsonPath),
+    true
+  );
+});
+
+test("linuxMountInfoListsMountPoint rejects unrelated mount points", () => {
+  const mountInfo = [
+    "185 35 0:68 / / rw,relatime - overlay overlay rw",
+    "212 185 0:71 /host/auth.json /run/paretoproof/other/auth.json ro,relatime - ext4 /dev/sda ro"
+  ].join("\n");
+
+  assert.equal(
+    linuxMountInfoListsMountPoint(mountInfo, trustedLocalCodexContainerAuthJsonPath),
+    false
+  );
+});

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -187,6 +187,7 @@ Use this mode for `run-problem9-attempt --auth-mode trusted_local_user`.
   - on Windows, the default inferred path is `%USERPROFILE%\\.codex\\auth.json`
   - on non-Windows hosts, the default inferred path is `$HOME/.codex/auth.json`
   - this is a trusted-local path only; do not reuse it for hosted worker modes
+  - if you run this mode inside a container, the only supported auth shape is the trusted-local devbox mount at `/run/paretoproof/codex-home/auth.json`; copied or baked auth files are rejected
 
 ### Trusted-local devbox wrapper
 
@@ -207,6 +208,7 @@ Use this mode for:
 - Notes:
   - this wrapper mounts the auth file into the container read-only
   - do not move trusted-local auth into `apps/worker/.env`
+  - do not start this wrapper from inside a container or hosted worker image; the runtime now rejects that unsupported path explicitly
 
 ### Offline ingest CLI
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -23,6 +23,7 @@ This repo uses a small number of runtime rules.
 
 - Local trusted runs may use host-mounted auth material where explicitly supported.
 - Local trusted auth stays host-local and enters the devbox only as a read-only `auth.json` mount, never as a copied repo file or baked image layer.
+- Containerized trusted-local execution is supported only through that canonical devbox mount path; copied or image-baked auth files must fail closed.
 - Hosted runs must use machine auth only.
 - Offline ingest is a control-plane import path, not a worker-bootstrap-token flow.
 


### PR DESCRIPTION
## Summary
- make trusted-local worker auth context-aware so direct host runs keep using host `CODEX_HOME/auth.json`, while containerized runs require the canonical devbox mount path and reject baked/copied auth files
- make the trusted-local devbox wrapper fail closed when launched from inside a containerized or image-baked worker environment
- add worker tests and docs for the trusted-local mount contract and the hosted/image rejection paths

## Testing
- bun --cwd apps/worker typecheck
- bun --cwd apps/worker test
- bun run check:bidi

Closes #763
