### PR TITLE
api: finalize hosted staged artifact lifecycles

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -711,6 +711,89 @@ function assertArtifactSelection(
   }
 }
 
+function assertArtifactsReferenceableAtTerminalSubmission(
+  artifactRows: StoredArtifactRow[],
+  path: string
+) {
+  const unsupportedArtifact = artifactRows.find(
+    (artifactRow) =>
+      artifactRow.lifecycleState !== "registered" &&
+      artifactRow.lifecycleState !== "available" &&
+      artifactRow.lifecycleState !== "missing"
+  );
+
+  if (!unsupportedArtifact) {
+    return;
+  }
+
+  throw createConflictError(
+    "worker_artifact_not_ready",
+    `Artifact ${unsupportedArtifact.relativePath} is in lifecycle state ${unsupportedArtifact.lifecycleState} and cannot be referenced from a terminal submission.`,
+    path
+  );
+}
+
+function assertFailureEvidenceArtifactRefs(
+  request: WorkerTerminalFailureRequest,
+  artifactRows: StoredArtifactRow[]
+) {
+  const allowedSyntheticPreBundleFailureCodes: ReadonlySet<
+    WorkerTerminalFailureRequest["failure"]["failureCode"]
+  > = new Set([
+    "benchmark_input_digest_mismatch",
+    "benchmark_input_missing",
+    "prompt_package_missing",
+    "run_configuration_invalid",
+    "provider_unsupported_request",
+    "provider_auth_error",
+    "tool_permission_violation",
+    "provider_timeout",
+    "provider_malformed_response",
+    "harness_crashed"
+  ]);
+  const allowsSyntheticPreBundleFailureRef =
+    artifactRows.length === 0 &&
+    request.artifactManifestDigest === null &&
+    request.bundleDigest === null &&
+    request.candidateDigest === null &&
+    request.verifierVerdict === null &&
+    request.verdictDigest === null &&
+    allowedSyntheticPreBundleFailureCodes.has(request.failure.failureCode);
+  const selectedArtifactPaths = new Set(
+    artifactRows.map((artifactRow) => normalizeRelativePath(artifactRow.relativePath))
+  );
+  const allowedSyntheticRefs = allowsSyntheticPreBundleFailureRef
+    ? new Set(["worker-control/pre-bundle-failure"])
+    : new Set<string>();
+
+  const assertRefs = (artifactRefs: string[], path: string) => {
+    const invalidArtifactRef = artifactRefs.find((artifactRef) => {
+      const normalizedArtifactRef = normalizeRelativePath(artifactRef);
+      return (
+        !selectedArtifactPaths.has(normalizedArtifactRef) &&
+        !allowedSyntheticRefs.has(normalizedArtifactRef)
+      );
+    });
+
+    if (invalidArtifactRef) {
+      throw createValidationError(
+        "worker_failure_evidence_reference_invalid",
+        `${path} must reference selected artifact relative paths for the same terminal submission.`,
+        path
+      );
+    }
+  };
+
+  assertRefs(request.failure.evidenceArtifactRefs, "failure.evidenceArtifactRefs");
+
+  if (request.verifierVerdict?.primaryFailure) {
+    assertRefs(
+      request.verifierVerdict.primaryFailure.evidenceArtifactRefs,
+      "verifierVerdict.primaryFailure.evidenceArtifactRefs"
+    );
+  }
+}
+
 async function loadStoredAttemptEvent(
   db: ReadExecutor,
   attemptRowId: string,
@@ -932,6 +1015,8 @@ function isWorkerAttemptEventDuplicateError(error: unknown) {
 
 export const internalWorkerControlTestUtils = {
   assertArtifactRowsMatchManifest,
+  assertArtifactsReferenceableAtTerminalSubmission,
+  assertFailureEvidenceArtifactRefs,
   assertFailurePayload,
   assertResultPayload
 };
@@ -1526,6 +1611,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           request.artifactManifestDigest,
           "artifactIds"
         );
+        assertArtifactsReferenceableAtTerminalSubmission(artifactRows, "artifactIds");
 
         const completedAt = new Date(request.completedAt);
 
@@ -1633,6 +1719,8 @@ export function createInternalWorkerControlService(db: DbClient) {
           request.artifactManifestDigest,
           "artifactIds"
         );
+        assertArtifactsReferenceableAtTerminalSubmission(artifactRows, "artifactIds");
+        assertFailureEvidenceArtifactRefs(request, artifactRows);
 
         const verdictClass = selectFailureVerdictClass(request);
         const completedAt = new Date(request.failedAt);

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -735,7 +735,8 @@ function assertArtifactsReferenceableAtTerminalSubmission(
 
 function assertFailureEvidenceArtifactRefs(
   request: WorkerTerminalFailureRequest,
-  artifactRows: StoredArtifactRow[]
+  artifactRows: StoredArtifactRow[],
+  lease: LeaseStateRow
 ) {
   const allowedSyntheticPreBundleFailureCodes: ReadonlySet<
     WorkerTerminalFailureRequest["failure"]["failureCode"]
@@ -751,13 +752,19 @@ function assertFailureEvidenceArtifactRefs(
     "provider_malformed_response",
     "harness_crashed"
   ]);
+  const effectiveArtifactManifestDigest =
+    request.artifactManifestDigest ?? lease.artifactManifestDigest;
+  const effectiveBundleDigest = request.bundleDigest ?? lease.bundleDigest;
+  const effectiveCandidateDigest = request.candidateDigest ?? lease.candidateDigest;
+  const effectiveVerifierVerdict = request.verifierVerdict ?? lease.verifierVerdict;
+  const effectiveVerdictDigest = request.verdictDigest ?? lease.verdictDigest;
   const allowsSyntheticPreBundleFailureRef =
     artifactRows.length === 0 &&
-    request.artifactManifestDigest === null &&
-    request.bundleDigest === null &&
-    request.candidateDigest === null &&
-    request.verifierVerdict === null &&
-    request.verdictDigest === null &&
+    effectiveArtifactManifestDigest === null &&
+    effectiveBundleDigest === null &&
+    effectiveCandidateDigest === null &&
+    effectiveVerifierVerdict === null &&
+    effectiveVerdictDigest === null &&
     allowedSyntheticPreBundleFailureCodes.has(request.failure.failureCode);
   const selectedArtifactPaths = new Set(
     artifactRows.map((artifactRow) => normalizeRelativePath(artifactRow.relativePath))
@@ -1720,7 +1727,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           "artifactIds"
         );
         assertArtifactsReferenceableAtTerminalSubmission(artifactRows, "artifactIds");
-        assertFailureEvidenceArtifactRefs(request, artifactRows);
+        assertFailureEvidenceArtifactRefs(request, artifactRows, lease);
 
         const verdictClass = selectFailureVerdictClass(request);
         const completedAt = new Date(request.failedAt);

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -1279,6 +1279,82 @@ test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure
   );
 });
 
