### PR TITLE
docs: refresh worker and project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 ParetoProof is a benchmark platform for reproducible mathematical evaluation. The project combines a public website, branded auth entry, a contributor portal, a Fastify control plane, and worker runtimes that execute benchmark attempts under explicit contracts.
 
-The current repository is centered on one real benchmark kernel: the offline `firstproof/Problem9` slice. Around that, the platform now includes run, job, attempt, artifact, and worker-lease models; internal worker APIs; offline ingest; portal benchmark operations; and the Docker/runtime pieces needed to execute and verify the benchmark flow.
+The current repository is centered on one real benchmark kernel: the offline `firstproof/Problem9` slice. Around that kernel, the repo now carries the concrete run, job, attempt, artifact, worker-lease, offline-ingest, and portal benchmark-ops surfaces needed to execute and review reproducible runs instead of only planning the auth or API shell around them.
 
 The MVP stack is TypeScript across the repo. The web application lives in React with Vite, the API runs on Fastify, data is stored through Drizzle on Neon Postgres, Cloudflare hosts the public and auth surfaces, Railway runs the API, Modal and containerized workers handle execution, Cloudflare R2 stores larger artifacts, and GHCR holds worker images.
+
+## Current Repo Reality
+
+- `apps/web` owns the public site, auth-entry relay, portal bootstrap, and the contributor/admin benchmark operations UI.
+- `apps/api` owns the control-plane API, portal/admin read models, offline-ingest routes, and the internal worker claim/finalize surface.
+- `apps/worker` owns the benchmark package materializers, local trusted and machine-auth attempt paths, offline-ingest CLI, and the hosted claim loop.
+- `packages/shared` owns the canonical schemas, contracts, and lifecycle vocab shared across the API, worker, and frontend.
+
+The current worker and control-plane flow is already concrete enough to run deterministic Problem 9 package, verifier, run-bundle, and startup-validation smoke gates in PR CI. The broader "what becomes the canonical benchmark after the bootstrap Problem 9 slice" decision is still open, so the docs and code should keep describing `firstproof/Problem9` as the current kernel rather than overstating a wider benchmark catalog.
 
 ## Start here
 
@@ -12,6 +21,7 @@ The MVP stack is TypeScript across the repo. The web application lives in React 
 - [docs/architecture.md](docs/architecture.md) for the system shape
 - [docs/benchmarks.md](docs/benchmarks.md) for the benchmark kernel
 - [docs/runtime.md](docs/runtime.md) for runtime and deployment rules
+- [apps/worker/README.md](apps/worker/README.md) for the worker runtime, image, and CLI contract
 
 ## Project boards
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,6 +1,8 @@
 # Worker
 
-`apps/worker` holds the CLI and runtime code for benchmark package materialization, local attempts, offline ingest, and the hosted claim loop.
+`apps/worker` holds the CLI and runtime code for the current benchmark execution kernel. In the repo today that means package and prompt materialization for `firstproof/Problem9`, deterministic verifier and run-bundle assembly, offline ingest, trusted-local local attempts, and the hosted worker claim loop.
+
+The broader benchmark target is still a live scope question, but the worker/image/runtime contract for the current Problem 9 kernel is already concrete and enforced by the repository-owned smoke and boundary checks described below.
 
 Docker targets:
 
@@ -35,6 +37,14 @@ Runtime env guidance:
 - use [`.env.example`](./.env.example) only as the local developer-facing example
 - use `bun run bootstrap:modal:worker-secrets -- --worker-environment dev --apply` to sync the base worker bootstrap token into Modal from a local runtime-only source
 - the checked-in `ingest-problem9-run-bundle` CLI is not a `WORKER_BOOTSTRAP_TOKEN` flow; offline ingest uses an explicit admin-authenticated control-plane handoff
