### PR TITLE
fix(csv): harden formula export escaping

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -235,7 +235,7 @@ function toPortalProfile(options: {
 }
 
 function escapeCsvValue(value: string) {
-  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  const safeValue = /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
 
   if (/[",\n]/.test(safeValue)) {
     return `"${safeValue.replaceAll('"', '""')}"`;

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -571,6 +571,61 @@ test("GET /portal/benchmarks/:packageId/export streams csv when requested", asyn
   assert.match(response.body, /problem9,2026\.03,PP-318/);
 });
 
+test("GET /portal/benchmarks/:packageId/export neutralizes whitespace-prefixed spreadsheet formulas", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService({
+        getBenchmarkDataset: async () => {
+          const dataset = buildBenchmarkDatasetResponse();
+
+          dataset.benchmark.benchmarkPackageId = "  =problem9";
+          dataset.benchmark.versions = ["\t=2026.03"];
+          dataset.runs[0] = {
+            ...dataset.runs[0],
+            modelConfigId: "@gpt-oss",
+            runId: "=PP-318"
+          };
+          dataset.attempts[0] = {
+            ...dataset.attempts[0],
+            attemptId: "-attempt-1",
+            failure: {
+              ...dataset.attempts[0].failure,
+              summary: '  =SUM("a","b")'
+            },
+            jobId: "  +job-1",
+            runId: "=PP-318",
+            verifierResult: dataset.attempts[0].verifierResult
+          };
+
+          return dataset;
+        }
+      }),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/benchmarks/problem9/export?format=csv"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.match(response.body, /^benchmarkPackageId,benchmarkVersions,runId/m);
+  assert.match(response.body, /'  =problem9,'\t=2026\.03,'=PP-318/);
+  assert.match(response.body, /,openai,'@gpt-oss,/);
+  assert.match(response.body, /,'  \+job-1,'-attempt-1,succeeded,pass,accepted,/);
+  assert.match(response.body, /,"'  =SUM\(""a"",""b""\)"$/m);
+});
+
 test("GET /portal/runs/:runId returns 404 when the run read model is missing", async (t) => {
   const app = Fastify();
 

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -66,6 +66,50 @@ describe("buildRunsCsv", () => {
     expect(csv).toContain("succeeded,Succeeded,terminal_success,Terminal success,pass,Pass");
     expect(csv).not.toContain("succeeded,Completed");
   });
+
+  it("neutralizes direct and whitespace-prefixed spreadsheet formulas", () => {
+    const csv = buildRunsCsv([
+      {
+        authMode: "oidc",
+        benchmarkItemId: "item-1",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:abc",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "@problem9@2026.03",
+        completedAt: '  =SUM("a","b")',
+        durationMs: 120000,
+        failure: { code: "+code", family: "\t=family", summary: null },
+        laneId: "lane-1",
+        latestAttemptId: "-attempt-1",
+        latestJobId: "  +job-1",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-1"],
+          jobCount: 1,
+          jobIds: ["job-1"],
+          latestAttemptId: "attempt-1",
+          latestJobId: "job-1"
+        },
+        modelConfigId: "=gpt-oss",
+        modelConfigLabel: "  =GPT OSS",
+        modelSnapshotId: "gpt-oss-2026-03-13",
+        providerFamily: "openai",
+        runId: "\t=PP-318",
+        runKind: "single_run",
+        runLifecycleBucket: "terminal_success",
+        runMode: "eval",
+        runState: "succeeded",
+        startedAt: "2026-03-13T19:58:00.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: "pass"
+      }
+    ]);
+
+    expect(csv).toContain("'\t=PP-318,'  +job-1,'-attempt-1,'@problem9@2026.03,'=gpt-oss,'  =GPT OSS");
+    expect(csv).toContain("'\t=family,'+code");
+    expect(csv).toContain("\"'  =SUM(\"\"a\"\",\"\"b\"\")\"");
+  });
 });
 
 describe("benchmark dataset exports", () => {

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1353,7 +1353,7 @@ function buildRunsModelOptionsFromItems(
 }
 
 function escapeCsvValue(value: string) {
-  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  const safeValue = /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
 
   if (/[",\n]/.test(safeValue)) {
     return `"${safeValue.replaceAll('"', '""')}"`;


### PR DESCRIPTION
## Summary
- neutralize CSV formula prefixes even when spaces or tabs appear before `=`, `+`, `-`, or `@`
- keep the existing quoting behavior intact after neutralization in both API and web-side export builders
- add regressions covering direct-prefix, whitespace-prefixed, and quoted formula payloads

## Verification
- `bun test apps/web/src/lib/portal-benchmark-ops.test.js`
- `bun --cwd apps/api test test/portal-benchmark-ops.test.ts`
- `bun run typecheck:api`
- `bun run typecheck:web`
- `git diff --check`

Closes #963