### PR TITLE
infra(auth): codify API Access bypass split

### DIFF
--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -103,6 +103,8 @@ Use this mode for the hosted `api.paretoproof.com` control plane.
 - Platform notes:
   - Railway normally supplies `PORT`
   - keep migration credentials out of the live service runtime
+  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access because the portal SPA talks to it with cross-origin `fetch()` and needs JSON `200`/`401` responses, not Access redirects
+  - keep `api.paretoproof.com/internal/*` on its own Cloudflare Access app for owner and service-token callers
 
 ### API migration mode
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -18,6 +18,9 @@ This repo uses a small number of runtime rules.
 - Workers run locally or in hosted runtimes against the API control plane.
 - GHCR holds worker images.
 - Cloudflare R2 holds larger artifacts when the flow requires object storage.
+- Hosted Cloudflare Access split:
+  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access so `portal.paretoproof.com` can make cross-origin JSON `fetch()` calls without an opaque Access redirect.
+  - `api.paretoproof.com/internal/*` stays behind its own Cloudflare Access app for owner and service-token callers.
 
 ## Worker rules
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,6 +4,7 @@
 
 Current helper scripts:
 - `infra/scripts/configure-github-environment-secrets.mjs`: bootstraps and updates staging/production GitHub environment secrets from local shell variables.
+- `infra/scripts/check-cloudflare-api-access.mjs`: owner-only live audit for the hosted Cloudflare Access split on `api.paretoproof.com`; it requires `/portal/*` to bypass Access for browser fetches while `/internal/*` remains protected for owner and service-token callers.
 - `infra/scripts/check-bidi-chars.mjs`: fails CI when tracked files contain hidden or bidirectional Unicode control characters that could hide malicious diffs or review artifacts. It does not scan issue bodies, PR bodies, comments, or other GitHub discussion text, so GitHub can still warn on pasted content even when this repo check passes.
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.
 - `infra/scripts/check-problem9-image-policy.mjs`: fails CI when the Problem 9 image manifest, publish workflows, root build scripts, or operator docs drift apart.

