### PR TITLE
fix(auth): route branded finalize relay through submit boundary

### DIFF
--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -14,7 +14,7 @@ describe("handleAccessFinalize", () => {
 
   it("relays a successful finalize response back to the portal and forwards cookies", async () => {
     globalThis.fetch = async (input, init) => {
-      expect(input).toBe("https://api.paretoproof.com/portal/session/finalize");
+      expect(input).toBe("https://api.paretoproof.com/portal/session/finalize/submit");
       expect(init?.method).toBe("POST");
       expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBe("assertion-1");
       expect((init?.headers as Headers).get("cookie")).toContain("PortalAccessProvider=");
@@ -103,6 +103,40 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/access-request");
+  });
+
+  it("targets the API finalize-submit boundary for branded relay handoffs", async () => {
+    const relayTargets: string[] = [];
+
+    globalThis.fetch = async (input) => {
+      relayTargets.push(String(input));
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/profile"
+        }),
+        {
+          status: 200
+        }
+      );
+    };
+
+    await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-3",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(relayTargets).toEqual([
+      "https://api.paretoproof.com/portal/session/finalize/submit"
+    ]);
   });
 
   it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -184,7 +184,7 @@ export async function handleAccessFinalize(request: Request) {
   const redirectPath = await readRedirectPath(request);
   const retryUrl = buildAuthRetryUrl(redirectPath);
   const requestUrl = new URL(request.url);
-  const apiUrl = new URL("/portal/session/finalize", resolveApiBaseUrl(requestUrl));
+  const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
   const forwardedHeaders = new Headers({
     accept: "application/json",
     "content-type": "application/json",


### PR DESCRIPTION
## Summary
- route the Pages branded finalize relay to `POST /portal/session/finalize/submit`, which is the API boundary that trusts branded auth-host audiences
- lock the web relay test to the finalize-submit target so the Pages/API boundary cannot drift back apart
- preserve the existing API-side branded finalize-submit coverage and typecheck the web and API workspaces on the patched head

## Why
Fresh live desktop-browser verification on the real Chrome profile still reproduced `#806` after `#865` merged: a new GitHub provider start from `https://auth.paretoproof.com/api/access/start/github?redirect=%2Fprofile` jumped straight back to `https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry`.

The repo-side reason is that the Pages relay in `apps/web/functions/_shared/access-finalize.ts` was still posting to `POST /portal/session/finalize`, while the branded-audience verifier added in `#865` only applies on `POST /portal/session/finalize/submit`.

Addresses #806. The issue should stay open until post-deploy live browser verification confirms the branded retry loop is gone for both providers.

## Verification
- `bun test apps/web/functions/_shared/access-finalize.test.ts`
- `bun test apps/api/test/portal-session-finalize.test.ts apps/api/test/trusted-mutation-origin.test.ts apps/api/test/cloudflare-access.test.ts apps/api/test/runtime-env.test.ts`
- `bun run build:shared`
- `bun run typecheck:web`
- `bun run typecheck:api`