### PR TITLE
fix(auth): dedicate portal session secret

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,6 +17,7 @@ CF_ACCESS_PORTAL_AUD=replace-with-portal-cloudflare-access-audience
 CF_ACCESS_BRANDED_AUDS=replace-with-github-and-google-cloudflare-access-audiences
 CF_ACCESS_INTERNAL_AUD=replace-with-internal-cloudflare-access-audience
 ACCESS_PROVIDER_STATE_SECRET=replace-with-the-pages-provider-hint-secret
+PORTAL_SESSION_SECRET=replace-with-a-dedicated-portal-session-secret
 WORKER_BOOTSTRAP_TOKEN=replace-with-the-worker-bootstrap-token
 
 # Owner-ops platform credentials. Leave unset unless you are intentionally doing platform ops.

--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -28,6 +28,14 @@ export type VerifiedAccessLinkIntent = {
   intentId: string;
 };
 
+function readAccessProviderStateSecret() {
+  return process.env.ACCESS_PROVIDER_STATE_SECRET;
+}
+
+function readPortalAccessSessionSecret() {
+  return process.env.PORTAL_SESSION_SECRET ?? readAccessProviderStateSecret();
+}
+
 function createSignedAccessValue(value: string, secret: string, maxAgeSeconds = 600) {
   const expiresAt = Math.floor(Date.now() / 1000) + maxAgeSeconds;
   const payload = `${value}.${expiresAt}`;
@@ -254,8 +262,11 @@ function readCookieValue(cookieHeader: string | undefined, name: string) {
   return null;
 }
 
-function verifySignedAccessCookie(cookieHeader: string | undefined, cookieName: string) {
-  const secret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+function verifySignedAccessCookie(
+  cookieHeader: string | undefined,
+  cookieName: string,
+  secret: string | undefined
+) {
   const rawValue = readCookieValue(cookieHeader, cookieName);
 
   if (!secret || !rawValue) {
@@ -299,7 +310,11 @@ export function verifyAccessProviderHint(
   cookieHeader: string | undefined,
   expectedSubject?: string
 ) {
-  const verifiedCookie = verifySignedAccessCookie(cookieHeader, "PortalAccessProvider");
+  const verifiedCookie = verifySignedAccessCookie(
+    cookieHeader,
+    "PortalAccessProvider",
+    readAccessProviderStateSecret()
+  );
   const parsedPayload = verifiedCookie?.payload
     ? parseVerifiedProviderHintPayload(verifiedCookie.payload)
     : null;
@@ -316,7 +331,11 @@ export function verifyAccessProviderHint(
 }
 
 export function verifyAccessLinkIntent(cookieHeader: string | undefined) {
-  const verifiedCookie = verifySignedAccessCookie(cookieHeader, "PortalLinkIntent");
+  const verifiedCookie = verifySignedAccessCookie(
+    cookieHeader,
+    "PortalLinkIntent",
+    readAccessProviderStateSecret()
+  );
 
   if (!verifiedCookie?.payload) {
     return null;
@@ -331,17 +350,12 @@ export function verifyAccessLinkIntent(cookieHeader: string | undefined) {
 function buildSignedCookie(
   name: "PortalAccessProvider" | "PortalLinkIntent" | "PortalAccessSession",
   value: string,
+  secret: string,
   options?: {
     maxAgeSeconds?: number;
     sameSite?: "Strict" | "Lax";
   }
 ) {
-  const secret = process.env.ACCESS_PROVIDER_STATE_SECRET;
-
-  if (!secret) {
-    throw new Error("ACCESS_PROVIDER_STATE_SECRET is not configured.");
-  }
-
   const maxAgeSeconds = options?.maxAgeSeconds ?? 600;
   const sameSite = options?.sameSite ?? "Strict";
 
@@ -364,7 +378,13 @@ export function buildSignedAccessCookie(
     sameSite?: "Strict" | "Lax";
   }
 ) {
-  return buildSignedCookie(name, value, options);
+  const secret = readAccessProviderStateSecret();
+
+  if (!secret) {
+    throw new Error("ACCESS_PROVIDER_STATE_SECRET is not configured.");
+  }
+
+  return buildSignedCookie(name, value, secret, options);
 }
 
 export function buildSignedPortalAccessSessionCookie(
@@ -374,6 +394,14 @@ export function buildSignedPortalAccessSessionCookie(
     maxAgeSeconds?: number;
   }
 ) {
+  const secret = readPortalAccessSessionSecret();
+
+  if (!secret) {
+    throw new Error(
+      "PORTAL_SESSION_SECRET or ACCESS_PROVIDER_STATE_SECRET is required."
+    );
+  }
+
   return buildSignedCookie(
     "PortalAccessSession",
     Buffer.from(
@@ -383,6 +411,7 @@ export function buildSignedPortalAccessSessionCookie(
       }),
       "utf8"
     ).toString("base64url"),
+    secret,
     {
       maxAgeSeconds: options?.maxAgeSeconds ?? 5 * 60,
       sameSite: "Lax"
@@ -391,7 +420,11 @@ export function buildSignedPortalAccessSessionCookie(
 }
 
 export function verifyPortalAccessSession(cookieHeader: string | undefined) {
-  const verifiedCookie = verifySignedAccessCookie(cookieHeader, "PortalAccessSession");
+  const verifiedCookie = verifySignedAccessCookie(
+    cookieHeader,
+    "PortalAccessSession",
+    readPortalAccessSessionSecret()
+  );
 
   if (!verifiedCookie?.payload) {
     return null;

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -47,6 +47,7 @@ const rawApiRuntimeEnvSchema = z
     HOST: trimmedOptionalStringSchema,
     NODE_ENV: trimmedOptionalStringSchema,
     PORT: portSchema,
+    PORTAL_SESSION_SECRET: trimmedOptionalStringSchema,
     WORKER_BOOTSTRAP_TOKEN: requiredTrimmedStringSchema
   })
   .superRefine((env, context) => {
@@ -70,6 +71,7 @@ export type ApiRuntimeEnv = {
   nodeEnv?: string;
   port: number;
   portalAccessAudience: string;
+  portalSessionSecret: string;
   teamDomain: string;
   workerBootstrapToken: string;
 };
@@ -137,6 +139,7 @@ export function parseApiRuntimeEnv(
     HOST,
     NODE_ENV,
     PORT,
+    PORTAL_SESSION_SECRET,
     WORKER_BOOTSTRAP_TOKEN
   } = parsed.data;
 
@@ -153,6 +156,7 @@ export function parseApiRuntimeEnv(
     nodeEnv: NODE_ENV,
     port: PORT === undefined ? 3000 : Number(PORT),
     portalAccessAudience,
+    portalSessionSecret: PORTAL_SESSION_SECRET ?? ACCESS_PROVIDER_STATE_SECRET,
     teamDomain: CF_ACCESS_TEAM_DOMAIN,
     workerBootstrapToken: WORKER_BOOTSTRAP_TOKEN
   };

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildSignedAccessCookie,
   buildSignedPortalAccessSessionCookie,
   readAccessJwtAssertion,
   selectCloudflareAccessVerifier,
+  verifyAccessProviderHint,
   verifyPortalAccessSession,
   type CloudflareAccessVerifierSet
 } from "../src/auth/cloudflare-access.ts";
@@ -83,6 +85,60 @@ test("verifyPortalAccessSession round-trips a signed portal access session cooki
   }
 });
 
+test("PortalAccessSession uses PORTAL_SESSION_SECRET without changing provider-hint cookie verification", () => {
+  const originalProviderSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+  const originalSessionSecret = process.env.PORTAL_SESSION_SECRET;
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "provider-secret";
+  process.env.PORTAL_SESSION_SECRET = "session-secret";
+
+  try {
+    const sessionCookie = buildSignedPortalAccessSessionCookie(
+      {
+        email: "person@example.com",
+        issuer: "https://paretoproof.cloudflareaccess.com",
+        provider: "cloudflare_google",
+        subject: "subject-1"
+      },
+      {
+        email: "person@example.com",
+        identityId: "identity-1",
+        roles: ["helper"],
+        status: "approved",
+        subject: "subject-1",
+        userId: "user-1"
+      }
+    );
+    const providerCookie = buildSignedAccessCookie(
+      "PortalAccessProvider",
+      "cloudflare_google|subject-1"
+    );
+
+    assert.equal(
+      verifyAccessProviderHint(providerCookie, "subject-1"),
+      "cloudflare_google"
+    );
+    assert.deepEqual(verifyPortalAccessSession(sessionCookie)?.context, {
+      email: "person@example.com",
+      identityId: "identity-1",
+      roles: ["helper"],
+      status: "approved",
+      subject: "subject-1",
+      userId: "user-1"
+    });
+
+    process.env.PORTAL_SESSION_SECRET = "wrong-session-secret";
+
+    assert.equal(
+      verifyAccessProviderHint(providerCookie, "subject-1"),
+      "cloudflare_google"
+    );
+    assert.equal(verifyPortalAccessSession(sessionCookie), null);
+  } finally {
+    process.env.ACCESS_PROVIDER_STATE_SECRET = originalProviderSecret;
+    process.env.PORTAL_SESSION_SECRET = originalSessionSecret;
+  }
+});
+
 test("createAccessResolver accepts the signed portal access session on portal routes without touching Access verification", async () => {
   const originalEnv = {
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
@@ -90,6 +146,7 @@ test("createAccessResolver accepts the signed portal access session on portal ro
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
     CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
     DATABASE_URL: process.env.DATABASE_URL,
+    PORTAL_SESSION_SECRET: process.env.PORTAL_SESSION_SECRET,
     WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
   };
 

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -26,6 +26,7 @@ test("parseApiRuntimeEnv accepts the documented local API runtime contract", () 
     nodeEnv: undefined,
     port: 3000,
     portalAccessAudience: "portal-audience",
+    portalSessionSecret: "state-secret",
     teamDomain: "paretoproof.cloudflareaccess.com",
     workerBootstrapToken: "worker-bootstrap-token"
   });
@@ -44,6 +45,7 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
     HOST: "127.0.0.1",
     NODE_ENV: "production",
     PORT: "4310",
+    PORTAL_SESSION_SECRET: "session-secret",
     WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
   });
 
@@ -64,6 +66,7 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
     nodeEnv: "production",
     port: 4310,
     portalAccessAudience: "legacy-audience",
+    portalSessionSecret: "session-secret",
     teamDomain: "paretoproof.cloudflareaccess.com",
     workerBootstrapToken: "worker-bootstrap-token"
   });

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -26,6 +26,7 @@ const checks = [
       { name: "CF_ACCESS_BRANDED_AUDS", commented: false },
       { name: "CF_ACCESS_INTERNAL_AUD", commented: false },
       { name: "ACCESS_PROVIDER_STATE_SECRET", commented: false },
+      { name: "PORTAL_SESSION_SECRET", commented: false },
       { name: "WORKER_BOOTSTRAP_TOKEN", commented: false },
       { name: "CLOUDFLARE_API_TOKEN", commented: false },
       { name: "CLOUDFLARE_EMAIL", commented: false },


### PR DESCRIPTION
## Summary
- dedicate `PORTAL_SESSION_SECRET` to `PortalAccessSession` signing and verification
- keep `PortalAccessProvider` and `PortalLinkIntent` on `ACCESS_PROVIDER_STATE_SECRET`
- preserve fallback to `ACCESS_PROVIDER_STATE_SECRET` when `PORTAL_SESSION_SECRET` is unset so rollout can happen without a lockstep deploy
- document the new variable in `apps/api/.env.example` and the env-contract checker

## Verification
- `bun --cwd apps/api test test/cloudflare-access.test.ts test/runtime-env.test.ts`
- `bun run typecheck:api`
- `bun run check:env-contract`
- `bun run check:bidi`

Closes #905
Follow-up: #904 remains the longer-term opaque DB-backed session migration.