--- a/infra/scripts/check-cloudflare-api-access.mjs
+++ b/infra/scripts/check-cloudflare-api-access.mjs
@@ -1,0 +1,146 @@
+function getCloudflareHeaders() {
+  if (process.env.CLOUDFLARE_API_TOKEN) {
+    return {
+      Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  if (process.env.CLOUDFLARE_EMAIL && process.env.CLOUDFLARE_GLOBAL_API_KEY) {
+    return {
+      "Content-Type": "application/json",
+      "X-Auth-Email": process.env.CLOUDFLARE_EMAIL,
+      "X-Auth-Key": process.env.CLOUDFLARE_GLOBAL_API_KEY
+    };
+  }
+
+  throw new Error(
+    "Cloudflare API credentials are required. Set CLOUDFLARE_API_TOKEN or CLOUDFLARE_EMAIL together with CLOUDFLARE_GLOBAL_API_KEY."
+  );
+}
+
+function getCloudflareAccountId() {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+
+  if (!accountId) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID is required.");
+  }
+
+  return accountId;
+}
+
+async function readJson(url) {
+  const response = await fetch(url, {
+    headers: getCloudflareHeaders()
+  });
+
+  if (!response.ok) {
+    throw new Error(`Cloudflare API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+
+  if (!payload?.success) {
+    throw new Error(`Cloudflare API request was not successful for ${url.toString()}.`);
+  }
+
+  return payload.result;
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value ? [value] : [];
+}
+
+function appMatchesDomain(app, expectedDomain) {
+  return (
+    app?.domain === expectedDomain ||
+    toArray(app?.self_hosted_domains).includes(expectedDomain)
+  );
+}
+
+function policyIncludesEveryone(policy) {
+  return toArray(policy?.include).some((rule) => {
+    return Boolean(rule && typeof rule === "object" && "everyone" in rule);
+  });
+}
+
+function describePolicies(policies) {
+  return policies.map((policy) => `${policy.name ?? policy.id}:${policy.decision}`).join(", ");
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  const accountId = getCloudflareAccountId();
+  const appsUrl = new URL(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/access/apps`
+  );
+  const apps = toArray(await readJson(appsUrl));
+
+  const portalApp = apps.find((app) => appMatchesDomain(app, "api.paretoproof.com/portal/*"));
+  assert(
+    portalApp,
+    "Missing Cloudflare Access app for api.paretoproof.com/portal/*."
+  );
+
+  const internalApp = apps.find((app) => appMatchesDomain(app, "api.paretoproof.com/internal/*"));
+  assert(
+    internalApp,
+    "Missing Cloudflare Access app for api.paretoproof.com/internal/*."
+  );
+
+  const portalPolicies = toArray(
+    await readJson(
+      new URL(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/access/apps/${portalApp.id}/policies`
+      )
+    )
+  );
+  const internalPolicies = toArray(
+    await readJson(
+      new URL(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/access/apps/${internalApp.id}/policies`
+      )
+    )
+  );
+
+  assert(
+    portalPolicies.some(
+      (policy) => policy.decision === "bypass" && policyIncludesEveryone(policy)
+    ),
+    `api.paretoproof.com/portal/* must have an everyone+bypass policy. Current policies: ${describePolicies(portalPolicies)}`
+  );
+  assert(
+    !portalPolicies.some((policy) => policy.decision === "allow"),
+    `api.paretoproof.com/portal/* must not require Cloudflare Access allow policies. Current policies: ${describePolicies(portalPolicies)}`
+  );
+  assert(
+    internalPolicies.length > 0,
+    "api.paretoproof.com/internal/* must keep at least one Cloudflare Access policy."
+  );
+  assert(
+    !internalPolicies.some((policy) => policy.decision === "bypass"),
+    `api.paretoproof.com/internal/* must stay protected by Cloudflare Access. Current policies: ${describePolicies(internalPolicies)}`
+  );
+
+  console.log(
+    [
+      "Cloudflare Access API split verified.",
+      `Portal app ${portalApp.id} bypasses /portal/* for browser fetches.`,
+      `Internal app ${internalApp.id} still protects /internal/* for owner and service-token callers.`
+    ].join(" ")
+  );
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "check:bidi": "node infra/scripts/check-bidi-chars.mjs",
+    "check:cloudflare-api-access": "node infra/scripts/check-cloudflare-api-access.mjs",
     "check:deployment-workflow-node-runtime": "node infra/scripts/check-deployment-workflow-node-runtime.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",


### PR DESCRIPTION
## Summary
- add a live Cloudflare Access audit script plus runtime/operator notes for the hosted `api.paretoproof.com` split
- document that `api.paretoproof.com/portal/*` must bypass Access while `api.paretoproof.com/internal/*` stays protected
- record the production fix that flipped the existing `ParetoProof Portal` Access app from `allow` to `bypass`

## Live production change
- updated Cloudflare Access app `094a6e5d-aded-45b0-8469-9d197842c6de` (`api.paretoproof.com/portal/*`)
- changed policy `5d270166-e44f-423f-b75b-56a9f171ddaf` from `allow` to `bypass`
- preserved the separate internal app `2e4903fb-e47d-4c22-9b77-f482bf954a73` for `/internal/*`

## Verification
- `bun run check:cloudflare-api-access`
- `bun run check:env-contract`
- unauthenticated `GET https://api.paretoproof.com/portal/me` with `Origin: https://portal.paretoproof.com` now returns `401` JSON with no `Location` header
- unauthenticated `POST https://api.paretoproof.com/internal/worker/claims` still returns a `302` Cloudflare Access login redirect

## Issue linkage
- Refs #871
- Remaining end-to-end auth landing proof still depends on #872 reaching production