### PR TITLE
fix(auth): normalize relayed set-cookie arrays

### DIFF
--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -228,6 +228,55 @@ describe("handleAccessFinalize", () => {
     expect(setCookies[2]).toContain("PortalLinkIntent=");
   });
 
+  it("splits a combined Set-Cookie entry returned by getSetCookie into individual cookies", async () => {
+    globalThis.fetch = async () => {
+      const combinedCookieHeader = [
+        "PortalAccessSession=session; Domain=.paretoproof.com; Path=/; Secure; HttpOnly",
+        "PortalAccessProvider=provider; Domain=.paretoproof.com; Path=/; Secure; HttpOnly",
+        "PortalLinkIntent=; Domain=.paretoproof.com; Path=/; Max-Age=0; Secure; HttpOnly"
+      ].join(", ");
+
+      const response = new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/profile"
+        }),
+        {
+          status: 200
+        }
+      );
+
+      const responseHeaders = response.headers as Headers & {
+        getSetCookie?: () => string[];
+      };
+
+      Object.defineProperty(responseHeaders, "getSetCookie", {
+        value: () => [combinedCookieHeader]
+      });
+
+      return response;
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-6",
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        method: "POST"
+      })
+    );
+
+    const setCookies =
+      (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+    expect(setCookies).toHaveLength(3);
+    expect(setCookies[0]).toContain("PortalAccessSession=session");
+    expect(setCookies[1]).toContain("PortalAccessProvider=provider");
+    expect(setCookies[2]).toContain("PortalLinkIntent=");
+  });
+
   it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {
     const response = await handleAccessFinalize(
       new Request("https://github.auth.paretoproof.com/api/access/finalize", {

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -128,6 +128,10 @@ function splitCombinedSetCookieHeader(cookieHeader: string) {
     .filter(Boolean);
 }
 
+function normalizeSetCookieHeaderValues(cookieHeaders: string[]) {
+  return cookieHeaders.flatMap((cookieHeader) => splitCombinedSetCookieHeader(cookieHeader));
+}
+
 function readSetCookieHeaders(headers: Headers) {
   const cookieHeaders = headers as Headers & {
     getAll?: (name: string) => string[];
@@ -135,11 +139,11 @@ function readSetCookieHeaders(headers: Headers) {
   };
 
   if (typeof cookieHeaders.getSetCookie === "function") {
-    return cookieHeaders.getSetCookie();
+    return normalizeSetCookieHeaderValues(cookieHeaders.getSetCookie());
   }
 
   if (typeof cookieHeaders.getAll === "function") {
-    return cookieHeaders.getAll("set-cookie");
+    return normalizeSetCookieHeaderValues(cookieHeaders.getAll("set-cookie"));
   }
 
   const singleCookieHeader = headers.get("set-cookie");


### PR DESCRIPTION
﻿## Summary
- normalize every relayed `Set-Cookie` source through the same combined-header splitter instead of only the plain `headers.get('set-cookie')` fallback
- cover the runtime where `getSetCookie()` returns a single combined cookie string so the Pages relay preserves the portal session and clear-cookie headers together
- keep the prior branded finalize regression coverage green across the broader auth/finalize suite

## Testing
- bun test apps/web/functions/_shared/access-finalize.test.ts
- bun test apps/api/test/portal-session-finalize.test.ts apps/web/functions/_shared/access-finalize.test.ts apps/api/test/cloudflare-access.test.ts
- bun run typecheck:web
- bun run build:shared
