### PR TITLE
fix(ci): unstick devbox publish verification

### DIFF
--- a/.github/workflows/publish-problem9-devbox-image.yml
+++ b/.github/workflows/publish-problem9-devbox-image.yml
@@ -42,12 +42,14 @@ jobs:
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-
 
-      - name: Build devbox rootfs for toolchain verification
+      - name: Build devbox image for toolchain verification
         run: >-
           docker buildx build
+          --progress plain
           --file apps/worker/Dockerfile
           --target problem9-devbox
-          --output type=local,dest=.tmp/problem9-devbox-rootfs
+          --tag paretoproof-problem9-devbox:verify
+          --load
           --cache-from type=gha,scope=problem9-execution
           --cache-from type=gha,scope=problem9-devbox
           .
@@ -56,7 +58,7 @@ jobs:
         run: >-
           node infra/scripts/verify-problem9-image-toolchains.mjs
           --target problem9-devbox
-          --rootfs .tmp/problem9-devbox-rootfs
+          --image paretoproof-problem9-devbox:verify
 
       - name: Build and publish devbox image
         id: build_devbox

--- a/infra/problem9-image-policy.md
+++ b/infra/problem9-image-policy.md
@@ -52,6 +52,7 @@ The authoritative source of truth for the Problem 9 image graph is [`infra/docke
 - If a local image-store issue blocks `--load`, export the target filesystem instead with `docker buildx build --file apps/worker/Dockerfile --target <target> --output type=local,dest=<directory> .` and pass `--rootfs <directory>` to `infra/scripts/verify-problem9-image-toolchains.mjs`.
 - The verifier also checks the worker/shared workspace-local runtime dependency paths because Bun may keep packages such as `@paretoproof/shared` and `zod` under those workspace trees instead of hoisting them into repo-root `node_modules`.
 - Pull-request CI is the authoritative pre-merge image smoke gate: it builds `paretoproof-problem9-execution:pr-smoke` and `paretoproof-problem9-devbox:pr-smoke` without publishing, then runs `infra/scripts/verify-problem9-image-toolchains.mjs` against those loaded images so the `lean`, `codex`, `lean-lsp-mcp`, and runtime-dependency surfaces fail before merge.
-- The publish workflows now build a local rootfs export and run `infra/scripts/verify-problem9-image-toolchains.mjs` before they push mutable or immutable tags, so a toolchain mismatch fails the publish path before new tags move.
+- The worker-image publish workflow verifies an exported `problem9-execution` rootfs before it pushes mutable or immutable tags.
+- The devbox publish workflow verifies a loaded `paretoproof-problem9-devbox:verify` image before publish instead of exporting a local rootfs, because the rootfs export path can stall on GitHub Actions for the larger devbox target.
 - For rollback, identify the required digest from the workflow artifact, re-publish or deploy by digest, and record the chosen digest in the release evidence instead of relying on `main`.
 

--- a/infra/scripts/check-problem9-image-policy.mjs
+++ b/infra/scripts/check-problem9-image-policy.mjs
@@ -77,6 +77,35 @@ for (const image of manifest.images) {
     fail(`${workflowPath} is missing the immutable sha tag rule`);
   }
 
+  if (image.target === "problem9-execution") {
+    const requiredExecutionVerificationSnippets = [
+      "Build execution rootfs for toolchain verification",
+      "--output type=local,dest=.tmp/problem9-execution-rootfs",
+      "--rootfs .tmp/problem9-execution-rootfs",
+    ];
+
+    for (const snippet of requiredExecutionVerificationSnippets) {
+      if (!workflowContent.includes(snippet)) {
+        fail(`${workflowPath} is missing execution verification snippet "${snippet}"`);
+      }
+    }
+  }
+
+  if (image.target === "problem9-devbox") {
+    const requiredDevboxVerificationSnippets = [
+      "Build devbox image for toolchain verification",
+      "--tag paretoproof-problem9-devbox:verify",
+      "--load",
+      "--image paretoproof-problem9-devbox:verify",
+    ];
+
+    for (const snippet of requiredDevboxVerificationSnippets) {
+      if (!workflowContent.includes(snippet)) {
+        fail(`${workflowPath} is missing devbox verification snippet "${snippet}"`);
+      }
+    }
+  }
+
   const buildScript = packageJson.scripts?.[image.localBuildScript];
   if (!buildScript) {
     fail(`package.json is missing script ${image.localBuildScript}`);
@@ -148,6 +177,14 @@ for (const snippet of prCiRequiredSnippets) {
 
 if (!/pull-request CI/i.test(policyDoc)) {
   fail(`${policyDocPath} must document the pull-request CI image smoke gate`);
+}
+
+if (!policyDoc.includes("verifies an exported `problem9-execution` rootfs")) {
+  fail(`${policyDocPath} must document the execution publish rootfs verification path`);
+}
+
+if (!policyDoc.includes("verifies a loaded `paretoproof-problem9-devbox:verify` image")) {
+  fail(`${policyDocPath} must document the devbox publish image verification path`);
 }
 
 console.log("Problem 9 image policy check passed.");


### PR DESCRIPTION
## Summary
- switch the devbox publish verification path from a local rootfs export to a loaded `paretoproof-problem9-devbox:verify` image
- keep the toolchain contract check in place while avoiding the GitHub Actions rootfs-export path that stalled for 30+ minutes on `main`
- update the Problem 9 image policy doc and drift checker so the new verification shape stays enforced

## Verification
- `bun run check:problem9-image-policy`
- `bun run check:bidi`
- `bun run check:deployment-workflow-node-runtime`

## Validation Context
- blocked `main` runs from issue #729: `23103017926`, `23103433903`
- those runs stalled in `Build devbox rootfs for toolchain verification`
- this PR keeps the pre-publish verification step but verifies a loaded local image instead of exporting a rootfs

Closes #853
