### PR TITLE
docs(scope): activate math workflow surface baseline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use these files:
 - [benchmark-product-objects-baseline.md](./benchmark-product-objects-baseline.md) for the first-class benchmark, launch, release, and comparison objects above the run kernel
 - [benchmark-intake-review-workflow-baseline.md](./benchmark-intake-review-workflow-baseline.md) for the repository-first benchmark candidate intake and curation-review boundary
 - [benchmarks.md](./benchmarks.md) for the current benchmark scope
+- [math-surface-activation-baseline.md](./math-surface-activation-baseline.md) for the accepted dedicated `math.paretoproof.com` workflow surface split
 - [offline-ingest-operator-auth-baseline.md](./offline-ingest-operator-auth-baseline.md) for the later-scope unattended offline-ingest auth lane
 - [next-product-slice-sequencing-baseline.md](./next-product-slice-sequencing-baseline.md) for the ordered next backlog refill after the current benchmark kernel
 - [portal-launch-mutation-baseline.md](./portal-launch-mutation-baseline.md) for the scoped browser-to-queue launch contract

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,18 +1,19 @@
 # Architecture
 
-ParetoProof has three user-facing web surfaces and one worker/control-plane backbone.
+ParetoProof has four user-facing web surfaces and one worker/control-plane backbone.
 
 - `paretoproof.com` is the public site for project context and released benchmark reporting.
 - `auth.paretoproof.com` plus provider-specific auth hosts handle sign-in and access-request entry.
 - `portal.paretoproof.com` is the authenticated contributor and admin workspace.
+- `math.paretoproof.com` is the authenticated math workflow surface for question, submission, review, and question-centric launch work.
 - `api.paretoproof.com` is the Fastify control plane for state, authz, ingest, and worker coordination.
 
-There is no separate `math.paretoproof.com` hostname in MVP. Public benchmark reporting stays on the apex site, and deeper operational or execution views stay behind the portal and worker surfaces.
+Public benchmark reporting stays on the apex site. Generic operational and execution views stay behind the portal and worker surfaces. Math workflow gets its own authenticated surface rather than growing as a sidecar inside the portal.
 
 Execution is intentionally split away from the browser.
 
 - `apps/api` owns control-plane state and contracts.
-- `apps/web` owns the public site, auth entry UI, and portal UI.
+- `apps/web` owns the public site, auth entry UI, portal UI, and math UI.
 - `apps/worker` owns package materialization, local attempts, offline ingest, and the hosted claim loop.
 
 The current benchmark kernel is the repository-owned `benchmarks/firstproof/problem9` slice. Public reporting is narrow, and deeper run evidence stays in the portal or worker artifacts instead of the public site.

--- a/docs/benchmark-intake-review-workflow-baseline.md
+++ b/docs/benchmark-intake-review-workflow-baseline.md
@@ -6,7 +6,7 @@ This document defines how new benchmark candidates should enter ParetoProof afte
 
 - `docs/benchmarks.md` already treats repository-owned benchmark packages as the active execution kernel.
 - `docs/problem9-benchmark-target-baseline.md` now fixes `firstproof/Problem9` as the canonical current benchmark target rather than leaving it as a bootstrap-only theorem.
-- `docs/web-surface-policy.md` explicitly keeps `math.paretoproof.com` out of MVP and limits authenticated operational work to `portal.paretoproof.com`.
+- `docs/math-surface-activation-baseline.md` now accepts `math.paretoproof.com` as the authenticated math workflow surface while keeping package truth repository-owned.
 - `docs/portal-launch-mutation-baseline.md` and `docs/portal-run-control-actions-baseline.md` keep `/runs`, `/launch`, and `/workers` focused on execution and evidence, not benchmark authoring or curation.
 - The current repository state still makes the benchmark package itself the authoritative source of theorem statement, support files, gold proof, and releaseable materialization inputs.
 
@@ -18,7 +18,7 @@ Near-term benchmark intake should remain repository- and pull-request-driven.
 
 The portal should not gain raw benchmark package authoring or freeform theorem-submission forms in the next slice.
 
