### PR TITLE
docs(web): remove deferred math hostname assumptions

### DIFF
--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -115,6 +115,9 @@ describe("surface ownership helpers", () => {
       "https://auth.paretoproof.com/?redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace"
     );
     expect(buildAuthUrl("/benchmarks")).toBe("https://auth.paretoproof.com/");
+    expect(buildAuthUrl("https://math.paretoproof.com/runs/problem-9")).toBe(
+      "https://auth.paretoproof.com/"
+    );
   });
 
   it("preserves only portal-owned redirect targets for finalize URLs", () => {
@@ -133,6 +136,11 @@ describe("surface ownership helpers", () => {
       "/profile?tab=details"
     );
     expect(readPortalRedirectTarget("?redirect=%2Fbenchmarks")).toBe("/");
+    expect(
+      readPortalRedirectTarget(
+        "?redirect=https%3A%2F%2Fmath.paretoproof.com%2Fruns%2Fproblem-9"
+      )
+    ).toBe("/");
     expect(readPortalRedirectTarget("?redirect=https%3A%2F%2Fparetoproof.com%2Fprofile")).toBe(
       "/"
     );
@@ -143,5 +151,6 @@ describe("surface ownership helpers", () => {
 
     expect(buildPortalUrl("/workers")).toBe("https://portal.paretoproof.com/workers");
     expect(buildPortalUrl("/project")).toBe("https://portal.paretoproof.com/");
+    expect(buildPortalUrl("/math/problem-9")).toBe("https://portal.paretoproof.com/");
   });
 });

--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -62,7 +62,7 @@ describe("resolvePublicSiteRoute", () => {
   });
 
   it("handles malformed percent-encoding in report routes", async () => {
-    setWindowUrl("http://127.0.0.1/");
+    setWindow("http://127.0.0.1/");
     const { resolvePublicSiteRoute } = await loadPublicSiteModule();
 
     expect(resolvePublicSiteRoute("/reports/%")).toEqual({
@@ -149,9 +149,10 @@ describe("PublicSite", () => {
       "Approved contributors sign in directly. New collaborators use the separate access-request entry"
     );
     expect(html).toContain("Read contributor rules");
-    expect(html).toContain("public-content-pack-baseline.md");
-    expect(html).toContain("public-contact-channel-baseline.md");
-    expect(html).toContain("product-surface-boundary-baseline.md");
+    expect(html).toContain("web-surface-policy.md#contributor-path");
+    expect(html).toContain("web-surface-policy.md#public-pack");
+    expect(html).toContain("web-surface-policy.md#contact-boundary");
+    expect(html).toContain("web-surface-policy.md#surface-ownership");
     expect(html).toContain("Keep unsupported enrollment and support promises off the public site.");
     expect(html).toContain("No open self-serve enrollment or waitlist");
     expect(html).toContain("No public support mailbox or contact form");

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -5,9 +5,6 @@ import { Fragment, useEffect, useState } from "react";
 
 const githubDiscussionsUrl = "https://github.com/Tomodovodoo/ParetoProof/discussions";
 const publicDocsBaseUrl = "https://github.com/Tomodovodoo/ParetoProof/blob/main/docs";
-const publicContentPackDocsUrl = `${publicDocsBaseUrl}/public-content-pack-baseline.md`;
-const publicContactPolicyDocsUrl = `${publicDocsBaseUrl}/public-contact-channel-baseline.md`;
-const productSurfaceBoundaryDocsUrl = `${publicDocsBaseUrl}/product-surface-boundary-baseline.md`;
 
 const projectRoute = "/project";
 const benchmarksRoute = "/benchmarks";
@@ -17,6 +14,12 @@ function buildDocsUrl(path: string) {
   const normalizedPath = path.replace(/^\/+/, "");
   return `${publicDocsBaseUrl}/${normalizedPath}`;
 }
+
+const webSurfacePolicyDocsUrl = buildDocsUrl("web-surface-policy.md");
+const publicContentPackDocsUrl = `${webSurfacePolicyDocsUrl}#public-pack`;
+const publicContactPolicyDocsUrl = `${webSurfacePolicyDocsUrl}#contact-boundary`;
+const productSurfaceBoundaryDocsUrl = `${webSurfacePolicyDocsUrl}#surface-ownership`;
+const contributorPathDocsUrl = `${webSurfacePolicyDocsUrl}#contributor-path`;
 
 const publicBenchmarks = [
   {
@@ -1125,7 +1128,7 @@ function PublicProjectPack() {
           </a>
           <a
             className="button button-secondary"
-            href={publicContentPackDocsUrl}
+            href={contributorPathDocsUrl}
             rel="noreferrer"
             target="_blank"
           >
@@ -1161,7 +1164,7 @@ function PublicProjectPack() {
           </a>
           <a
             className="button button-secondary"
-            href={publicContentPackDocsUrl}
+            href={contributorPathDocsUrl}
             rel="noreferrer"
             target="_blank"
           >

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Use these files:
 
 - [architecture.md](./architecture.md) for the product and system shape
 - [benchmarks.md](./benchmarks.md) for the current benchmark scope
+- [web-surface-policy.md](./web-surface-policy.md) for the approved apex/auth/portal split and contributor path
 - [runtime.md](./runtime.md) for environment, deploy, and worker runtime rules
 - [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) for supported-mode env and operator checklists
 - [project-management.md](./project-management.md) for issue and scope workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,8 @@ ParetoProof has three user-facing web surfaces and one worker/control-plane back
 - `portal.paretoproof.com` is the authenticated contributor and admin workspace.
 - `api.paretoproof.com` is the Fastify control plane for state, authz, ingest, and worker coordination.
 
+There is no separate `math.paretoproof.com` hostname in MVP. Public benchmark reporting stays on the apex site, and deeper operational or execution views stay behind the portal and worker surfaces.
+
 Execution is intentionally split away from the browser.
 
 - `apps/api` owns control-plane state and contracts.

--- a/docs/web-surface-policy.md
+++ b/docs/web-surface-policy.md
@@ -1,0 +1,40 @@
+# Web Surface Policy
+
+ParetoProof ships three user-facing web surfaces in MVP:
+
+- `paretoproof.com` for the public site and released benchmark reporting
+- `auth.paretoproof.com` plus provider-specific auth hosts for approved sign-in and new collaborator identity verification
+- `portal.paretoproof.com` for the authenticated contributor and admin workspace
+
+There is no separate `math.paretoproof.com` hostname in MVP. Public benchmark releases stay on the apex site, and deeper operational views stay in the portal.
+
+## Surface Ownership
+
+- `paretoproof.com` owns the public home page, the compact project pack, and public benchmark release pages.
+- `auth.paretoproof.com` owns the branded sign-in and request-access entry flow.
+- `portal.paretoproof.com` owns contributor profile, access state, admin review, run views, launch, and worker operations.
+
+Redirect helpers, route tests, and public copy should preserve this split and reject cross-surface drift.
+
+## Contributor Path
+
+- Approved contributors start at the sign-in entry on `auth.paretoproof.com`.
+- New collaborators verify identity first and then continue to the dedicated access-request path.
+- Approval stays manual before any contributor work opens inside the portal.
+
+The public site should explain this path without implying self-serve enrollment, hidden sign-in shortcuts, or a separate benchmark hostname.
+
+## Public Pack
+
+The public project route stays compact:
+
+- project overview and mission
+- contributor path and approved sign-in versus request-access guidance
+- public contact boundary
+- links into released benchmark reporting and working docs
+
+Unsupported or deferred asks such as open waitlists, support mailboxes, or extra top-level public trees should stay out of MVP copy.
+
+## Contact Boundary
+
+Public questions route to GitHub Discussions. Account recovery, approvals, and contributor-state resolution belong on the auth or portal surfaces, not in public threads.


### PR DESCRIPTION
## Summary
- replace stale public baseline-doc links with a live `docs/web-surface-policy.md` reference that states the approved apex/auth/portal split and explicitly says there is no MVP `math.paretoproof.com` hostname
- update the docs index and architecture summary so the shipped docs surface matches the current contributor path and surface ownership policy
- extend web surface tests to pin rejection of deferred math-hostname redirects and update the public site route test to assert the new live docs links

## Verification
- bun --cwd apps/web typecheck
- bun test apps/web/src/lib/surface.test.js apps/web/src/routes/public-site.test.js
- bun run check:bidi
- search audit for `public-content-pack-baseline`, `public-contact-channel-baseline`, and `product-surface-boundary-baseline` returned no matches

## Intentional remaining references
- `math.paretoproof.com` now appears only in the explicit "not in MVP" docs note and the redirect rejection tests

Closes #753
