### PR TITLE
chore(ci): move deployment workflows to node24

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -40,12 +43,11 @@ jobs:
         run: bun run build:web
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/web
-          command: >-
-            pages deploy dist
-            --project-name=paretoproof-web
-            --branch=main
+        working-directory: apps/web
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          bunx wrangler pages deploy dist
+          --project-name=paretoproof-web
+          --branch=main

--- a/.github/workflows/publish-problem9-devbox-image.yml
+++ b/.github/workflows/publish-problem9-devbox-image.yml
@@ -8,6 +8,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   DEVBOX_IMAGE: ghcr.io/${{ github.repository_owner }}/paretoproof-problem9-devbox
 
 jobs:
@@ -20,13 +21,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -34,7 +35,7 @@ jobs:
 
       - name: Generate devbox image metadata
         id: devbox_metadata
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.DEVBOX_IMAGE }}
           tags: |
@@ -59,7 +60,7 @@ jobs:
 
       - name: Build and publish devbox image
         id: build_devbox
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: apps/worker/Dockerfile
@@ -86,7 +87,7 @@ jobs:
           } | tee problem9-devbox-image-digest.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload image digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: problem9-devbox-image-digest
           path: problem9-devbox-image-digest.md

--- a/.github/workflows/publish-worker-image.yml
+++ b/.github/workflows/publish-worker-image.yml
@@ -19,6 +19,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   EXECUTION_IMAGE: ghcr.io/${{ github.repository_owner }}/paretoproof-problem9-execution
   WORKER_IMAGE: ghcr.io/${{ github.repository_owner }}/paretoproof-worker
 
@@ -32,13 +33,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -46,7 +47,7 @@ jobs:
 
       - name: Generate execution image metadata
         id: execution_metadata
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.EXECUTION_IMAGE }}
           tags: |
@@ -55,7 +56,7 @@ jobs:
 
       - name: Generate worker image metadata
         id: worker_metadata
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ env.WORKER_IMAGE }}
           tags: |
@@ -79,7 +80,7 @@ jobs:
 
       - name: Build and publish Problem 9 execution image
         id: build_execution
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: apps/worker/Dockerfile
@@ -92,7 +93,7 @@ jobs:
 
       - name: Build and publish worker image
         id: build_worker
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: apps/worker/Dockerfile
@@ -127,7 +128,7 @@ jobs:
           } | tee problem9-image-digests.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload image digest artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: problem9-image-digests
           path: problem9-image-digests.md

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check Problem 9 image policy
         run: node infra/scripts/check-problem9-image-policy.mjs
 
