### PR TITLE
fix(auth): accept branded audiences on api finalize route

### DIFF
--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -67,6 +67,13 @@ function normalizeTeamDomain(teamDomain: string) {
   return teamDomain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
 }
 
+function usesBrandedFinalizeRelayAudiences(routePath: string) {
+  return (
+    routePath === "/portal/session/finalize" ||
+    routePath === "/portal/session/finalize/submit"
+  );
+}
+
 function readCookieValue(cookieHeader: string | undefined, name: string) {
   if (!cookieHeader) {
     return null;
@@ -249,7 +256,7 @@ export function selectCloudflareAccessVerifier(
     return verifiers.internal;
   }
 
-  if (routePath === "/portal/session/finalize/submit") {
+  if (usesBrandedFinalizeRelayAudiences(routePath)) {
     return verifiers.brandedRelay;
   }
 

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -37,13 +37,27 @@ test("readAccessJwtAssertion returns null when no usable Access assertion is pre
   assert.equal(assertion, null);
 });
 
-test("selectCloudflareAccessVerifier keeps the finalize submit boundary on the branded relay audiences", () => {
+test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on the relay audiences", () => {
   const verifiers = {
     brandedRelay: { audiences: ["portal-aud", "github-aud", "google-aud"] },
     internal: { audiences: ["internal-aud"] },
     portal: { audiences: ["portal-aud"] }
   } satisfies Record<keyof CloudflareAccessVerifierSet, { audiences: string[] }>;
 
+  assert.equal(
+    selectCloudflareAccessVerifier(
+      {
+        raw: {
+          url: "/portal/session/finalize"
+        },
+        routeOptions: {
+          url: "/portal/session/finalize"
+        }
+      } as never,
+      verifiers as never
+    ),
+    verifiers.brandedRelay
+  );
   assert.equal(
     selectCloudflareAccessVerifier(
       {


### PR DESCRIPTION
## Summary
- route `/portal/session/finalize` through the branded relay audience verifier as well as `/portal/session/finalize/submit`
- extend the Cloudflare Access selector test to cover both finalize boundaries
- follow up the live #806 investigation after Railway logs showed the production 401 is on `/portal/session/finalize`

## Testing
- bun test apps/api/test/cloudflare-access.test.ts apps/api/test/portal-session-finalize.test.ts
- bun run typecheck:api

Closes #806