-A later portal workflow is allowed, but only as a structured review layer on top of repository-owned package candidates, not as a replacement for repository-owned source control.
+A later math workflow is allowed, but only as a structured review layer on top of repository-owned package candidates, not as a replacement for repository-owned source control.
 
 ## Near-term workflow
 
@@ -55,15 +55,15 @@ The near-term workflow should be:
 
 This is intentionally narrower than a general submission portal. The project still needs trusted package authorship and reproducible review more than it needs browser-based theorem intake.
 
-## Portal role in the later slice
+## Math surface role in the later slice
 
-The portal may later gain structured benchmark intake and curation review, but only for metadata, workflow state, and reviewer decisions.
+The math surface may later gain structured benchmark intake and curation review, but only for metadata, workflow state, and reviewer decisions.
 
-The portal should not become a raw package editor.
+The math surface should not become a raw package editor.
 
-### Allowed later portal responsibilities
+### Allowed later math-surface responsibilities
 
-A later portal workflow may own:
+A later math workflow may own:
 
 - benchmark candidate registration metadata
 - triage state
@@ -72,9 +72,9 @@ A later portal workflow may own:
 - approval or rejection decisions
 - publication readiness and release visibility state
 
-### Forbidden later portal responsibilities
+### Forbidden later math-surface responsibilities
 
-Even in the next portal-enabled slice, the browser should stay out of:
+Even in the next math-enabled slice, the browser should stay out of:
 
 - direct editing of Lean theorem files
 - freeform theorem authoring without repository review
@@ -84,7 +84,7 @@ Even in the next portal-enabled slice, the browser should stay out of:
 
 ## Minimum object model for the later workflow
 
-If the portal later gains structured benchmark intake or review capabilities, the minimum object model should be:
+If the math surface later gains structured benchmark intake or review capabilities, the minimum object model should be:
 
 - `benchmark_candidate`
 - `curation_review`
@@ -151,7 +151,7 @@ Publication state must remain separate from review state, because an accepted ca
 
 Near-term submit authority remains repository contributors who can open the package PR.
 
-Later portal candidate registration may be allowed for:
+Later math-surface candidate registration may be allowed for:
 
 - approved collaborator or higher
 
@@ -260,9 +260,9 @@ The repository owns:
 - releaseable package revisions
 - code review on the substantive benchmark content
 
-### Portal-owned later
+### Math-surface-owned later
 
-If implemented later, the portal should own:
+If implemented later, the math surface should own:
 
 - candidate registration and queue state
 - structured curation-review status
@@ -277,20 +277,20 @@ The current benchmark-ops route family should not absorb benchmark intake.
 - `/launch` remains package-selection and run-preflight workflow
 - `/workers` remains operational posture and incident visibility
 
-Benchmark intake and curation review, if they later become portal features, should live in a separate route family rather than mutating the execution cluster into a benchmark CMS.
+Benchmark intake and curation review, if they later become math-surface features, should live in a separate route family rather than mutating the execution cluster into a benchmark CMS.
 
 ## Recommended later route boundary
 
-If the portal later gains this workflow, the route family should be separate from execution routes.
+If the math surface later gains this workflow, the route family should be separate from execution routes.
 
 Recommended shape:
 
-- `/admin/benchmark-candidates`
-- `/admin/benchmark-candidates/:candidateId`
+- `/review/benchmark-candidates`
+- `/review/benchmark-candidates/:candidateId`
 
 That keeps benchmark curation aligned with privileged review work instead of confusing it with ordinary collaborator run operations.
 
-A collaborator-visible submission entry may later exist, but it should still create or point at a structured candidate object reviewed under the admin route family.
+A collaborator-visible submission entry may later exist, but it should still create or point at a structured candidate object reviewed under the privileged review route family.
 
 ## Explicit non-goals for the next slice
 
@@ -299,15 +299,14 @@ The next slice should not attempt:
 - raw browser package editing
 - theorem submission directly from a public form
 - benchmark authoring under `/runs`, `/launch`, or `/workers`
