### PR TITLE
feat(worker): upgrade the canonical Problem 9 package

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -2,7 +2,7 @@
 
 `apps/worker` holds the CLI and runtime code for the current benchmark execution kernel. In the repo today that means package and prompt materialization for `firstproof/Problem9`, deterministic verifier and run-bundle assembly, offline ingest, trusted-local local attempts, and the hosted worker claim loop.
 
-The broader benchmark target is still a live scope question, but the worker/image/runtime contract for the current Problem 9 kernel is already concrete and enforced by the repository-owned smoke and boundary checks described below.
+The current Problem 9 benchmark target is the repository-owned closed-form triangular-number identity, and the worker/image/runtime contract around that package is enforced by the smoke and boundary checks described below.
 
 Docker targets:
 

--- a/apps/worker/prompts/problem9/benchmark.md
+++ b/apps/worker/prompts/problem9/benchmark.md
@@ -5,6 +5,7 @@ Benchmark policy summary:
 - the benchmark package defines the theorem target, support definitions, and gold reference together as one immutable package version
 - compilation is the first gate; theorem-target and proof-policy checks only count after a clean compile
 - `sorry` and `admit` are always disallowed
+- importing the benchmark-owned `FirstProof.Problem9.Gold` reference proof is invalid
 - introducing new unpinned dependencies or mutating benchmark-owned files is invalid
 - the final candidate must be reviewable and reproducible from the emitted run bundle
 

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -128,6 +128,7 @@ type VerificationResult = {
   containsSorry: boolean;
   diagnosticGate: "passed" | "failed";
   failureCode: VerificationFailureCode | null;
+  importPolicy: "passed" | "failed" | "not_evaluated";
   semanticEquality: "matched" | "mismatched" | "not_evaluated";
   surfaceEquality: "matched" | "drifted" | "not_evaluated";
   verifierOutput: Record<string, unknown>;
@@ -161,6 +162,8 @@ type ProviderResponse = {
     totalTokens: number | null;
   };
 };
