### PR TITLE
worker: isolate hosted lease workspaces

### DIFF
--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import {
   assertProblem9HostedCapability,
@@ -154,6 +154,15 @@ type PreparedBundleSubmission = {
   verdictDigest: string;
 };
 
+type LeaseFilesystemRoots = {
+  attemptOutputRoot: string;
+  attemptWorkspaceRoot: string;
+  benchmarkPackageRoot: string;
+  leaseStagingRoot: string;
+  leaseWorkspaceRoot: string;
+  promptPackageRoot: string;
+};
+
 export async function runWorkerClaimLoop(
   rawOptions: WorkerClaimLoopOptions,
   dependencies: WorkerClaimLoopDependencies = {}
@@ -284,21 +293,30 @@ async function processClaimedJob(
     stopHeartbeat: null,
     stopped: false
   };
-  const jobWorkspaceRoot = path.join(
-    path.resolve(options.workspaceRoot),
-    sanitizePathSegment(workerJob.jobId)
-  );
-  const jobOutputRoot = path.join(
-    path.resolve(options.outputRoot),
-    sanitizePathSegment(workerJob.jobId)
-  );
+  const leaseRoots = buildLeaseFilesystemRoots({
+    jobId: workerJob.jobId,
+    leaseId: workerJob.leaseId,
+    outputRoot: options.outputRoot,
+    workspaceRoot: options.workspaceRoot
+  });
   let heartbeatLoop = Promise.resolve();
 
   try {
-    await rm(jobWorkspaceRoot, { force: true, recursive: true });
-    await rm(jobOutputRoot, { force: true, recursive: true });
-    await mkdir(jobWorkspaceRoot, { recursive: true });
-    await mkdir(jobOutputRoot, { recursive: true });
+    try {
+      await prepareLeaseFilesystemRoots(leaseRoots);
+    } catch (error) {
+      await submitHarnessFailure(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        buildStaticFailure({
+          summary: error instanceof Error ? error.message : String(error),
+          failureCode: "tool_permission_violation",
+          phase: "prepare"
+        })
+      );
+      return "completed";
+    }
 
     await refreshLease(leaseState, apiBaseUrl, dependencies);
 
@@ -372,12 +390,8 @@ async function processClaimedJob(
       return "completed";
     }
 
-    const benchmarkPackageRoot = path.join(jobWorkspaceRoot, "benchmark");
-    const promptPackageRoot = path.join(jobWorkspaceRoot, "prompt");
-    const attemptWorkspaceRoot = path.join(jobWorkspaceRoot, "workspace");
-    const attemptOutputRoot = path.join(jobOutputRoot, "attempt-output");
     const benchmarkResult = await dependencies.materializeBenchmarkPackage({
-      outputRoot: benchmarkPackageRoot
+      outputRoot: leaseRoots.benchmarkPackageRoot
     });
 
     assertExpectedBenchmarkIdentity(workerJob.target, benchmarkResult);
@@ -391,7 +405,7 @@ async function processClaimedJob(
       jobId: workerJob.jobId,
       laneId: workerJob.target.laneId,
       modelConfigId: workerJob.target.modelConfigId,
-      outputRoot: promptPackageRoot,
+      outputRoot: leaseRoots.promptPackageRoot,
       passKCount: null,
       passKIndex: null,
       promptLayerVersions: promptDefaults.promptLayerVersions,
@@ -442,7 +456,7 @@ async function processClaimedJob(
         benchmarkPackageRoot: benchmarkResult.outputRoot,
         modelSnapshotId: workerJob.target.modelSnapshotId,
         networkPolicyMode: "hosted",
-        outputRoot: attemptOutputRoot,
+        outputRoot: leaseRoots.attemptOutputRoot,
         promptPackageRoot: promptResult.outputRoot,
         providerFamily: workerJob.target.providerFamily,
         providerModel: resolveProviderModel({
@@ -451,7 +465,7 @@ async function processClaimedJob(
           modelConfigId: workerJob.target.modelConfigId
         }),
         stubScenario: inferStubScenario(workerJob.target.modelSnapshotId),
-        workspaceRoot: attemptWorkspaceRoot
+        workspaceRoot: leaseRoots.attemptWorkspaceRoot
       });
     } catch (error) {
       if (leaseState.cancelRequested) {
@@ -606,7 +620,7 @@ async function processClaimedJob(
     leaseState.stopped = true;
     leaseState.stopHeartbeat?.();
     await heartbeatLoop;
-    await rm(jobWorkspaceRoot, { force: true, recursive: true });
+    await cleanupLeaseFilesystemRoots(leaseRoots);
   }
 }
 
@@ -952,6 +966,60 @@ function sanitizePathSegment(value: string): string {
   }
 
   return sanitized;
+}
+
+function buildLeaseFilesystemRoots(options: {
+  jobId: string;
+  leaseId: string;
+  outputRoot: string;
+  workspaceRoot: string;
+}): LeaseFilesystemRoots {
+  const leasePathSegment = [
+    sanitizePathSegment(options.leaseId),
+    sanitizePathSegment(options.jobId)
+  ].join("__");
+  const leaseWorkspaceRoot = path.join(path.resolve(options.workspaceRoot), leasePathSegment);
+  const leaseStagingRoot = path.join(path.resolve(options.outputRoot), leasePathSegment);
+
+  return {
+    attemptOutputRoot: path.join(leaseStagingRoot, "attempt-output"),
+    attemptWorkspaceRoot: path.join(leaseWorkspaceRoot, "workspace"),
+    benchmarkPackageRoot: path.join(leaseWorkspaceRoot, "benchmark"),
+    leaseStagingRoot,
+    leaseWorkspaceRoot,
+    promptPackageRoot: path.join(leaseWorkspaceRoot, "prompt")
+  };
+}
+
+async function prepareLeaseFilesystemRoots(roots: LeaseFilesystemRoots): Promise<void> {
+  await ensureLeaseWritableRootPrepared(roots.leaseWorkspaceRoot, "lease workspace root");
+  await ensureLeaseWritableRootPrepared(roots.leaseStagingRoot, "lease staging root");
+}
+
+async function ensureLeaseWritableRootPrepared(rootPath: string, description: string): Promise<void> {
+  const rootStats = await stat(rootPath).catch(() => null);
+
+  if (rootStats === null) {
+    await mkdir(rootPath, { recursive: true });
+    return;
+  }
+
+  if (!rootStats.isDirectory()) {
+    throw new Error(`Hosted ${description} is not a directory: ${rootPath}.`);
+  }
+
+  const entries = await readdir(rootPath);
+
+  if (entries.length > 0) {
+    throw new Error(
+      `Unsafe hosted residue detected in ${description} ${rootPath}; expected an empty per-lease root before execution.`
+    );
+  }
+}
+
+async function cleanupLeaseFilesystemRoots(roots: LeaseFilesystemRoots): Promise<void> {
+  await rm(roots.leaseWorkspaceRoot, { force: true, recursive: true });
+  await rm(roots.leaseStagingRoot, { force: true, recursive: true });
 }
 
 function classifyHostedAttemptError(error: unknown): WorkerFailureClassification {

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -216,6 +216,8 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
       stopReason: "verification_passed",
       verifierRepairCount: 0
     });
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }
@@ -302,6 +304,8 @@ test("runWorkerClaimLoop exits explicitly when the first heartbeat requests canc
       calls.map((call) => call.path),
       ["/internal/worker/claims", `/internal/worker/jobs/${workerJob.jobId}/heartbeat`]
     );
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {
     await rm(tempRoot, { force: true, recursive: true });
   }
@@ -656,7 +660,7 @@ test("runWorkerClaimLoop constrains claimed job filesystem paths under the confi
     );
 
     assert.equal(benchmarkRoots.length, 1);
-    assert.match(benchmarkRoots[0]!, /C__danger/i);
+    assert.match(benchmarkRoots[0]!, /lease-1__C__danger/i);
     assert.ok(benchmarkRoots[0]!.startsWith(path.join(tempRoot, "workspace")));
     assert.ok(!benchmarkRoots[0]!.includes("C:\\danger"));
     assert.equal(attemptCalls.length, 1);
@@ -694,6 +698,99 @@ test("runWorkerClaimLoop rejects modal control-plane raw IP origins before any h
       ),
     /raw_ip_forbidden/
   );
