### PR TITLE
worker: enforce hosted network egress policy

### DIFF
--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -13,6 +13,8 @@ API_BASE_URL=http://127.0.0.1:3000
 
 # Mode-specific hosted provider auth. Trusted-local Codex auth does not belong in this file.
 # CODEX_API_KEY=replace-with-a-machine-api-key-for-hosted-worker-modes
+# Hosted claim-loop modes also reject proxy and provider base-URL override env such as
+# HTTPS_PROXY, HTTP_PROXY, ALL_PROXY, NO_PROXY, OPENAI_BASE_URL, OPENAI_API_BASE, and OPENAI_API_BASE_URL.
 
 # Offline ingest uses a short-lived admin Access assertion supplied explicitly at command runtime.
 # Do not store that assertion in this file.

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -132,6 +132,7 @@ Hosted claim loop:
   - `API_BASE_URL`
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY`
+- hosted claim-loop execution fails closed if proxy env or provider base-URL override env is present, and modal workers reject raw-IP or loopback control-plane origins instead of treating them as normal hosted targets
 - hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home/auth.json` path instead of silently attempting to reuse contributor auth material
 - the hosted loop only accepts `single_run` claims with machine auth, materializes the canonical benchmark and prompt packages from repo-owned sources, reuses the same `runProblem9Attempt` inner runner as local single-run execution, and submits heartbeats, execution events, artifact manifests, and terminal success or failure objects through the internal API
 - if a heartbeat returns `cancel_requested` or `expired`, the loop exits that claim without sending a stale terminal finalize

--- a/apps/worker/src/lib/hosted-network-policy.ts
+++ b/apps/worker/src/lib/hosted-network-policy.ts
@@ -1,0 +1,159 @@
+import { isIP } from "node:net";
+import type { Problem9ProviderFamily } from "@paretoproof/shared";
+
+type WorkerFetch = typeof fetch;
+
+const hostedProxyEnvNames = [
+  "ALL_PROXY",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "all_proxy",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy"
+] as const;
+
+const hostedProviderOverrideEnvNames: Record<Problem9ProviderFamily, readonly string[]> = {
+  openai: ["OPENAI_API_BASE", "OPENAI_API_BASE_URL", "OPENAI_BASE_URL"]
+};
+
+type HostedControlPlaneOriginOptions = {
+  allowLoopback: boolean;
+};
+
+export function resolveHostedControlPlaneOrigin(
+  apiBaseUrl: string,
+  options: HostedControlPlaneOriginOptions
+): URL {
+  const url = new URL(apiBaseUrl);
+
+  if (url.username || url.password) {
+    throw new Error(
+      "Hosted network policy blocked API_BASE_URL: credentials in control-plane origins are forbidden."
+    );
+  }
+
+  if (url.search || url.hash || url.pathname !== "/") {
+    throw new Error(
+      "Hosted network policy blocked API_BASE_URL: only bare control-plane origins are allowed."
+    );
+  }
+
+  if (isIpLiteral(url.hostname)) {
+    if (isLoopbackIp(url.hostname) && options.allowLoopback && url.protocol === "http:") {
+      return url;
+    }
+
+    throw new Error(
+      `Hosted network policy blocked API_BASE_URL: raw_ip_forbidden (${url.hostname}).`
+    );
+  }
+
+  if (isLoopbackHostname(url.hostname)) {
+    if (options.allowLoopback && url.protocol === "http:") {
+      return url;
+    }
+
+    throw new Error(
+      `Hosted network policy blocked API_BASE_URL: host_not_allowlisted (${url.hostname}).`
+    );
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error(
+      `Hosted network policy blocked API_BASE_URL: HTTPS is required for hosted control-plane origins (${url.protocol}).`
+    );
+  }
+
+  return url;
+}
+
+export function createHostedControlPlaneFetch(
+  fetchImpl: WorkerFetch,
+  allowedOrigin: URL
+): WorkerFetch {
+  return async (input, init) => {
+    const url = resolveRequestUrl(input);
+
+    if (url.origin !== allowedOrigin.origin) {
+      throw new Error(
+        `Hosted network policy blocked control-plane request: host_not_allowlisted (${url.origin}).`
+      );
+    }
+
+    if (!url.pathname.startsWith("/internal/worker/")) {
+      throw new Error(
+        `Hosted network policy blocked control-plane request: path_outside_policy (${url.pathname}).`
+      );
+    }
+
+    return fetchImpl(input, init);
+  };
+}
+
+export function buildHostedProviderCommandEnv(
+  env: NodeJS.ProcessEnv,
+  providerFamily: Problem9ProviderFamily
+): NodeJS.ProcessEnv {
+  const forbiddenOverrideNames = [
+    ...hostedProxyEnvNames,
+    ...hostedProviderOverrideEnvNames[providerFamily]
+  ];
+  const offendingNames = forbiddenOverrideNames.filter((name) => hasNonEmptyEnvValue(env[name]));
+
+  if (offendingNames.length > 0) {
+    throw new Error(
+      `Hosted network policy blocked provider execution: forbidden env override(s) ${offendingNames.join(", ")}.`
+    );
+  }
+
+  const sanitizedEnv = { ...env };
+
+  for (const name of forbiddenOverrideNames) {
+    delete sanitizedEnv[name];
+  }
+
+  return sanitizedEnv;
+}
+
+function resolveRequestUrl(input: URL | RequestInfo): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+
+  return new URL(String(input));
+}
+
+function hasNonEmptyEnvValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isIpLiteral(hostname: string): boolean {
+  return isIP(hostname) !== 0;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname.endsWith(".localhost");
+}
+
+function isLoopbackIp(hostname: string): boolean {
+  if (isIP(hostname) === 4) {
+    return hostname.startsWith("127.");
+  }
+
+  if (isIP(hostname) === 6) {
+    const normalized = hostname.toLowerCase();
+    return normalized === "::1" || normalized === "0:0:0:0:0:0:0:1";
+  }
+
+  return false;
+}

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -16,6 +16,7 @@ import {
   type Problem9AuthPreflight,
   preflightProblem9AuthMode
 } from "./problem9-auth.js";
