### PR TITLE
fix(web): reauth stale portal shell after protected 401

### DIFF
--- a/apps/web/src/lib/api-fetch.test.js
+++ b/apps/web/src/lib/api-fetch.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ApiRateLimitError, fetchApi } from "./api-fetch.ts";
+import {
+  ApiRateLimitError,
+  fetchApi,
+  portalAuthExpiredEventName
+} from "./api-fetch.ts";
 
 test("fetchApi retries one safe request after Retry-After and eventually succeeds", async () => {
   const originalFetch = globalThis.fetch;
@@ -84,6 +88,74 @@ test("fetchApi throws ApiRateLimitError for non-idempotent requests after readin
         return true;
       }
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.window = originalWindow;
+  }
+});
+
+test("fetchApi emits a portal auth-expired event for 401 portal responses", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+  const observedEvents = [];
+
+  globalThis.window = {
+    dispatchEvent(event) {
+      observedEvents.push(event.type);
+      return true;
+    },
+    location: {
+      origin: "https://portal.paretoproof.com"
+    },
+    setTimeout(callback) {
+      callback();
+      return 0;
+    }
+  };
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: "access_assertion_required" }), {
+      headers: {
+        "Content-Type": "application/json"
+      },
+      status: 401
+    });
+
+  try {
+    const response = await fetchApi("https://api.paretoproof.com/portal/admin/access-requests");
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(observedEvents, [portalAuthExpiredEventName]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.window = originalWindow;
+  }
+});
+
+test("fetchApi does not emit a portal auth-expired event for non-portal 401 responses", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+  const observedEvents = [];
+
+  globalThis.window = {
+    dispatchEvent(event) {
+      observedEvents.push(event.type);
+      return true;
+    },
+    location: {
+      origin: "https://portal.paretoproof.com"
+    },
+    setTimeout(callback) {
+      callback();
+      return 0;
+    }
+  };
+  globalThis.fetch = async () => new Response(null, { status: 401 });
+
+  try {
+    const response = await fetchApi("https://api.paretoproof.com/health");
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(observedEvents, []);
   } finally {
     globalThis.fetch = originalFetch;
     globalThis.window = originalWindow;

--- a/apps/web/src/lib/api-fetch.ts
+++ b/apps/web/src/lib/api-fetch.ts
@@ -1,4 +1,5 @@
 const rateLimitBackoffByOrigin = new Map<string, number>();
+export const portalAuthExpiredEventName = "paretoproof:portal-auth-expired";
 
 export class ApiRateLimitError extends Error {
   response: Response;
@@ -48,7 +49,7 @@ function readRetryAfterMs(response: Response) {
   return Math.max(resetSeconds * 1000 - Date.now(), 1000);
 }
 
-function getBackoffOrigin(input: RequestInfo | URL) {
+function resolveRequestUrl(input: RequestInfo | URL) {
   const requestUrl =
     typeof input === "string"
       ? input
@@ -56,7 +57,11 @@ function getBackoffOrigin(input: RequestInfo | URL) {
         ? input.toString()
         : input.url;
 
-  return new URL(requestUrl, window.location.origin).origin;
+  return new URL(requestUrl, window.location.origin);
+}
+
+function getBackoffOrigin(input: RequestInfo | URL) {
+  return resolveRequestUrl(input).origin;
 }
 
 function shouldAutoRetry(init: RequestInit | undefined) {
@@ -64,8 +69,21 @@ function shouldAutoRetry(init: RequestInit | undefined) {
   return method === "GET" || method === "HEAD";
 }
 
+function signalPortalAuthExpired(requestUrl: URL, response: Response) {
+  if (response.status !== 401 || !requestUrl.pathname.startsWith("/portal/")) {
+    return;
+  }
+
+  if (typeof window.dispatchEvent !== "function" || typeof Event !== "function") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(portalAuthExpiredEventName));
+}
+
 export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   const backoffOrigin = getBackoffOrigin(input);
+  const requestUrl = resolveRequestUrl(input);
   const autoRetry = shouldAutoRetry(init);
   let attemptCount = 0;
 
@@ -80,6 +98,7 @@ export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Pr
     const response = await fetch(input, init);
 
     if (response.status !== 429) {
+      signalPortalAuthExpired(requestUrl, response);
       return response;
     }
 

--- a/apps/web/src/routes/portal-bootstrap-state.ts
+++ b/apps/web/src/routes/portal-bootstrap-state.ts
@@ -1,0 +1,42 @@
+export type PortalAccessState =
+  | { status: "loading" }
+  | { status: "unauthenticated" }
+  | { status: "approved"; email: string | null; roles: string[] }
+  | { status: "pending"; email: string | null }
+  | {
+      email: string | null;
+      reason:
+        | "access_request_required"
+        | "identity_recovery_required"
+        | "rejected_or_withdrawn"
+        | "unknown_identity";
+      status: "denied";
+    }
+  | { status: "error"; message: string };
+
+export function buildLocalPendingPortalUrl(currentSearch = window.location.search) {
+  const currentParams = new URLSearchParams(currentSearch);
+  const nextParams = new URLSearchParams(currentParams);
+
+  nextParams.set("surface", "portal");
+  nextParams.set("access", "pending");
+  nextParams.delete("reason");
+  nextParams.delete("roles");
+
+  const email = currentParams.get("email");
+
+  if (email) {
+    nextParams.set("email", email);
+  }
+
+  const nextSearch = nextParams.toString();
+  return `/pending${nextSearch ? `?${nextSearch}` : ""}`;
+}
+
+export function reducePortalStateAfterAuthExpiry(currentState: PortalAccessState) {
+  if (currentState.status === "loading" || currentState.status === "unauthenticated") {
+    return currentState;
+  }
+
+  return { status: "unauthenticated" } satisfies PortalAccessState;
+}

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { buildLocalPendingPortalUrl } from "./portal-bootstrap.tsx";
+import {
+  buildLocalPendingPortalUrl,
+  reducePortalStateAfterAuthExpiry
+} from "./portal-bootstrap-state.ts";
 
 describe("buildLocalPendingPortalUrl", () => {
   it("promotes the local access state to pending and clears denial-only params", () => {
@@ -14,5 +17,27 @@ describe("buildLocalPendingPortalUrl", () => {
     expect(
       buildLocalPendingPortalUrl("?surface=portal&access=denied&email=ada@paretoproof.local")
     ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
+  });
+
+  it("collapses stale approved state back to unauthenticated after auth expiry", () => {
+    expect(
+      reducePortalStateAfterAuthExpiry({
+        email: "tomthegreatest04@gmail.com",
+        roles: ["admin"],
+        status: "approved"
+      })
+    ).toEqual({
+      status: "unauthenticated"
+    });
+  });
+
+  it("keeps loading state untouched while bootstrap is still resolving", () => {
+    expect(
+      reducePortalStateAfterAuthExpiry({
+        status: "loading"
+      })
+    ).toEqual({
+      status: "loading"
+    });
   });
 });

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -5,10 +5,15 @@ import type {
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
-import { fetchApi } from "../lib/api-fetch";
+import { fetchApi, portalAuthExpiredEventName } from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { resolvePortalRouteRedirect } from "../lib/portal-route-access";
 import { AccessRequestScreen } from "./access-request-screen";
+import {
+  buildLocalPendingPortalUrl,
+  reducePortalStateAfterAuthExpiry,
+  type PortalAccessState
+} from "./portal-bootstrap-state";
 import {
   buildPortalUrl,
   buildAuthUrl,
@@ -16,22 +21,6 @@ import {
   isLocalHostname
 } from "../lib/surface";
 import { PortalShell } from "./portal-shell";
-
-type PortalAccessState =
-  | { status: "loading" }
-  | { status: "unauthenticated" }
-  | { status: "approved"; email: string | null; roles: string[] }
-  | { status: "pending"; email: string | null }
-  | {
-      email: string | null;
-      reason:
-        | "access_request_required"
-        | "identity_recovery_required"
-        | "rejected_or_withdrawn"
-        | "unknown_identity";
-      status: "denied";
-    }
-  | { status: "error"; message: string };
 
 type PortalMeResponse = {
   access: {
@@ -108,27 +97,6 @@ function readLocalAccessOverride(): PortalAccessState | null {
   return null;
 }
 
-export function buildLocalPendingPortalUrl(
-  currentSearch = window.location.search
-) {
-  const currentParams = new URLSearchParams(currentSearch);
-  const nextParams = new URLSearchParams(currentParams);
-
-  nextParams.set("surface", "portal");
-  nextParams.set("access", "pending");
-  nextParams.delete("reason");
-  nextParams.delete("roles");
-
-  const email = currentParams.get("email");
-
-  if (email) {
-    nextParams.set("email", email);
-  }
-
-  const nextSearch = nextParams.toString();
-  return `/pending${nextSearch ? `?${nextSearch}` : ""}`;
-}
-
 function formatPortalBootstrapError(error: unknown) {
   if (error instanceof Error) {
     if (error.message === "Failed to fetch") {
@@ -140,7 +108,6 @@ function formatPortalBootstrapError(error: unknown) {
 
   return "The portal could not finish loading right now. Try again in a moment.";
 }
-
 export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
@@ -245,6 +212,18 @@ export function PortalBootstrap() {
       controller.abort();
     };
   }, [apiBaseUrl]);
+
+  useEffect(() => {
+    const handlePortalAuthExpired = () => {
+      setState((currentState) => reducePortalStateAfterAuthExpiry(currentState));
+    };
+
+    window.addEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
+
+    return () => {
+      window.removeEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
+    };
+  }, []);
 
   useEffect(() => {
     if (state.status !== "unauthenticated") {


### PR DESCRIPTION
﻿## Summary
- emit a portal auth-expired browser event when protected `/portal/*` API requests return `401`
- let `PortalBootstrap` collapse stale in-app portal state back to `unauthenticated` so the normal auth handoff restarts
- move the pure portal bootstrap state helpers into a plain TypeScript module and cover the new auth-expiry path with focused tests

## Testing
- `bun test apps/web/src/lib/api-fetch.test.js apps/web/src/routes/portal-bootstrap.test.js`

Relates #876
