### PR TITLE
Add authenticated portal benchmark dataset exports

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -4,6 +4,9 @@ import {
   getRunLifecycleStateLabel,
   defaultRunControlPolicy,
   portalRunsLifecycleBuckets,
+  type PortalBenchmarkDatasetResponse,
+  type PortalBenchmarkListItem,
+  type PortalBenchmarksListResponse,
   runKindCatalog,
   runKindConcurrencyOverrides,
   type PortalLaunchBenchmarkOption,
@@ -43,6 +46,8 @@ type WorkerJobLeaseRow = typeof workerJobLeases.$inferSelect;
 type WorkerAttemptEventRow = typeof workerAttemptEvents.$inferSelect;
 
 export type PortalBenchmarkOpsReadModelService = {
+  getBenchmarkDataset(packageId: string): Promise<PortalBenchmarkDatasetResponse | null>;
+  getBenchmarksList(): Promise<PortalBenchmarksListResponse>;
   getLaunchView(): Promise<PortalLaunchViewResponse>;
   getRunDetail(runId: string): Promise<PortalRunDetailResponse | null>;
   getRunsList(query: PortalRunsListQuery): Promise<PortalRunsListResponse>;
@@ -64,6 +69,14 @@ function getBenchmarkVersionId(runRow: RunRow) {
 
 function getBenchmarkLabel(runRow: RunRow) {
   return `${runRow.benchmarkPackageId} @ ${runRow.benchmarkPackageVersion}`;
+}
+
+function getBenchmarkPackageLabel(packageId: string, versions: string[]) {
+  if (versions.length === 1) {
+    return `${packageId} @ ${versions[0]}`;
+  }
+
+  return `${packageId} (${versions.length} versions)`;
 }
 
 function getRunLifecycleBucket(runState: RunRow["state"]): PortalRunsLifecycleBucket {
@@ -408,6 +421,25 @@ function buildEmptyRunsFilters(): PortalRunsAvailableFilters {
   };
 }
 
+function createEmptyVerdictCounts() {
+  return {
+    fail: 0,
+    invalid_result: 0,
+    pass: 0
+  } satisfies Record<RunRow["verdictClass"], number>;
+}
+
+function incrementVerdictCounts(
+  verdictCounts: Record<RunRow["verdictClass"], number>,
+  verdictClass: RunRow["verdictClass"]
+) {
+  verdictCounts[verdictClass] += 1;
+}
+
+function listSortedUnique(values: string[]) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
 function buildEmptyRunsListResponse(query: PortalRunsListQuery): PortalRunsListResponse {
   return {
     filters: buildEmptyRunsFilters(),
@@ -467,10 +499,181 @@ async function loadRunsFilters(
   };
 }
 
+async function loadAttemptCountsByRunId(db: ReturnTypeOfCreateDbClient) {
+  const rows = await db
+    .select({
+      runId: attempts.runId,
+      total: count()
+    })
+    .from(attempts)
+    .groupBy(attempts.runId);
+
+  return new Map(rows.map((row) => [row.runId, row.total]));
+}
+
 export function createPortalBenchmarkOpsReadModelService(
   db: ReturnTypeOfCreateDbClient
 ): PortalBenchmarkOpsReadModelService {
   return {
+    async getBenchmarksList() {
+      const [runRows, attemptCountsByRunId] = await Promise.all([
+        db
+          .select()
+          .from(runs)
+          .orderBy(desc(runs.completedAt), desc(runs.createdAt)),
+        loadAttemptCountsByRunId(db)
+      ]);
+
+      const benchmarks = new Map<string, PortalBenchmarkListItem>();
+
+      for (const runRow of runRows) {
+        const existing = benchmarks.get(runRow.benchmarkPackageId);
+        const attemptCount = attemptCountsByRunId.get(runRow.id) ?? 0;
+
+        if (!existing) {
+          const verdictCounts = createEmptyVerdictCounts();
+          incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+          benchmarks.set(runRow.benchmarkPackageId, {
+            attemptCount,
+            benchmarkLabel: getBenchmarkPackageLabel(runRow.benchmarkPackageId, [
+              runRow.benchmarkPackageVersion
+            ]),
+            benchmarkPackageId: runRow.benchmarkPackageId,
+            latestCompletedAt: runRow.completedAt.toISOString(),
+            latestRunId: runRow.sourceRunId,
+            modelConfigIds: [runRow.modelConfigId],
+            providerFamilies: [runRow.providerFamily],
+            runCount: 1,
+            versions: [runRow.benchmarkPackageVersion],
+            verdictCounts
+          });
+          continue;
+        }
+
+        existing.attemptCount += attemptCount;
+        existing.runCount += 1;
+        incrementVerdictCounts(existing.verdictCounts, runRow.verdictClass);
+
+        if (!existing.latestCompletedAt) {
+          existing.latestCompletedAt = runRow.completedAt.toISOString();
+          existing.latestRunId = runRow.sourceRunId;
+        }
+
+        if (!existing.modelConfigIds.includes(runRow.modelConfigId)) {
+          existing.modelConfigIds.push(runRow.modelConfigId);
+        }
+
+        if (!existing.providerFamilies.includes(runRow.providerFamily)) {
+          existing.providerFamilies.push(runRow.providerFamily);
+        }
+
+        if (!existing.versions.includes(runRow.benchmarkPackageVersion)) {
+          existing.versions.push(runRow.benchmarkPackageVersion);
+        }
+      }
+
+      const items = [...benchmarks.values()]
+        .map((item) => {
+          const versions = listSortedUnique(item.versions);
+          return {
+            ...item,
+            benchmarkLabel: getBenchmarkPackageLabel(item.benchmarkPackageId, versions),
+            modelConfigIds: listSortedUnique(item.modelConfigIds),
+            providerFamilies: listSortedUnique(item.providerFamilies),
+            versions
+          };
+        })
+        .sort((left, right) => {
+          if (!left.latestCompletedAt || !right.latestCompletedAt) {
+            return left.benchmarkPackageId.localeCompare(right.benchmarkPackageId);
+          }
+
+          return Date.parse(right.latestCompletedAt) - Date.parse(left.latestCompletedAt);
+        });
+
+      return { items };
+    },
+
+    async getBenchmarkDataset(packageId) {
+      const runRows = await db
+        .select()
+        .from(runs)
+        .where(eq(runs.benchmarkPackageId, packageId))
+        .orderBy(desc(runs.completedAt), desc(runs.createdAt));
+
+      if (runRows.length === 0) {
+        return null;
+      }
+
+      const runIds = runRows.map((runRow) => runRow.id);
+      const [jobRows, attemptRows] = await Promise.all([
+        loadJobsForRunIds(db, runIds),
+        loadAttemptsForRunIds(db, runIds)
+      ]);
+      const runById = new Map(runRows.map((runRow) => [runRow.id, runRow]));
+      const jobsByRunId = groupByRunId(jobRows);
+      const attemptsByRunId = groupByRunId(attemptRows);
+      const jobById = new Map(jobRows.map((jobRow) => [jobRow.id, jobRow]));
+      const verdictCounts = createEmptyVerdictCounts();
+      const versions = listSortedUnique(runRows.map((runRow) => runRow.benchmarkPackageVersion));
+      const providerFamilies = listSortedUnique(runRows.map((runRow) => runRow.providerFamily));
+      const modelConfigIds = listSortedUnique(runRows.map((runRow) => runRow.modelConfigId));
+      const laneIds = listSortedUnique(runRows.map((runRow) => runRow.laneId));
+      const latestRun = runRows[0] ?? null;
+
+      for (const runRow of runRows) {
+        incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+      }
+
+      return {
+        attempts: [...attemptRows]
+          .sort(compareByCreatedAtDesc)
+          .map((attemptRow) => {
+            const runRow = runById.get(attemptRow.runId);
+
+            if (!runRow) {
+              throw new Error("Attempt references a run outside the benchmark dataset.");
+            }
+
+            return buildAttemptSummary(runRow, attemptRow, jobById);
+          }),
+        benchmark: {
+          benchmarkLabel: getBenchmarkPackageLabel(packageId, versions),
+          benchmarkPackageId: packageId,
+          laneIds,
+          latestRunId: latestRun?.sourceRunId ?? null,
+          modelConfigIds,
+          providerFamilies,
+          versions
+        },
+        jobs: [...jobRows]
+          .sort(compareByCreatedAtDesc)
+          .map((jobRow) => {
+            const runRow = runById.get(jobRow.runId);
+
+            if (!runRow) {
+              throw new Error("Job references a run outside the benchmark dataset.");
+            }
+
+            return buildJobSummary(runRow, jobRow);
+          }),
+        runs: runRows.map((runRow) =>
+          buildRunListItem({
+            attemptRows: attemptsByRunId.get(runRow.id) ?? [],
+            jobRows: jobsByRunId.get(runRow.id) ?? [],
+            runRow
+          })
+        ),
+        summary: {
+          attemptCount: attemptRows.length,
+          jobCount: jobRows.length,
+          latestCompletedAt: latestRun?.completedAt.toISOString() ?? null,
+          runCount: runRows.length,
+          verdictCounts
+        }
+      };
+    },
+
     async getRunsList(query) {
       const runConditions = [];
 

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -1,11 +1,14 @@
 import {
   portalBenchmarkOpsReadModelsContract,
+  portalBenchmarkDatasetParamsSchema,
+  portalBenchmarkExportQuerySchema,
   portalAccessRecoveryInputSchema,
   portalAccessRequestInputSchema,
   portalRunDetailParamsSchema,
   portalProfileLinkIntentInputSchema,
   portalProfileUpdateInputSchema,
   portalRunsListQuerySchema,
+  type PortalBenchmarkDatasetResponse,
   type PortalProfile,
   type PortalProfileLinkIntent
 } from "@paretoproof/shared";
@@ -221,6 +224,93 @@ function toPortalProfile(options: {
     linkedUserId: options.userRow?.id ?? null,
     updatedAt: options.userRow?.updatedAt.toISOString() ?? null
   };
+}
+
+function escapeCsvValue(value: string) {
+  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+
+  if (/[",\n]/.test(safeValue)) {
+    return `"${safeValue.replaceAll('"', '""')}"`;
+  }
+
+  return safeValue;
+}
+
+function sanitizeExportFilenameSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "benchmark";
+}
+
+function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
+  const runById = new Map(dataset.runs.map((run) => [run.runId, run]));
+  const attemptsByRunId = new Map<string, typeof dataset.attempts>();
+
+  for (const attempt of dataset.attempts) {
+    const existing = attemptsByRunId.get(attempt.runId);
+
+    if (existing) {
+      existing.push(attempt);
+      continue;
+    }
+
+    attemptsByRunId.set(attempt.runId, [attempt]);
+  }
+
+  const headers = [
+    "benchmarkPackageId",
+    "benchmarkVersions",
+    "runId",
+    "runState",
+    "runVerdictClass",
+    "providerFamily",
+    "modelConfigId",
+    "startedAt",
+    "completedAt",
+    "durationMs",
+    "jobId",
+    "attemptId",
+    "attemptState",
+    "attemptVerdictClass",
+    "verifierResult",
+    "failureFamily",
+    "failureCode",
+    "failureSummary"
+  ];
+  const rows = dataset.runs.flatMap((run) => {
+    const attempts = attemptsByRunId.get(run.runId) ?? [null];
+
+    return attempts.map((attempt) => [
+      dataset.benchmark.benchmarkPackageId,
+      dataset.benchmark.versions.join("|"),
+      run.runId,
+      run.runState,
+      run.verdictClass,
+      run.providerFamily,
+      run.modelConfigId,
+      run.startedAt,
+      run.completedAt,
+      String(run.durationMs),
+      attempt?.jobId ?? run.latestJobId ?? "",
+      attempt?.attemptId ?? "",
+      attempt?.state ?? "",
+      attempt?.verdictClass ?? "",
+      attempt?.verifierResult ?? "",
+      attempt?.failure.family ?? run.failure.family ?? "",
+      attempt?.failure.code ?? run.failure.code ?? "",
+      attempt?.failure.summary ?? run.failure.summary ?? ""
+    ]);
+  });
+
+  for (const runId of attemptsByRunId.keys()) {
+    if (runById.has(runId)) {
+      continue;
+    }
+
+    throw new Error(`Benchmark dataset export could not resolve run ${runId}.`);
+  }
+
+  return [headers, ...rows]
+    .map((row) => row.map((value) => escapeCsvValue(String(value))).join(","))
+    .join("\n");
 }
 
 async function loadPortalProfile(db: ReturnTypeOfCreateDbClient, options: {
@@ -612,6 +702,110 @@ export function registerPortalRoutes(
           identitySubject: identity.subject
         })
       };
+    }
+  );
+
+  app.get(
+    "/portal/benchmarks",
+    {
+      config: {
+        contract: portalBenchmarkOpsReadModelsContract.benchmarksListResponse
+      },
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
+    },
+    async () => portalBenchmarkOpsReadModels.getBenchmarksList()
+  );
+
+  app.get(
+    "/portal/benchmarks/:packageId/dataset",
+    {
+      config: {
+        contract: portalBenchmarkOpsReadModelsContract.benchmarkDatasetResponse
+      },
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
+    },
+    async (request, reply) => {
+      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(request.params ?? {});
+
+      if (!parsedParams.success) {
+        reply.code(400).send({
+          error: "invalid_portal_benchmark_dataset_params",
+          issues: parsedParams.error.issues
+        });
+        return;
+      }
+
+      const dataset = await portalBenchmarkOpsReadModels.getBenchmarkDataset(
+        parsedParams.data.packageId
+      );
+
+      if (!dataset) {
+        reply.code(404).send({
+          error: "portal_benchmark_dataset_not_found"
+        });
+        return;
+      }
+
+      return dataset;
+    }
+  );
+
+  app.get(
+    "/portal/benchmarks/:packageId/export",
+    {
+      preHandler: [
+        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
+      ]
+    },
+    async (request, reply) => {
+      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(request.params ?? {});
+
+      if (!parsedParams.success) {
+        reply.code(400).send({
+          error: "invalid_portal_benchmark_export_params",
+          issues: parsedParams.error.issues
+        });
+        return;
+      }
+
+      const parsedQuery = portalBenchmarkExportQuerySchema.safeParse(request.query ?? {});
+
+      if (!parsedQuery.success) {
+        reply.code(400).send({
+          error: "invalid_portal_benchmark_export_query",
+          issues: parsedQuery.error.issues
+        });
+        return;
+      }
+
+      const dataset = await portalBenchmarkOpsReadModels.getBenchmarkDataset(
+        parsedParams.data.packageId
+      );
+
+      if (!dataset) {
+        reply.code(404).send({
+          error: "portal_benchmark_dataset_not_found"
+        });
+        return;
+      }
+
+      const filenameRoot = sanitizeExportFilenameSegment(parsedParams.data.packageId);
+
+      if (parsedQuery.data.format === "csv") {
+        reply
+          .header("content-disposition", `attachment; filename="${filenameRoot}-dataset.csv"`)
+          .type("text/csv; charset=utf-8");
+        return reply.send(buildBenchmarkDatasetCsv(dataset));
+      }
+
+      reply
+        .header("content-disposition", `attachment; filename="${filenameRoot}-dataset.json"`)
+        .type("application/json; charset=utf-8");
+      return reply.send(dataset);
     }
   );
 

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
 import type {
+  PortalBenchmarkDatasetResponse,
+  PortalBenchmarksListResponse,
   PortalLaunchViewResponse,
   PortalRunDetailResponse,
   PortalRunsListQuery,
@@ -158,6 +160,110 @@ function buildRunDetailResponse(): PortalRunDetailResponse {
   };
 }
 
+function buildBenchmarksListResponse(): PortalBenchmarksListResponse {
+  return {
+    items: [
+      {
+        attemptCount: 1,
+        benchmarkLabel: "problem9 @ 2026.03",
+        benchmarkPackageId: "problem9",
+        latestCompletedAt: "2026-03-13T20:00:00.000Z",
+        latestRunId: "PP-318",
+        modelConfigIds: ["gpt-oss"],
+        providerFamilies: ["openai"],
+        runCount: 1,
+        versions: ["2026.03"],
+        verdictCounts: {
+          fail: 0,
+          invalid_result: 0,
+          pass: 1
+        }
+      }
+    ]
+  };
+}
+
+function buildBenchmarkDatasetResponse(): PortalBenchmarkDatasetResponse {
+  return {
+    attempts: [
+      {
+        attemptId: "attempt-1",
+        completedAt: "2026-03-13T20:00:00.000Z",
+        failure: {
+          code: null,
+          family: null,
+          summary: null
+        },
+        jobId: "job-1",
+        runId: "PP-318",
+        startedAt: "2026-03-13T19:58:30.000Z",
+        state: "succeeded",
+        stopReason: "completed",
+        verdictClass: "pass",
+        verifierResult: "accepted"
+      }
+    ],
+    benchmark: {
+      benchmarkLabel: "problem9 @ 2026.03",
+      benchmarkPackageId: "problem9",
+      laneIds: ["problem9-default"],
+      latestRunId: "PP-318",
+      modelConfigIds: ["gpt-oss"],
+      providerFamilies: ["openai"],
+      versions: ["2026.03"]
+    },
+    jobs: [
+      {
+        completedAt: "2026-03-13T20:00:00.000Z",
+        failure: {
+          code: null,
+          family: null,
+          summary: null
+        },
+        jobId: "job-1",
+        runId: "PP-318",
+        startedAt: "2026-03-13T19:58:10.000Z",
+        state: "completed",
+        stopReason: "completed",
+        verdictClass: "pass"
+      }
+    ],
+    runs: buildRunsListResponse({
+      attemptId: null,
+      authMode: null,
+      benchmarkPackageDigest: null,
+      benchmarkPackageId: null,
+      benchmarkPackageVersion: null,
+      failureCode: null,
+      failureFamily: null,
+      jobId: null,
+      lifecycleBucket: null,
+      limit: 25,
+      modelConfigId: null,
+      providerFamily: null,
+      q: null,
+      runId: null,
+      runLifecycle: [],
+      runMode: null,
+      runKind: null,
+      sort: "started_at_desc",
+      toolProfile: null,
+      verdict: []
+    }).items,
+    summary: {
+      attemptCount: 1,
+      jobCount: 1,
+      latestCompletedAt: "2026-03-13T20:00:00.000Z",
+      runCount: 1,
+      verdictCounts: {
+        fail: 0,
+        invalid_result: 0,
+        pass: 1
+      }
+    }
+  };
+}
+
 function buildLaunchViewResponse(): PortalLaunchViewResponse {
   return {
     benchmarks: [
@@ -251,12 +357,18 @@ function buildWorkersViewResponse(): PortalWorkersViewResponse {
 }
 
 function createReadModelService(overrides?: {
+  getBenchmarkDataset?: (packageId: string) => Promise<PortalBenchmarkDatasetResponse | null>;
+  getBenchmarksList?: () => Promise<PortalBenchmarksListResponse>;
   getLaunchView?: () => Promise<PortalLaunchViewResponse>;
   getRunDetail?: (runId: string) => Promise<PortalRunDetailResponse | null>;
   getRunsList?: (query: PortalRunsListQuery) => Promise<PortalRunsListResponse>;
   getWorkersView?: () => Promise<PortalWorkersViewResponse>;
 }): PortalBenchmarkOpsReadModelService {
   return {
+    getBenchmarkDataset:
+      overrides?.getBenchmarkDataset ?? (async () => buildBenchmarkDatasetResponse()),
+    getBenchmarksList:
+      overrides?.getBenchmarksList ?? (async () => buildBenchmarksListResponse()),
     getLaunchView: overrides?.getLaunchView ?? (async () => buildLaunchViewResponse()),
     getRunDetail: overrides?.getRunDetail ?? (async () => buildRunDetailResponse()),
     getRunsList: overrides?.getRunsList ?? (async (query) => buildRunsListResponse(query)),
@@ -372,6 +484,91 @@ test("GET /portal/runs rejects invalid benchmark-ops query params", async (t) =>
 
   assert.equal(response.statusCode, 400);
   assert.equal(response.json().error, "invalid_portal_runs_query");
+});
+
+test("GET /portal/benchmarks returns a contract-valid package summary list", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService(),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/benchmarks"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = portalBenchmarkOpsReadModelsContract.benchmarksListResponse.parse(
+    response.json()
+  );
+  assert.equal(payload.items[0]?.benchmarkPackageId, "problem9");
+});
+
+test("GET /portal/benchmarks/:packageId/dataset returns 404 when the package is missing", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService({
+        getBenchmarkDataset: async () => null
+      }),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/benchmarks/problem9/dataset"
+  });
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.json().error, "portal_benchmark_dataset_not_found");
+});
+
+test("GET /portal/benchmarks/:packageId/export streams csv when requested", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService(),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/benchmarks/problem9/export?format=csv"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.headers["content-type"] ?? "", /^text\/csv/);
+  assert.match(response.body, /benchmarkPackageId,benchmarkVersions,runId/);
+  assert.match(response.body, /problem9,2026\.03,PP-318/);
 });
 
 test("GET /portal/runs/:runId returns 404 when the run read model is missing", async (t) => {

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildPortalBenchmarkDatasetCsv,
+  buildPortalBenchmarkDatasetExportFileName,
   buildRunsCsv,
   buildRunsModelOptions,
   buildRunsProviderOptions,
@@ -63,6 +65,99 @@ describe("buildRunsCsv", () => {
     expect(csv).toContain("runLifecycleBucketLabel");
     expect(csv).toContain("succeeded,Succeeded,terminal_success,Terminal success,pass,Pass");
     expect(csv).not.toContain("succeeded,Completed");
+  });
+});
+
+describe("benchmark dataset exports", () => {
+  it("builds a stable dataset export filename for the selected package", () => {
+    expect(
+      buildPortalBenchmarkDatasetExportFileName(
+        "problem9/core",
+        "json",
+        new Date("2026-03-15T08:45:30.000Z")
+      )
+    ).toBe("paretoproof-problem9-core-dataset-2026-03-15T08-45-30.json");
+  });
+
+  it("flattens dataset attempts into csv rows for export", () => {
+    const csv = buildPortalBenchmarkDatasetCsv({
+      attempts: [
+        {
+          attemptId: "attempt-1",
+          completedAt: "2026-03-13T20:00:00.000Z",
+          failure: { code: null, family: null, summary: null },
+          jobId: "job-1",
+          runId: "PP-318",
+          startedAt: "2026-03-13T19:58:30.000Z",
+          state: "succeeded",
+          stopReason: "completed",
+          verdictClass: "pass",
+          verifierResult: "accepted"
+        }
+      ],
+      benchmark: {
+        benchmarkLabel: "problem9 @ 2026.03",
+        benchmarkPackageId: "problem9",
+        laneIds: ["problem9-default"],
+        latestRunId: "PP-318",
+        modelConfigIds: ["gpt-oss"],
+        providerFamilies: ["openai"],
+        versions: ["2026.03"]
+      },
+      jobs: [],
+      runs: [
+        {
+          authMode: "oidc",
+          benchmarkItemId: "item-1",
+          benchmarkLabel: "problem9 core",
+          benchmarkPackageDigest: "sha256:abc",
+          benchmarkPackageId: "problem9",
+          benchmarkPackageVersion: "2026.03",
+          benchmarkVersionId: "problem9@2026.03",
+          completedAt: "2026-03-13T20:00:00.000Z",
+          durationMs: 120000,
+          failure: { code: null, family: null, summary: null },
+          laneId: "lane-1",
+          latestAttemptId: "attempt-1",
+          latestJobId: "job-1",
+          lineage: {
+            attemptCount: 1,
+            attemptIds: ["attempt-1"],
+            jobCount: 1,
+            jobIds: ["job-1"],
+            latestAttemptId: "attempt-1",
+            latestJobId: "job-1"
+          },
+          modelConfigId: "gpt-oss",
+          modelConfigLabel: "GPT OSS",
+          modelSnapshotId: "gpt-oss-2026-03-13",
+          providerFamily: "openai",
+          runId: "PP-318",
+          runKind: "single_run",
+          runLifecycleBucket: "terminal_success",
+          runMode: "eval",
+          runState: "succeeded",
+          startedAt: "2026-03-13T19:58:00.000Z",
+          toolProfile: "lean4-proof",
+          verdictClass: "pass"
+        }
+      ],
+      summary: {
+        attemptCount: 1,
+        jobCount: 1,
+        latestCompletedAt: "2026-03-13T20:00:00.000Z",
+        runCount: 1,
+        verdictCounts: {
+          fail: 0,
+          invalid_result: 0,
+          pass: 1
+        }
+      }
+    });
+
+    expect(csv).toContain("benchmarkPackageId,benchmarkVersions,runId");
+    expect(csv).toContain("problem9,2026.03,PP-318,succeeded,pass,openai");
+    expect(csv).toContain("job-1,attempt-1,succeeded,pass,accepted");
   });
 });
 

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1,5 +1,7 @@
 import {
   evaluationVerdictLabels,
+  portalBenchmarkDatasetResponseSchema,
+  portalBenchmarksListResponseSchema,
   getPortalRunsLifecycleBucketLabel,
   getRunLifecycleStateLabel,
   portalLaunchViewResponseSchema,
@@ -8,6 +10,9 @@ import {
   portalRunsListQuerySchema,
   portalRunsListResponseSchema,
   portalWorkersViewResponseSchema,
+  type PortalBenchmarkDatasetResponse,
+  type PortalBenchmarkExportFormat,
+  type PortalBenchmarksListResponse,
   type EvaluationVerdictClass,
   type PortalLaunchViewResponse,
   type PortalRunsAvailableFilters,
@@ -710,6 +715,137 @@ const localWorkersView: PortalWorkersViewResponse = {
   ]
 };
 
+function createEmptyVerdictCounts() {
+  return {
+    fail: 0,
+    invalid_result: 0,
+    pass: 0
+  } satisfies Record<EvaluationVerdictClass, number>;
+}
+
+function incrementVerdictCounts(
+  verdictCounts: Record<EvaluationVerdictClass, number>,
+  verdictClass: EvaluationVerdictClass
+) {
+  verdictCounts[verdictClass] += 1;
+}
+
+function listSortedUnique(values: string[]) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function getBenchmarkPackageLabel(packageId: string, versions: string[]) {
+  if (versions.length === 1) {
+    return `${packageId} @ ${versions[0]}`;
+  }
+
+  return `${packageId} (${versions.length} versions)`;
+}
+
+function buildLocalBenchmarkDataset(packageId: string): PortalBenchmarkDatasetResponse {
+  const runs = localRunItems
+    .filter((item) => item.benchmarkPackageId === packageId)
+    .sort((left, right) => Date.parse(right.completedAt) - Date.parse(left.completedAt));
+
+  if (runs.length === 0) {
+    throw new Error(`Benchmark package ${packageId} was not found.`);
+  }
+
+  const jobs = runs.flatMap((run) => localRunDetailById[run.runId]?.jobs ?? []);
+  const attempts = runs.flatMap((run) => localRunDetailById[run.runId]?.attempts ?? []);
+  const versions = listSortedUnique(runs.map((run) => run.benchmarkPackageVersion));
+  const providerFamilies = listSortedUnique(runs.map((run) => run.providerFamily));
+  const modelConfigIds = listSortedUnique(runs.map((run) => run.modelConfigId));
+  const laneIds = listSortedUnique(runs.map((run) => run.laneId));
+  const verdictCounts = createEmptyVerdictCounts();
+
+  for (const run of runs) {
+    incrementVerdictCounts(verdictCounts, run.verdictClass);
+  }
+
+  return {
+    attempts,
+    benchmark: {
+      benchmarkLabel: getBenchmarkPackageLabel(packageId, versions),
+      benchmarkPackageId: packageId,
+      laneIds,
+      latestRunId: runs[0]?.runId ?? null,
+      modelConfigIds,
+      providerFamilies,
+      versions
+    },
+    jobs,
+    runs,
+    summary: {
+      attemptCount: attempts.length,
+      jobCount: jobs.length,
+      latestCompletedAt: runs[0]?.completedAt ?? null,
+      runCount: runs.length,
+      verdictCounts
+    }
+  };
+}
+
+function buildLocalBenchmarksListResponse(): PortalBenchmarksListResponse {
+  const benchmarks = new Map<string, PortalBenchmarksListResponse["items"][number]>();
+
+  for (const run of localRunItems) {
+    const existing = benchmarks.get(run.benchmarkPackageId);
+    const attemptCount = localRunDetailById[run.runId]?.attempts.length ?? 0;
+
+    if (!existing) {
+      const verdictCounts = createEmptyVerdictCounts();
+      incrementVerdictCounts(verdictCounts, run.verdictClass);
+      benchmarks.set(run.benchmarkPackageId, {
+        attemptCount,
+        benchmarkLabel: getBenchmarkPackageLabel(run.benchmarkPackageId, [
+          run.benchmarkPackageVersion
+        ]),
+        benchmarkPackageId: run.benchmarkPackageId,
+        latestCompletedAt: run.completedAt,
+        latestRunId: run.runId,
+        modelConfigIds: [run.modelConfigId],
+        providerFamilies: [run.providerFamily],
+        runCount: 1,
+        versions: [run.benchmarkPackageVersion],
+        verdictCounts
+      });
+      continue;
+    }
+
+    existing.attemptCount += attemptCount;
+    existing.runCount += 1;
+    incrementVerdictCounts(existing.verdictCounts, run.verdictClass);
+
+    if (!existing.modelConfigIds.includes(run.modelConfigId)) {
+      existing.modelConfigIds.push(run.modelConfigId);
+    }
+
+    if (!existing.providerFamilies.includes(run.providerFamily)) {
+      existing.providerFamilies.push(run.providerFamily);
+    }
+
+    if (!existing.versions.includes(run.benchmarkPackageVersion)) {
+      existing.versions.push(run.benchmarkPackageVersion);
+    }
+  }
+
+  return {
+    items: [...benchmarks.values()]
+      .map((item) => {
+        const versions = listSortedUnique(item.versions);
+        return {
+          ...item,
+          benchmarkLabel: getBenchmarkPackageLabel(item.benchmarkPackageId, versions),
+          modelConfigIds: listSortedUnique(item.modelConfigIds),
+          providerFamilies: listSortedUnique(item.providerFamilies),
+          versions
+        };
+      })
+      .sort((left, right) => Date.parse(right.latestCompletedAt ?? "") - Date.parse(left.latestCompletedAt ?? ""))
+  };
+}
+
 function parseNullableParam(value: string | null) {
   const trimmed = value?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
@@ -1033,6 +1169,102 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
     .join("\n");
 }
 
+export function buildPortalBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
+  const attemptsByRunId = new Map<string, PortalBenchmarkDatasetResponse["attempts"]>();
+
+  for (const attempt of dataset.attempts) {
+    const existing = attemptsByRunId.get(attempt.runId);
+
+    if (existing) {
+      existing.push(attempt);
+      continue;
+    }
+
+    attemptsByRunId.set(attempt.runId, [attempt]);
+  }
+
+  const headers = [
+    "benchmarkPackageId",
+    "benchmarkVersions",
+    "runId",
+    "runState",
+    "runVerdictClass",
+    "providerFamily",
+    "modelConfigId",
+    "startedAt",
+    "completedAt",
+    "durationMs",
+    "jobId",
+    "attemptId",
+    "attemptState",
+    "attemptVerdictClass",
+    "verifierResult",
+    "failureFamily",
+    "failureCode",
+    "failureSummary"
+  ];
+  const rows = dataset.runs.flatMap((run) => {
+    const attempts = attemptsByRunId.get(run.runId) ?? [null];
+
+    return attempts.map((attempt) => [
+      dataset.benchmark.benchmarkPackageId,
+      dataset.benchmark.versions.join("|"),
+      run.runId,
+      run.runState,
+      run.verdictClass,
+      run.providerFamily,
+      run.modelConfigId,
+      run.startedAt,
+      run.completedAt,
+      String(run.durationMs),
+      attempt?.jobId ?? run.latestJobId ?? "",
+      attempt?.attemptId ?? "",
+      attempt?.state ?? "",
+      attempt?.verdictClass ?? "",
+      attempt?.verifierResult ?? "",
+      attempt?.failure.family ?? run.failure.family ?? "",
+      attempt?.failure.code ?? run.failure.code ?? "",
+      attempt?.failure.summary ?? run.failure.summary ?? ""
+    ]);
+  });
+
+  return [headers, ...rows]
+    .map((row) => row.map((value) => escapeCsvValue(String(value))).join(","))
+    .join("\n");
+}
+
+function sanitizeExportFilenameSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "benchmark";
+}
+
+export function buildPortalBenchmarkDatasetExportFileName(
+  packageId: string,
+  format: PortalBenchmarkExportFormat,
+  now = new Date()
+) {
+  const timestamp = now.toISOString().slice(0, 19).replaceAll(":", "-");
+  return `paretoproof-${sanitizeExportFilenameSegment(packageId)}-dataset-${timestamp}.${format}`;
+}
+
+function readContentDispositionFilename(headerValue: string | null) {
+  if (!headerValue) {
+    return null;
+  }
+
+  const encodedMatch = /filename\*=UTF-8''([^;]+)/i.exec(headerValue);
+
+  if (encodedMatch?.[1]) {
+    try {
+      return decodeURIComponent(encodedMatch[1]);
+    } catch {
+      return encodedMatch[1];
+    }
+  }
+
+  const plainMatch = /filename="([^"]+)"/i.exec(headerValue) ?? /filename=([^;]+)/i.exec(headerValue);
+  return plainMatch?.[1]?.trim() ?? null;
+}
+
 export type PortalRunsModelFilterOption = {
   count: number;
   label: string;
@@ -1164,6 +1396,74 @@ export async function fetchPortalRunsView(query: PortalRunsListQuery) {
     `/portal/runs${queryString ? `?${queryString}` : ""}`,
     portalRunsListResponseSchema
   );
+}
+
+export async function fetchPortalBenchmarksList() {
+  if (isLocalHostname(window.location.hostname)) {
+    return portalBenchmarksListResponseSchema.parse(buildLocalBenchmarksListResponse());
+  }
+
+  return fetchPortalBenchmarkOpsJson(
+    "/portal/benchmarks",
+    portalBenchmarksListResponseSchema
+  );
+}
+
+export async function fetchPortalBenchmarkDataset(packageId: string) {
+  if (isLocalHostname(window.location.hostname)) {
+    return portalBenchmarkDatasetResponseSchema.parse(buildLocalBenchmarkDataset(packageId));
+  }
+
+  return fetchPortalBenchmarkOpsJson(
+    `/portal/benchmarks/${encodeURIComponent(packageId)}/dataset`,
+    portalBenchmarkDatasetResponseSchema
+  );
+}
+
+export async function fetchPortalBenchmarkDatasetExport(
+  packageId: string,
+  format: PortalBenchmarkExportFormat
+) {
+  const fallbackFileName = buildPortalBenchmarkDatasetExportFileName(packageId, format);
+
+  if (isLocalHostname(window.location.hostname)) {
+    const dataset = buildLocalBenchmarkDataset(packageId);
+    const body =
+      format === "json"
+        ? JSON.stringify(dataset, null, 2)
+        : buildPortalBenchmarkDatasetCsv(dataset);
+
+    return {
+      blob: new Blob([body], {
+        type:
+          format === "json"
+            ? "application/json;charset=utf-8"
+            : "text/csv;charset=utf-8"
+      }),
+      fileName: fallbackFileName
+    };
+  }
+
+  const response = await fetchApi(
+    `${getApiBaseUrl()}/portal/benchmarks/${encodeURIComponent(packageId)}/export?format=${format}`,
+    {
+      credentials: "include",
+      headers: {
+        Accept: format === "json" ? "application/json" : "text/csv"
+      }
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Request failed with ${response.status}.`);
+  }
+
+  return {
+    blob: await response.blob(),
+    fileName:
+      readContentDispositionFilename(response.headers.get("content-disposition")) ??
+      fallbackFileName
+  };
 }
 
 export async function fetchPortalRunDetail(runId: string) {

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -1,6 +1,7 @@
 import {
   portalRunsLifecycleBuckets,
   portalRunsSortOptions,
+  type PortalBenchmarkExportFormat,
   type EvaluationVerdictClass,
   type PortalRunsLifecycleBucket,
   type PortalLaunchViewResponse,
@@ -28,6 +29,7 @@ import {
   buildRunsCsv,
   defaultPortalRunsQuery,
   extractPortalRunsQueryString,
+  fetchPortalBenchmarkDatasetExport,
   fetchPortalLaunchView,
   fetchPortalRunDetail,
   fetchPortalRunsView,
@@ -167,11 +169,15 @@ function downloadRunsCsv(items: PortalRunsListResponse["items"]) {
   const blob = new Blob([buildRunsCsv(items)], {
     type: "text/csv;charset=utf-8"
   });
+  downloadBlob(blob, `paretoproof-runs-${new Date().toISOString().slice(0, 19)}.csv`);
+}
+
+function downloadBlob(blob: Blob, fileName: string) {
   const objectUrl = URL.createObjectURL(blob);
   const link = document.createElement("a");
 
   link.href = objectUrl;
-  link.download = `paretoproof-runs-${new Date().toISOString().slice(0, 19)}.csv`;
+  link.download = fileName;
   document.body.append(link);
   link.click();
   link.remove();
@@ -442,6 +448,13 @@ function PortalRunsSurface({
   search: string;
 }) {
   const awaitingFirstLoad = isAwaitingFirstLoad(loadState);
+  const [datasetExportState, setDatasetExportState] = useState<{
+    error: string | null;
+    format: PortalBenchmarkExportFormat | null;
+  }>({
+    error: null,
+    format: null
+  });
   const providerOptions = buildRunsProviderOptions(
     loadState.data?.filters ?? { modelConfigs: [], providerFamilies: [] },
     query.providerFamily
@@ -450,7 +463,49 @@ function PortalRunsSurface({
     loadState.data?.filters ?? { modelConfigs: [], providerFamilies: [] },
     query.modelConfigId
   );
+  const benchmarkPackageOptions = useMemo(() => {
+    const values = new Set(
+      (loadState.data?.items ?? []).map((item) => item.benchmarkPackageId)
+    );
+
+    if (query.benchmarkPackageId) {
+      values.add(query.benchmarkPackageId);
+    }
+
+    return [...values].sort((left, right) => left.localeCompare(right));
+  }, [loadState.data?.items, query.benchmarkPackageId]);
+  const selectedBenchmarkPackageId =
+    query.benchmarkPackageId ??
+    (benchmarkPackageOptions.length === 1 ? benchmarkPackageOptions[0] : null);
   const isCompactLayout = useCompactLayout(480);
+
+  async function handleDatasetExport(format: PortalBenchmarkExportFormat) {
+    if (!selectedBenchmarkPackageId) {
+      return;
+    }
+
+    setDatasetExportState({
+      error: null,
+      format
+    });
+
+    try {
+      const download = await fetchPortalBenchmarkDatasetExport(
+        selectedBenchmarkPackageId,
+        format
+      );
+      downloadBlob(download.blob, download.fileName);
+      setDatasetExportState({
+        error: null,
+        format: null
+      });
+    } catch (error) {
+      setDatasetExportState({
+        error: toDisplayError(error),
+        format: null
+      });
+    }
+  }
 
   const runsSlice = (
     <article
@@ -587,6 +642,25 @@ function PortalRunsSurface({
             ))}
           </select>
         </label>
+        <label className="portal-field">
+          <span>Benchmark package</span>
+          <select
+            className="input"
+            onChange={(event) => {
+              updateRunsQuery(pathname, query, onReplaceLocation, {
+                benchmarkPackageId: event.target.value || null
+              });
+            }}
+            value={query.benchmarkPackageId ?? ""}
+          >
+            <option value="">All packages</option>
+            {benchmarkPackageOptions.map((packageId) => (
+              <option key={packageId} value={packageId}>
+                {packageId}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
     </article>
   );
@@ -611,6 +685,26 @@ function PortalRunsSurface({
           >
             Export CSV
           </button>
+          <button
+            className="button button-secondary"
+            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
+            onClick={() => {
+              void handleDatasetExport("json");
+            }}
+            type="button"
+          >
+            {datasetExportState.format === "json" ? "Exporting JSON" : "Export package JSON"}
+          </button>
+          <button
+            className="button button-secondary"
+            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
+            onClick={() => {
+              void handleDatasetExport("csv");
+            }}
+            type="button"
+          >
+            {datasetExportState.format === "csv" ? "Exporting CSV" : "Export package CSV"}
+          </button>
           <a className="button button-secondary" href={buildPortalUrl("/")}>
             Overview
           </a>
@@ -626,7 +720,13 @@ function PortalRunsSurface({
         <span className="role-chip role-chip-muted">
           {loadState.data?.summary.failedRuns ?? 0} failed
         </span>
+        {selectedBenchmarkPackageId ? (
+          <span className="role-chip role-chip-muted">
+            package {selectedBenchmarkPackageId}
+          </span>
+        ) : null}
       </div>
+      {datasetExportState.error ? <PortalErrorState error={datasetExportState.error} /> : null}
     </article>
   );
 
@@ -641,6 +741,9 @@ function PortalRunsSurface({
       <p className="portal-panel-muted">
         Filter, export, and triage runs here, then open one run&apos;s evidence in
         <code className="portal-inline-code"> /runs/:runId</code>.
+      </p>
+      <p className="portal-panel-muted">
+        Package dataset export unlocks once one benchmark package is selected in the current slice.
       </p>
       <PortalFreshnessCard
         isRefreshing={loadState.isLoading}

--- a/packages/shared/src/contracts/portal-benchmark-ops.ts
+++ b/packages/shared/src/contracts/portal-benchmark-ops.ts
@@ -1,4 +1,8 @@
 import {
+  portalBenchmarkDatasetParamsSchema,
+  portalBenchmarkDatasetResponseSchema,
+  portalBenchmarkExportQuerySchema,
+  portalBenchmarksListResponseSchema,
   portalLaunchViewResponseSchema,
   portalRunDetailResponseSchema,
   portalRunsListQuerySchema,
@@ -85,6 +89,10 @@ export const portalRunsSortOptions = [
 // routes and the portal UI. Runs filter facets belong here so the UI does not
 // infer option catalogs from a paginated row slice.
 export const portalBenchmarkOpsReadModelsContract = {
+  benchmarkDatasetParams: portalBenchmarkDatasetParamsSchema,
+  benchmarkDatasetResponse: portalBenchmarkDatasetResponseSchema,
+  benchmarkExportQuery: portalBenchmarkExportQuerySchema,
+  benchmarksListResponse: portalBenchmarksListResponseSchema,
   launchViewResponse: portalLaunchViewResponseSchema,
   runDetailResponse: portalRunDetailResponseSchema,
   runsListQuery: portalRunsListQuerySchema,

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -223,6 +223,67 @@ export const portalRunDetailResponseSchema = z.object({
   workerLeases: z.array(portalWorkerLeaseSummarySchema)
 });
 
+export const portalBenchmarkDatasetParamsSchema = z.object({
+  packageId: z.string().trim().min(1)
+});
+
+export const portalBenchmarkExportFormatSchema = z.enum(["csv", "json"]);
+
+export const portalBenchmarkExportQuerySchema = z.object({
+  format: portalBenchmarkExportFormatSchema.default("json")
+});
+
+export const portalBenchmarkListItemSchema = z.object({
+  attemptCount: z.number().int().nonnegative(),
+  benchmarkLabel: z.string(),
+  benchmarkPackageId: z.string(),
+  latestCompletedAt: timestampSchema.nullable(),
+  latestRunId: z.string().nullable(),
+  modelConfigIds: z.array(z.string()),
+  providerFamilies: z.array(z.string()),
+  runCount: z.number().int().nonnegative(),
+  versions: z.array(z.string()),
+  verdictCounts: z.object({
+    fail: z.number().int().nonnegative(),
+    invalid_result: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative()
+  })
+});
+
+export const portalBenchmarksListResponseSchema = z.object({
+  items: z.array(portalBenchmarkListItemSchema)
+});
+
+export const portalBenchmarkDatasetSummarySchema = z.object({
+  attemptCount: z.number().int().nonnegative(),
+  jobCount: z.number().int().nonnegative(),
+  latestCompletedAt: timestampSchema.nullable(),
+  runCount: z.number().int().nonnegative(),
+  verdictCounts: z.object({
+    fail: z.number().int().nonnegative(),
+    invalid_result: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative()
+  })
+});
+
+export const portalBenchmarkDatasetMetadataSchema = z.object({
+  benchmarkLabel: z.string(),
+  benchmarkPackageId: z.string(),
+  laneIds: z.array(z.string()),
+  latestRunId: z.string().nullable(),
+  modelConfigIds: z.array(z.string()),
+  providerFamilies: z.array(z.string()),
+  versions: z.array(z.string())
+});
+
+export const portalBenchmarkDatasetResponseSchema = z.object({
+  attempts: z.array(portalRunAttemptSummarySchema),
+  benchmark: portalBenchmarkDatasetMetadataSchema,
+  jobs: z.array(portalRunJobSummarySchema),
+  runs: z.array(portalRunListItemSchema),
+  summary: portalBenchmarkDatasetSummarySchema
+});
+
 export const portalLaunchBenchmarkOptionSchema = z.object({
   benchmarkItemCount: z.number().int().nonnegative(),
   benchmarkLabel: z.string(),

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -202,6 +202,59 @@ export type PortalRunDetailResponse = {
   workerLeases: PortalWorkerLeaseSummary[];
 };
 
+export type PortalBenchmarkDatasetParams = {
+  packageId: string;
+};
+
+export type PortalBenchmarkExportFormat = "csv" | "json";
+
+export type PortalBenchmarkExportQuery = {
+  format: PortalBenchmarkExportFormat;
+};
+
+export type PortalBenchmarkListItem = {
+  attemptCount: number;
+  benchmarkLabel: string;
+  benchmarkPackageId: string;
+  latestCompletedAt: string | null;
+  latestRunId: string | null;
+  modelConfigIds: string[];
+  providerFamilies: string[];
+  runCount: number;
+  versions: string[];
+  verdictCounts: Record<EvaluationVerdictClass, number>;
+};
+
+export type PortalBenchmarksListResponse = {
+  items: PortalBenchmarkListItem[];
+};
+
+export type PortalBenchmarkDatasetSummary = {
+  attemptCount: number;
+  jobCount: number;
+  latestCompletedAt: string | null;
+  runCount: number;
+  verdictCounts: Record<EvaluationVerdictClass, number>;
+};
+
+export type PortalBenchmarkDatasetMetadata = {
+  benchmarkLabel: string;
+  benchmarkPackageId: string;
+  laneIds: string[];
+  latestRunId: string | null;
+  modelConfigIds: string[];
+  providerFamilies: string[];
+  versions: string[];
+};
+
+export type PortalBenchmarkDatasetResponse = {
+  attempts: PortalRunAttemptSummary[];
+  benchmark: PortalBenchmarkDatasetMetadata;
+  jobs: PortalRunJobSummary[];
+  runs: PortalRunListItem[];
+  summary: PortalBenchmarkDatasetSummary;
+};
+
 export type PortalLaunchBenchmarkOption = {
   benchmarkItemCount: number;
   benchmarkLabel: string;


### PR DESCRIPTION
﻿## Summary
- add authenticated portal benchmark package list, dataset, and export contracts in shared plus API read-model/routes for `/portal/benchmarks`, `/portal/benchmarks/:packageId/dataset`, and `/portal/benchmarks/:packageId/export`
- add server-side CSV serialization for benchmark datasets and extend portal benchmark-ops route tests for the new endpoints
- wire the portal Runs surface to filter by benchmark package and download per-package JSON or CSV datasets through the new authenticated export path

## Verification
- bun install
- bun run build:shared
- bun run typecheck:shared
- bun run typecheck:api
- bun run typecheck:web
- bunx tsx --test apps/api/test/portal-benchmark-ops.test.ts
- bun test apps/web/src/lib/portal-benchmark-ops.test.js apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
- bun run build:api
- bun run build:web
- bun run check:bidi

Closes #800
