### PR TITLE
worker: enforce hosted provider capability matrix

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -12,7 +12,7 @@ import {
 } from "drizzle-orm";
 import {
   problem9HostedAuthModes,
-  problem9ProviderFamilies
+  problem9HostedProviderFamilies
 } from "@paretoproof/shared";
 import type {
   Problem9HostedAuthMode,
@@ -224,7 +224,7 @@ function queuedJobWhereClause(): SQL {
     eq(attempts.state, "prepared"),
     eq(runs.runKind, "single_run"),
     inArray(runs.authMode, [...problem9HostedAuthModes]),
-    inArray(runs.providerFamily, [...problem9ProviderFamilies]),
+    inArray(runs.providerFamily, [...problem9HostedProviderFamilies]),
     or(eq(runs.state, "queued"), eq(runs.state, "running"))
   )!;
 }

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -3,6 +3,7 @@ import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  assertProblem9HostedCapability,
   getProblem9ModelConfigIdPrefix,
   problem9LocalAuthModes,
   problem9ProviderFamilies,
@@ -535,6 +536,14 @@ function validateAttemptInputs(
 
   if (options.authMode && options.authMode !== promptManifest.authMode) {
     throw new Error("Requested auth mode does not match the prompt package.");
+  }
+
+  if (options.networkPolicyMode === "hosted") {
+    assertProblem9HostedCapability({
+      authMode: promptManifest.authMode,
+      modelConfigId: promptManifest.modelConfigId,
+      providerFamily: promptManifest.providerFamily
+    });
   }
 }
 

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import {
+  assertProblem9HostedCapability,
   problem9HostedAuthModes,
   type WorkerArtifactManifestEntry,
   type WorkerArtifactManifestRequest,
@@ -345,6 +346,26 @@ async function processClaimedJob(
         buildStaticFailure({
           summary: "Hosted worker single-run execution does not support pass_k_probe targets yet.",
           failureCode: "run_configuration_invalid",
+          phase: "prepare"
+        })
+      );
+      return "completed";
+    }
+
+    try {
+      assertProblem9HostedCapability({
+        authMode: workerJob.target.authMode,
+        modelConfigId: workerJob.target.modelConfigId,
+        providerFamily: workerJob.target.providerFamily
+      });
+    } catch (error) {
+      await submitHarnessFailure(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        buildStaticFailure({
+          summary: error instanceof Error ? error.message : String(error),
+          failureCode: "provider_unsupported_request",
           phase: "prepare"
         })
       );

--- a/apps/worker/test/hosted-provider-capability.test.ts
+++ b/apps/worker/test/hosted-provider-capability.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertProblem9HostedCapability,
+  getProblem9HostedCapabilityViolation
+} from "@paretoproof/shared";
+
+test("hosted provider capability rejects unsupported hosted auth modes", () => {
+  const violation = getProblem9HostedCapabilityViolation({
+    authMode: "local_stub",
+    modelConfigId: "local_stub/problem9_fixture.v1",
+    providerFamily: "openai"
+  });
+
+  assert.equal(violation?.code, "unsupported_hosted_auth_mode");
+  assert.match(violation?.message ?? "", /Unsupported hosted auth mode local_stub/);
+});
+
+test("hosted provider capability rejects unsupported hosted provider families", () => {
+  const violation = getProblem9HostedCapabilityViolation({
+    authMode: "machine_api_key",
+    modelConfigId: "anthropic/claude-opus",
+    providerFamily: "anthropic"
+  });
+
+  assert.equal(violation?.code, "unsupported_hosted_provider_family");
+  assert.match(violation?.message ?? "", /Unsupported hosted provider family anthropic/);
+});
+
+test("hosted provider capability accepts the current hosted allowlist", () => {
+  assert.doesNotThrow(() =>
+    assertProblem9HostedCapability({
+      authMode: "machine_api_key",
+      modelConfigId: "openai/gpt-5",
+      providerFamily: "openai"
+    })
+  );
+});

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -266,6 +266,26 @@ test(
   }
 );
 
+test("runProblem9Attempt rejects local_stub prompt packages in hosted mode", async () => {
+  const fixture = await createAttemptFixture();
+
+  try {
+    await assert.rejects(
+      () =>
+        runProblem9Attempt({
+          benchmarkPackageRoot: fixture.benchmarkPackageRoot,
+          networkPolicyMode: "hosted",
+          outputRoot: path.join(fixture.tempRoot, "attempt-hosted-output"),
+          promptPackageRoot: fixture.promptPackageRoot,
+          workspaceRoot: path.join(fixture.tempRoot, "attempt-hosted-workspace")
+        }),
+      /Unsupported hosted auth mode local_stub/
+    );
+  } finally {
+    await rm(fixture.tempRoot, { force: true, recursive: true });
+  }
+});
+
 async function createAttemptFixture(): Promise<{
   benchmarkPackageRoot: string;
   promptPackageRoot: string;

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -172,6 +172,9 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
       stoppedReason: "max_jobs_reached"
     });
     assert.equal(attemptCalls.length, 1);
