### PR TITLE
fix(auth): preserve relayed finalize session cookies

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -459,27 +459,19 @@ export function registerPortalRoutes(
       portalUrl.searchParams.set("link", linkStatus);
     }
 
-    const responseCookies = [clearSignedAccessCookie("PortalLinkIntent")];
-
-    if (identity && accessContext) {
-      responseCookies.unshift(
-        buildSignedPortalAccessSessionCookie(identity, accessContext)
-      );
-    } else {
-      responseCookies.unshift(clearSignedAccessCookie("PortalAccessSession"));
-    }
-
-    if (identity && providerHint) {
-      responseCookies.unshift(
-        buildSignedAccessCookie(
-          "PortalAccessProvider",
-          `${providerHint}|${identity.subject}`,
-          { maxAgeSeconds: 24 * 60 * 60, sameSite: "Lax" }
-        )
-      );
-    } else {
-      responseCookies.unshift(clearSignedAccessCookie("PortalAccessProvider"));
-    }
+    const responseCookies = [
+      identity && accessContext
+        ? buildSignedPortalAccessSessionCookie(identity, accessContext)
+        : clearSignedAccessCookie("PortalAccessSession"),
+      identity && providerHint
+        ? buildSignedAccessCookie(
+            "PortalAccessProvider",
+            `${providerHint}|${identity.subject}`,
+            { maxAgeSeconds: 24 * 60 * 60, sameSite: "Lax" }
+          )
+        : clearSignedAccessCookie("PortalAccessProvider"),
+      clearSignedAccessCookie("PortalLinkIntent")
+    ];
 
     reply.header("set-cookie", responseCookies);
 

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -124,8 +124,8 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   const setCookies = response.headers["set-cookie"];
   assert.ok(Array.isArray(setCookies));
   assert.equal(setCookies.length, 3);
-  assert.match(setCookies[0], /^PortalAccessProvider=/);
-  assert.match(setCookies[1], /^PortalAccessSession=/);
+  assert.match(setCookies[0], /^PortalAccessSession=/);
+  assert.match(setCookies[1], /^PortalAccessProvider=/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
 });
 
@@ -267,8 +267,8 @@ test("POST /portal/session/finalize/submit completes a pending-user handoff from
   const setCookies = response.headers["set-cookie"];
   assert.ok(Array.isArray(setCookies));
   assert.equal(setCookies.length, 3);
-  assert.match(setCookies[0], /^PortalAccessProvider=/);
-  assert.match(setCookies[1], /^PortalAccessSession=/);
+  assert.match(setCookies[0], /^PortalAccessSession=/);
+  assert.match(setCookies[1], /^PortalAccessProvider=/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
 });
 

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -30,11 +30,11 @@ describe("handleAccessFinalize", () => {
           headers: [
             [
               "set-cookie",
-              "PortalAccessProvider=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
+              "PortalAccessSession=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
             ],
             [
               "set-cookie",
-              "PortalAccessSession=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
+              "PortalAccessProvider=signed; Domain=.paretoproof.com; Path=/; Secure; HttpOnly"
             ],
             [
               "set-cookie",
@@ -66,8 +66,8 @@ describe("handleAccessFinalize", () => {
     const setCookies =
       (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
     expect(setCookies).toHaveLength(3);
-    expect(setCookies[0]).toContain("PortalAccessProvider=signed");
-    expect(setCookies[1]).toContain("PortalAccessSession=signed");
+    expect(setCookies[0]).toContain("PortalAccessSession=signed");
+    expect(setCookies[1]).toContain("PortalAccessProvider=signed");
     expect(setCookies[2]).toContain("PortalLinkIntent=");
   });
 
@@ -172,6 +172,60 @@ describe("handleAccessFinalize", () => {
     expect(response.headers.get("location")).toBe(
       "https://portal.paretoproof.com/admin/users?tab=review#pending"
     );
+  });
+
+  it("splits a combined Set-Cookie fallback header into individual cookies", async () => {
+    globalThis.fetch = async () => {
+      const response = new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/profile"
+        }),
+        {
+          headers: {
+            "set-cookie": [
+              "PortalAccessSession=session; Domain=.paretoproof.com; Path=/; Secure; HttpOnly",
+              "PortalAccessProvider=provider; Domain=.paretoproof.com; Path=/; Secure; HttpOnly",
+              "PortalLinkIntent=; Domain=.paretoproof.com; Path=/; Max-Age=0; Secure; HttpOnly"
+            ].join(", ")
+          },
+          status: 200
+        }
+      );
+
+      const responseHeaders = response.headers as Headers & {
+        getAll?: undefined;
+        getSetCookie?: undefined;
+      };
+
+      Object.defineProperty(responseHeaders, "getAll", {
+        value: undefined
+      });
+      Object.defineProperty(responseHeaders, "getSetCookie", {
+        value: undefined
+      });
+
+      return response;
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-5",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    const setCookies =
+      (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+    expect(setCookies).toHaveLength(3);
+    expect(setCookies[0]).toContain("PortalAccessSession=session");
+    expect(setCookies[1]).toContain("PortalAccessProvider=provider");
+    expect(setCookies[2]).toContain("PortalLinkIntent=");
   });
 
   it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -121,6 +121,13 @@ function resolvePortalRedirectTarget(rawRedirectTarget: unknown, fallbackRedirec
   }
 }
 
+function splitCombinedSetCookieHeader(cookieHeader: string) {
+  return cookieHeader
+    .split(/, (?=[^;,=\s]+=[^;,]*)/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
 function readSetCookieHeaders(headers: Headers) {
   const cookieHeaders = headers as Headers & {
     getAll?: (name: string) => string[];
@@ -136,7 +143,7 @@ function readSetCookieHeaders(headers: Headers) {
   }
 
   const singleCookieHeader = headers.get("set-cookie");
-  return singleCookieHeader ? [singleCookieHeader] : [];
+  return singleCookieHeader ? splitCombinedSetCookieHeader(singleCookieHeader) : [];
 }
 
 async function readRedirectPath(request: Request) {


### PR DESCRIPTION
﻿## Summary
- split combined fallback `Set-Cookie` headers in the Pages access finalize relay so empty-valued clear cookies survive
- emit `PortalAccessSession` before `PortalAccessProvider` from the API finalize handlers so the bridge cookie is preserved even if only one relayed cookie survives
- lock the API and Pages finalize tests to the new cookie order and combined-header fallback behavior

## Testing
- bun test apps/api/test/portal-session-finalize.test.ts apps/web/functions/_shared/access-finalize.test.ts apps/api/test/cloudflare-access.test.ts
- bun run typecheck:api
- bun run typecheck:web
- bun run build:shared
