### PR TITLE
fix(web): validate auth finalize relay origin

### DIFF
--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -54,7 +54,8 @@ describe("handleAccessFinalize", () => {
         headers: {
           "cf-access-jwt-assertion": "assertion-1",
           cookie: "PortalAccessProvider=signed; PortalLinkIntent=intent-1",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://google.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -100,7 +101,8 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -133,7 +135,8 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           "cf-access-jwt-assertion": "assertion-3",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -162,7 +165,8 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           "cf-access-jwt-assertion": "assertion-4",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -214,7 +218,8 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           "cf-access-jwt-assertion": "assertion-5",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://google.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -263,7 +268,8 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           "cf-access-jwt-assertion": "assertion-6",
-          "content-type": "application/x-www-form-urlencoded"
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://google.auth.paretoproof.com"
         },
         method: "POST"
       })
@@ -334,6 +340,33 @@ describe("handleAccessFinalize", () => {
         }),
         headers: {
           "cf-access-jwt-assertion": "assertion-2",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    );
+  });
+
+  it("redirects back to retry without relaying when the browser Origin header is absent", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(null, { status: 200 });
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-missing-origin",
           "content-type": "application/x-www-form-urlencoded"
         },
         method: "POST"
@@ -344,5 +377,34 @@ describe("handleAccessFinalize", () => {
     expect(response.headers.get("location")).toBe(
       "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
     );
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("redirects back to retry without relaying when the browser Origin header is untrusted", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(null, { status: 200 });
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-untrusted-origin",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://evil.example"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    );
+    expect(fetchCalled).toBe(false);
   });
 });

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -28,6 +28,11 @@ const brandedHosts = new Set([
   "google.auth.paretoproof.com",
   "portal.paretoproof.com"
 ]);
+const brandedFinalizeRelayHosts = new Set([
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com"
+]);
 
 function isLocalHostname(hostname: string) {
   return (
@@ -36,6 +41,39 @@ function isLocalHostname(hostname: string) {
     hostname === "::1" ||
     hostname.endsWith(".localhost")
   );
+}
+
+function readTrustedFinalizeRelayOrigin(request: Request) {
+  const originHeader = request.headers.get("origin");
+
+  if (!originHeader) {
+    return null;
+  }
+
+  try {
+    const originUrl = new URL(originHeader);
+
+    if (
+      originUrl.protocol === "https:" &&
+      brandedFinalizeRelayHosts.has(originUrl.hostname)
+    ) {
+      return originUrl.origin;
+    }
+
+    if (
+      originUrl.protocol === "http:" &&
+      (
+        brandedFinalizeRelayHosts.has(originUrl.hostname) ||
+        isLocalHostname(originUrl.hostname)
+      )
+    ) {
+      return originUrl.origin;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 function sanitizeRedirectPath(rawRedirectPath: string | null) {
@@ -196,10 +234,16 @@ export async function handleAccessFinalize(request: Request) {
   const retryUrl = buildAuthRetryUrl(redirectPath);
   const requestUrl = new URL(request.url);
   const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
+  const trustedOrigin = readTrustedFinalizeRelayOrigin(request);
+
+  if (!trustedOrigin) {
+    return buildRedirectResponse(retryUrl);
+  }
+
   const forwardedHeaders = new Headers({
     accept: "application/json",
     "content-type": "application/json",
-    origin: requestUrl.origin
+    origin: trustedOrigin
   });
   const accessAssertion = request.headers.get("cf-access-jwt-assertion");
   const cookieHeader = request.headers.get("cookie");


### PR DESCRIPTION
## Summary
- stop the branded auth finalize relay from synthesizing a trusted Origin header from `request.url`
- require a real trusted inbound auth-surface Origin before relaying to the API finalize mutation
- add regressions for missing-origin and untrusted-origin relay attempts

## Verification
- `bun test apps/web/functions/_shared/access-finalize.test.ts`
- `bun run typecheck:web`
- `git diff --check`

Closes #962