+      - name: Check deployment workflow Node runtimes
+        run: node infra/scripts/check-deployment-workflow-node-runtime.mjs
+
       - name: Check main-branch promotion gate docs
         run: node infra/scripts/check-main-branch-promotion-gate.mjs
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,6 +7,7 @@ Current helper scripts:
 - `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts. It does not scan issue bodies, PR bodies, comments, or other GitHub discussion text, so GitHub can still warn on pasted content even when this repo check passes.
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.
 - `infra/scripts/check-problem9-image-policy.mjs`: fails CI when the Problem 9 image manifest, publish workflows, root build scripts, or operator docs drift apart.
+- `infra/scripts/check-deployment-workflow-node-runtime.mjs`: fails CI when deployment workflows drift away from the approved Node 24-compatible action/runtime shape, replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step, and pins the active deployment workflows to Node-24-compatible action revisions.
 - `infra/scripts/verify-problem9-image-toolchains.mjs`: runs toolchain checks against a built `problem9-execution` or `problem9-devbox` image, or against a filesystem export of one, and fails on Lean, Node, Bun, Codex CLI, or `lean-lsp-mcp` drift.
 - `infra/scripts/check-trusted-local-boundaries.mjs`: fails CI when repo ignore rules, worker Docker packaging, or trusted-local docs drift toward persisting Codex auth material in the repository or image build context.
 

--- a/infra/scripts/check-deployment-workflow-node-runtime.mjs
+++ b/infra/scripts/check-deployment-workflow-node-runtime.mjs
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDirectory, "..", "..");
+
+function readText(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fail(message) {
+  console.error(`Deployment workflow Node runtime check failed: ${message}`);
+  process.exit(1);
+}
+
+function assertIncludes(contents, snippets, file) {
+  for (const snippet of snippets) {
+    if (!contents.includes(snippet)) {
+      fail(`${file} is missing required snippet "${snippet}"`);
+    }
+  }
+}
+
+function assertExcludes(contents, snippets, file) {
+  for (const snippet of snippets) {
+    if (contents.includes(snippet)) {
+      fail(`${file} still includes forbidden snippet "${snippet}"`);
+    }
+  }
+}
+
+const deployPagesWorkflowPath = ".github/workflows/deploy-pages.yml";
+const publishWorkerWorkflowPath = ".github/workflows/publish-worker-image.yml";
+const publishDevboxWorkflowPath = ".github/workflows/publish-problem9-devbox-image.yml";
+const pullRequestCiWorkflowPath = ".github/workflows/pull-request-ci.yml";
+const infraReadmePath = "infra/README.md";
+const packageJsonPath = "package.json";
+
+const deployPagesWorkflow = readText(deployPagesWorkflowPath);
+const publishWorkerWorkflow = readText(publishWorkerWorkflowPath);
+const publishDevboxWorkflow = readText(publishDevboxWorkflowPath);
+const pullRequestCiWorkflow = readText(pullRequestCiWorkflowPath);
+const infraReadme = readText(infraReadmePath);
+const packageJson = JSON.parse(readText(packageJsonPath));
+
+assertIncludes(
+  deployPagesWorkflow,
+  [
+    "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+    "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
+    "working-directory: apps/web",
+    "bunx wrangler pages deploy dist",
+    "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+    "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
+  ],
+  deployPagesWorkflowPath
+);
+assertExcludes(
+  deployPagesWorkflow,
+  ["cloudflare/wrangler-action@", "actions/checkout@v4"],
+  deployPagesWorkflowPath
+);
+
+for (const [file, contents] of [
+  [publishWorkerWorkflowPath, publishWorkerWorkflow],
+  [publishDevboxWorkflowPath, publishDevboxWorkflow]
+]) {
+  assertIncludes(
+    contents,
+    [
+      "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+      "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
+      "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0",
+      "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0",
+      "docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0",
+      "docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0",
+      "actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0"
+    ],
+    file
+  );
+}
+
+assertIncludes(
+  pullRequestCiWorkflow,
+  [
+    "Check deployment workflow Node runtimes",
+    "node infra/scripts/check-deployment-workflow-node-runtime.mjs"
+  ],
+  pullRequestCiWorkflowPath
+);
+
+assertIncludes(
+  infraReadme,
+  [
+    "check-deployment-workflow-node-runtime.mjs",
+    "replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step",
+    "pins the active deployment workflows to Node-24-compatible action revisions"
+  ],
+  infraReadmePath
+);
+
+if (
+  packageJson.scripts?.["check:deployment-workflow-node-runtime"] !==
+  "node infra/scripts/check-deployment-workflow-node-runtime.mjs"
+) {
+  fail(`${packageJsonPath} is missing script check:deployment-workflow-node-runtime`);
+}
+
+console.log("Deployment workflows are pinned to the approved Node 24-compatible action/runtime shape.");

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
+    "check:deployment-workflow-node-runtime": "node infra/scripts/check-deployment-workflow-node-runtime.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",


### PR DESCRIPTION
## Summary
- pin the active deployment workflows to Node 24-compatible action revisions and set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- replace `cloudflare/wrangler-action` with a local `bunx wrangler pages deploy` step because the current action release still runs on Node 20
- add a CI-enforced drift check so PRs fail if these workflow/runtime guarantees are removed

## Verification
- `node infra/scripts/check-deployment-workflow-node-runtime.mjs`
- `bun run check:deployment-workflow-node-runtime`
- `bun run check:problem9-image-policy`
- `bun run check:bidi`

## Notes
- `cloudflare/wrangler-action@v3.14.1` still declares `runs.using: node20`, so this PR uses the Wrangler CLI directly instead of keeping a Node 20 blocker in the deploy path.
- Post-merge validation on `main` is still required for issue closure: `Deploy Pages`, `Publish Problem 9 Execution and Worker Images`, and `Publish Problem 9 Devbox Image` should each be rerun and linked back to the issue.

Closes #729