-- a new `math.paretoproof.com` app
-- replacing repository PR review with portal-only workflow state
+- replacing repository PR review with browser-only workflow state
 
 ## Follow-up execution slices
 
 Execution work after this scope should split into:
 
 1. define the canonical `benchmark_candidate`, `curation_review`, `release_decision`, and `publication_status` contracts
-2. add the chosen portal review/read-model routes on a separate admin benchmark-candidates route family if the project wants structured in-product review next
+2. add the chosen math review/read-model routes on a separate benchmark-candidates review route family if the project wants structured in-product review next
 3. add audit coverage for candidate creation, review decisions, hold-out state, and publication changes
 4. align public benchmark release reporting so only approved and publicly reportable candidates appear on the apex site
 5. keep benchmark package authoring, theorem changes, and gold-proof updates repository-owned until a separate scope explicitly changes that rule

--- a/docs/math-surface-activation-baseline.md
+++ b/docs/math-surface-activation-baseline.md
@@ -1,0 +1,150 @@
+# Math Surface Activation Baseline
+
+This document defines the accepted web-surface split for the next ParetoProof product step now that benchmark authoring, review, and question-centric launch work need a dedicated authenticated home.
+
+## Current baseline
+
+- `docs/web-surface-policy.md` and `docs/architecture.md` previously deferred a separate `math.paretoproof.com` hostname.
+- `docs/benchmark-intake-review-workflow-baseline.md` keeps launchable benchmark packages repository-owned and rejects browser-side package truth.
+- `docs/portal-launch-mutation-baseline.md` and `docs/portal-run-control-actions-baseline.md` keep `/launch`, `/runs`, and `/workers` centered on execution and evidence rather than math authoring or review.
+- The API and auth stack already support branded handoff into authenticated browser surfaces, even though the current continuation paths are portal-centric.
+
+The project now needs a dedicated authenticated math workflow surface without collapsing that work into the public site, the generic ops portal, or ad hoc repository comments.
+
+## Decision
+
+ParetoProof should activate `math.paretoproof.com` as a fourth user-facing web surface.
+
+The accepted surface split becomes:
+
+- `paretoproof.com` for the public site and released benchmark reporting
+- `auth.paretoproof.com` plus provider-specific auth hosts for branded sign-in and recovery entry
+- `portal.paretoproof.com` for generic contributor profile, access state, execution evidence, worker posture, and platform admin
+- `math.paretoproof.com` for authenticated math question intake, submission workflow, review workflow, package-readiness posture, and question-centric launch/bootstrap entry
+
+This is a product-surface decision, not approval to move launchable benchmark truth out of the repository.
+
+## Surface ownership
+
+### `paretoproof.com`
+
+The apex site continues to own:
+
+- public project context
+- released benchmark reporting
+- approved release pages and public summaries
+
+It should not own authenticated math authoring, reviewer queue state, or private launch preparation.
+
+### `auth.paretoproof.com`
+
+The auth surface continues to own:
+
+- branded sign-in and provider start flows
+- access-request and recovery entry
+- redirect continuation into the correct authenticated app after identity resolution
+
+The auth surface should not become a long-lived workspace shell for either portal or math tasks.
+
+### `portal.paretoproof.com`
+
+The portal remains the generic contributor and admin workspace for:
+
+- profile and linked-identity management
+- approval and access-state handling
+- run, worker, and artifact operations
+- generic admin and operational views that are not specific to the math workflow
+
+The portal should not absorb question authoring, submission review, package-freeze preparation, or question-centric launch as sidecars under `/runs`, `/launch`, or `/workers`.
+
+### `math.paretoproof.com`
+
+The math surface should own:
+
+- question catalog and question detail workflow
+- submission intake and submission status
+- peer review, editor review, and release-decision workflow
+- package-readiness and freeze-preparation posture for approved math work
+- question-centric launch entry for hosted, local connected, and offline export flows
+
+The math surface is the authenticated product home for math workflow. It is not a public reporting site, a generic account portal, or a replacement for worker and scheduler operations.
+
+## Repository truth boundary
+
+Activating `math.paretoproof.com` does not change the canonical source of truth for launchable benchmark packages.
+
+The repository remains authoritative for:
+
+- launchable benchmark package trees
+- Lean source, support files, and gold/reference material
+- immutable package revisions and freezeable release inputs
+- reviewable diffs on the substance of benchmark content
+
+The math surface may own workflow metadata and structured reviewer state around those artifacts, but it must not become an unbounded browser-side package editor or create a parallel benchmark truth outside source control.
+
+## Auth and continuation boundary
+
+Branded sign-in should remain centralized on `auth.paretoproof.com`, but continuation must become app-aware.
+
+The auth stack should:
+
+- continue to authenticate users through the branded auth hosts
+- preserve the caller's intended continuation target
+- route successful continuation into either `portal.paretoproof.com` or `math.paretoproof.com` based on the requested destination
+
+Math-specific sign-in should not require users to land in the portal first and then navigate manually into math.
+
+Profile, access-request, and recovery flows that are generic to the account system may still resolve on portal-owned routes when that is the right continuation target.
+
+## Launch and evidence boundary
+
+Question-centric launch entry should live on the math surface because launch intent starts from a question, submission, or review context there.
+
+That does not move all execution evidence into the math app.
+
+The accepted split is:
+
+- math owns question-centric launch entry, bootstrap choices, and question-local readiness context
+- portal remains the generic home for durable run evidence, worker posture, and operational drilldown unless a later scope explicitly reassigns a read model
+
+The project should prefer explicit deep links between math and portal over duplicating whole execution consoles in both surfaces.
+
+## What stays out of math
+
+`math.paretoproof.com` should not own:
+
+- public released benchmark reporting
+- generic profile and access-state management
+- worker fleet posture or incident response consoles
+- raw provider secret vending to browsers by default
+- a second source of truth for benchmark package contents outside the repository
+
+## Relationship to earlier docs
+
+This baseline supersedes the older "no separate `math.paretoproof.com` hostname in MVP" rule in:
+
+- `docs/web-surface-policy.md`
+- `docs/architecture.md`
+- any downstream scope text that only deferred math workflow because the dedicated surface had not yet been accepted
+
+It does not supersede the repository-truth decisions in `docs/benchmark-intake-review-workflow-baseline.md` or the execution-evidence boundaries in the portal launch and run-control baselines.
+
+## Follow-up scope and execution work
+
+This baseline unblocks the child scopes under `#882`:
+
+- data model
+- Lean submission and automated-check rules
+- review and release workflow
+- `/math` API namespace and auth destinations
+- question-centric launch/bootstrap
+- provider-credential policy
+- harness and image distribution
+- repo-sync and package-freeze workflow
+
+Execution after those scopes should build:
+
+1. the dedicated `math.paretoproof.com` app shell and auth continuation
+2. `/math/*` backend routes and service modules
+3. the math question, submission, review, package, and release object layer
+4. question-centric launch flows that connect cleanly to the existing execution kernel