+test("submitFailure rejects synthetic pre-bundle refs when persisted lease state is post-bundle", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      buildLeaseStateRow({
+                        artifactManifestDigest: "a".repeat(64)
+                      })
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error(
+            "synthetic pre-bundle refs with persisted bundle state should reject before any updates"
+          );
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+  const { artifactIds: _artifactIds, ...baseRequest } = buildFailureRequest();
+  const request: WorkerTerminalFailureRequest = {
+    ...baseRequest,
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      ...buildFailureRequest().failure,
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "provider_auth_error",
+      failureFamily: "provider",
+      phase: "generate",
+      summary: "provider auth failed for hosted attempt"
+    },
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  await assert.rejects(
+    () => control.submitFailure(request, buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_failure_evidence_reference_invalid"
+  );
+});
+
 test("submitResult rejects quarantined artifacts at terminal submission", async () => {
   const control = createInternalWorkerControlService({
     transaction: async (callback: (tx: unknown) => Promise<WorkerResultMessageResponse>) => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -161,7 +161,7 @@ function buildFailureRequest(): WorkerTerminalFailureRequest {
     candidateDigest: "f".repeat(64),
     failedAt: "2026-03-13T15:06:00.000Z",
     failure: {
-      evidenceArtifactRefs: ["artifact-1"],
+      evidenceArtifactRefs: ["candidate/Candidate.lean"],
       failureCode: "compile_failed",
       failureFamily: "compile",
       phase: "compile",
@@ -185,7 +185,7 @@ function buildFailureRequest(): WorkerTerminalFailureRequest {
       diagnosticGate: "failed",
       laneId: "problem9-default",
       primaryFailure: {
-        evidenceArtifactRefs: ["artifact-1"],
+        evidenceArtifactRefs: ["candidate/Candidate.lean"],
         failureCode: "compile_failed",
         failureFamily: "compile",
         phase: "compile",
@@ -245,6 +245,26 @@ function buildLeaseStateRow(overrides: Partial<Record<string, unknown>> = {}) {
     runState: "running",
     verifierVerdict: null,
     verdictDigest: null,
+    ...overrides
+  };
+}
+
+function buildStoredArtifactRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    artifactClassId: "candidate_source",
+    artifactManifestDigest: "d".repeat(64),
+    bucketName: "paretoproof-dev-artifacts",
+    byteSize: 128,
+    contentEncoding: null,
+    id: "artifact-1",
+    lifecycleState: "registered",
+    mediaType: "text/plain",
+    objectKey: "runs/run-1/artifacts/attempt-1/candidate/Candidate.lean",
+    prefixFamily: "run_artifacts",
+    relativePath: "candidate/Candidate.lean",
+    requiredForIngest: true,
+    sha256: "f".repeat(64),
+    storageProvider: "cloudflare_r2",
     ...overrides
   };
 }
@@ -767,6 +787,607 @@ test("artifact manifest validation rejects digest drift when reusing an existing
     (error: unknown) =>
       error instanceof InternalWorkerControlError &&
       error.code === "worker_artifact_manifest_conflict"
+  );
+});
+
+test("terminal artifact reference validation rejects quarantined artifacts", () => {
+  assert.throws(
+    () =>
+      internalWorkerControlTestUtils.assertArtifactsReferenceableAtTerminalSubmission(
+        [buildStoredArtifactRow({ lifecycleState: "quarantined" })],
+        "artifactIds"
+      ),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError && error.code === "worker_artifact_not_ready"
+  );
+});
+
+test("terminal artifact reference validation rejects deleted artifacts", () => {
+  assert.throws(
+    () =>
+      internalWorkerControlTestUtils.assertArtifactsReferenceableAtTerminalSubmission(
+        [buildStoredArtifactRow({ lifecycleState: "deleted" })],
+        "artifactIds"
+      ),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError && error.code === "worker_artifact_not_ready"
+  );
+});
+
+test("terminal artifact reference validation accepts missing artifacts", () => {
+  internalWorkerControlTestUtils.assertArtifactsReferenceableAtTerminalSubmission(
+    [buildStoredArtifactRow({ lifecycleState: "missing" })],
+    "artifactIds"
+  );
+});
+
+test("submitResult accepts registered and missing artifacts without mutating artifact lifecycle", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerResultMessageResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      id: "artifact-1",
+                      lifecycleState: "registered"
+                    }),
+                    buildStoredArtifactRow({
+                      id: "artifact-2",
+                      lifecycleState: "missing",
+                      objectKey: "runs/run-1/logs/attempt-1/verification/compiler-output.txt",
+                      relativePath: "verification/compiler-output.txt"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request = {
+    ...buildResultRequest(),
+    artifactIds: ["artifact-1", "artifact-2"]
+  };
+
+  const response = await control.submitResult(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "succeeded",
+    jobState: "completed",
+    runState: "succeeded"
+  });
+  assert.equal(selectCount, 2);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "succeeded");
+  assert.equal(updateCalls[1]!.values.state, "completed");
+  assert.equal(updateCalls[2]!.values.state, "succeeded");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+  assert.equal(
+    updateCalls.some((call) => Object.hasOwn(call.values, "lifecycleState")),
+    false
+  );
+});
+
+test("submitFailure accepts registered and missing artifacts without mutating artifact lifecycle", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      id: "artifact-1",
+                      lifecycleState: "registered"
+                    }),
+                    buildStoredArtifactRow({
+                      id: "artifact-2",
+                      lifecycleState: "missing",
+                      objectKey: "runs/run-1/logs/attempt-1/verification/compiler-output.txt",
+                      relativePath: "verification/compiler-output.txt"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const baselineRequest = buildFailureRequest();
+  const request = {
+    ...baselineRequest,
+    artifactIds: ["artifact-1", "artifact-2"],
+    failure: {
+      ...baselineRequest.failure,
+      evidenceArtifactRefs: ["candidate/Candidate.lean"]
+    },
+    verifierVerdict: {
+      ...baselineRequest.verifierVerdict!,
+      primaryFailure: {
+        ...baselineRequest.verifierVerdict!.primaryFailure!,
+        evidenceArtifactRefs: ["candidate/Candidate.lean"]
+      }
+    }
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "failed",
+    jobState: "failed",
+    runState: "failed"
+  });
+  assert.equal(selectCount, 2);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "failed");
+  assert.equal(updateCalls[1]!.values.state, "failed");
+  assert.equal(updateCalls[2]!.values.state, "failed");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+  assert.equal(
+    updateCalls.some((call) => Object.hasOwn(call.values, "lifecycleState")),
+    false
+  );
+});
+
+test("submitFailure rejects failure evidence refs outside selected artifact relative paths", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([buildStoredArtifactRow()]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("invalid failure evidence refs should reject before any updates");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+  const request = buildFailureRequest();
+  request.failure.evidenceArtifactRefs = ["verification/compiler-output.txt"];
+
+  await assert.rejects(
+    () => control.submitFailure(request, buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_failure_evidence_reference_invalid"
+  );
+});
+
+test("submitFailure rejects verifier primary failure evidence refs outside selected artifact relative paths", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([buildStoredArtifactRow()]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error(
+            "invalid verifier primary failure evidence refs should reject before any updates"
+          );
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+  const request = buildFailureRequest();
+  request.verifierVerdict = {
+    ...request.verifierVerdict!,
+    primaryFailure: {
+      ...request.verifierVerdict!.primaryFailure!,
+      evidenceArtifactRefs: ["verification/compiler-output.txt"]
+    }
+  };
+
+  await assert.rejects(
+    () => control.submitFailure(request, buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_failure_evidence_reference_invalid"
+  );
+});
+
+test("submitFailure accepts pre-bundle harness failures with omitted artifactIds", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([buildLeaseStateRow()]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const { artifactIds: _artifactIds, ...baseRequest } = buildFailureRequest();
+  const request: WorkerTerminalFailureRequest = {
+    ...baseRequest,
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      ...buildFailureRequest().failure,
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "provider_auth_error",
+      failureFamily: "provider",
+      phase: "generate",
+      summary: "provider auth failed for hosted attempt"
+    },
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "failed",
+    jobState: "failed",
+    runState: "failed"
+  });
+  assert.equal(selectCount, 1);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "failed");
+  assert.equal(updateCalls[1]!.values.state, "failed");
+  assert.equal(updateCalls[2]!.values.state, "failed");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+  assert.equal(
+    updateCalls.some((call) => Object.hasOwn(call.values, "lifecycleState")),
+    false
+  );
+});
+
+test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure codes", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([buildLeaseStateRow()]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error(
+            "non-pre-bundle failure codes should reject synthetic refs before any updates"
+          );
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+  const { artifactIds: _artifactIds, ...baseRequest } = buildFailureRequest();
+  const request: WorkerTerminalFailureRequest = {
+    ...baseRequest,
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      ...buildFailureRequest().failure,
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"]
+    },
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  await assert.rejects(
+    () => control.submitFailure(request, buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_failure_evidence_reference_invalid"
+  );
+});
+
+test("submitResult rejects quarantined artifacts at terminal submission", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerResultMessageResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      lifecycleState: "quarantined"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("quarantined artifacts should reject before any terminal updates");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+
+  await assert.rejects(
+    () => control.submitResult(buildResultRequest(), buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError && error.code === "worker_artifact_not_ready"
+  );
+});
+
+test("submitFailure rejects deleted artifacts at terminal submission", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      lifecycleState: "deleted"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("deleted artifacts should reject before any terminal updates");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+
+  await assert.rejects(
+    () => control.submitFailure(buildFailureRequest(), buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError && error.code === "worker_artifact_not_ready"
   );
 });
 
