### PR TITLE
fix(auth): bootstrap API session after branded finalize

### DIFF
--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -12,7 +12,7 @@ describe("handleAccessFinalize", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("relays a successful finalize response back to the portal and forwards cookies", async () => {
+  it("relays a successful finalize response through the API bootstrap boundary and forwards cookies", async () => {
     globalThis.fetch = async (input, init) => {
       expect(input).toBe("https://api.paretoproof.com/portal/session/finalize/submit");
       expect(init?.method).toBe("POST");
@@ -57,7 +57,9 @@ describe("handleAccessFinalize", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/profile");
+    expect(response.headers.get("location")).toBe(
+      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fprofile"
+    );
     expect(response.headers.get("cache-control")).toBe("no-store");
     const setCookies =
       (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
@@ -102,7 +104,9 @@ describe("handleAccessFinalize", () => {
     );
 
     expect(response.status).toBe(303);
-    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/access-request");
+    expect(response.headers.get("location")).toBe(
+      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Faccess-request"
+    );
   });
 
   it("targets the API finalize-submit boundary for branded relay handoffs", async () => {
@@ -137,6 +141,36 @@ describe("handleAccessFinalize", () => {
     expect(relayTargets).toEqual([
       "https://api.paretoproof.com/portal/session/finalize/submit"
     ]);
+  });
+
+  it("preserves the finalized portal path when converting the response into an API bootstrap redirect", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/admin/users?tab=review#pending"
+        }),
+        {
+          status: 200
+        }
+      );
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-4",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://api.paretoproof.com/portal/session/finalize/submit?redirect=%2Fadmin%2Fusers%3Ftab%3Dreview%23pending"
+    );
   });
 
   it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -121,6 +121,21 @@ function resolvePortalRedirectTarget(rawRedirectTarget: unknown, fallbackRedirec
   }
 }
 
+function buildApiSessionBootstrapUrl(requestUrl: URL, portalRedirectTarget: string) {
+  const portalUrl = new URL(portalRedirectTarget);
+  const apiBootstrapUrl = new URL(
+    "/portal/session/finalize/submit",
+    resolveApiBaseUrl(requestUrl)
+  );
+  const redirectPath = `${portalUrl.pathname}${portalUrl.search}${portalUrl.hash}` || "/";
+
+  if (redirectPath !== "/") {
+    apiBootstrapUrl.searchParams.set("redirect", redirectPath);
+  }
+
+  return apiBootstrapUrl.toString();
+}
+
 function readSetCookieHeaders(headers: Headers) {
   const cookieHeaders = headers as Headers & {
     getAll?: (name: string) => string[];
@@ -246,5 +261,8 @@ export async function handleAccessFinalize(request: Request) {
     return buildRedirectResponse(retryUrl, finalizeResponse.headers);
   }
 
-  return buildRedirectResponse(redirectTarget, finalizeResponse.headers);
+  return buildRedirectResponse(
+    buildApiSessionBootstrapUrl(requestUrl, redirectTarget),
+    finalizeResponse.headers
+  );
 }


### PR DESCRIPTION
## Summary
- route successful branded finalize completions through the browser-visible API bootstrap boundary before landing in the portal
- preserve the finalized portal path when converting API JSON redirect targets into bootstrap redirects
- lock the new redirect sequence with focused Pages finalize tests

## Verification
- bun test apps/web/functions/_shared/access-finalize.test.ts
- bun run build:shared
- bun test apps/api/test/portal-session-finalize.test.ts apps/api/test/cloudflare-access.test.ts
- bun run typecheck:web

Refs #806