### PR TITLE
fix(api): harden in-memory rate limiting

### DIFF
--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -25,6 +25,8 @@ type RateLimitDecision = {
 };
 
 type ApiRateLimitOptions = {
+  cleanupIntervalMs?: number;
+  maxTrackedKeys?: number;
   now?: () => number;
   policies?: Partial<Record<ApiRateLimitPolicyId, Partial<Omit<ApiRateLimitPolicy, "id">>>>;
 };
@@ -42,27 +44,13 @@ const defaultPolicies: Record<ApiRateLimitPolicyId, ApiRateLimitPolicy> = {
   }
 };
 
-function readClientIp(request: FastifyRequest) {
-  const cfConnectingIp =
-    typeof request.headers["cf-connecting-ip"] === "string"
-      ? request.headers["cf-connecting-ip"].trim()
-      : "";
+const defaultCleanupIntervalMs = 30_000;
+const defaultMaxTrackedKeys = 10_000;
 
-  if (cfConnectingIp) {
-    return cfConnectingIp;
-  }
-
-  const forwardedFor =
-    typeof request.headers["x-forwarded-for"] === "string"
-      ? request.headers["x-forwarded-for"]
-      : "";
-  const forwardedIp = forwardedFor.split(",")[0]?.trim() ?? "";
-
-  if (forwardedIp) {
-    return forwardedIp;
-  }
-
-  return request.ip;
+function readTrustedClientIp(request: FastifyRequest) {
+  return typeof request.ip === "string" && request.ip.trim().length > 0
+    ? request.ip.trim()
+    : "unknown";
 }
 
 function getRateLimitKey(request: FastifyRequest, policyId: ApiRateLimitPolicyId) {
@@ -82,7 +70,7 @@ function getRateLimitKey(request: FastifyRequest, policyId: ApiRateLimitPolicyId
     }
   }
 
-  return `ip:${readClientIp(request)}`;
+  return `ip:${readTrustedClientIp(request)}`;
 }
 
 export function applyRateLimitHeaders(
@@ -101,6 +89,8 @@ export function applyRateLimitHeaders(
 
 export function createInMemoryRateLimiter(options: ApiRateLimitOptions = {}) {
   const now = options.now ?? Date.now;
+  const cleanupIntervalMs = Math.max(1, options.cleanupIntervalMs ?? defaultCleanupIntervalMs);
+  const maxTrackedKeys = Math.max(1, options.maxTrackedKeys ?? defaultMaxTrackedKeys);
   const policies = {
     authenticated: {
       ...defaultPolicies.authenticated,
@@ -112,12 +102,59 @@ export function createInMemoryRateLimiter(options: ApiRateLimitOptions = {}) {
     }
   } satisfies Record<ApiRateLimitPolicyId, ApiRateLimitPolicy>;
   const stateByKey = new Map<string, RateLimitState>();
+  let lastCleanupAt = 0;
+
+  function cleanupExpiredEntries(currentTime: number) {
+    if (currentTime - lastCleanupAt < cleanupIntervalMs && stateByKey.size < maxTrackedKeys) {
+      return;
+    }
+
+    for (const [key, state] of stateByKey.entries()) {
+      if (state.resetAt <= currentTime) {
+        stateByKey.delete(key);
+      }
+    }
+
+    lastCleanupAt = currentTime;
+  }
+
+  function resolveTrackedKey(
+    policyId: ApiRateLimitPolicyId,
+    request: FastifyRequest,
+    currentTime: number
+  ) {
+    cleanupExpiredEntries(currentTime);
+
+    const rawKey = `${policyId}:${getRateLimitKey(request, policyId)}`;
+
+    if (stateByKey.has(rawKey) || stateByKey.size < maxTrackedKeys) {
+      return rawKey;
+    }
+
+    const overflowKey = `${policyId}:overflow`;
+
+    if (stateByKey.has(overflowKey)) {
+      return overflowKey;
+    }
+
+    while (stateByKey.size >= maxTrackedKeys) {
+      const oldestTrackedKey = stateByKey.keys().next().value;
+
+      if (typeof oldestTrackedKey !== "string") {
+        break;
+      }
+
+      stateByKey.delete(oldestTrackedKey);
+    }
+
+    return overflowKey;
+  }
 
   return {
     check(policyId: ApiRateLimitPolicyId, request: FastifyRequest) {
       const policy = policies[policyId];
-      const key = `${policy.id}:${getRateLimitKey(request, policyId)}`;
       const currentTime = now();
+      const key = resolveTrackedKey(policy.id, request, currentTime);
       const previousState = stateByKey.get(key);
       const state =
         previousState && previousState.resetAt > currentTime
@@ -155,6 +192,9 @@ export function createInMemoryRateLimiter(options: ApiRateLimitOptions = {}) {
           retryAfterSeconds: Math.max(1, Math.ceil((state.resetAt - currentTime) / 1000))
         } satisfies RateLimitDecision
       };
+    },
+    getTrackedKeyCount() {
+      return stateByKey.size;
     }
   };
 }

--- a/apps/api/test/rate-limit.test.ts
+++ b/apps/api/test/rate-limit.test.ts
@@ -36,6 +36,16 @@ function createApprovedAccessGuard() {
   };
 }
 
+function createPublicRequest(options: {
+  headers?: Record<string, string>;
+  ip?: string;
+}) {
+  return {
+    headers: options.headers ?? {},
+    ip: options.ip ?? "198.51.100.10"
+  } as never;
+}
+
 test("public routes emit rate-limit headers and block after the configured budget", async (t) => {
   const app = Fastify();
   const rateLimitPreHandlers = createRateLimitPreHandlers(
@@ -157,4 +167,81 @@ test("authenticated portal and admin routes share the authenticated per-user bud
   assert.equal(blockedResponse.statusCode, 429);
   assert.equal(blockedResponse.json().scope, "authenticated");
   assert.equal(blockedResponse.headers["retry-after"], "60");
+});
+
+test("public rate limiting ignores spoofed forwarding headers and keys off the trusted request ip", () => {
+  const rateLimiter = createInMemoryRateLimiter({
+    policies: {
+      public: {
+        limit: 2
+      }
+    }
+  });
+
+  const firstResult = rateLimiter.check(
+    "public",
+    createPublicRequest({
+      headers: {
+        "cf-connecting-ip": "203.0.113.1",
+        "x-forwarded-for": "203.0.113.2"
+      },
+      ip: "198.51.100.25"
+    })
+  );
+  const secondResult = rateLimiter.check(
+    "public",
+    createPublicRequest({
+      headers: {
+        "cf-connecting-ip": "203.0.113.99",
+        "x-forwarded-for": "203.0.113.100"
+      },
+      ip: "198.51.100.25"
+    })
+  );
+  const blockedResult = rateLimiter.check(
+    "public",
+    createPublicRequest({
+      headers: {
+        "cf-connecting-ip": "192.0.2.1",
+        "x-forwarded-for": "192.0.2.2"
+      },
+      ip: "198.51.100.25"
+    })
+  );
+
+  assert.equal(firstResult.allowed, true);
+  assert.equal(secondResult.allowed, true);
+  assert.equal(blockedResult.allowed, false);
+  assert.equal(blockedResult.decision.remaining, 0);
+});
+
+test("public rate limiting stays bounded under high-cardinality client pressure", () => {
+  const rateLimiter = createInMemoryRateLimiter({
+    maxTrackedKeys: 3,
+    policies: {
+      public: {
+        limit: 1,
+        windowMs: 60_000
+      }
+    }
+  });
+
+  const first = rateLimiter.check("public", createPublicRequest({ ip: "198.51.100.1" }));
+  const second = rateLimiter.check("public", createPublicRequest({ ip: "198.51.100.2" }));
+  const thirdDistinct = rateLimiter.check("public", createPublicRequest({ ip: "198.51.100.3" }));
+  const overflowFirst = rateLimiter.check(
+    "public",
+    createPublicRequest({ ip: "198.51.100.4" })
+  );
+  const overflowBlocked = rateLimiter.check(
+    "public",
+    createPublicRequest({ ip: "198.51.100.5" })
+  );
+
+  assert.equal(first.allowed, true);
+  assert.equal(second.allowed, true);
+  assert.equal(thirdDistinct.allowed, true);
+  assert.equal(overflowFirst.allowed, true);
+  assert.equal(overflowBlocked.allowed, false);
+  assert.equal(rateLimiter.getTrackedKeyCount(), 3);
 });


### PR DESCRIPTION
## Summary
- stop public rate limiting from trusting raw forwarding headers as client identity input
- bound in-memory key tracking and route excess cardinality through a shared overflow bucket
- add regressions for header spoof attempts and long-cardinality pressure

Closes #960

## Verification
- bun run build:shared
- bun --cwd apps/api test test/rate-limit.test.ts
- bun run typecheck:api
- git diff --check