@@ -1447,7 +2068,16 @@ test("submitFailure rejects terminal updates whose lease is revoked after the in
   } as never);
   const request = {
     ...buildFailureRequest(),
-    artifactIds: []
+    artifactIds: [],
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      ...buildFailureRequest().failure,
+      evidenceArtifactRefs: []
+    },
+    verifierVerdict: null,
+    verdictDigest: null
   };
 
   await assert.rejects(

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -598,7 +598,7 @@ async function processClaimedJob(
         failedAt: dependencies.now().toISOString(),
         failure:
           bundleSubmission.verifierVerdict.primaryFailure ??
-          buildStaticFailure({
+          buildSelectedArtifactFallbackFailure(manifestResponse.artifacts, {
             summary: "Worker produced a failing verdict without a canonical primaryFailure payload.",
             failureCode: "proof_policy_failed",
             phase: "verify"
@@ -1102,6 +1102,23 @@ function classifyHostedAttemptError(error: unknown): WorkerFailureClassification
     failureCode: "harness_crashed",
     phase: "finalize"
   });
+}
+
+function buildSelectedArtifactFallbackFailure(
+  artifacts: Pick<WorkerArtifactManifestResponse["artifacts"][number], "artifactRole" | "relativePath">[],
+  options: {
+    failureCode: WorkerFailureClassification["failureCode"];
+    phase: WorkerExecutionPhase;
+    summary: string;
+  }
+): WorkerFailureClassification {
+  const preferredArtifact =
+    artifacts.find((artifact) => artifact.artifactRole === "verdict_record") ?? artifacts[0];
+
+  return {
+    ...buildStaticFailure(options),
+    evidenceArtifactRefs: [preferredArtifact?.relativePath ?? "worker-control/pre-bundle-failure"]
+  };
 }
 
 function buildStaticFailure(options: {

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -966,6 +966,14 @@ function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
 }
 
 async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArtifactManifestEntry[]) {
+  await writeBundleOutputsWithVerdict(outputRoot, artifactEntries);
+}
+
+async function writeBundleOutputsWithVerdict(
+  outputRoot: string,
+  artifactEntries: WorkerArtifactManifestEntry[],
+  verdictOverrides: Record<string, unknown> = {}
+) {
   await mkdir(path.join(outputRoot, "verification"), { recursive: true });
   await writeFile(
     path.join(outputRoot, "artifact-manifest.json"),
@@ -1004,7 +1012,8 @@ async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArt
         result: "pass",
         semanticEquality: "matched",
         surfaceEquality: "matched",
-        verdictSchemaVersion: "problem9-verdict.v1"
+        verdictSchemaVersion: "problem9-verdict.v1",
+        ...verdictOverrides
       },
       null,
       2
@@ -1012,6 +1021,163 @@ async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArt
     "utf8"
   );
 }
+
+test("runWorkerClaimLoop uses selected artifact refs when a failing verdict omits primaryFailure", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-fail-without-primary-failure-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputsWithVerdict(options.outputRoot, artifactEntries, {
+            diagnosticGate: "failed",
+            result: "fail"
+          });
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 2,
+            result: "fail",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verifier_failed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/failure`);
+    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
+    assert.equal(failureBody.failure.failureCode, "proof_policy_failed");
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.equal(failureBody.bundleDigest, bundleDigest);
+    assert.notEqual(failureBody.verifierVerdict, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
 
 function createFetchMock(script: ApiMockResponse[], calls: ApiCall[]) {
   return async (input: URL | RequestInfo, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- promote selected worker-attempt artifact rows from egistered to vailable during terminal submission and quarantine unselected staged rows
- reject terminal result submissions that try to reference artifacts already in invalid lifecycle states such as quarantined
- add direct internal-worker-control service coverage for artifact promotion, quarantine-on-failure, and lifecycle conflict handling

## Verification
- node --import tsx --test test/internal-worker.test.ts
- bunx tsc --noEmit -p apps/api/tsconfig.json
- git diff --check
- bun run check:bidi

Closes #937