### PR TITLE
fix(auth): harden portal state cookies against cross-site navigation

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -117,7 +117,7 @@ function sanitizePortalRedirectPath(rawRedirectPath: string | null) {
 function clearSignedAccessCookie(
   name: "PortalAccessProvider" | "PortalLinkIntent" | "PortalAccessSession"
 ) {
-  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Lax; Max-Age=0; Secure; HttpOnly`;
+  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Strict; Max-Age=0; Secure; HttpOnly`;
 }
 
 function buildPortalAuthStartUrl(options: {
@@ -467,7 +467,7 @@ export function registerPortalRoutes(
         ? buildSignedAccessCookie(
             "PortalAccessProvider",
             `${providerHint}|${identity.subject}`,
-            { maxAgeSeconds: 24 * 60 * 60, sameSite: "Lax" }
+            { maxAgeSeconds: 24 * 60 * 60 }
           )
         : clearSignedAccessCookie("PortalAccessProvider"),
       clearSignedAccessCookie("PortalLinkIntent")
@@ -1083,9 +1083,7 @@ export function registerPortalRoutes(
 
       reply.header(
         "set-cookie",
-        buildSignedAccessCookie("PortalLinkIntent", intent.id, {
-          sameSite: "Lax"
-        })
+        buildSignedAccessCookie("PortalLinkIntent", intent.id)
       );
 
       return {

--- a/apps/api/test/portal-link-intent-cookie.test.ts
+++ b/apps/api/test/portal-link-intent-cookie.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+function createApprovedAccessGuard() {
+  return () => (
+    request: {
+      accessIdentity?: unknown;
+      accessRbacContext?: unknown;
+    },
+    _reply: unknown,
+    done: () => void
+  ) => {
+    request.accessIdentity = {
+      email: "person@example.com",
+      issuer: "https://paretoproof.cloudflareaccess.com",
+      provider: "cloudflare_google",
+      subject: "subject-1"
+    };
+    request.accessRbacContext = {
+      email: "person@example.com",
+      identityId: "identity-1",
+      roles: ["helper"],
+      status: "approved",
+      subject: "subject-1",
+      userId: "user-1"
+    };
+    done();
+  };
+}
+
+test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie for profile linking", async (t) => {
+  const app = Fastify();
+  const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
+
+  t.after(async () => {
+    process.env.ACCESS_PROVIDER_STATE_SECRET = originalSecret;
+    await app.close();
+  });
+
+  const insertedAuditEvents: Array<{ eventId?: string }> = [];
+  const db = {
+    query: {
+      userIdentities: {
+        findFirst: async () => ({
+          user: {
+            id: "user-1",
+            identities: [
+              {
+                provider: "cloudflare_google"
+              }
+            ]
+          }
+        })
+      }
+    },
+    transaction: async (
+      callback: (tx: {
+        insert: () => {
+          values: (value: unknown) => {
+            returning?: () => Promise<Array<{ expiresAt: Date; id: string; redirectPath: string; targetProvider: "cloudflare_github" }>>;
+          };
+        };
+        update: () => {
+          set: () => {
+            where: () => Promise<void>;
+          };
+        };
+      }) => Promise<unknown>
+    ) =>
+      callback({
+        insert() {
+          return {
+            values(value: unknown) {
+              const record = value as { targetProvider?: string };
+
+              if (record.targetProvider) {
+                return {
+                  returning: async () => [
+                    {
+                      expiresAt: new Date("2026-03-15T11:00:00.000Z"),
+                      id: "intent-1",
+                      redirectPath: "/profile?tab=identities",
+                      targetProvider: "cloudflare_github"
+                    }
+                  ]
+                };
+              }
+
+              insertedAuditEvents.push(value as { eventId?: string });
+              return {};
+            }
+          };
+        },
+        update() {
+          return {
+            set() {
+              return {
+                where: async () => undefined
+              };
+            }
+          };
+        }
+      } as never)
+  };
+
+  registerPortalRoutes(app, db as never, createApprovedAccessGuard() as never, {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      provider: "cloudflare_github",
+      redirectPath: "/profile?tab=identities"
+    },
+    url: "/portal/profile/link-intents"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(
+    response.json().intent.startUrl,
+    "https://auth.paretoproof.com/api/access/start/github?redirect=%2Fprofile%3Ftab%3Didentities&flow=link"
+  );
+  assert.equal(insertedAuditEvents[0]?.eventId, "user_identity.link_intent_created");
+
+  const setCookie = response.headers["set-cookie"];
+  const setCookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+  assert.equal(setCookies.length, 1);
+  assert.match(String(setCookies[0]), /^PortalLinkIntent=/);
+  assert.match(String(setCookies[0]), /; SameSite=Strict;/);
+});

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -125,8 +125,11 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   assert.ok(Array.isArray(setCookies));
   assert.equal(setCookies.length, 3);
   assert.match(setCookies[0], /^PortalAccessSession=/);
+  assert.match(setCookies[0], /; SameSite=Lax;/);
   assert.match(setCookies[1], /^PortalAccessProvider=/);
+  assert.match(setCookies[1], /; SameSite=Strict;/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
+  assert.match(setCookies[2], /; SameSite=Strict;/);
 });
 
 test("POST /portal/session/finalize/submit bounces stale direct browser handoffs back to the branded auth relay", async (t) => {
@@ -268,8 +271,11 @@ test("POST /portal/session/finalize/submit completes a pending-user handoff from
   assert.ok(Array.isArray(setCookies));
   assert.equal(setCookies.length, 3);
   assert.match(setCookies[0], /^PortalAccessSession=/);
+  assert.match(setCookies[0], /; SameSite=Lax;/);
   assert.match(setCookies[1], /^PortalAccessProvider=/);
+  assert.match(setCookies[1], /; SameSite=Strict;/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
+  assert.match(setCookies[2], /; SameSite=Strict;/);
 });
 
 test("GET /portal/me accepts the signed portal access session cookie when no Access assertion is present", async (t) => {

--- a/apps/web/functions/_shared/access-start.test.ts
+++ b/apps/web/functions/_shared/access-start.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { handleAccessStart } from "./access-start";
+
+function readSetCookies(response: Response) {
+  return (response.headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+}
+
+describe("handleAccessStart", () => {
+  it("starts Google sign-in with Strict provider state and clears abandoned link state", async () => {
+    const response = await handleAccessStart(
+      new Request("https://auth.paretoproof.com/api/access/start/google?redirect=/profile"),
+      {
+        ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+      },
+      "google"
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://google.auth.paretoproof.com/?redirect=%2Fprofile"
+    );
+
+    const setCookies = readSetCookies(response);
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain("PortalLinkIntent=");
+    expect(setCookies[0]).toContain("SameSite=Strict");
+    expect(setCookies[1]).toContain("PortalAccessProvider=");
+    expect(setCookies[1]).toContain("SameSite=Strict");
+  });
+
+  it("starts GitHub profile linking without clearing the existing link intent and keeps provider state Strict", async () => {
+    const response = await handleAccessStart(
+      new Request(
+        "https://auth.paretoproof.com/api/access/start/github?flow=link&redirect=/profile?tab=identities"
+      ),
+      {
+        ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+      },
+      "github"
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://github.auth.paretoproof.com/?redirect=%2Fprofile%3Ftab%3Didentities&flow=link"
+    );
+
+    const setCookies = readSetCookies(response);
+    expect(setCookies).toHaveLength(1);
+    expect(setCookies[0]).toContain("PortalAccessProvider=");
+    expect(setCookies[0]).toContain("SameSite=Strict");
+  });
+});

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -76,7 +76,7 @@ async function buildProviderHintCookie(env: AccessStartEnv, provider: Provider) 
     `PortalAccessProvider=${value}`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Lax",
+    "SameSite=Strict",
     "Max-Age=600",
     "Secure",
     "HttpOnly"
@@ -88,7 +88,7 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
     `${name}=`,
     "Domain=.paretoproof.com",
     "Path=/",
-    "SameSite=Lax",
+    "SameSite=Strict",
     "Max-Age=0",
     "Secure",
     "HttpOnly"

--- a/docs/web-surface-policy.md
+++ b/docs/web-surface-policy.md
@@ -24,6 +24,13 @@ Redirect helpers, route tests, and public copy should preserve this split and re
 
 The public site should explain this path without implying self-serve enrollment, hidden sign-in shortcuts, or a separate benchmark hostname.
 
+## Auth State Cookies
+
+- `PortalAccessProvider` and `PortalLinkIntent` are same-site coordination cookies for the branded auth and profile-link flows. They should be `SameSite=Strict`.
+- Google sign-in, GitHub sign-in, branded retry, and profile-link entry only need these cookies on same-site `*.paretoproof.com` redirects. They must not rely on truly cross-site top-level cookie delivery.
+- `PortalAccessProvider` may survive the internal branded handoff long enough to bind the finalized provider to the resolved subject, then it should be refreshed or cleared by the finalize response.
+- `PortalLinkIntent` exists only to authorize a deliberate profile-link flow that started from the authenticated portal. It should be issued on that path and cleared on normal sign-in or after finalize so abandoned link state does not ride later navigations.
+
 ## Public Pack
 
 The public project route stays compact:


### PR DESCRIPTION
## Summary
- tighten `PortalAccessProvider` and `PortalLinkIntent` back to `SameSite=Strict` on both the API finalize path and the Pages auth-start helper
- add regression coverage for Google sign-in, GitHub link entry, finalized provider refresh, and profile-link intent issuance
- document the tested cookie matrix in `docs/web-surface-policy.md`

## Cookie matrix
- `PortalAccessProvider`: `SameSite=Strict`; only needed on same-site `*.paretoproof.com` auth hops, then refreshed or cleared by finalize
- `PortalLinkIntent`: `SameSite=Strict`; only issued from the authenticated portal link flow, preserved for `flow=link`, and cleared on ordinary sign-in or after finalize
- `PortalAccessSession`: unchanged in this slice; finalize tests still assert it remains `SameSite=Lax`

## Why this supersedes #748
Draft PR #748 only flipped the flag. This replacement proves the policy against the current branded auth relay and profile-link paths after #806, and carries the explicit matrix the issue asked for.

Closes #780
Supersedes #748

## Verification
- `bun test apps/web/functions/_shared/access-start.test.ts apps/web/functions/_shared/access-finalize.test.ts`
- `bun run build:shared`
- `bun --cwd apps/api test`
- `bun run typecheck:api`
- `bun run typecheck:web`
- `bun run check:bidi`