### PR TITLE
Add API rate limiting and browser backoff

### DIFF
--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,197 @@
+import type {
+  FastifyReply,
+  FastifyRequest,
+  preHandlerHookHandler
+} from "fastify";
+
+export type ApiRateLimitPolicyId = "public" | "authenticated";
+
+type ApiRateLimitPolicy = {
+  id: ApiRateLimitPolicyId;
+  limit: number;
+  windowMs: number;
+};
+
+type RateLimitState = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitDecision = {
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfterSeconds: number;
+};
+
+type ApiRateLimitOptions = {
+  now?: () => number;
+  policies?: Partial<Record<ApiRateLimitPolicyId, Partial<Omit<ApiRateLimitPolicy, "id">>>>;
+};
+
+const defaultPolicies: Record<ApiRateLimitPolicyId, ApiRateLimitPolicy> = {
+  authenticated: {
+    id: "authenticated",
+    limit: 300,
+    windowMs: 60_000
+  },
+  public: {
+    id: "public",
+    limit: 60,
+    windowMs: 60_000
+  }
+};
+
+function readClientIp(request: FastifyRequest) {
+  const cfConnectingIp =
+    typeof request.headers["cf-connecting-ip"] === "string"
+      ? request.headers["cf-connecting-ip"].trim()
+      : "";
+
+  if (cfConnectingIp) {
+    return cfConnectingIp;
+  }
+
+  const forwardedFor =
+    typeof request.headers["x-forwarded-for"] === "string"
+      ? request.headers["x-forwarded-for"]
+      : "";
+  const forwardedIp = forwardedFor.split(",")[0]?.trim() ?? "";
+
+  if (forwardedIp) {
+    return forwardedIp;
+  }
+
+  return request.ip;
+}
+
+function getRateLimitKey(request: FastifyRequest, policyId: ApiRateLimitPolicyId) {
+  if (policyId === "authenticated") {
+    const accessContext = request.accessRbacContext;
+
+    if (
+      accessContext &&
+      "userId" in accessContext &&
+      typeof accessContext.userId === "string"
+    ) {
+      return `user:${accessContext.userId}`;
+    }
+
+    if (request.accessIdentity?.subject) {
+      return `subject:${request.accessIdentity.subject}`;
+    }
+  }
+
+  return `ip:${readClientIp(request)}`;
+}
+
+export function applyRateLimitHeaders(
+  reply: FastifyReply,
+  decision: RateLimitDecision,
+  includeRetryAfter = false
+) {
+  reply.header("X-RateLimit-Limit", String(decision.limit));
+  reply.header("X-RateLimit-Remaining", String(decision.remaining));
+  reply.header("X-RateLimit-Reset", String(Math.ceil(decision.resetAt / 1000)));
+
+  if (includeRetryAfter) {
+    reply.header("Retry-After", String(decision.retryAfterSeconds));
+  }
+}
+
+export function createInMemoryRateLimiter(options: ApiRateLimitOptions = {}) {
+  const now = options.now ?? Date.now;
+  const policies = {
+    authenticated: {
+      ...defaultPolicies.authenticated,
+      ...options.policies?.authenticated
+    },
+    public: {
+      ...defaultPolicies.public,
+      ...options.policies?.public
+    }
+  } satisfies Record<ApiRateLimitPolicyId, ApiRateLimitPolicy>;
+  const stateByKey = new Map<string, RateLimitState>();
+
+  return {
+    check(policyId: ApiRateLimitPolicyId, request: FastifyRequest) {
+      const policy = policies[policyId];
+      const key = `${policy.id}:${getRateLimitKey(request, policyId)}`;
+      const currentTime = now();
+      const previousState = stateByKey.get(key);
+      const state =
+        previousState && previousState.resetAt > currentTime
+          ? previousState
+          : {
+              count: 0,
+              resetAt: currentTime + policy.windowMs
+            };
+
+      if (state.count >= policy.limit) {
+        const decision = {
+          limit: policy.limit,
+          remaining: 0,
+          resetAt: state.resetAt,
+          retryAfterSeconds: Math.max(1, Math.ceil((state.resetAt - currentTime) / 1000))
+        } satisfies RateLimitDecision;
+
+        stateByKey.set(key, state);
+
+        return {
+          allowed: false as const,
+          decision
+        };
+      }
+
+      state.count += 1;
+      stateByKey.set(key, state);
+
+      return {
+        allowed: true as const,
+        decision: {
+          limit: policy.limit,
+          remaining: Math.max(policy.limit - state.count, 0),
+          resetAt: state.resetAt,
+          retryAfterSeconds: Math.max(1, Math.ceil((state.resetAt - currentTime) / 1000))
+        } satisfies RateLimitDecision
+      };
+    }
+  };
+}
+
+export function createRateLimitPreHandlers(
+  rateLimiter: ReturnType<typeof createInMemoryRateLimiter>
+): Record<ApiRateLimitPolicyId, preHandlerHookHandler> {
+  return {
+    authenticated: (request, reply, done) => {
+      const result = rateLimiter.check("authenticated", request);
+      applyRateLimitHeaders(reply, result.decision, !result.allowed);
+
+      if (!result.allowed) {
+        reply.code(429).send({
+          error: "rate_limit_exceeded",
+          retryAfterSeconds: result.decision.retryAfterSeconds,
+          scope: "authenticated"
+        });
+        return;
+      }
+
+      done();
+    },
+    public: (request, reply, done) => {
+      const result = rateLimiter.check("public", request);
+      applyRateLimitHeaders(reply, result.decision, !result.allowed);
+
+      if (!result.allowed) {
+        reply.code(429).send({
+          error: "rate_limit_exceeded",
+          retryAfterSeconds: result.decision.retryAfterSeconds,
+          scope: "public"
+        });
+        return;
+      }
+
+      done();
+    }
+  };
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -19,7 +19,11 @@ import {
   portalAdminAccessRequestRejectInputSchema
 } from "@paretoproof/shared";
 import { and, asc, desc, eq, gt, isNull } from "drizzle-orm";
-import type { FastifyInstance, FastifyRequest } from "fastify";
+import type {
+  FastifyInstance,
+  FastifyRequest,
+  preHandlerHookHandler
+} from "fastify";
 import {
   accessRequests,
   auditEvents,
@@ -29,6 +33,7 @@ import {
   users
 } from "../db/schema.js";
 import { toAccessRequestSummary } from "../lib/access-request-summary.js";
+import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
@@ -553,12 +558,21 @@ async function loadAdminUserDetail(
 export function registerAdminRoutes(
   app: FastifyInstance,
   db: ReturnTypeOfCreateDbClient,
-  requireAccess: ReturnTypeOfCreateAccessGuard
+  requireAccess: ReturnTypeOfCreateAccessGuard,
+  options?: {
+    rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
+  }
 ) {
+  const rateLimitPreHandlers = options?.rateLimitPreHandlers;
+  const withAuthenticatedRateLimit = (guard: preHandlerHookHandler) =>
+    rateLimitPreHandlers?.authenticated
+      ? [guard, rateLimitPreHandlers.authenticated]
+      : [guard];
+
   app.get(
     "/portal/admin/access-requests",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async () => {
       return {
@@ -570,7 +584,7 @@ export function registerAdminRoutes(
   app.get(
     "/portal/admin/access-requests/:accessRequestId",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async (request, reply) => {
       const accessRequestId = (request.params as { accessRequestId?: string }).accessRequestId;
@@ -592,7 +606,7 @@ export function registerAdminRoutes(
   app.get(
     "/portal/admin/users",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async () => {
       return {
@@ -604,7 +618,7 @@ export function registerAdminRoutes(
   app.get(
     "/portal/admin/users/:userId",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async (request, reply) => {
       const userId = (request.params as { userId?: string }).userId;
@@ -624,7 +638,7 @@ export function registerAdminRoutes(
   app.post(
     "/portal/admin/users/:userId/revoke-role",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async (request, reply) => {
       const parsedBody = portalAdminReadModelsContract.userRevokeInput.safeParse(
@@ -770,7 +784,7 @@ export function registerAdminRoutes(
   app.post(
     "/portal/admin/access-requests/:accessRequestId/approve",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async (request, reply) => {
       const parsedBody = portalAdminAccessRequestApproveInputSchema.safeParse(
@@ -1056,7 +1070,7 @@ export function registerAdminRoutes(
   app.post(
     "/portal/admin/access-requests/:accessRequestId/reject",
     {
-      preHandler: requireAccess("admin_only")
+      preHandler: withAuthenticatedRateLimit(requireAccess("admin_only"))
     },
     async (request, reply) => {
       const parsedBody = portalAdminAccessRequestRejectInputSchema.safeParse(

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,7 +1,15 @@
 import type { FastifyInstance } from "fastify";
+import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 
-export function registerHealthRoute(app: FastifyInstance) {
-  app.get("/health", async () => {
+export function registerHealthRoute(
+  app: FastifyInstance,
+  options?: {
+    rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
+  }
+) {
+  app.get("/health", {
+    preHandler: options?.rateLimitPreHandlers?.public
+  }, async () => {
     return {
       ok: true,
       service: "api"

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -10,7 +10,12 @@ import {
   type PortalProfileLinkIntent
 } from "@paretoproof/shared";
 import { and, desc, eq, isNull } from "drizzle-orm";
-import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  preHandlerHookHandler
+} from "fastify";
 import {
   accessRequests,
   auditEvents,
@@ -34,6 +39,7 @@ import {
   createAccessResolver,
   isAccessAssertionVerificationError
 } from "../auth/require-access.js";
+import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
@@ -246,12 +252,18 @@ export function registerPortalRoutes(
   requireAccess: ReturnTypeOfCreateAccessGuard,
   options?: {
     portalBenchmarkOpsReadModels?: PortalBenchmarkOpsReadModelService;
+    rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
     resolvePortalAccess?: ReturnType<typeof createAccessResolver>;
   }
 ) {
   const resolvePortalAccess = options?.resolvePortalAccess ?? createAccessResolver(db);
   const portalBenchmarkOpsReadModels =
     options?.portalBenchmarkOpsReadModels ?? createPortalBenchmarkOpsReadModelService(db);
+  const rateLimitPreHandlers = options?.rateLimitPreHandlers;
+  const withAuthenticatedRateLimit = (guard: preHandlerHookHandler) =>
+    rateLimitPreHandlers?.authenticated
+      ? [guard, rateLimitPreHandlers.authenticated]
+      : [guard];
 
   const handlePortalSessionRetryRedirect = (
     request: FastifyRequest,
@@ -472,7 +484,9 @@ export function registerPortalRoutes(
   app.get(
     "/portal/me",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     async (request) => {
       return {
@@ -482,14 +496,22 @@ export function registerPortalRoutes(
     }
   );
 
-  app.get("/portal/session/complete", handlePortalSessionRetryRedirect);
-  app.get("/portal/session/finalize", handlePortalSessionRetryRedirect);
-  app.get("/portal/session/finalize/submit", handlePortalSessionFinalizeGet);
+  app.get("/portal/session/complete", {
+    preHandler: rateLimitPreHandlers?.public
+  }, handlePortalSessionRetryRedirect);
+  app.get("/portal/session/finalize", {
+    preHandler: rateLimitPreHandlers?.public
+  }, handlePortalSessionRetryRedirect);
+  app.get("/portal/session/finalize/submit", {
+    preHandler: rateLimitPreHandlers?.public
+  }, handlePortalSessionFinalizeGet);
 
   app.post(
     "/portal/session/complete",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     handlePortalSessionCompletion
   );
@@ -497,20 +519,27 @@ export function registerPortalRoutes(
   app.post(
     "/portal/session/finalize",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     handlePortalSessionCompletion
   );
 
   app.post(
     "/portal/session/finalize/submit",
+    {
+      preHandler: rateLimitPreHandlers?.public
+    },
     handlePortalSessionFinalizeSubmit
   );
 
   app.get(
     "/portal/access-requests/me",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     async (request) => {
       const identity = request.accessIdentity;
@@ -566,7 +595,9 @@ export function registerPortalRoutes(
   app.get(
     "/portal/profile",
     {
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     async (request) => {
       const identity = request.accessIdentity;
@@ -590,7 +621,9 @@ export function registerPortalRoutes(
       config: {
         contract: portalBenchmarkOpsReadModelsContract.runsListResponse
       },
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     async (request, reply) => {
       const parsedQuery = portalRunsListQuerySchema.safeParse(request.query ?? {});
@@ -613,7 +646,9 @@ export function registerPortalRoutes(
       config: {
         contract: portalBenchmarkOpsReadModelsContract.runDetailResponse
       },
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     async (request, reply) => {
       const parsedParams = portalRunDetailParamsSchema.safeParse(request.params ?? {});
@@ -645,7 +680,9 @@ export function registerPortalRoutes(
       config: {
         contract: portalBenchmarkOpsReadModelsContract.launchViewResponse
       },
-      preHandler: requireAccess("approved_collaborator_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_collaborator_or_higher"))
+      ]
     },
     async () => portalBenchmarkOpsReadModels.getLaunchView()
   );
@@ -656,7 +693,9 @@ export function registerPortalRoutes(
       config: {
         contract: portalBenchmarkOpsReadModelsContract.workersViewResponse
       },
-      preHandler: requireAccess("approved_collaborator_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_collaborator_or_higher"))
+      ]
     },
     async () => portalBenchmarkOpsReadModels.getWorkersView()
   );
@@ -714,7 +753,9 @@ export function registerPortalRoutes(
   app.patch(
     "/portal/profile",
     {
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     handlePortalProfileUpdate
   );
@@ -722,7 +763,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/profile",
     {
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     handlePortalProfileUpdate
   );
@@ -730,7 +773,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/profile/link-intents",
     {
-      preHandler: requireAccess("approved_helper_or_higher")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
     },
     async (request, reply) => {
       const parsedBody = portalProfileLinkIntentInputSchema.safeParse(request.body ?? {});
@@ -853,7 +898,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/access-requests",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     async (request, reply) => {
       const parsedBody = portalAccessRequestInputSchema.safeParse(request.body ?? {});
@@ -1104,7 +1151,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/access-recovery",
     {
-      preHandler: requireAccess("authenticated_access_identity")
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
+      ]
     },
     async (request, reply) => {
       const parsedBody = portalAccessRecoveryInputSchema.safeParse(request.body ?? {});

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -10,6 +10,10 @@ import { registerInternalWorkerRoutes } from "../routes/internal-worker.js";
 import { registerOfflineIngestRoutes } from "../routes/offline-ingest.js";
 import { registerPortalRoutes } from "../routes/portal.js";
 import {
+  createInMemoryRateLimiter,
+  createRateLimitPreHandlers
+} from "../middleware/rate-limit.js";
+import {
   createTrustedMutationOriginHook,
   isAllowedLocalOrigin,
   normalizeOrigin
@@ -36,6 +40,7 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
   });
   const db = createDbClient(runtimeEnv.databaseUrl);
   const requireAccess = createAccessGuard(db);
+  const rateLimitPreHandlers = createRateLimitPreHandlers(createInMemoryRateLimiter());
   const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
 
@@ -69,9 +74,15 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
     })
   );
 
-  registerHealthRoute(app);
-  registerPortalRoutes(app, db, requireAccess);
-  registerAdminRoutes(app, db, requireAccess);
+  registerHealthRoute(app, {
+    rateLimitPreHandlers
+  });
+  registerPortalRoutes(app, db, requireAccess, {
+    rateLimitPreHandlers
+  });
+  registerAdminRoutes(app, db, requireAccess, {
+    rateLimitPreHandlers
+  });
   registerOfflineIngestRoutes(app, db, requireAccess);
   registerInternalWorkerRoutes(app, db, runtimeEnv);
 

--- a/apps/api/test/rate-limit.test.ts
+++ b/apps/api/test/rate-limit.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { registerAdminRoutes } from "../src/routes/admin.ts";
+import { registerHealthRoute } from "../src/routes/health.ts";
+import {
+  createInMemoryRateLimiter,
+  createRateLimitPreHandlers
+} from "../src/middleware/rate-limit.ts";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+function createApprovedAccessGuard() {
+  return () => (
+    request: {
+      accessIdentity?: unknown;
+      accessRbacContext?: unknown;
+    },
+    _reply: unknown,
+    done: () => void
+  ) => {
+    request.accessIdentity = {
+      email: "person@example.com",
+      issuer: "https://paretoproof.cloudflareaccess.com",
+      provider: "cloudflare_github",
+      subject: "subject-1"
+    };
+    request.accessRbacContext = {
+      email: "person@example.com",
+      identityId: "identity-1",
+      roles: ["admin"],
+      status: "approved",
+      subject: "subject-1",
+      userId: "user-1"
+    };
+    done();
+  };
+}
+
+test("public routes emit rate-limit headers and block after the configured budget", async (t) => {
+  const app = Fastify();
+  const rateLimitPreHandlers = createRateLimitPreHandlers(
+    createInMemoryRateLimiter({
+      policies: {
+        public: {
+          limit: 2
+        }
+      }
+    })
+  );
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerHealthRoute(app, {
+    rateLimitPreHandlers
+  });
+
+  const firstResponse = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(firstResponse.headers["x-ratelimit-limit"], "2");
+  assert.equal(firstResponse.headers["x-ratelimit-remaining"], "1");
+
+  const secondResponse = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(secondResponse.statusCode, 200);
+  assert.equal(secondResponse.headers["x-ratelimit-remaining"], "0");
+
+  const blockedResponse = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(blockedResponse.statusCode, 429);
+  assert.equal(blockedResponse.headers["x-ratelimit-remaining"], "0");
+  assert.equal(blockedResponse.json().error, "rate_limit_exceeded");
+  assert.equal(blockedResponse.json().scope, "public");
+});
+
+test("authenticated portal and admin routes share the authenticated per-user budget", async (t) => {
+  const app = Fastify();
+  const rateLimitPreHandlers = createRateLimitPreHandlers(
+    createInMemoryRateLimiter({
+      policies: {
+        authenticated: {
+          limit: 2
+        }
+      }
+    })
+  );
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, {} as never, createApprovedAccessGuard() as never, {
+    rateLimitPreHandlers,
+    resolvePortalAccess: async (request) => {
+      request.accessIdentity = {
+        email: "person@example.com",
+        issuer: "https://paretoproof.cloudflareaccess.com",
+        provider: "cloudflare_github",
+        subject: "subject-1"
+      };
+      request.accessRbacContext = {
+        email: "person@example.com",
+        identityId: "identity-1",
+        roles: ["admin"],
+        status: "approved",
+        subject: "subject-1",
+        userId: "user-1"
+      };
+
+      return request.accessRbacContext;
+    }
+  });
+  registerAdminRoutes(app, {
+    query: {
+      users: {
+        findMany: async () => [],
+        findFirst: async () => null
+      }
+    }
+  } as never, createApprovedAccessGuard() as never, {
+    rateLimitPreHandlers
+  });
+
+  const portalResponse = await app.inject({
+    method: "GET",
+    url: "/portal/me"
+  });
+
+  assert.equal(portalResponse.statusCode, 200);
+  assert.equal(portalResponse.headers["x-ratelimit-limit"], "2");
+  assert.equal(portalResponse.headers["x-ratelimit-remaining"], "1");
+
+  const adminResponse = await app.inject({
+    method: "GET",
+    url: "/portal/admin/users"
+  });
+
+  assert.equal(adminResponse.statusCode, 200);
+  assert.equal(adminResponse.headers["x-ratelimit-remaining"], "0");
+
+  const blockedResponse = await app.inject({
+    method: "GET",
+    url: "/portal/runs"
+  });
+
+  assert.equal(blockedResponse.statusCode, 429);
+  assert.equal(blockedResponse.json().scope, "authenticated");
+  assert.equal(blockedResponse.headers["retry-after"], "60");
+});

--- a/apps/web/src/lib/api-fetch.test.js
+++ b/apps/web/src/lib/api-fetch.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ApiRateLimitError, fetchApi } from "./api-fetch.ts";
+
+test("fetchApi retries one safe request after Retry-After and eventually succeeds", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+  const observedWaits = [];
+  let callCount = 0;
+
+  globalThis.window = {
+    location: {
+      origin: "https://portal.paretoproof.com"
+    },
+    setTimeout(callback, delay) {
+      observedWaits.push(delay);
+      callback();
+      return 0;
+    }
+  };
+  globalThis.fetch = async () => {
+    callCount += 1;
+
+    if (callCount === 1) {
+      return new Response(null, {
+        headers: {
+          "Retry-After": "1"
+        },
+        status: 429
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: {
+        "Content-Type": "application/json"
+      },
+      status: 200
+    });
+  };
+
+  try {
+    const response = await fetchApi("https://api.paretoproof.com/portal/me");
+
+    assert.equal(response.status, 200);
+    assert.equal(callCount, 2);
+    assert.deepEqual(observedWaits, [1000, 1000]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.window = originalWindow;
+  }
+});
+
+test("fetchApi throws ApiRateLimitError for non-idempotent requests after reading retry headers", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+
+  globalThis.window = {
+    location: {
+      origin: "https://portal.paretoproof.com"
+    },
+    setTimeout(callback) {
+      callback();
+      return 0;
+    }
+  };
+  globalThis.fetch = async () =>
+    new Response(null, {
+      headers: {
+        "Retry-After": "2"
+      },
+      status: 429
+    });
+
+  try {
+    await assert.rejects(
+      () =>
+        fetchApi("https://api.paretoproof.com/portal/profile", {
+          body: "displayName=Test",
+          method: "POST"
+        }),
+      (error) => {
+        assert.equal(error instanceof ApiRateLimitError, true);
+        assert.equal(error.retryAfterMs, 2000);
+        return true;
+      }
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.window = originalWindow;
+  }
+});

--- a/apps/web/src/lib/api-fetch.ts
+++ b/apps/web/src/lib/api-fetch.ts
@@ -1,0 +1,101 @@
+const rateLimitBackoffByOrigin = new Map<string, number>();
+
+export class ApiRateLimitError extends Error {
+  response: Response;
+  retryAfterMs: number;
+
+  constructor(message: string, response: Response, retryAfterMs: number) {
+    super(message);
+    this.name = "ApiRateLimitError";
+    this.response = response;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+function sleep(milliseconds: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+function readRetryAfterMs(response: Response) {
+  const retryAfterHeader = response.headers.get("Retry-After");
+
+  if (retryAfterHeader) {
+    const retryAfterSeconds = Number(retryAfterHeader);
+
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+      return retryAfterSeconds * 1000;
+    }
+
+    const retryAfterDate = Date.parse(retryAfterHeader);
+
+    if (Number.isFinite(retryAfterDate)) {
+      return Math.max(retryAfterDate - Date.now(), 0);
+    }
+  }
+
+  const resetHeader = response.headers.get("X-RateLimit-Reset");
+
+  if (!resetHeader) {
+    return 1000;
+  }
+
+  const resetSeconds = Number(resetHeader);
+
+  if (!Number.isFinite(resetSeconds)) {
+    return 1000;
+  }
+
+  return Math.max(resetSeconds * 1000 - Date.now(), 1000);
+}
+
+function getBackoffOrigin(input: RequestInfo | URL) {
+  const requestUrl =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+  return new URL(requestUrl, window.location.origin).origin;
+}
+
+function shouldAutoRetry(init: RequestInit | undefined) {
+  const method = (init?.method ?? "GET").toUpperCase();
+  return method === "GET" || method === "HEAD";
+}
+
+export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const backoffOrigin = getBackoffOrigin(input);
+  const autoRetry = shouldAutoRetry(init);
+  let attemptCount = 0;
+
+  while (true) {
+    const nextAllowedAt = rateLimitBackoffByOrigin.get(backoffOrigin) ?? 0;
+    const waitMs = nextAllowedAt - Date.now();
+
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+
+    const response = await fetch(input, init);
+
+    if (response.status !== 429) {
+      return response;
+    }
+
+    const retryAfterMs = Math.min(readRetryAfterMs(response), 30_000);
+    rateLimitBackoffByOrigin.set(backoffOrigin, Date.now() + retryAfterMs);
+
+    if (autoRetry && attemptCount < 1) {
+      attemptCount += 1;
+      await sleep(retryAfterMs);
+      continue;
+    }
+
+    throw new ApiRateLimitError(
+      `The API is rate limiting this browser. Retry in ${Math.ceil(retryAfterMs / 1000)}s.`,
+      response,
+      retryAfterMs
+    );
+  }
+}

--- a/apps/web/src/lib/portal-admin.ts
+++ b/apps/web/src/lib/portal-admin.ts
@@ -13,6 +13,7 @@ import {
   type PortalAdminUserDetail,
   type PortalAdminUserListItem
 } from "@paretoproof/shared";
+import { fetchApi } from "./api-fetch";
 import { createApiFormBody } from "./api-form";
 import { isLocalHostname } from "./surface";
 
@@ -700,7 +701,7 @@ export async function loadPortalAdminAccessRequests(apiBaseUrl: string) {
     return sortByCreatedDesc(readLocalAdminState().accessRequests.map(toAccessRequestListItem));
   }
 
-  const response = await fetch(`${apiBaseUrl}/portal/admin/access-requests`, {
+  const response = await fetchApi(`${apiBaseUrl}/portal/admin/access-requests`, {
     credentials: "include",
     headers: {
       Accept: "application/json"
@@ -751,7 +752,7 @@ export async function loadPortalAdminAccessRequestDetail(
     return item;
   }
 
-  const response = await fetch(
+  const response = await fetchApi(
     `${apiBaseUrl}/portal/admin/access-requests/${encodeURIComponent(accessRequestId)}`,
     {
       credentials: "include",
@@ -945,7 +946,7 @@ export async function approvePortalAdminAccessRequest(
     return { ok: true };
   }
 
-  const response = await fetch(
+  const response = await fetchApi(
     `${apiBaseUrl}/portal/admin/access-requests/${encodeURIComponent(accessRequestId)}/approve`,
     {
       body: createApiFormBody({
@@ -1050,7 +1051,7 @@ export async function rejectPortalAdminAccessRequest(
     return { ok: true };
   }
 
-  const response = await fetch(
+  const response = await fetchApi(
     `${apiBaseUrl}/portal/admin/access-requests/${encodeURIComponent(accessRequestId)}/reject`,
     {
       body: createApiFormBody({
@@ -1078,7 +1079,7 @@ export async function loadPortalAdminUsers(apiBaseUrl: string) {
       .map(toUserListItem);
   }
 
-  const response = await fetch(`${apiBaseUrl}/portal/admin/users`, {
+  const response = await fetchApi(`${apiBaseUrl}/portal/admin/users`, {
     credentials: "include",
     headers: {
       Accept: "application/json"
@@ -1120,7 +1121,7 @@ export async function loadPortalAdminUserDetail(apiBaseUrl: string, userId: stri
     return item;
   }
 
-  const response = await fetch(`${apiBaseUrl}/portal/admin/users/${encodeURIComponent(userId)}`, {
+  const response = await fetchApi(`${apiBaseUrl}/portal/admin/users/${encodeURIComponent(userId)}`, {
     credentials: "include",
     headers: {
       Accept: "application/json"
@@ -1214,7 +1215,7 @@ export async function revokePortalAdminUserRole(
     return { ok: true };
   }
 
-  const response = await fetch(
+  const response = await fetchApi(
     `${apiBaseUrl}/portal/admin/users/${encodeURIComponent(userId)}/revoke-role`,
     {
       body: createApiFormBody({

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -24,6 +24,7 @@ import {
   type RunLifecycleState
 } from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
+import { fetchApi } from "./api-fetch";
 import { portalResultsExportHeaders } from "./results-state";
 import { isLocalHostname } from "./surface";
 
@@ -877,7 +878,7 @@ async function fetchPortalBenchmarkOpsJson<T>(
   path: string,
   schema: { parse: (value: unknown) => T }
 ): Promise<T> {
-  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+  const response = await fetchApi(`${getApiBaseUrl()}${path}`, {
     credentials: "include",
     headers: {
       Accept: "application/json"

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import { fetchApi } from "../lib/api-fetch";
 import {
   buildAccessRequestUrl,
   buildAccessStartUrl,
@@ -78,7 +79,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
 
     async function resolveExistingSession() {
       try {
-        const response = await fetch(
+        const response = await fetchApi(
           `${apiBaseUrl}/portal/me`,
           buildAuthEntrySessionCheckRequestInit(controller.signal)
         );

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -5,6 +5,7 @@ import type {
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import { fetchApi } from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { resolvePortalRouteRedirect } from "../lib/portal-route-access";
 import { AccessRequestScreen } from "./access-request-screen";
@@ -179,7 +180,7 @@ export function PortalBootstrap() {
 
     async function loadAccessState() {
       try {
-        const response = await fetch(`${apiBaseUrl}/portal/me`, {
+        const response = await fetchApi(`${apiBaseUrl}/portal/me`, {
           credentials: "include",
           headers: {
             Accept: "application/json"
@@ -271,7 +272,7 @@ export function PortalBootstrap() {
       return;
     }
 
-    const response = await fetch(`${apiBaseUrl}/portal/access-requests`, {
+    const response = await fetchApi(`${apiBaseUrl}/portal/access-requests`, {
       body: createApiFormBody({
         rationale: payload.rationale ?? "",
         requestedRole: payload.requestedRole
@@ -304,7 +305,7 @@ export function PortalBootstrap() {
       return;
     }
 
-    const response = await fetch(`${apiBaseUrl}/portal/access-recovery`, {
+    const response = await fetchApi(`${apiBaseUrl}/portal/access-recovery`, {
       body: createApiFormBody({
         rationale: payload.rationale ?? ""
       }),

--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useMemo, useState, startTransition } from "react";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import { fetchApi } from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { isLocalHostname } from "../lib/surface";
 import { useCompactLayout } from "../lib/use-compact-layout";
@@ -248,7 +249,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
           return;
         }
 
-        const response = await fetch(`${apiBaseUrl}/portal/profile`, {
+        const response = await fetchApi(`${apiBaseUrl}/portal/profile`, {
           credentials: "include",
           headers: {
             Accept: "application/json"
@@ -328,7 +329,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         return;
       }
 
-      const response = await fetch(`${apiBaseUrl}/portal/profile/link-intents`, {
+      const response = await fetchApi(`${apiBaseUrl}/portal/profile/link-intents`, {
         body: createApiFormBody({
           provider: parsed.data.provider,
           redirectPath: parsed.data.redirectPath ?? ""
@@ -383,7 +384,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         return;
       }
 
-      const response = await fetch(`${apiBaseUrl}/portal/profile`, {
+      const response = await fetchApi(`${apiBaseUrl}/portal/profile`, {
         body: createApiFormBody({
           displayName: parsed.data.displayName ?? ""
         }),


### PR DESCRIPTION
## Summary
- add shared in-memory API rate limiting with public and authenticated budgets plus standard `Retry-After` / `X-RateLimit-*` headers
- apply rate limiting to the current public health/auth-handoff routes and the authenticated portal/admin browser API surface
- add a shared browser fetch wrapper that backs off on `429` responses and switch the existing portal/admin/profile/auth fetchers onto it

## Related issues
- Closes #803

## Verification
- `bun run typecheck:api`
- `bun run typecheck:web`
- `bun --cwd apps/api test`
- `bunx tsx --test apps/web/src/lib/api-fetch.test.js`
- `bun run check:bidi`