+
+const forbiddenProblem9CandidateImports = new Set(["FirstProof.Problem9.Gold"]);
 
 export type Problem9AttemptResult = {
   artifactManifestDigest: string;
@@ -718,6 +721,8 @@ async function verifyCandidate(options: {
     ((options.compileResult.diagnostics.diagnostics as Array<Record<string, unknown>> | undefined) ??
       []);
   const diagnosticGate = diagnostics.length > 0 ? "failed" : "passed";
+  const forbiddenImports = findForbiddenProblem9CandidateImports(options.candidateSource);
+  const importPolicy = forbiddenImports.length > 0 ? "failed" : "passed";
 
   const semanticProbePath = path.join(options.compileRoot, "ParetoProofSemanticCheck.lean");
 
@@ -729,8 +734,8 @@ async function verifyCandidate(options: {
       "namespace ParetoProofVerifier",
       "",
       "example (n : Nat) :",
-      "    FirstProof.Problem9.triangular (Nat.succ n) =",
-      "    FirstProof.Problem9.triangular n + Nat.succ n := by",
+      "    2 * FirstProof.Problem9.triangular n =",
+      "    n * Nat.succ n := by",
       "  simpa using FirstProof.Problem9.problem9 n",
       "",
       "end ParetoProofVerifier"
@@ -796,6 +801,7 @@ async function verifyCandidate(options: {
     containsAdmit,
     containsSorry,
     diagnosticGate,
+    importPolicy,
     semanticEquality,
     semanticOutput
   });
@@ -810,6 +816,10 @@ async function verifyCandidate(options: {
     forbiddenTokens: {
       containsAdmit,
       containsSorry
+    },
+    importPolicy: {
+      importedModules: forbiddenImports,
+      result: importPolicy
     },
     result: failureCode === null ? "pass" : "fail",
     semanticCheck: {
@@ -834,6 +844,7 @@ async function verifyCandidate(options: {
     containsSorry,
     diagnosticGate,
     failureCode,
+    importPolicy,
     semanticEquality,
     surfaceEquality,
     verifierOutput,
@@ -860,6 +871,10 @@ async function createCompileFailureVerificationResult(options: {
       containsAdmit: false,
       containsSorry: false
     },
+    importPolicy: {
+      importedModules: [],
+      result: "not_evaluated"
+    },
     result: "fail",
     semanticCheck: {
       output: options.compileResult.outputText,
@@ -883,6 +898,7 @@ async function createCompileFailureVerificationResult(options: {
     containsSorry: false,
     diagnosticGate: "failed",
     failureCode: "proof_policy_failed",
+    importPolicy: "not_evaluated",
     semanticEquality: "not_evaluated",
     surfaceEquality: "not_evaluated",
     verifierOutput,
@@ -895,11 +911,16 @@ function deriveVerificationFailureCode(options: {
   containsAdmit: boolean;
   containsSorry: boolean;
   diagnosticGate: "passed" | "failed";
+  importPolicy: "passed" | "failed" | "not_evaluated";
   semanticEquality: "matched" | "mismatched" | "not_evaluated";
   semanticOutput: string;
 }): VerificationFailureCode | null {
   if (options.containsSorry || options.containsAdmit) {
     return "forbidden_placeholder_token";
+  }
+
+  if (options.importPolicy === "failed") {
+    return "proof_policy_failed";
   }
 
   if (options.semanticEquality === "not_evaluated") {
@@ -1114,7 +1135,7 @@ function buildStubCandidate(stubScenario: "compile_failure" | "exact_canonical")
         "namespace FirstProof.Problem9",
         "",
         "theorem problem9 (n : Nat) :",
-        "    triangular (Nat.succ n) = triangular n + Nat.succ n := by",
+        "    2 * triangular n = n * Nat.succ n := by",
         "  this is not valid Lean",
         "",
         "end FirstProof.Problem9"
@@ -1126,8 +1147,33 @@ function buildStubCandidate(stubScenario: "compile_failure" | "exact_canonical")
         "namespace FirstProof.Problem9",
         "",
         "theorem problem9 (n : Nat) :",
-        "    triangular (Nat.succ n) = triangular n + Nat.succ n := by",
-        "  rfl",
+        "    2 * triangular n = n * Nat.succ n := by",
+        "  induction n with",
+        "  | zero =>",
+        "      rfl",
+        "  | succ n ih =>",
+        "      calc",
+        "        2 * triangular (Nat.succ n)",
+        "            = 2 * (triangular n + Nat.succ n) := by",
+        "                exact congrArg (fun value => 2 * value) (triangular_succ n)",
+        "        _ = 2 * triangular n + 2 * Nat.succ n := by",
+        "              exact Nat.left_distrib 2 (triangular n) (Nat.succ n)",
+        "        _ = n * Nat.succ n + 2 * Nat.succ n := by",
+        "              exact congrArg (fun value => value + 2 * Nat.succ n) ih",
+        "        _ = n * Nat.succ n + (Nat.succ n + Nat.succ n) := by",
+        "              exact congrArg (fun value => n * Nat.succ n + value) (two_mul_nat (Nat.succ n))",
+        "        _ = Nat.succ n * n + (Nat.succ n + Nat.succ n) := by",
+        "              exact congrArg",
+        "                (fun value => value + (Nat.succ n + Nat.succ n))",
+        "                (Nat.mul_comm n (Nat.succ n))",
+        "        _ = (Nat.succ n * n + Nat.succ n) + Nat.succ n := by",
+        "              exact (Nat.add_assoc (Nat.succ n * n) (Nat.succ n) (Nat.succ n)).symm",
+        "        _ = Nat.succ n * Nat.succ n + Nat.succ n := by",
+        "              exact congrArg",
+        "                (fun value => value + Nat.succ n)",
+        "                (Nat.mul_succ (Nat.succ n) n).symm",
+        "        _ = Nat.succ n * Nat.succ (Nat.succ n) := by",
+        "              exact (Nat.mul_succ (Nat.succ n) (Nat.succ n)).symm",
         "",
         "end FirstProof.Problem9"
       ].join("\n");
@@ -1135,8 +1181,40 @@ function buildStubCandidate(stubScenario: "compile_failure" | "exact_canonical")
 }
 
 function extractCanonicalTheoremHeader(sourceText: string): string {
-  const match = sourceText.match(/theorem\s+problem9[\s\S]*?:=\s*by/u);
-  return match ? normalizeWhitespace(match[0]) : "";
+  const theoremMatch = sourceText.match(/theorem\s+problem9[\s\S]*?:=\s*by/u);
+
+  if (theoremMatch) {
+    return normalizeWhitespace(
+      theoremMatch[0]
+        .replace(/^theorem/u, "declaration")
+        .replace(/\s*:=\s*by$/u, "")
+    );
+  }
+
+  const axiomMatch = sourceText.match(/axiom\s+problem9[^\r\n]*/u);
+  return axiomMatch
+    ? normalizeWhitespace(axiomMatch[0].replace(/^axiom/u, "declaration"))
+    : "";
+}
+
+export function findForbiddenProblem9CandidateImports(candidateSource: string): string[] {
+  const imports = new Set<string>();
+
+  for (const line of candidateSource.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+
+    if (!trimmed.startsWith("import ")) {
+      continue;
+    }
+
+    for (const moduleName of trimmed.slice("import ".length).split(/\s+/u)) {
+      if (forbiddenProblem9CandidateImports.has(moduleName)) {
+        imports.add(moduleName);
+      }
+    }
+  }
+
+  return [...imports].sort();
 }
 
 function sanitizeCandidateOutput(candidateSource: string): string {

--- a/apps/worker/src/lib/problem9-run-bundle.test.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.test.ts
@@ -157,8 +157,33 @@ async function createFixtureInputs(root: string): Promise<FixturePaths> {
       "namespace FirstProof.Problem9",
       "",
       "theorem problem9 (n : Nat) :",
-      "    triangular (Nat.succ n) = triangular n + Nat.succ n := by",
-      "  rfl",
+      "    2 * triangular n = n * Nat.succ n := by",
+      "  induction n with",
+      "  | zero =>",
+      "      rfl",
+      "  | succ n ih =>",
+      "      calc",
+      "        2 * triangular (Nat.succ n)",
+      "            = 2 * (triangular n + Nat.succ n) := by",
+      "                exact congrArg (fun value => 2 * value) (triangular_succ n)",
+      "        _ = 2 * triangular n + 2 * Nat.succ n := by",
+      "              exact Nat.left_distrib 2 (triangular n) (Nat.succ n)",
+      "        _ = n * Nat.succ n + 2 * Nat.succ n := by",
+      "              exact congrArg (fun value => value + 2 * Nat.succ n) ih",
+      "        _ = n * Nat.succ n + (Nat.succ n + Nat.succ n) := by",
+      "              exact congrArg (fun value => n * Nat.succ n + value) (two_mul_nat (Nat.succ n))",
+      "        _ = Nat.succ n * n + (Nat.succ n + Nat.succ n) := by",
+      "              exact congrArg",
+      "                (fun value => value + (Nat.succ n + Nat.succ n))",
+      "                (Nat.mul_comm n (Nat.succ n))",
+      "        _ = (Nat.succ n * n + Nat.succ n) + Nat.succ n := by",
+      "              exact (Nat.add_assoc (Nat.succ n * n) (Nat.succ n) (Nat.succ n)).symm",
+      "        _ = Nat.succ n * Nat.succ n + Nat.succ n := by",
+      "              exact congrArg",
+      "                (fun value => value + Nat.succ n)",
+      "                (Nat.mul_succ (Nat.succ n) n).symm",
+      "        _ = Nat.succ n * Nat.succ (Nat.succ n) := by",
+      "              exact (Nat.mul_succ (Nat.succ n) (Nat.succ n)).symm",
       "",
       "end FirstProof.Problem9"
     ].join("\n")
@@ -193,9 +218,9 @@ async function createFixtureInputs(root: string): Promise<FixturePaths> {
     surface_drift: false,
     theoremHeaders: {
       canonical:
-        "theorem problem9 (n : Nat) : triangular (Nat.succ n) = triangular n + Nat.succ n := by",
+        "declaration problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n",
       candidate:
-        "theorem problem9 (n : Nat) : triangular (Nat.succ n) = triangular n + Nat.succ n := by"
+        "declaration problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n"
     },
     verifierOutputSchemaVersion: "1"
   });

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { problem9AuthModes } from "../src/lib/problem9-auth.ts";
 import {
+  findForbiddenProblem9CandidateImports,
   resolveProblem9ModelSnapshotId,
   runProblem9Attempt
 } from "../src/lib/problem9-attempt.ts";
@@ -64,6 +65,19 @@ test("resolveProblem9ModelSnapshotId preserves explicit overrides and non-stub p
       stubScenario: "exact_canonical"
     }),
     "prompt/default-model"
+  );
+});
+
+test("findForbiddenProblem9CandidateImports flags benchmark-owned gold-proof imports", () => {
+  assert.deepEqual(
+    findForbiddenProblem9CandidateImports(
+      [
+        "import FirstProof.Problem9.Support FirstProof.Problem9.Gold",
+        "import Mathlib",
+        "import FirstProof.Problem9.Gold"
+      ].join("\n")
+    ),
+    ["FirstProof.Problem9.Gold"]
   );
 });
 

--- a/apps/worker/test/problem9-integrity.test.ts
+++ b/apps/worker/test/problem9-integrity.test.ts
@@ -13,9 +13,9 @@ import {
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
 
 const expectedIntegrityDigests = {
-  benchmarkPackage: "4267f36c8a4d0af091f647e00ae87974cc0125daa4a2024d9d71f968e33454f2",
-  promptPackage: "aedc0f7bc73c79b6c838fba19c39d7028a12511cb904ff65fb8949d93e1ed7b2",
-  runBundle: "c3fbd4156a16bf615edf351cf865ac846e4d414a5da7893d8efddc0b951c153c"
+  benchmarkPackage: "e1655ac26ee234718c07c719396c7856c55895974092753d48cf7763622df345",
+  promptPackage: "c8b3b51316ab410631804b8e132fcacd009f929ff2bba097cfcc564e92c5f203",
+  runBundle: "2ec1ea32e9cf567bb92f4a781c95be83089f8b73871a075a4c66c8f6d4340580"
 } as const;
 
 // Update these only when the checked-in canonical Problem 9 fixtures intentionally change.
@@ -219,8 +219,33 @@ async function createIntegrityFixture(tempRoot: string): Promise<IntegrityFixtur
       "namespace FirstProof.Problem9",
       "",
       "theorem problem9 (n : Nat) :",
-      "    triangular (Nat.succ n) = triangular n + Nat.succ n := by",
-      "  rfl",
+      "    2 * triangular n = n * Nat.succ n := by",
+      "  induction n with",
+      "  | zero =>",
+      "      rfl",
+      "  | succ n ih =>",
+      "      calc",
+      "        2 * triangular (Nat.succ n)",
+      "            = 2 * (triangular n + Nat.succ n) := by",
+      "                exact congrArg (fun value => 2 * value) (triangular_succ n)",
+      "        _ = 2 * triangular n + 2 * Nat.succ n := by",
+      "              exact Nat.left_distrib 2 (triangular n) (Nat.succ n)",
+      "        _ = n * Nat.succ n + 2 * Nat.succ n := by",
+      "              exact congrArg (fun value => value + 2 * Nat.succ n) ih",
+      "        _ = n * Nat.succ n + (Nat.succ n + Nat.succ n) := by",
+      "              exact congrArg (fun value => n * Nat.succ n + value) (two_mul_nat (Nat.succ n))",
+      "        _ = Nat.succ n * n + (Nat.succ n + Nat.succ n) := by",
+      "              exact congrArg",
+      "                (fun value => value + (Nat.succ n + Nat.succ n))",
+      "                (Nat.mul_comm n (Nat.succ n))",
+      "        _ = (Nat.succ n * n + Nat.succ n) + Nat.succ n := by",
+      "              exact (Nat.add_assoc (Nat.succ n * n) (Nat.succ n) (Nat.succ n)).symm",
+      "        _ = Nat.succ n * Nat.succ n + Nat.succ n := by",
+      "              exact congrArg",
+      "                (fun value => value + Nat.succ n)",
+      "                (Nat.mul_succ (Nat.succ n) n).symm",
+      "        _ = Nat.succ n * Nat.succ (Nat.succ n) := by",
+      "              exact (Nat.mul_succ (Nat.succ n) (Nat.succ n)).symm",
       "",
       "end FirstProof.Problem9"
     ].join("\n")
@@ -252,9 +277,9 @@ async function createIntegrityFixture(tempRoot: string): Promise<IntegrityFixtur
     surface_drift: false,
     theoremHeaders: {
       canonical:
-        "theorem problem9 (n : Nat) : triangular (Nat.succ n) = triangular n + Nat.succ n := by",
+        "declaration problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n",
       candidate:
-        "theorem problem9 (n : Nat) : triangular (Nat.succ n) = triangular n + Nat.succ n := by"
+        "declaration problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n"
     },
     verifierOutputSchemaVersion: "1"
   });

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
@@ -1,9 +1,34 @@
-import FirstProof.Problem9.Statement
+import FirstProof.Problem9.Support
 
 namespace FirstProof.Problem9
 
 theorem problem9_gold (n : Nat) :
-    triangular (Nat.succ n) = triangular n + Nat.succ n := by
-  simpa using problem9 n
+    2 * triangular n = n * Nat.succ n := by
+  induction n with
+  | zero =>
+      rfl
+  | succ n ih =>
+      calc
+        2 * triangular (Nat.succ n)
+            = 2 * (triangular n + Nat.succ n) := by
+                exact congrArg (fun value => 2 * value) (triangular_succ n)
+        _ = 2 * triangular n + 2 * Nat.succ n := by
+              exact Nat.left_distrib 2 (triangular n) (Nat.succ n)
+        _ = n * Nat.succ n + 2 * Nat.succ n := by
+              exact congrArg (fun value => value + 2 * Nat.succ n) ih
+        _ = n * Nat.succ n + (Nat.succ n + Nat.succ n) := by
+              exact congrArg (fun value => n * Nat.succ n + value) (two_mul_nat (Nat.succ n))
+        _ = Nat.succ n * n + (Nat.succ n + Nat.succ n) := by
+              exact congrArg
+                (fun value => value + (Nat.succ n + Nat.succ n))
+                (Nat.mul_comm n (Nat.succ n))
+        _ = (Nat.succ n * n + Nat.succ n) + Nat.succ n := by
+              exact (Nat.add_assoc (Nat.succ n * n) (Nat.succ n) (Nat.succ n)).symm
+        _ = Nat.succ n * Nat.succ n + Nat.succ n := by
+              exact congrArg
+                (fun value => value + Nat.succ n)
+                (Nat.mul_succ (Nat.succ n) n).symm
+        _ = Nat.succ n * Nat.succ (Nat.succ n) := by
+              exact (Nat.mul_succ (Nat.succ n) (Nat.succ n)).symm
 
 end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
@@ -2,8 +2,6 @@ import FirstProof.Problem9.Support
 
 namespace FirstProof.Problem9
 
-theorem problem9 (n : Nat) :
-    triangular (Nat.succ n) = triangular n + Nat.succ n := by
-  rfl
+axiom problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n
 
 end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Support.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Support.lean
@@ -4,4 +4,11 @@ def triangular : Nat -> Nat
   | 0 => 0
   | Nat.succ n => triangular n + Nat.succ n
 
+@[simp] theorem triangular_succ (n : Nat) :
+    triangular (Nat.succ n) = triangular n + Nat.succ n := rfl
+
+@[simp] theorem two_mul_nat (n : Nat) :
+    2 * n = n + n := by
+  rw [show 2 = Nat.succ 1 by rfl, Nat.succ_mul, Nat.one_mul]
+
 end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/README.md
+++ b/benchmarks/firstproof/problem9/README.md
@@ -15,8 +15,16 @@ materialized manifest:
 The benchmark theorem for this initial package is a narrow recurrence identity
 for the benchmark-owned `triangular` helper:
 
-`triangular (Nat.succ n) = triangular n + Nat.succ n`
+`2 * triangular n = n * (n + 1)`
 
-That theorem is intentionally small enough to keep the first immutable package
-easy to review while the broader offline runner and verifier stack is still
-landing.
+The checked-in package now separates the target declaration from the repository
+reference proof:
+
+- `FirstProof/Problem9/Statement.lean` declares the canonical target without
+  leaking the gold proof into prompt materialization
+- `FirstProof/Problem9/Gold.lean` carries the repository-owned proof artifact
+- `FirstProof/Problem9/Support.lean` keeps the benchmark-owned helper and the
+  old recurrence identity only as a support lemma
+
+This keeps the immutable package honest while preserving deterministic local
+materialization and verifier behavior.

--- a/benchmarks/firstproof/problem9/benchmark-package.json
+++ b/benchmarks/firstproof/problem9/benchmark-package.json
@@ -1,7 +1,7 @@
 {
   "sourceSchemaVersion": "1",
   "packageId": "firstproof/Problem9",
-  "packageVersion": "2026.03.13",
+  "packageVersion": "2026.03.15",
   "benchmarkFamily": "firstproof",
   "benchmarkItemId": "Problem9",
   "canonicalModules": {

--- a/benchmarks/firstproof/problem9/statements/problem.md
+++ b/benchmarks/firstproof/problem9/statements/problem.md
@@ -7,7 +7,7 @@ Let `triangular : Nat -> Nat` be the benchmark-owned helper defined by:
 
 Prove that for every natural number `n`,
 
-`triangular (n + 1) = triangular n + (n + 1)`.
+`2 * triangular n = n * (n + 1)`.
 
 The benchmark package fixes the helper definition, theorem target, namespace,
 and gold proof together as one immutable package version.


### PR DESCRIPTION
## Summary
- upgrade irstproof/Problem9 to the closed-form triangular-number target chosen in #717 and bump the immutable package version
- keep Statement.lean proof-free, move the real repository proof into Gold.lean, and refresh the source docs plus worker prompt guidance
- update worker verifier fixtures and integrity snapshots for the new theorem, and reject candidate imports of the benchmark-owned gold module

## Testing
- un run typecheck:shared
- un run typecheck:worker
- un run materialize:problem9-package -- --output C:\\Users\\Tom\\AppData\\Local\\Temp\\paretoproof-problem9-materialize-check
- un --cwd apps/worker test:attempt-smoke
- un --cwd apps/worker test:run-bundle
- un --cwd apps/worker test:verifier-smoke
- 
ode --import tsx --test test/problem9-attempt.test.ts test/problem9-integrity.test.ts
- un run check:bidi

Closes #718