### PR TITLE
fix(csv): harden exports against whitespace-prefixed formulas

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -234,8 +234,12 @@ function toPortalProfile(options: {
   };
 }
 
+const unsafeSpreadsheetFormulaPrefixPattern = /^[\t ]*[=+\-@]/;
+
 function escapeCsvValue(value: string) {
-  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  const safeValue = unsafeSpreadsheetFormulaPrefixPattern.test(value)
+    ? `'${value}`
+    : value;
 
   if (/[",\n]/.test(safeValue)) {
     return `"${safeValue.replaceAll('"', '""')}"`;

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -571,6 +571,79 @@ test("GET /portal/benchmarks/:packageId/export streams csv when requested", asyn
   assert.match(response.body, /problem9,2026\.03,PP-318/);
 });
 
+test("GET /portal/benchmarks/:packageId/export neutralizes whitespace-prefixed spreadsheet formulas", async (t) => {
+  const app = Fastify();
+  const dataset = buildBenchmarkDatasetResponse();
+
+  dataset.attempts[0]!.failure = {
+    code: "\t=SUM(1,1)",
+    family: "@family",
+    summary: "  =SUM(\"danger\",1)"
+  };
+  dataset.runs[0]!.failure = {
+    code: "+fallback",
+    family: "-fallback",
+    summary: "=HYPERLINK(\"https://example.com\")"
+  };
+  dataset.runs.push({
+    ...dataset.runs[0]!,
+    completedAt: "2026-03-13T20:05:00.000Z",
+    durationMs: 60000,
+    failure: {
+      code: "+fallback",
+      family: "-fallback",
+      summary: "=HYPERLINK(\"https://example.com\")"
+    },
+    latestAttemptId: null,
+    latestJobId: "job-2",
+    lineage: {
+      attemptCount: 0,
+      attemptIds: [],
+      jobCount: 1,
+      jobIds: ["job-2"],
+      latestAttemptId: null,
+      latestJobId: "job-2"
+    },
+    modelConfigId: "claude-sonnet",
+    modelConfigLabel: "Claude Sonnet",
+    modelSnapshotId: "claude-sonnet-2026-03-13",
+    providerFamily: "anthropic",
+    runId: "PP-319",
+    runState: "failed",
+    startedAt: "2026-03-13T20:04:00.000Z",
+    verdictClass: "fail"
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService({
+        getBenchmarkDataset: async () => dataset
+      }),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/benchmarks/problem9/export?format=csv"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.ok(response.body.includes(",'@family,\"'\t=SUM(1,1)\",\"'  =SUM(\"\"danger\"\",1)\""));
+  assert.ok(
+    response.body.includes(
+      ",'-fallback,'+fallback,\"'=HYPERLINK(\"\"https://example.com\"\")\""
+    )
+  );
+});
+
 test("GET /portal/runs/:runId returns 404 when the run read model is missing", async (t) => {
   const app = Fastify();
 

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -66,6 +66,120 @@ describe("buildRunsCsv", () => {
     expect(csv).toContain("succeeded,Succeeded,terminal_success,Terminal success,pass,Pass");
     expect(csv).not.toContain("succeeded,Completed");
   });
+
+  it("neutralizes direct and whitespace-prefixed spreadsheet formulas in run export fields", () => {
+    const csv = buildRunsCsv([
+      {
+        authMode: "oidc",
+        benchmarkItemId: "item-1",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:abc",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: "2026-03-13T20:00:00.000Z",
+        durationMs: 120000,
+        failure: { code: "  =SUM(11)", family: "=family", summary: null },
+        laneId: "lane-1",
+        latestAttemptId: "attempt-1",
+        latestJobId: "job-1",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-1"],
+          jobCount: 1,
+          jobIds: ["job-1"],
+          latestAttemptId: "attempt-1",
+          latestJobId: "job-1"
+        },
+        modelConfigId: "gpt-oss",
+        modelConfigLabel: "GPT OSS",
+        modelSnapshotId: "gpt-oss-2026-03-13",
+        providerFamily: "openai",
+        runId: "PP-318",
+        runKind: "single_run",
+        runLifecycleBucket: "terminal_success",
+        runMode: "eval",
+        runState: "succeeded",
+        startedAt: "2026-03-13T19:58:00.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: "pass"
+      },
+      {
+        authMode: "oidc",
+        benchmarkItemId: "item-2",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:def",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: "2026-03-13T20:05:00.000Z",
+        durationMs: 90000,
+        failure: { code: "\t@cmd", family: "-family", summary: null },
+        laneId: "lane-2",
+        latestAttemptId: "attempt-2",
+        latestJobId: "job-2",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-2"],
+          jobCount: 1,
+          jobIds: ["job-2"],
+          latestAttemptId: "attempt-2",
+          latestJobId: "job-2"
+        },
+        modelConfigId: "claude-sonnet",
+        modelConfigLabel: "Claude Sonnet",
+        modelSnapshotId: "claude-sonnet-2026-03-13",
+        providerFamily: "anthropic",
+        runId: "PP-319",
+        runKind: "single_run",
+        runLifecycleBucket: "terminal_failure",
+        runMode: "eval",
+        runState: "failed",
+        startedAt: "2026-03-13T20:03:30.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: "fail"
+      },
+      {
+        authMode: "service_token",
+        benchmarkItemId: "item-3",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:ghi",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: "2026-03-13T20:10:00.000Z",
+        durationMs: 60000,
+        failure: { code: "+code", family: "@family", summary: null },
+        laneId: "lane-3",
+        latestAttemptId: "attempt-3",
+        latestJobId: "job-3",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-3"],
+          jobCount: 1,
+          jobIds: ["job-3"],
+          latestAttemptId: "attempt-3",
+          latestJobId: "job-3"
+        },
+        modelConfigId: "gemini-pro",
+        modelConfigLabel: "Gemini Pro",
+        modelSnapshotId: "gemini-pro-2026-03-13",
+        providerFamily: "google",
+        runId: "PP-320",
+        runKind: "single_run",
+        runLifecycleBucket: "active",
+        runMode: "eval",
+        runState: "running",
+        startedAt: "2026-03-13T20:09:00.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: "invalid_result"
+      }
+    ]);
+
+    expect(csv).toContain(",'=family,'  =SUM(11),");
+    expect(csv).toContain(",'-family,'\t@cmd,");
+    expect(csv).toContain(",'@family,'+code,");
+  });
 });
 
 describe("benchmark dataset exports", () => {

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -1352,8 +1352,12 @@ function buildRunsModelOptionsFromItems(
   return Array.from(modelOptions.values());
 }
 
+const unsafeSpreadsheetFormulaPrefixPattern = /^[\t ]*[=+\-@]/;
+
 function escapeCsvValue(value: string) {
-  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  const safeValue = unsafeSpreadsheetFormulaPrefixPattern.test(value)
+    ? `'${value}`
+    : value;
 
   if (/[",\n]/.test(safeValue)) {
     return `"${safeValue.replaceAll('"', '""')}"`;


### PR DESCRIPTION
## Summary
- neutralize spreadsheet formula prefixes even when they are preceded by spaces or tabs in both API and web CSV exporters
- keep existing CSV quoting behavior intact after the neutralization step
- add API and web regressions covering direct-prefix, whitespace-prefixed, and quoted formula payloads

## Testing
- bun --cwd apps/api test test/portal-benchmark-ops.test.ts
- bun test apps/web/src/lib/portal-benchmark-ops.test.js
- bun run build:shared
- bun run typecheck:api
- bun run typecheck:web
- bun run check:bidi
- git -c safe.directory='C:/Users/Tom/.codex/worktrees/e73d/ParetoProof' diff --check

Fixes #963