+});
+
+test("runWorkerClaimLoop fails closed on pre-existing lease residue and skips execution", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-residue-"));
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const leaseWorkspaceRoot = buildLeaseScopedRoot(path.join(tempRoot, "workspace"), workerJob);
+    const leaseStagingRoot = buildLeaseScopedRoot(path.join(tempRoot, "output"), workerJob);
+    await mkdir(leaseWorkspaceRoot, { recursive: true });
+    await mkdir(leaseStagingRoot, { recursive: true });
+    await writeFile(path.join(leaseWorkspaceRoot, "stale.txt"), "stale workspace", "utf8");
+    await writeFile(path.join(leaseStagingRoot, "stale.txt"), "stale staging", "utf8");
+
+    let attemptRunnerCalled = false;
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async () => {
+          attemptRunnerCalled = true;
+          throw new Error("attempt runner should not execute");
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.equal(attemptRunnerCalled, false);
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "tool_permission_violation");
+    assert.match(failureBody.failure.summary, /Unsafe hosted residue detected/);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
 });
 
 test("runWorkerClaimLoop reports invalid hosted modelConfigId prefixes before attempt execution", async () => {
@@ -954,6 +1051,28 @@ function jobEndpointPath(jobId: string, suffix: string): string {
     `/internal/worker/jobs/${jobId}/${suffix}`,
     "https://api.paretoproof.test"
   ).pathname;
+}
+
+function buildLeaseScopedRoot(baseRoot: string, workerJob: ReturnType<typeof buildWorkerJob>): string {
+  return path.join(
+    baseRoot,
+    [sanitizePathSegment(workerJob.leaseId), sanitizePathSegment(workerJob.jobId)].join("__")
+  );
+}
+
+function sanitizePathSegment(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]/g, "_");
+
+  if (sanitized.length === 0 || /^\.+$/u.test(sanitized)) {
+    return "_";
+  }
+
+  return sanitized;
+}
+
+async function assertDirectoryEmptyOrMissing(rootPath: string): Promise<void> {
+  const entries = await readdir(rootPath).catch(() => null);
+  assert.deepEqual(entries ?? [], []);
 }
 
 function jsonResponse(body: unknown): Response {


### PR DESCRIPTION
## Summary
- make hosted worker writable roots lease-scoped instead of job-scoped and clean both workspace and staging trees after each lease
- fail closed when pre-existing residue is detected in a lease workspace or staging root before execution starts
- add regression coverage for success, cancellation, and residue-handling cleanup paths

## Verification
- node --import tsx --test test/worker-claim-loop.test.ts
- bunx tsc --noEmit -p apps/worker/tsconfig.json
- git diff --check

Closes #936