--- a/docs/next-product-slice-sequencing-baseline.md
+++ b/docs/next-product-slice-sequencing-baseline.md
@@ -9,10 +9,10 @@ The repository now has materially more kernel definition than it had when this s
 Accepted upstream scope now includes:
 
 - `docs/problem9-benchmark-target-baseline.md`: `firstproof/Problem9` is no longer a bootstrap-only theorem and now has an accepted canonical target
-- `docs/benchmark-intake-review-workflow-baseline.md`: benchmark intake stays repository-first, with any later portal workflow limited to structured candidate and review state
+- `docs/benchmark-intake-review-workflow-baseline.md`: benchmark intake stays repository-first, with any later math workflow limited to structured candidate and review state
 - `docs/portal-launch-mutation-baseline.md`: launch is a portal-owned browser-to-queue mutation
 - `docs/portal-run-control-actions-baseline.md`: run-detail browser control is intentionally narrow
-- `docs/web-surface-policy.md`: `math.paretoproof.com` remains out of MVP and released reporting stays on the apex site
+- `docs/math-surface-activation-baseline.md`: `math.paretoproof.com` is now the accepted authenticated math workflow surface, while released reporting still stays on the apex site
 
 There is also now an active benchmark-product object scope in flight, which means the project can stop guessing about the layer above raw runs and start sequencing real follow-on work deliberately.
 