+    assert.equal(attemptCalls[0]?.authMode, "machine_api_key");
+    assert.equal(attemptCalls[0]?.providerFamily, "openai");
+    assert.equal(attemptCalls[0]?.networkPolicyMode, "hosted");
     assert.equal(attemptCalls[0]?.providerModel, "gpt-5");
     assert.equal(attemptCalls[0]?.stubScenario, "exact_canonical");
 
@@ -691,6 +694,102 @@ test("runWorkerClaimLoop rejects modal control-plane raw IP origins before any h
       ),
     /raw_ip_forbidden/
   );
+});
+
+test("runWorkerClaimLoop reports invalid hosted modelConfigId prefixes before attempt execution", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-model-config-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = {
+      ...buildWorkerJob(),
+      target: {
+        ...buildWorkerJob().target,
+        modelConfigId: "local_stub/problem9_fixture.v1"
+      }
+    };
+    let attemptRunnerCalled = false;
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse(),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async () => {
+          attemptRunnerCalled = true;
+          throw new Error("attempt runner should not execute");
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.equal(attemptRunnerCalled, false);
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "provider_unsupported_request");
+    assert.match(failureBody.failure.summary, /Hosted modelConfigId must start with openai\//);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
 });
 
 function buildWorkerJob() {

--- a/packages/shared/src/contracts/problem9-execution.ts
+++ b/packages/shared/src/contracts/problem9-execution.ts
@@ -14,6 +14,10 @@ export const problem9HostedAuthModes = ["machine_api_key"] as const;
 
 export type Problem9HostedAuthMode = (typeof problem9HostedAuthModes)[number];
 
+export const problem9HostedProviderFamilies = ["openai"] as const;
+
+export type Problem9HostedProviderFamily = (typeof problem9HostedProviderFamilies)[number];
+
 export const problem9RunModes = [
   "single_pass_probe",
   "pass_k_probe",
@@ -38,4 +42,65 @@ export const problem9ModelConfigIdPrefixesByAuthMode = {
 
 export function getProblem9ModelConfigIdPrefix(authMode: Problem9LocalAuthMode): string {
   return problem9ModelConfigIdPrefixesByAuthMode[authMode];
+}
+
+export type Problem9HostedCapabilityViolationCode =
+  | "unsupported_hosted_auth_mode"
+  | "unsupported_hosted_provider_family"
+  | "invalid_hosted_model_config";
+
+export type Problem9HostedCapabilityViolation = {
+  code: Problem9HostedCapabilityViolationCode;
+  message: string;
+};
+
+export function getProblem9HostedCapabilityViolation(options: {
+  authMode: string;
+  modelConfigId?: string | null;
+  providerFamily: string;
+}): Problem9HostedCapabilityViolation | null {
+  if (!problem9HostedAuthModes.includes(options.authMode as Problem9HostedAuthMode)) {
+    return {
+      code: "unsupported_hosted_auth_mode",
+      message: `Unsupported hosted auth mode ${options.authMode}. Hosted workers support only ${problem9HostedAuthModes.join(", ")}.`
+    };
+  }
+
+  if (
+    !problem9HostedProviderFamilies.includes(
+      options.providerFamily as Problem9HostedProviderFamily
+    )
+  ) {
+    return {
+      code: "unsupported_hosted_provider_family",
+      message: `Unsupported hosted provider family ${options.providerFamily}. Hosted workers support only ${problem9HostedProviderFamilies.join(", ")}.`
+    };
+  }
+
+  if (options.modelConfigId) {
+    const expectedPrefix = getProblem9ModelConfigIdPrefix(
+      options.authMode as Problem9HostedAuthMode
+    );
+
+    if (!options.modelConfigId.startsWith(expectedPrefix)) {
+      return {
+        code: "invalid_hosted_model_config",
+        message: `Hosted modelConfigId must start with ${expectedPrefix} for auth mode ${options.authMode}; received ${options.modelConfigId}.`
+      };
+    }
+  }
+
+  return null;
+}
+
+export function assertProblem9HostedCapability(options: {
+  authMode: string;
+  modelConfigId?: string | null;
+  providerFamily: string;
+}): void {
+  const violation = getProblem9HostedCapabilityViolation(options);
+
+  if (violation) {
+    throw new Error(violation.message);
+  }
 }


### PR DESCRIPTION
## Summary
- add a shared hosted Problem 9 capability gate for auth mode, provider family, and hosted model-config prefix validation
- enforce that hosted worker execution rejects unsupported capability combinations before prompt or provider execution
- add regression coverage for hosted allowlist violations and the hosted positive path

## Verification
- bun run build --cwd packages/shared
- bunx tsc --noEmit -p apps/worker/tsconfig.json
- bunx tsc --noEmit -p apps/api/tsconfig.json
- node --import tsx --test test/hosted-provider-capability.test.ts test/problem9-attempt.test.ts test/worker-claim-loop.test.ts
- node --import tsx --test test/internal-worker.test.ts
- bun run check:bidi

Closes #934