+
+Repository-owned verification commands:
+
+- `bun run test:startup-validation` is the cross-surface startup env smoke owner for web, API, worker, and the local Docker execution-image claim-loop entrypoint
+- `bun run verify:problem9-execution-image` and `bun run verify:problem9-devbox-image` are the publish-critical image verification gates
+- `bun run test:worker:verifier-smoke` and `bun run test:worker:attempt-smoke` are the deterministic verifier and local-stub attempt smoke gates used for PR promotion evidence
+- `bun run check:trusted-local-boundary` is the fail-closed gate for trusted-local auth reuse and host-mount policy
+- the authoritative named PR-CI evidence for worker/image/auth/runtime slices is documented in [docs/runtime.md](../../docs/runtime.md)
 
 CLI contract:
 
@@ -111,26 +121,19 @@ Trusted-local devbox wrapper:
 
 Hosted claim loop:
 
-- use `bun run run:worker-claim-loop -- --worker-id <id> --worker-pool <pool> --worker-version <version> --workspace-root <directory> --output-root <directory>` to claim hosted worker jobs from the internal worker API and run them through the existing Problem 9 attempt runner
-- hosted claim-loop runtime env still comes from `API_BASE_URL`, `WORKER_BOOTSTRAP_TOKEN`, and the selected machine-auth provider credentials such as `CODEX_API_KEY`
-- the loop claims one job at a time, materializes the benchmark and prompt package locally from the claimed identity, heartbeats while the attempt is running, appends explicit lifecycle events, submits the artifact manifest, and then submits either terminal success or terminal failure
-- if a heartbeat returns `cancel_requested` or `expired`, the loop stops terminal submission for that job instead of racing a stale result write against a revoked lease
-
-Hosted claim loop:
-
 - use `bun run run:worker-claim-loop -- --auth-mode machine_api_key --once` to run one hosted claim attempt against the internal worker API
-- required flags for hosted mode:
+- hosted mode also requires:
   - `--worker-id <id>`
   - `--worker-pool <pool>`
   - `--worker-version <version>`
   - `--workspace-root <directory>`
   - `--output-root <directory>`
-- required env for hosted mode:
+- hosted runtime env still comes from:
   - `API_BASE_URL`
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY` when `--auth-mode machine_api_key`
 - hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home/auth.json` path instead of silently attempting to reuse contributor auth material
 - the hosted loop only accepts `single_run` claims with machine auth, materializes the canonical benchmark and prompt packages from repo-owned sources, reuses the same `runProblem9Attempt` inner runner as local single-run execution, and submits heartbeats, execution events, artifact manifests, and terminal success or failure objects through the internal API
+- if a heartbeat returns `cancel_requested` or `expired`, the loop exits that claim without sending a stale terminal finalize
 - use `--max-jobs <n>` to bound a longer poller run, `--provider-model <model>` to override the provider model derived from `modelConfigId`, and `--worker-runtime` to choose the runtime label sent in claim requests
-- if the API reports `cancel_requested` or `expired` on a heartbeat before terminal submission, the loop exits that claim explicitly without sending a stale terminal finalize
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -13,7 +13,14 @@ A scoping issue is only complete when it produces a clear implementation path. I
 
 - `Scoping - ParetoProof` is for scoping issues only
 - `Roadmap - ParetoProof` is for execution work
-- team boards hold the execution backlog by ownership
+- execution issues should also sit on exactly one team board by ownership:
+  - `Frontend - ParetoProof`
+  - `Backend - ParetoProof`
+  - `AI Workers - ParetoProof`
+  - `Infrastructure / Deployment - ParetoProof`
+  - `Admin - ParetoProof`
+- scoping work stays off the roadmap board until it has been decomposed into execution issues
+- backlog issues should stay undated until they are actually scheduled
 
 ## PR rule
 


### PR DESCRIPTION
## Summary
- refresh the top-level README so it describes the current worker, benchmark, portal, and control-plane reality instead of the earlier bootstrap framing
- clean up `apps/worker/README.md` so it reflects the concrete image/runtime contract and removes the duplicated hosted claim-loop section
- align `docs/project-management.md` with the actual team-board ownership and backlog scheduling rules

## Verification
- `Select-String -Path README.md,docs/project-management.md,apps/worker/README.md -Pattern ''handking|sync-project-metadata|exact image contents and Lean toolchain policy remain a separate scope''`
- `bun run check:bidi`

Closes #722