+import { buildHostedProviderCommandEnv } from "./hosted-network-policy.js";
 import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
@@ -94,6 +95,7 @@ const problem9AttemptOptionsSchema = z.object({
   authMode: authModeSchema.optional(),
   benchmarkPackageRoot: z.string().min(1),
   modelSnapshotId: z.string().min(1).optional(),
+  networkPolicyMode: z.enum(["default", "hosted"]).default("default"),
   outputRoot: z.string().min(1),
   promptPackageRoot: z.string().min(1),
   providerFamily: providerFamilySchema.optional(),
@@ -102,7 +104,7 @@ const problem9AttemptOptionsSchema = z.object({
   workspaceRoot: z.string().min(1)
 });
 
-type Problem9AttemptOptions = z.infer<typeof problem9AttemptOptionsSchema>;
+type Problem9AttemptOptions = z.input<typeof problem9AttemptOptionsSchema>;
 type BenchmarkPackageManifest = z.infer<typeof benchmarkPackageManifestSchema>;
 type PromptPackageManifest = z.infer<typeof promptPackageManifestSchema>;
 type RunEnvelope = z.infer<typeof runEnvelopeSchema>;
@@ -147,6 +149,7 @@ type AttemptTerminalFailure = {
     | "provider_timeout"
     | "theorem_reference_missing"
     | "theorem_semantic_mismatch"
+    | "tool_permission_violation"
     | "turn_budget_exhausted"
     | "wall_clock_budget_exhausted";
   phase: "compile" | "generate" | "verify";
@@ -312,12 +315,13 @@ export async function runProblem9Attempt(
         compileResult,
         promptPackageRoot,
         providerFamily: effectiveProviderFamily,
-        providerModel: options.providerModel ?? null,
-        providerTurnsUsed,
-        runEnvelope,
-        stubScenario: options.stubScenario,
-        verificationResult,
-        workspaceRoot
+      providerModel: options.providerModel ?? null,
+      providerTurnsUsed,
+      runEnvelope,
+      networkPolicyMode: options.networkPolicyMode,
+      stubScenario: options.stubScenario,
+      verificationResult,
+      workspaceRoot
       });
     } catch (error) {
       terminalFailure = classifyProviderFailure(error);
@@ -538,6 +542,7 @@ async function generateCandidate(options: {
   authMode: Problem9AuthMode;
   authPreflight: Problem9AuthPreflight;
   compileResult: CompileResult | null;
+  networkPolicyMode: "default" | "hosted";
   promptPackageRoot: string;
   providerFamily: Problem9ProviderFamily;
   providerModel: string | null;
@@ -602,6 +607,8 @@ async function generateCandidate(options: {
       env: await buildCodexExecutionEnv(
         options.authMode,
         options.authPreflight,
+        options.networkPolicyMode,
+        options.providerFamily,
         options.workspaceRoot
       ),
       stdin: promptText,
@@ -626,11 +633,18 @@ async function generateCandidate(options: {
 async function buildCodexExecutionEnv(
   authMode: Problem9AuthMode,
   authPreflight: Problem9AuthPreflight,
+  networkPolicyMode: "default" | "hosted",
+  providerFamily: Problem9ProviderFamily,
   workspaceRoot: string
 ): Promise<NodeJS.ProcessEnv> {
+  const baseEnv =
+    networkPolicyMode === "hosted"
+      ? buildHostedProviderCommandEnv(process.env, providerFamily)
+      : { ...process.env };
+
   if (authMode === "trusted_local_user" && authPreflight.authMode === "trusted_local_user") {
     return {
-      ...process.env,
+      ...baseEnv,
       CODEX_HOME: authPreflight.codexHome
     };
   }
@@ -640,12 +654,12 @@ async function buildCodexExecutionEnv(
     await mkdir(machineAuthHome, { recursive: true });
 
     return {
-      ...process.env,
+      ...baseEnv,
       CODEX_HOME: machineAuthHome
     };
   }
 
-  return { ...process.env };
+  return baseEnv;
 }
 
 async function buildProviderPrompt(options: {
@@ -1079,6 +1093,7 @@ function classifyFailureFamily(
   | "budget"
   | "compile"
   | "provider"
+  | "tooling"
   | "verification" {
   switch (failureCode) {
     case "turn_budget_exhausted":
@@ -1091,6 +1106,8 @@ function classifyFailureFamily(
     case "provider_malformed_response":
     case "provider_timeout":
       return "provider";
+    case "tool_permission_violation":
+      return "tooling";
     case "forbidden_axiom_dependency":
     case "forbidden_placeholder_token":
     case "proof_policy_failed":
@@ -1102,6 +1119,15 @@ function classifyFailureFamily(
 
 function classifyProviderFailure(error: unknown): AttemptTerminalFailure {
   const message = error instanceof Error ? error.message : String(error);
+
+  if (/network policy|forbidden env override|host_not_allowlisted|raw_ip_forbidden/i.test(message)) {
+    return {
+      failureCode: "tool_permission_violation",
+      phase: "generate",
+      stopReason: "provider_failed",
+      summary: message
+    };
+  }
 
   if (/auth/i.test(message)) {
     return {

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -35,6 +35,10 @@ import {
   materializeProblem9PromptPackage
 } from "./problem9-prompt-package.js";
 import { materializeProblem9Package } from "./problem9-package.js";
+import {
+  createHostedControlPlaneFetch,
+  resolveHostedControlPlaneOrigin
+} from "./hosted-network-policy.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 const workerClaimLoopOptionsSchema = z.object({
@@ -154,7 +158,7 @@ export async function runWorkerClaimLoop(
   dependencies: WorkerClaimLoopDependencies = {}
 ): Promise<RunWorkerClaimLoopResult> {
   const options = workerClaimLoopOptionsSchema.parse(rawOptions);
-  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const baseFetchImpl = dependencies.fetchImpl ?? fetch;
   const sleep = dependencies.sleep ?? defaultSleep;
   const now = dependencies.now ?? (() => new Date());
   const attemptRunner = dependencies.attemptRunner ?? runProblem9Attempt;
@@ -167,6 +171,20 @@ export async function runWorkerClaimLoop(
     authMode: options.authMode,
     commandFamily: "worker_claim_loop"
   }, dependencies.rawEnv);
+  const fetchImpl =
+    options.workerRuntime === "modal"
+      ? createHostedControlPlaneFetch(
+          baseFetchImpl,
+          resolveHostedControlPlaneOrigin(runtimeEnv.apiBaseUrl!, {
+            allowLoopback: false
+          })
+        )
+      : createHostedControlPlaneFetch(
+          baseFetchImpl,
+          resolveHostedControlPlaneOrigin(runtimeEnv.apiBaseUrl!, {
+            allowLoopback: true
+          })
+        );
 
   if (startupValidationOnlyEnabled) {
     return {
@@ -402,6 +420,7 @@ async function processClaimedJob(
         authMode: workerJob.target.authMode,
         benchmarkPackageRoot: benchmarkResult.outputRoot,
         modelSnapshotId: workerJob.target.modelSnapshotId,
+        networkPolicyMode: "hosted",
         outputRoot: attemptOutputRoot,
         promptPackageRoot: promptResult.outputRoot,
         providerFamily: workerJob.target.providerFamily,
@@ -961,6 +980,14 @@ function classifyHostedAttemptError(error: unknown): WorkerFailureClassification
     return buildStaticFailure({
       summary: message,
       failureCode: "provider_auth_error",
+      phase: "generate"
+    });
+  }
+
+  if (/network policy|host_not_allowlisted|raw_ip_forbidden|path_outside_policy/i.test(message)) {
+    return buildStaticFailure({
+      summary: message,
+      failureCode: "tool_permission_violation",
       phase: "generate"
     });
   }

--- a/apps/worker/test/hosted-network-policy.test.ts
+++ b/apps/worker/test/hosted-network-policy.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildHostedProviderCommandEnv,
+  createHostedControlPlaneFetch,
+  resolveHostedControlPlaneOrigin
+} from "../src/lib/hosted-network-policy.ts";
+
+test("resolveHostedControlPlaneOrigin accepts HTTPS branded origins for modal workers", () => {
+  const origin = resolveHostedControlPlaneOrigin("https://api.paretoproof.test", {
+    allowLoopback: false
+  });
+
+  assert.equal(origin.origin, "https://api.paretoproof.test");
+});
+
+test("resolveHostedControlPlaneOrigin rejects raw IP control-plane origins for modal workers", () => {
+  assert.throws(
+    () =>
+      resolveHostedControlPlaneOrigin("http://127.0.0.1:3000", {
+        allowLoopback: false
+      }),
+    /raw_ip_forbidden/
+  );
+});
+
+test("resolveHostedControlPlaneOrigin allows loopback origins only for local worker parity", () => {
+  const origin = resolveHostedControlPlaneOrigin("http://localhost:3000", {
+    allowLoopback: true
+  });
+
+  assert.equal(origin.origin, "http://localhost:3000");
+});
+
+test("createHostedControlPlaneFetch blocks requests outside the internal worker path", async () => {
+  const wrappedFetch = createHostedControlPlaneFetch(
+    async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        headers: {
+          "content-type": "application/json"
+        }
+      }),
+    new URL("https://api.paretoproof.test")
+  );
+
+  await assert.rejects(
+    () => wrappedFetch(new URL("https://api.paretoproof.test/portal/workers")),
+    /path_outside_policy/
+  );
+});
+
+test("buildHostedProviderCommandEnv rejects proxy and provider-base overrides", () => {
+  assert.throws(
+    () =>
+      buildHostedProviderCommandEnv(
+        {
+          CODEX_API_KEY: "worker-api-key",
+          HTTPS_PROXY: "https://proxy.example.test",
+          OPENAI_BASE_URL: "https://evil.example.test"
+        },
+        "openai"
+      ),
+    /forbidden env override\(s\) HTTPS_PROXY, OPENAI_BASE_URL/
+  );
+});

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -666,6 +666,33 @@ test("runWorkerClaimLoop constrains claimed job filesystem paths under the confi
   }
 });
 
+test("runWorkerClaimLoop rejects modal control-plane raw IP origins before any hosted fetch", async () => {
+  await assert.rejects(
+    () =>
+      runWorkerClaimLoop(
+        {
+          authMode: "machine_api_key",
+          maxJobs: 1,
+          once: true,
+          outputRoot: path.join(os.tmpdir(), "paretoproof-worker-output"),
+          workerId: "worker-1",
+          workerPool: "modal-dev",
+          workerRuntime: "modal",
+          workerVersion: "worker.v1",
+          workspaceRoot: path.join(os.tmpdir(), "paretoproof-worker-workspace")
+        },
+        {
+          rawEnv: {
+            API_BASE_URL: "http://127.0.0.1:3000",
+            CODEX_API_KEY: "worker-api-key",
+            WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+          }
+        }
+      ),
+    /raw_ip_forbidden/
+  );
+});
+
 function buildWorkerJob() {
   return {
     attemptId: "attempt-1",

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -251,6 +251,7 @@ Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key 
   - this is the fully documented hosted worker path in the repository today
   - hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT` or point `CODEX_HOME` at `/run/paretoproof/codex-home`
   - hosted Problem 9 execution currently supports only provider family `openai`
+  - hosted claim-loop runs fail closed when proxy env or provider base-URL override env is present, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `OPENAI_BASE_URL`, `OPENAI_API_BASE`, and `OPENAI_API_BASE_URL`
 
 ## Reserved later-scope variables
 


### PR DESCRIPTION
## Summary
- enforce hosted worker control-plane origin and internal-path restrictions in the claim loop
- fail closed on hosted provider proxy/base-url override env before codex exec inherits them
- add worker regression coverage and runtime docs for allowed and forbidden hosted network paths

## Verification
- bun run build:shared
- node --import tsx --test test/hosted-network-policy.test.ts test/worker-claim-loop.test.ts test/runtime-env.test.ts
- bunx tsc --noEmit -p tsconfig.json
- bun run check:env-contract
- bun run check:bidi
- PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER=1 bun run test:startup-validation

Closes #935