### PR TITLE
fix(auth): move portal sessions into db

### DIFF
--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -4,7 +4,6 @@ import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { normalizeOptionalEmail } from "../lib/email.js";
 import { parseApiRuntimeEnv } from "../config/runtime.js";
 import type { PortalIdentityProvider } from "@paretoproof/shared";
-import type { AccessRbacContext } from "./resolve-access-rbac-context.js";
 
 type CloudflareAccessTokenClaims = JWTPayload & {
   email?: string;
@@ -18,11 +17,6 @@ export type CloudflareAccessIdentity = {
   subject: string;
 };
 
-export type PortalAccessSession = {
-  context: AccessRbacContext;
-  identity: CloudflareAccessIdentity;
-};
-
 export type VerifiedAccessLinkIntent = {
   expiresAt: number;
   intentId: string;
@@ -30,10 +24,6 @@ export type VerifiedAccessLinkIntent = {
 
 function readAccessProviderStateSecret() {
   return process.env.ACCESS_PROVIDER_STATE_SECRET;
-}
-
-function readPortalAccessSessionSecret() {
-  return process.env.PORTAL_SESSION_SECRET ?? readAccessProviderStateSecret();
 }
 
 function createSignedAccessValue(value: string, secret: string, maxAgeSeconds = 600) {
@@ -65,164 +55,6 @@ function parseVerifiedProviderHintPayload(payload: string) {
   };
 }
 
-function parsePortalAccessSessionPayload(payload: string) {
-  let parsedPayload: unknown;
-
-  try {
-    parsedPayload = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
-  } catch {
-    return null;
-  }
-
-  if (!parsedPayload || typeof parsedPayload !== "object") {
-    return null;
-  }
-
-  const { context, identity } = parsedPayload as {
-    context?: unknown;
-    identity?: unknown;
-  };
-
-  if (
-    !identity ||
-    typeof identity !== "object" ||
-    typeof (identity as { issuer?: unknown }).issuer !== "string" ||
-    typeof (identity as { subject?: unknown }).subject !== "string"
-  ) {
-    return null;
-  }
-
-  const identityEmail = (identity as { email?: unknown }).email;
-  const identityProvider = (identity as { provider?: unknown }).provider;
-
-  if (identityEmail !== null && typeof identityEmail !== "string") {
-    return null;
-  }
-
-  if (
-    identityProvider !== null &&
-    identityProvider !== undefined &&
-    identityProvider !== "cloudflare_google" &&
-    identityProvider !== "cloudflare_github" &&
-    identityProvider !== "cloudflare_one_time_pin"
-  ) {
-    return null;
-  }
-
-  if (!context || typeof context !== "object") {
-    return null;
-  }
-
-  const status = (context as { status?: unknown }).status;
-  const email = (context as { email?: unknown }).email;
-  const subject = (context as { subject?: unknown }).subject;
-
-  if (
-    (email !== null && typeof email !== "string") ||
-    typeof subject !== "string"
-  ) {
-    return null;
-  }
-
-  if (status === "approved") {
-    const roles = (context as { roles?: unknown }).roles;
-    const identityId = (context as { identityId?: unknown }).identityId;
-    const userId = (context as { userId?: unknown }).userId;
-
-    if (
-      !Array.isArray(roles) ||
-      roles.some(
-        (role) => role !== "admin" && role !== "collaborator" && role !== "helper"
-      ) ||
-      typeof identityId !== "string" ||
-      typeof userId !== "string" ||
-      typeof email !== "string"
-    ) {
-      return null;
-    }
-
-    return {
-      context: {
-        email,
-        identityId,
-        roles: [...roles],
-        status,
-        subject,
-        userId
-      },
-      identity: {
-        email: identityEmail ?? null,
-        issuer: (identity as { issuer: string }).issuer,
-        provider: identityProvider ?? null,
-        subject: (identity as { subject: string }).subject
-      }
-    } satisfies PortalAccessSession;
-  }
-
-  if (status === "pending") {
-    const requestId = (context as { requestId?: unknown }).requestId;
-    const userId = (context as { userId?: unknown }).userId;
-
-    if (
-      requestId !== null &&
-      requestId !== undefined &&
-      typeof requestId !== "string"
-    ) {
-      return null;
-    }
-
-    if (userId !== null && userId !== undefined && typeof userId !== "string") {
-      return null;
-    }
-
-    return {
-      context: {
-        email,
-        requestId: requestId ?? null,
-        status,
-        subject,
-        userId: userId ?? null
-      },
-      identity: {
-        email: identityEmail ?? null,
-        issuer: (identity as { issuer: string }).issuer,
-        provider: identityProvider ?? null,
-        subject: (identity as { subject: string }).subject
-      }
-    } satisfies PortalAccessSession;
-  }
-
-  if (status === "denied") {
-    const reason = (context as { reason?: unknown }).reason;
-
-    if (
-      reason !== "access_request_required" &&
-      reason !== "identity_recovery_required" &&
-      reason !== "rejected_or_withdrawn" &&
-      reason !== "unknown_identity"
-    ) {
-      return null;
-    }
-
-    return {
-      context: {
-        email,
-        reason,
-        status,
-        subject
-      },
-      identity: {
-        email: identityEmail ?? null,
-        issuer: (identity as { issuer: string }).issuer,
-        provider: identityProvider ?? null,
-        subject: (identity as { subject: string }).subject
-      }
-    } satisfies PortalAccessSession;
-  }
-
-  return null;
-}
-
 export type CloudflareAccessVerifier = {
   audiences: string[];
   issuer: string;
@@ -246,7 +78,7 @@ function usesBrandedFinalizeRelayAudiences(routePath: string) {
   );
 }
 
-function readCookieValue(cookieHeader: string | undefined, name: string) {
+export function readCookieValue(cookieHeader: string | undefined, name: string) {
   if (!cookieHeader) {
     return null;
   }
@@ -348,7 +180,7 @@ export function verifyAccessLinkIntent(cookieHeader: string | undefined) {
 }
 
 function buildSignedCookie(
-  name: "PortalAccessProvider" | "PortalLinkIntent" | "PortalAccessSession",
+  name: "PortalAccessProvider" | "PortalLinkIntent",
   value: string,
   secret: string,
   options?: {
@@ -386,53 +218,6 @@ export function buildSignedAccessCookie(
 
   return buildSignedCookie(name, value, secret, options);
 }
-
-export function buildSignedPortalAccessSessionCookie(
-  identity: CloudflareAccessIdentity,
-  context: AccessRbacContext,
-  options?: {
-    maxAgeSeconds?: number;
-  }
-) {
-  const secret = readPortalAccessSessionSecret();
-
-  if (!secret) {
-    throw new Error(
-      "PORTAL_SESSION_SECRET or ACCESS_PROVIDER_STATE_SECRET is required."
-    );
-  }
-
-  return buildSignedCookie(
-    "PortalAccessSession",
-    Buffer.from(
-      JSON.stringify({
-        context,
-        identity
-      }),
-      "utf8"
-    ).toString("base64url"),
-    secret,
-    {
-      maxAgeSeconds: options?.maxAgeSeconds ?? 5 * 60,
-      sameSite: "Lax"
-    }
-  );
-}
-
-export function verifyPortalAccessSession(cookieHeader: string | undefined) {
-  const verifiedCookie = verifySignedAccessCookie(
-    cookieHeader,
-    "PortalAccessSession",
-    readPortalAccessSessionSecret()
-  );
-
-  if (!verifiedCookie?.payload) {
-    return null;
-  }
-
-  return parsePortalAccessSessionPayload(verifiedCookie.payload);
-}
-
 export function readAccessJwtAssertion(
   request: Pick<FastifyRequest, "headers">
 ) {

--- a/apps/api/src/auth/portal-access-session.ts
+++ b/apps/api/src/auth/portal-access-session.ts
@@ -1,0 +1,179 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import type { FastifyRequest } from "fastify";
+import { parseApiRuntimeEnv } from "../config/runtime.js";
+import { sessions, userIdentities } from "../db/schema.js";
+import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
+import type { CloudflareAccessIdentity } from "./cloudflare-access.js";
+import { readCookieValue } from "./cloudflare-access.js";
+import {
+  resolveAccessRbacContext,
+  type AccessRbacContext
+} from "./resolve-access-rbac-context.js";
+
+export const portalAccessSessionCookieName = "PortalAccessSession";
+export const portalAccessSessionMaxAgeSeconds = 5 * 60;
+
+export type ResolvedPortalAccessSession = {
+  context: AccessRbacContext;
+  identity: CloudflareAccessIdentity;
+  sessionId: string;
+  token: string;
+};
+
+function getPortalAccessSessionExpiry(now = Date.now()) {
+  return new Date(now + portalAccessSessionMaxAgeSeconds * 1000);
+}
+
+function buildCloudflareAccessIssuer() {
+  return `https://${parseApiRuntimeEnv().teamDomain}`;
+}
+
+export function buildPortalAccessSessionCookie(token: string) {
+  return [
+    `${portalAccessSessionCookieName}=${token}`,
+    "Domain=.paretoproof.com",
+    "Path=/",
+    "SameSite=Lax",
+    `Max-Age=${portalAccessSessionMaxAgeSeconds}`,
+    "Secure",
+    "HttpOnly"
+  ].join("; ");
+}
+
+export function readPortalAccessSessionToken(cookieHeader: string | undefined) {
+  return readCookieValue(cookieHeader, portalAccessSessionCookieName);
+}
+
+export function hashPortalAccessSessionToken(token: string) {
+  return createHash("sha256").update(token).digest("base64url");
+}
+
+function createPortalAccessSessionToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+export async function createPortalAccessSession(
+  db: ReturnTypeOfCreateDbClient,
+  request: Pick<FastifyRequest, "headers" | "ip">,
+  identity: CloudflareAccessIdentity,
+  context: Extract<AccessRbacContext, { status: "approved" }>
+) {
+  const linkedIdentity = await db.query.userIdentities.findFirst({
+    where: and(
+      eq(userIdentities.id, context.identityId),
+      eq(userIdentities.userId, context.userId)
+    )
+  });
+
+  if (!linkedIdentity || linkedIdentity.providerSubject !== identity.subject) {
+    throw new Error("Approved portal session identity could not be resolved.");
+  }
+
+  const token = createPortalAccessSessionToken();
+  const now = new Date();
+
+  await db.insert(sessions).values({
+    expiresAt: getPortalAccessSessionExpiry(now.getTime()),
+    identityId: context.identityId,
+    ipAddress: request.ip,
+    tokenHash: hashPortalAccessSessionToken(token),
+    userAgent:
+      typeof request.headers["user-agent"] === "string"
+        ? request.headers["user-agent"]
+        : null,
+    userId: context.userId
+  });
+
+  return token;
+}
+
+export async function resolvePortalAccessSession(
+  db: ReturnTypeOfCreateDbClient,
+  cookieHeader: string | undefined
+): Promise<ResolvedPortalAccessSession | null> {
+  const token = readPortalAccessSessionToken(cookieHeader);
+
+  if (!token) {
+    return null;
+  }
+
+  const sessionRow = await db.query.sessions.findFirst({
+    where: eq(sessions.tokenHash, hashPortalAccessSessionToken(token)),
+    with: {
+      identity: {
+        with: {
+          user: true
+        }
+      }
+    }
+  });
+
+  if (!sessionRow || !sessionRow.identity) {
+    return null;
+  }
+
+  const now = new Date();
+
+  if (sessionRow.revokedAt || sessionRow.expiresAt.getTime() <= now.getTime()) {
+    return null;
+  }
+
+  const identity: CloudflareAccessIdentity = {
+    email: sessionRow.identity.providerEmail ?? sessionRow.identity.user.email,
+    issuer: buildCloudflareAccessIssuer(),
+    provider: sessionRow.identity.provider,
+    subject: sessionRow.identity.providerSubject
+  };
+  const context = await resolveAccessRbacContext(db, identity);
+
+  await db
+    .update(sessions)
+    .set({
+      lastSeenAt: now
+    })
+    .where(
+      and(
+        eq(sessions.id, sessionRow.id),
+        gt(sessions.expiresAt, now),
+        isNull(sessions.revokedAt)
+      )
+    );
+
+  return {
+    context,
+    identity,
+    sessionId: sessionRow.id,
+    token
+  };
+}
+
+export async function revokePortalAccessSession(
+  db: ReturnTypeOfCreateDbClient,
+  cookieHeader: string | undefined
+) {
+  const token = readPortalAccessSessionToken(cookieHeader);
+
+  if (!token) {
+    return false;
+  }
+
+  const now = new Date();
+  const [revokedSession] = await db
+    .update(sessions)
+    .set({
+      revokedAt: now
+    })
+    .where(
+      and(
+        eq(sessions.tokenHash, hashPortalAccessSessionToken(token)),
+        gt(sessions.expiresAt, now),
+        isNull(sessions.revokedAt)
+      )
+    )
+    .returning({
+      id: sessions.id
+    });
+
+  return Boolean(revokedSession);
+}

--- a/apps/api/src/auth/require-access.ts
+++ b/apps/api/src/auth/require-access.ts
@@ -3,15 +3,17 @@ import type { HookHandlerDoneFunction } from "fastify/types/hooks";
 import type { AccessRbacContext } from "./resolve-access-rbac-context.js";
 import { resolveAccessRbacContext } from "./resolve-access-rbac-context.js";
 import {
-  buildSignedPortalAccessSessionCookie,
   createCloudflareAccessVerifierSetFromEnv,
   readAccessJwtAssertion,
   selectCloudflareAccessVerifier,
-  verifyPortalAccessSession,
   verifyAccessProviderHint,
   type CloudflareAccessIdentity,
   type CloudflareAccessVerifierSet
 } from "./cloudflare-access.js";
+import {
+  resolvePortalAccessSession,
+  type ResolvedPortalAccessSession
+} from "./portal-access-session.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 type RouteAccessRequirement =
@@ -38,6 +40,7 @@ declare module "fastify" {
   interface FastifyRequest {
     accessIdentity: CloudflareAccessIdentity | null;
     accessRbacContext: AccessRbacContext | null;
+    portalAccessSession: ResolvedPortalAccessSession | null;
   }
 }
 
@@ -85,11 +88,12 @@ async function resolveRequestAccess(
 
   if (!assertion) {
     if (routePath.startsWith("/portal/")) {
-      const cachedSession = verifyPortalAccessSession(cookieHeader);
+      const cachedSession = await resolvePortalAccessSession(db, cookieHeader);
 
       if (cachedSession) {
         request.accessIdentity = cachedSession.identity;
         request.accessRbacContext = cachedSession.context;
+        request.portalAccessSession = cachedSession;
 
         return cachedSession.context;
       }
@@ -119,6 +123,7 @@ async function resolveRequestAccess(
 
   request.accessIdentity = identity;
   request.accessRbacContext = context;
+  request.portalAccessSession = null;
 
   return context;
 }
@@ -157,14 +162,6 @@ export function createAccessGuard(db: ReturnTypeOfCreateDbClient) {
 
             return;
           }
-
-          if (request.accessIdentity && request.routeOptions?.url?.startsWith("/portal/")) {
-            reply.header(
-              "set-cookie",
-              buildSignedPortalAccessSessionCookie(request.accessIdentity, context)
-            );
-          }
-
           done();
         })
         .catch((error) => {

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -34,15 +34,20 @@ import {
   type PortalBenchmarkOpsReadModelService
 } from "../lib/portal-benchmark-ops.js";
 import {
-  buildSignedPortalAccessSessionCookie,
   buildSignedAccessCookie,
   verifyAccessProviderHint,
   verifyAccessLinkIntent
 } from "../auth/cloudflare-access.js";
 import {
+  buildPortalAccessSessionCookie,
+  createPortalAccessSession,
+  revokePortalAccessSession
+} from "../auth/portal-access-session.js";
+import {
   createAccessResolver,
   isAccessAssertionVerificationError
 } from "../auth/require-access.js";
+import { resolveAccessRbacContext } from "../auth/resolve-access-rbac-context.js";
 import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
@@ -390,6 +395,7 @@ export function registerPortalRoutes(
     const portalUrl = new URL(redirectPath, "https://portal.paretoproof.com");
     const linkIntent = verifyAccessLinkIntent(cookieHeader);
     const providerHint = verifyAccessProviderHint(cookieHeader, identity?.subject);
+    let resolvedAccessContext = accessContext;
 
     if (identity && linkIntent) {
       const linkStatus = await db.transaction(async (tx) => {
@@ -457,11 +463,23 @@ export function registerPortalRoutes(
       });
 
       portalUrl.searchParams.set("link", linkStatus);
+
+      if (linkStatus === "linked") {
+        resolvedAccessContext = await resolveAccessRbacContext(db, identity);
+        request.accessRbacContext = resolvedAccessContext;
+      }
     }
 
     const responseCookies = [
-      identity && accessContext
-        ? buildSignedPortalAccessSessionCookie(identity, accessContext)
+      identity && resolvedAccessContext?.status === "approved"
+        ? buildPortalAccessSessionCookie(
+            await createPortalAccessSession(
+              db,
+              request,
+              identity,
+              resolvedAccessContext
+            )
+          )
         : clearSignedAccessCookie("PortalAccessSession"),
       identity && providerHint
         ? buildSignedAccessCookie(
@@ -628,6 +646,21 @@ export function registerPortalRoutes(
     },
     handlePortalSessionFinalizeSubmit
   );
+
+  app.post("/portal/session/sign-out", {
+    preHandler: rateLimitPreHandlers?.public
+  }, async (request, reply) => {
+    const cookieHeader =
+      typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+
+    await revokePortalAccessSession(db, cookieHeader);
+    reply.code(204).header("set-cookie", [
+      clearSignedAccessCookie("PortalAccessSession"),
+      clearSignedAccessCookie("PortalAccessProvider"),
+      clearSignedAccessCookie("PortalLinkIntent")
+    ]);
+    return reply.send();
+  });
 
   app.get(
     "/portal/access-requests/me",

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -2,11 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildSignedAccessCookie,
-  buildSignedPortalAccessSessionCookie,
   readAccessJwtAssertion,
   selectCloudflareAccessVerifier,
   verifyAccessProviderHint,
-  verifyPortalAccessSession,
   type CloudflareAccessVerifierSet
 } from "../src/auth/cloudflare-access.ts";
 import { createAccessResolver } from "../src/auth/require-access.ts";
@@ -42,72 +40,13 @@ test("readAccessJwtAssertion returns null when no usable Access assertion is pre
   assert.equal(assertion, null);
 });
 
-test("verifyPortalAccessSession round-trips a signed portal access session cookie", () => {
-  const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
-  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
-
-  try {
-    const cookie = buildSignedPortalAccessSessionCookie(
-      {
-        email: "person@example.com",
-        issuer: "https://paretoproof.cloudflareaccess.com",
-        provider: "cloudflare_google",
-        subject: "subject-1"
-      },
-      {
-        email: "person@example.com",
-        identityId: "identity-1",
-        roles: ["helper"],
-        status: "approved",
-        subject: "subject-1",
-        userId: "user-1"
-      }
-    );
-
-    assert.deepEqual(verifyPortalAccessSession(cookie), {
-      context: {
-        email: "person@example.com",
-        identityId: "identity-1",
-        roles: ["helper"],
-        status: "approved",
-        subject: "subject-1",
-        userId: "user-1"
-      },
-      identity: {
-        email: "person@example.com",
-        issuer: "https://paretoproof.cloudflareaccess.com",
-        provider: "cloudflare_google",
-        subject: "subject-1"
-      }
-    });
-  } finally {
-    process.env.ACCESS_PROVIDER_STATE_SECRET = originalSecret;
-  }
-});
-
-test("PortalAccessSession uses PORTAL_SESSION_SECRET without changing provider-hint cookie verification", () => {
+test("PortalAccessProvider verification continues to use ACCESS_PROVIDER_STATE_SECRET", () => {
   const originalProviderSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
   const originalSessionSecret = process.env.PORTAL_SESSION_SECRET;
   process.env.ACCESS_PROVIDER_STATE_SECRET = "provider-secret";
   process.env.PORTAL_SESSION_SECRET = "session-secret";
 
   try {
-    const sessionCookie = buildSignedPortalAccessSessionCookie(
-      {
-        email: "person@example.com",
-        issuer: "https://paretoproof.cloudflareaccess.com",
-        provider: "cloudflare_google",
-        subject: "subject-1"
-      },
-      {
-        email: "person@example.com",
-        identityId: "identity-1",
-        roles: ["helper"],
-        status: "approved",
-        subject: "subject-1",
-        userId: "user-1"
-      }
-    );
     const providerCookie = buildSignedAccessCookie(
       "PortalAccessProvider",
       "cloudflare_google|subject-1"
@@ -117,14 +56,6 @@ test("PortalAccessSession uses PORTAL_SESSION_SECRET without changing provider-h
       verifyAccessProviderHint(providerCookie, "subject-1"),
       "cloudflare_google"
     );
-    assert.deepEqual(verifyPortalAccessSession(sessionCookie)?.context, {
-      email: "person@example.com",
-      identityId: "identity-1",
-      roles: ["helper"],
-      status: "approved",
-      subject: "subject-1",
-      userId: "user-1"
-    });
 
     process.env.PORTAL_SESSION_SECRET = "wrong-session-secret";
 
@@ -132,21 +63,19 @@ test("PortalAccessSession uses PORTAL_SESSION_SECRET without changing provider-h
       verifyAccessProviderHint(providerCookie, "subject-1"),
       "cloudflare_google"
     );
-    assert.equal(verifyPortalAccessSession(sessionCookie), null);
   } finally {
     process.env.ACCESS_PROVIDER_STATE_SECRET = originalProviderSecret;
     process.env.PORTAL_SESSION_SECRET = originalSessionSecret;
   }
 });
 
-test("createAccessResolver accepts the signed portal access session on portal routes without touching Access verification", async () => {
+test("createAccessResolver accepts an opaque portal access session when the DB session lookup succeeds", async () => {
   const originalEnv = {
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
     CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
     CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
     DATABASE_URL: process.env.DATABASE_URL,
-    PORTAL_SESSION_SECRET: process.env.PORTAL_SESSION_SECRET,
     WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
   };
 
@@ -158,27 +87,65 @@ test("createAccessResolver accepts the signed portal access session on portal ro
   process.env.WORKER_BOOTSTRAP_TOKEN = "worker-bootstrap-token";
 
   try {
-    const resolveAccess = createAccessResolver({} as never);
+    let touchedSession = false;
+    const resolveAccess = createAccessResolver({
+      query: {
+        sessions: {
+          findFirst: async () => ({
+            expiresAt: new Date(Date.now() + 60_000),
+            id: "session-1",
+            identity: {
+              id: "identity-1",
+              provider: "cloudflare_google",
+              providerEmail: "person@example.com",
+              providerSubject: "subject-1",
+              user: {
+                email: "person@example.com",
+                id: "user-1"
+              }
+            },
+            revokedAt: null
+          })
+        },
+        userIdentities: {
+          findFirst: async () => ({
+            id: "identity-1",
+            provider: "cloudflare_google",
+            providerEmail: "person@example.com",
+            providerSubject: "subject-1",
+            user: {
+              email: "person@example.com",
+              id: "user-1"
+            }
+          })
+        }
+      },
+      select() {
+        return {
+          from() {
+            return {
+              where: async () => [{ role: "helper" }]
+            };
+          }
+        };
+      },
+      update() {
+        return {
+          set() {
+            return {
+              where: async () => {
+                touchedSession = true;
+              }
+            };
+          }
+        };
+      }
+    } as never);
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
       headers: {
-        cookie: buildSignedPortalAccessSessionCookie(
-          {
-            email: "person@example.com",
-            issuer: "https://paretoproof.cloudflareaccess.com",
-            provider: "cloudflare_google",
-            subject: "subject-1"
-          },
-          {
-            email: "person@example.com",
-            identityId: "identity-1",
-            roles: ["helper"],
-            status: "approved",
-            subject: "subject-1",
-            userId: "user-1"
-          }
-        )
+        cookie: "PortalAccessSession=opaque-session-token"
       },
       raw: {
         url: "/portal/me"
@@ -200,6 +167,129 @@ test("createAccessResolver accepts the signed portal access session on portal ro
     });
     assert.equal(request.accessIdentity?.subject, "subject-1");
     assert.equal(request.accessIdentity?.provider, "cloudflare_google");
+    assert.equal(touchedSession, true);
+  } finally {
+    Object.assign(process.env, originalEnv);
+  }
+});
+
+test("createAccessResolver gracefully rejects legacy signed portal session cookies when no DB session exists", async () => {
+  const originalEnv = {
+    ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
+    CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
+    CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
+    DATABASE_URL: process.env.DATABASE_URL,
+    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+  };
+
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
+  process.env.CF_ACCESS_BRANDED_AUDS = "github-audience,google-audience";
+  process.env.CF_ACCESS_PORTAL_AUD = "portal-audience";
+  process.env.CF_ACCESS_TEAM_DOMAIN = "paretoproof.cloudflareaccess.com";
+  process.env.DATABASE_URL = "postgres://localhost:5432/paretoproof";
+  process.env.WORKER_BOOTSTRAP_TOKEN = "worker-bootstrap-token";
+
+  try {
+    const resolveAccess = createAccessResolver({
+      query: {
+        sessions: {
+          findFirst: async () => null
+        }
+      }
+    } as never);
+    const request = {
+      accessIdentity: null,
+      accessRbacContext: null,
+      headers: {
+        cookie: "PortalAccessSession=legacy.payload.signature"
+      },
+      raw: {
+        url: "/portal/me"
+      },
+      routeOptions: {
+        url: "/portal/me"
+      }
+    } as never;
+
+    const context = await resolveAccess(request);
+
+    assert.equal(context, null);
+    assert.equal(request.accessIdentity, null);
+  } finally {
+    Object.assign(process.env, originalEnv);
+  }
+});
+
+test("createAccessResolver rejects revoked opaque portal sessions", async () => {
+  const originalEnv = {
+    ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
+    CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
+    CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
+    DATABASE_URL: process.env.DATABASE_URL,
+    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+  };
+
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
+  process.env.CF_ACCESS_BRANDED_AUDS = "github-audience,google-audience";
+  process.env.CF_ACCESS_PORTAL_AUD = "portal-audience";
+  process.env.CF_ACCESS_TEAM_DOMAIN = "paretoproof.cloudflareaccess.com";
+  process.env.DATABASE_URL = "postgres://localhost:5432/paretoproof";
+  process.env.WORKER_BOOTSTRAP_TOKEN = "worker-bootstrap-token";
+
+  try {
+    let touchedSession = false;
+    const resolveAccess = createAccessResolver({
+      query: {
+        sessions: {
+          findFirst: async () => ({
+            expiresAt: new Date(Date.now() + 60_000),
+            id: "session-1",
+            identity: {
+              id: "identity-1",
+              provider: "cloudflare_google",
+              providerEmail: "person@example.com",
+              providerSubject: "subject-1",
+              user: {
+                email: "person@example.com",
+                id: "user-1"
+              }
+            },
+            revokedAt: new Date()
+          })
+        }
+      },
+      update() {
+        return {
+          set() {
+            return {
+              where: async () => {
+                touchedSession = true;
+              }
+            };
+          }
+        };
+      }
+    } as never);
+    const request = {
+      accessIdentity: null,
+      accessRbacContext: null,
+      headers: {
+        cookie: "PortalAccessSession=opaque-session-token"
+      },
+      raw: {
+        url: "/portal/me"
+      },
+      routeOptions: {
+        url: "/portal/me"
+      }
+    } as never;
+
+    const context = await resolveAccess(request);
+
+    assert.equal(context, null);
+    assert.equal(touchedSession, false);
   } finally {
     Object.assign(process.env, originalEnv);
   }

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
-import {
-  buildSignedAccessCookie,
-  buildSignedPortalAccessSessionCookie
-} from "../src/auth/cloudflare-access.ts";
+import { buildSignedAccessCookie } from "../src/auth/cloudflare-access.ts";
 import { createAccessGuard } from "../src/auth/require-access.ts";
+import { sessions } from "../src/db/schema.ts";
 import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+function readPortalSessionToken(setCookieHeader: string) {
+  const match = /^PortalAccessSession=([^;]+)/.exec(setCookieHeader);
+
+  assert.ok(match);
+
+  return match[1]!;
+}
 
 test("GET /portal/session/finalize/submit redirects back to the auth retry handoff when a link intent is present", async (t) => {
   let mutationAttempted = false;
@@ -60,8 +66,9 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
   assert.equal(mutationAttempted, false);
 });
 
-test("GET /portal/session/finalize/submit completes a normal sign-in handoff once access is attached", async (t) => {
+test("GET /portal/session/finalize/submit creates an opaque DB-backed session for approved users", async (t) => {
   let mutationAttempted = false;
+  const insertedSessions: Array<typeof sessions.$inferInsert> = [];
   const app = Fastify();
   const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -74,6 +81,23 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   registerPortalRoutes(
     app,
     {
+      insert() {
+        return {
+          values: async (value: unknown) => {
+            insertedSessions.push(value as typeof sessions.$inferInsert);
+            return value;
+          }
+        };
+      },
+      query: {
+        userIdentities: {
+          findFirst: async () => ({
+            id: "identity-1",
+            providerSubject: "subject-1",
+            userId: "user-1"
+          })
+        }
+      },
       transaction: async () => {
         mutationAttempted = true;
         throw new Error("plain sign-in finalize GET should not hit the identity-link mutation path");
@@ -120,6 +144,9 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   assert.equal(response.statusCode, 302);
   assert.equal(response.headers.location, "https://portal.paretoproof.com/profile");
   assert.equal(mutationAttempted, false);
+  assert.equal(insertedSessions.length, 1);
+  assert.equal(insertedSessions[0]?.identityId, "identity-1");
+  assert.equal(insertedSessions[0]?.userId, "user-1");
 
   const setCookies = response.headers["set-cookie"];
   assert.ok(Array.isArray(setCookies));
@@ -130,6 +157,11 @@ test("GET /portal/session/finalize/submit completes a normal sign-in handoff onc
   assert.match(setCookies[1], /; SameSite=Strict;/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
   assert.match(setCookies[2], /; SameSite=Strict;/);
+
+  const token = readPortalSessionToken(setCookies[0]);
+  assert.ok(token.length > 30);
+  assert.equal(token.includes("."), false);
+  assert.notEqual(insertedSessions[0]?.tokenHash, token);
 });
 
 test("POST /portal/session/finalize/submit bounces stale direct browser handoffs back to the branded auth relay", async (t) => {
@@ -197,7 +229,7 @@ test("POST /portal/session/finalize/submit still returns JSON auth errors for no
   assert.equal(response.json().error, "access_assertion_required");
 });
 
-test("POST /portal/session/finalize/submit completes a pending-user handoff from cookie-backed branded access", async (t) => {
+test("POST /portal/session/finalize/submit clears PortalAccessSession for pending users", async (t) => {
   const app = Fastify();
   const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -232,8 +264,7 @@ test("POST /portal/session/finalize/submit completes a pending-user handoff from
         };
         request.accessRbacContext = {
           email: "pending@example.com",
-          identityId: "identity-pending",
-          roles: [],
+          requestId: "request-pending",
           status: "pending",
           subject: "subject-pending",
           userId: "user-pending"
@@ -270,15 +301,72 @@ test("POST /portal/session/finalize/submit completes a pending-user handoff from
   const setCookies = response.headers["set-cookie"];
   assert.ok(Array.isArray(setCookies));
   assert.equal(setCookies.length, 3);
-  assert.match(setCookies[0], /^PortalAccessSession=/);
-  assert.match(setCookies[0], /; SameSite=Lax;/);
+  assert.match(setCookies[0], /^PortalAccessSession=;/);
+  assert.match(setCookies[0], /; SameSite=Strict;/);
   assert.match(setCookies[1], /^PortalAccessProvider=/);
   assert.match(setCookies[1], /; SameSite=Strict;/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
   assert.match(setCookies[2], /; SameSite=Strict;/);
 });
 
-test("GET /portal/me accepts the signed portal access session cookie when no Access assertion is present", async (t) => {
+test("POST /portal/session/sign-out revokes the active opaque session and clears portal cookies", async (t) => {
+  let revokedSession = false;
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      update(table: unknown) {
+        assert.equal(table, sessions);
+        return {
+          set(value: unknown) {
+            assert.ok((value as { revokedAt?: Date }).revokedAt instanceof Date);
+            return {
+              where() {
+                return {
+                  returning: async () => {
+                    revokedSession = true;
+                    return [{ id: "session-1" }];
+                  }
+                };
+              }
+            };
+          }
+        };
+      }
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/sign-out",
+    headers: {
+      cookie: "PortalAccessSession=opaque-session-token"
+    }
+  });
+
+  assert.equal(response.statusCode, 204);
+  assert.equal(revokedSession, true);
+
+  const setCookies = response.headers["set-cookie"];
+  assert.ok(Array.isArray(setCookies));
+  assert.equal(setCookies.length, 3);
+  assert.match(setCookies[0], /^PortalAccessSession=;/);
+  assert.match(setCookies[1], /^PortalAccessProvider=;/);
+  assert.match(setCookies[2], /^PortalLinkIntent=;/);
+});
+
+test("GET /portal/me rejects legacy signed portal session cookies without crashing", async (t) => {
   const app = Fastify();
   const originalEnv = {
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
@@ -303,39 +391,30 @@ test("GET /portal/me accepts the signed portal access session cookie when no Acc
 
   registerPortalRoutes(
     app,
-    {} as never,
-    createAccessGuard({} as never)
+    {
+      query: {
+        sessions: {
+          findFirst: async () => null
+        }
+      }
+    } as never,
+    createAccessGuard({
+      query: {
+        sessions: {
+          findFirst: async () => null
+        }
+      }
+    } as never)
   );
 
   const response = await app.inject({
     method: "GET",
     url: "/portal/me",
     headers: {
-      cookie: buildSignedPortalAccessSessionCookie(
-        {
-          email: "approved@example.com",
-          issuer: "https://paretoproof.cloudflareaccess.com",
-          provider: "cloudflare_google",
-          subject: "subject-approved"
-        },
-        {
-          email: "approved@example.com",
-          identityId: "identity-approved",
-          roles: ["helper"],
-          status: "approved",
-          subject: "subject-approved",
-          userId: "user-approved"
-        }
-      )
+      cookie: "PortalAccessSession=legacy.payload.signature"
     }
   });
 
-  assert.equal(response.statusCode, 200);
-  assert.equal(response.json().access.status, "approved");
-  assert.equal(response.json().access.email, "approved@example.com");
-  assert.deepEqual(response.json().access.roles, ["helper"]);
-
-  const setCookie = response.headers["set-cookie"];
-  const normalizedSetCookies = Array.isArray(setCookie) ? setCookie : [setCookie];
-  assert.match(String(normalizedSetCookies[0] ?? ""), /^PortalAccessSession=/);
+  assert.equal(response.statusCode, 401);
+  assert.equal(response.json().error, "access_assertion_required");
 });


### PR DESCRIPTION
## Summary
- replace signed PortalAccessSession cookies with opaque DB-backed session tokens
- create portal sessions on approved finalize handoffs and revoke them on sign-out
- add regression coverage for DB validation, evokedAt, and graceful legacy-cookie rejection

## Verification
- un --cwd apps/api test test/cloudflare-access.test.ts test/portal-session-finalize.test.ts
- un run typecheck:api
- un run check:env-contract
- un run check:bidi

Closes #904