### PR TITLE
refactor(run-control): normalize portal lifecycle wording

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -1,4 +1,7 @@
 import {
+  getAttemptLifecycleStateLabel,
+  getJobLifecycleStateLabel,
+  getRunLifecycleStateLabel,
   defaultRunControlPolicy,
   portalRunsLifecycleBuckets,
   runKindCatalog,
@@ -262,7 +265,7 @@ function buildTimeline(options: {
       state: options.runRow.state
     },
     {
-      label: "Run completed",
+      label: `Run ${getRunLifecycleStateLabel(options.runRow.state).toLowerCase()}`,
       occurredAt: options.runRow.completedAt.toISOString(),
       scope: "run",
       sourceId: options.runRow.sourceRunId,
@@ -279,7 +282,7 @@ function buildTimeline(options: {
       state: jobRow.state
     });
     timeline.push({
-      label: "Job completed",
+      label: `Job ${getJobLifecycleStateLabel(jobRow.state).toLowerCase()}`,
       occurredAt: jobRow.completedAt.toISOString(),
       scope: "job",
       sourceId: jobRow.sourceJobId,
@@ -296,7 +299,7 @@ function buildTimeline(options: {
       state: attemptRow.state
     });
     timeline.push({
-      label: "Attempt completed",
+      label: `Attempt ${getAttemptLifecycleStateLabel(attemptRow.state).toLowerCase()}`,
       occurredAt: attemptRow.completedAt.toISOString(),
       scope: "attempt",
       sourceId: attemptRow.sourceAttemptId,
@@ -318,6 +321,13 @@ function buildTimeline(options: {
     (left, right) => new Date(left.occurredAt).getTime() - new Date(right.occurredAt).getTime()
   );
 }
+
+export const portalBenchmarkOpsReadModelTestUtils = {
+  getRunLifecycleBucket,
+  getRunLifecycleStateLabel,
+  getJobLifecycleStateLabel,
+  getAttemptLifecycleStateLabel
+};
 
 async function loadJobsForRunIds(
   db: ReturnTypeOfCreateDbClient,

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@paretoproof/shared";
 import { portalBenchmarkOpsReadModelsContract } from "@paretoproof/shared";
 import type { PortalBenchmarkOpsReadModelService } from "../src/lib/portal-benchmark-ops.ts";
+import { portalBenchmarkOpsReadModelTestUtils } from "../src/lib/portal-benchmark-ops.ts";
 import { registerPortalRoutes } from "../src/routes/portal.ts";
 
 function createRequireAccessStub(roles: Array<"admin" | "collaborator" | "helper">) {
@@ -500,4 +501,23 @@ test("GET /portal/workers returns the worker posture view for collaborators", as
     response.json()
   );
   assert.equal(payload.queueSummary.queuedJobs, 1);
+});
+
+test("portal benchmark ops normalization helpers keep canonical lifecycle wording aligned", () => {
+  assert.equal(
+    portalBenchmarkOpsReadModelTestUtils.getRunLifecycleStateLabel("succeeded"),
+    "Succeeded"
+  );
+  assert.equal(
+    portalBenchmarkOpsReadModelTestUtils.getJobLifecycleStateLabel("completed"),
+    "Completed"
+  );
+  assert.equal(
+    portalBenchmarkOpsReadModelTestUtils.getAttemptLifecycleStateLabel("succeeded"),
+    "Succeeded"
+  );
+  assert.equal(
+    portalBenchmarkOpsReadModelTestUtils.getRunLifecycleBucket("succeeded"),
+    "terminal_success"
+  );
 });

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildRunsCsv,
   buildRunsModelOptions,
   buildRunsProviderOptions,
   defaultPortalRunsQuery,
@@ -15,6 +16,53 @@ describe("parsePortalRunsQuery", () => {
         "?surface=portal&sort=bogus&lifecycleBucket=not_real&verdict=pass,broken&limit=9999"
       )
     ).toEqual(defaultPortalRunsQuery);
+  });
+});
+
+describe("buildRunsCsv", () => {
+  it("exports canonical run-state and bucket labels instead of stale completed wording", () => {
+    const csv = buildRunsCsv([
+      {
+        authMode: "oidc",
+        benchmarkItemId: "item-1",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:abc",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: "2026-03-13T20:00:00.000Z",
+        durationMs: 120000,
+        failure: { code: null, family: null, summary: null },
+        laneId: "lane-1",
+        latestAttemptId: "attempt-1",
+        latestJobId: "job-1",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-1"],
+          jobCount: 1,
+          jobIds: ["job-1"],
+          latestAttemptId: "attempt-1",
+          latestJobId: "job-1"
+        },
+        modelConfigId: "gpt-oss",
+        modelConfigLabel: "GPT OSS",
+        modelSnapshotId: "gpt-oss-2026-03-13",
+        providerFamily: "openai",
+        runId: "PP-318",
+        runKind: "single_run",
+        runLifecycleBucket: "terminal_success",
+        runMode: "eval",
+        runState: "succeeded",
+        startedAt: "2026-03-13T19:58:00.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: "pass"
+      }
+    ]);
+
+    expect(csv).toContain("runStateLabel");
+    expect(csv).toContain("runLifecycleBucketLabel");
+    expect(csv).toContain("succeeded,Succeeded,terminal_success,Terminal success,pass,Pass");
+    expect(csv).not.toContain("succeeded,Completed");
   });
 });
 

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1,4 +1,7 @@
 import {
+  evaluationVerdictLabels,
+  getPortalRunsLifecycleBucketLabel,
+  getRunLifecycleStateLabel,
   portalLaunchViewResponseSchema,
   portalRunDetailResponseSchema,
   portalRunsLifecycleBuckets,
@@ -21,6 +24,7 @@ import {
   type RunLifecycleState
 } from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
+import { portalResultsExportHeaders } from "./results-state";
 import { isLocalHostname } from "./surface";
 
 const portalRunsSortIds: PortalRunsSortId[] = [
@@ -294,7 +298,7 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
     timeline: [
       ...baseDetail(localRunItems[0]).timeline,
       {
-        label: "Run completed",
+        label: "Run succeeded",
         occurredAt: "2026-03-13T15:38:00.000Z",
         scope: "run",
         sourceId: "PP-318",
@@ -1003,33 +1007,19 @@ export function buildPortalRunsQueryString(query: PortalRunsListQuery) {
 }
 
 export function buildRunsCsv(items: PortalRunListItem[]) {
-  const headers = [
-    "runId",
-    "benchmarkLabel",
-    "modelConfigLabel",
-    "providerFamily",
-    "runKind",
-    "runState",
-    "verdictClass",
-    "latestJobId",
-    "latestAttemptId",
-    "failureFamily",
-    "failureCode",
-    "startedAt",
-    "completedAt",
-    "durationMs"
-  ];
-
   const rows = items.map((item) => [
     item.runId,
-    item.benchmarkLabel,
-    item.modelConfigLabel,
-    item.providerFamily,
-    item.runKind,
-    item.runState,
-    item.verdictClass,
     item.latestJobId ?? "",
     item.latestAttemptId ?? "",
+    item.benchmarkVersionId,
+    item.modelConfigId,
+    item.modelConfigLabel,
+    item.runState,
+    getRunLifecycleStateLabel(item.runState),
+    item.runLifecycleBucket,
+    getPortalRunsLifecycleBucketLabel(item.runLifecycleBucket),
+    item.verdictClass,
+    evaluationVerdictLabels[item.verdictClass],
     item.failure.family ?? "",
     item.failure.code ?? "",
     item.startedAt,
@@ -1037,7 +1027,7 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
     String(item.durationMs)
   ]);
 
-  return [headers, ...rows]
+  return [portalResultsExportHeaders, ...rows]
     .map((row) => row.map((value) => escapeCsvValue(value)).join(","))
     .join("\n");
 }

--- a/apps/web/src/lib/results-state.ts
+++ b/apps/web/src/lib/results-state.ts
@@ -1,18 +1,17 @@
-import type { EvaluationVerdictClass, RunLifecycleState } from "@paretoproof/shared";
+import {
+  evaluationVerdictLabels,
+  portalRunsLifecycleBuckets,
+  portalRunsSortOptions,
+  runLifecycleStateLabels,
+  type EvaluationVerdictClass,
+  type PortalRunsLifecycleBucket,
+  type PortalRunsSortId,
+  type RunLifecycleState
+} from "@paretoproof/shared";
 
-export type PortalResultsLifecycleBucket =
-  | "pending"
-  | "active"
-  | "terminal_success"
-  | "terminal_failure"
-  | "terminal_cancelled";
+export type PortalResultsLifecycleBucket = PortalRunsLifecycleBucket;
 
-export type PortalResultsSortId =
-  | "started_at_desc"
-  | "finished_at_desc"
-  | "duration_desc"
-  | "run_state_asc"
-  | "verdict_asc";
+export type PortalResultsSortId = PortalRunsSortId;
 
 export type PortalResultsQueryState = {
   lifecycleBucket: PortalResultsLifecycleBucket | null;
@@ -21,91 +20,7 @@ export type PortalResultsQueryState = {
   verdict: EvaluationVerdictClass[];
 };
 
-export const runLifecycleStateLabels: Record<RunLifecycleState, string> = {
-  cancel_requested: "Cancelling",
-  cancelled: "Cancelled",
-  created: "Created",
-  failed: "Failed",
-  queued: "Queued",
-  running: "Running",
-  succeeded: "Completed"
-};
-
-export const evaluationVerdictLabels: Record<EvaluationVerdictClass, string> = {
-  fail: "Fail",
-  invalid_result: "Invalid result",
-  pass: "Pass"
-};
-
-export const portalResultsLifecycleBuckets: Array<{
-  description: string;
-  id: PortalResultsLifecycleBucket;
-  label: string;
-  runStates: RunLifecycleState[];
-}> = [
-  {
-    description: "Created and queued runs that have not reached worker execution yet.",
-    id: "pending",
-    label: "Pending",
-    runStates: ["created", "queued"]
-  },
-  {
-    description: "Currently executing runs plus ones waiting for cancellation to finish.",
-    id: "active",
-    label: "Active",
-    runStates: ["running", "cancel_requested"]
-  },
-  {
-    description: "Runs that completed their control-plane lifecycle normally.",
-    id: "terminal_success",
-    label: "Terminal success",
-    runStates: ["succeeded"]
-  },
-  {
-    description: "Runs that ended with a terminal control-plane failure.",
-    id: "terminal_failure",
-    label: "Terminal failure",
-    runStates: ["failed"]
-  },
-  {
-    description: "Runs that ended intentionally by cancellation.",
-    id: "terminal_cancelled",
-    label: "Terminal cancelled",
-    runStates: ["cancelled"]
-  }
-];
-
-export const portalResultsSortOptions: Array<{
-  description: string;
-  id: PortalResultsSortId;
-  label: string;
-}> = [
-  {
-    description: "Newest started-at timestamp first for operational triage.",
-    id: "started_at_desc",
-    label: "Newest start"
-  },
-  {
-    description: "Newest finished-at timestamp first for recent terminal outcomes.",
-    id: "finished_at_desc",
-    label: "Newest finish"
-  },
-  {
-    description: "Longest duration first when isolating slow or stuck runs.",
-    id: "duration_desc",
-    label: "Longest duration"
-  },
-  {
-    description: "Canonical run lifecycle id ascending for grouped state review.",
-    id: "run_state_asc",
-    label: "Run state"
-  },
-  {
-    description: "Canonical verdict id ascending for released result comparisons.",
-    id: "verdict_asc",
-    label: "Verdict"
-  }
-];
+export { evaluationVerdictLabels, portalRunsLifecycleBuckets as portalResultsLifecycleBuckets, portalRunsSortOptions as portalResultsSortOptions, runLifecycleStateLabels };
 
 export const portalResultsExportHeaders = [
   "runId",
@@ -117,6 +32,7 @@ export const portalResultsExportHeaders = [
   "runState",
   "runStateLabel",
   "runLifecycleBucket",
+  "runLifecycleBucketLabel",
   "verdictClass",
   "verdictLabel",
   "failureFamily",

--- a/packages/shared/src/contracts/portal-benchmark-ops.ts
+++ b/packages/shared/src/contracts/portal-benchmark-ops.ts
@@ -6,6 +6,7 @@ import {
   portalWorkersViewResponseSchema
 } from "../schemas/portal-benchmark-ops.js";
 import type {
+  PortalRunsLifecycleBucket,
   PortalRunsLifecycleBucketDefinition,
   PortalRunsSortOption
 } from "../types/portal-benchmark-ops.js";
@@ -42,6 +43,15 @@ export const portalRunsLifecycleBuckets = [
     runStates: ["cancelled"]
   }
 ] satisfies PortalRunsLifecycleBucketDefinition[];
+
+export const portalRunsLifecycleBucketLabels: Record<PortalRunsLifecycleBucket, string> =
+  Object.fromEntries(
+    portalRunsLifecycleBuckets.map((bucket) => [bucket.id, bucket.label])
+  ) as Record<PortalRunsLifecycleBucket, string>;
+
+export function getPortalRunsLifecycleBucketLabel(bucket: PortalRunsLifecycleBucket) {
+  return portalRunsLifecycleBucketLabels[bucket];
+}
 
 export const portalRunsSortOptions = [
   {

--- a/packages/shared/src/contracts/run-control.ts
+++ b/packages/shared/src/contracts/run-control.ts
@@ -1,7 +1,11 @@
 import type {
+  AttemptLifecycleState,
   AttemptLifecycleStateCatalogEntry,
+  EvaluationVerdictClass,
+  JobLifecycleState,
   JobLifecycleStateCatalogEntry,
   RunKindCatalogEntry,
+  RunLifecycleState,
   RunLifecycleStateCatalogEntry
 } from "../types/run-control.js";
 
@@ -173,3 +177,49 @@ export const attemptLifecycleCatalog = [
     terminal: true
   }
 ] satisfies AttemptLifecycleStateCatalogEntry[];
+
+export const runLifecycleStateLabels: Record<RunLifecycleState, string> = {
+  cancel_requested: "Cancel requested",
+  cancelled: "Cancelled",
+  created: "Created",
+  failed: "Failed",
+  queued: "Queued",
+  running: "Running",
+  succeeded: "Succeeded"
+};
+
+export const jobLifecycleStateLabels: Record<JobLifecycleState, string> = {
+  cancel_requested: "Cancel requested",
+  cancelled: "Cancelled",
+  claimed: "Claimed",
+  completed: "Completed",
+  failed: "Failed",
+  queued: "Queued",
+  running: "Running"
+};
+
+export const attemptLifecycleStateLabels: Record<AttemptLifecycleState, string> = {
+  active: "Active",
+  cancelled: "Cancelled",
+  failed: "Failed",
+  prepared: "Prepared",
+  succeeded: "Succeeded"
+};
+
+export const evaluationVerdictLabels: Record<EvaluationVerdictClass, string> = {
+  fail: "Fail",
+  invalid_result: "Invalid result",
+  pass: "Pass"
+};
+
+export function getRunLifecycleStateLabel(state: RunLifecycleState) {
+  return runLifecycleStateLabels[state];
+}
+
+export function getJobLifecycleStateLabel(state: JobLifecycleState) {
+  return jobLifecycleStateLabels[state];
+}
+
+export function getAttemptLifecycleStateLabel(state: AttemptLifecycleState) {
+  return attemptLifecycleStateLabels[state];
+}


### PR DESCRIPTION
## Summary
- centralize canonical run/job/attempt lifecycle labels and lifecycle-bucket labels in `@paretoproof/shared` so the portal shell, benchmark-ops UI, and API read models use the same vocabulary source
- update portal benchmark-ops CSV export and UI helpers to emit canonical labels such as `Succeeded` and `Cancel requested` instead of stale ad hoc wording like `Completed` for run success
- normalize API/operator timeline summaries so run, job, and attempt terminal events use the canonical lifecycle wording and add focused tests for the rollout

## Verification
- bun --cwd packages/shared build
- bun --cwd packages/shared typecheck
- bun --cwd apps/web typecheck
- bun --cwd apps/api typecheck
- bun test apps/web/src/lib/portal-benchmark-ops.test.js apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun test apps/web/src/routes/portal-shell.test.js
- bun --cwd apps/api test apps/api/test/portal-benchmark-ops.test.ts
- bun run check:bidi

Closes #758