@@ -153,7 +153,7 @@ Move approved benchmark releases and released reporting onto the apex site under
 
 Public reporting should consume approved release objects, not query draft review data or private portal state.
 
-The apex site is the right home for released benchmark reporting, and the project should keep it that way instead of reopening the deferred `math.paretoproof.com` decision.
+The apex site is still the right home for released benchmark reporting even after activating `math.paretoproof.com` for authenticated workflow.
 
 ## Slice 6: Richer Comparison And Frontier Reporting
 

--- a/docs/web-surface-policy.md
+++ b/docs/web-surface-policy.md
@@ -1,28 +1,31 @@
 # Web Surface Policy
 
-ParetoProof ships three user-facing web surfaces in MVP:
+ParetoProof ships four user-facing web surfaces in the current product split:
 
 - `paretoproof.com` for the public site and released benchmark reporting
 - `auth.paretoproof.com` plus provider-specific auth hosts for approved sign-in and new collaborator identity verification
 - `portal.paretoproof.com` for the authenticated contributor and admin workspace
+- `math.paretoproof.com` for authenticated math workflow, review, and question-centric launch entry
 
-There is no separate `math.paretoproof.com` hostname in MVP. Public benchmark releases stay on the apex site, and deeper operational views stay in the portal.
+Public benchmark releases stay on the apex site. Generic operational views stay in the portal. The dedicated math workflow lives on `math.paretoproof.com`.
 
 ## Surface Ownership
 
 - `paretoproof.com` owns the public home page, the compact project pack, and public benchmark release pages.
 - `auth.paretoproof.com` owns the branded sign-in and request-access entry flow.
 - `portal.paretoproof.com` owns contributor profile, access state, admin review, run views, launch, and worker operations.
+- `math.paretoproof.com` owns question workflow, submission review, release-decision posture, and question-centric launch/bootstrap.
 
 Redirect helpers, route tests, and public copy should preserve this split and reject cross-surface drift.
 
 ## Contributor Path
 
 - Approved contributors start at the sign-in entry on `auth.paretoproof.com`.
+- After auth resolves, continuation should land directly in the intended authenticated app: portal for generic account or ops work, math for question and review workflow.
 - New collaborators verify identity first and then continue to the dedicated access-request path.
-- Approval stays manual before any contributor work opens inside the portal.
+- Approval stays manual before any contributor work opens inside portal or math.
 
-The public site should explain this path without implying self-serve enrollment, hidden sign-in shortcuts, or a separate benchmark hostname.
+The public site should explain this path without implying self-serve enrollment, hidden sign-in shortcuts, or public authoring on the math surface.
 
 ## Auth State Cookies
 


### PR DESCRIPTION
## Summary
- add `docs/math-surface-activation-baseline.md` to accept `math.paretoproof.com` as the dedicated authenticated math workflow surface
- keep released benchmark reporting on `paretoproof.com`, generic ops in `portal.paretoproof.com`, and repository-backed package truth out of browser ownership
- align the existing surface-policy, architecture, benchmark-intake, and sequencing docs with the accepted four-surface split

## Scope decision
- `math.paretoproof.com` becomes the authenticated home for question workflow, submission/review, release-decision posture, and question-centric launch entry
- `auth.paretoproof.com` remains the branded sign-in entry, but continuation must land directly in either portal or math based on destination
- `portal.paretoproof.com` stays the generic contributor/admin and execution-ops workspace rather than absorbing math authoring as a sidecar
- `paretoproof.com` remains the public release and reporting surface

## Verification
- `bun run check:bidi`
- targeted docs drift search for the old deferred-math wording

Closes #882