### PR TITLE
fix(shared): catalog benchmark portal endpoints

### DIFF
--- a/packages/shared/src/contracts/api-call-boundary.ts
+++ b/packages/shared/src/contracts/api-call-boundary.ts
@@ -75,6 +75,30 @@ export const apiCallBoundaryCatalog = [
   },
   {
     credential: "cloudflare_access_jwt",
+    endpointId: "portal.benchmarks.list",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "Approved users browse benchmark package summaries directly from the protected portal surface without an intermediate backend hop."
+  },
+  {
+    credential: "cloudflare_access_jwt",
+    endpointId: "portal.benchmark-dataset.read",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "Benchmark dataset inspection is a portal-owned read model, so the browser reads one package dataset directly on the authenticated portal audience."
+  },
+  {
+    credential: "cloudflare_access_jwt",
+    endpointId: "portal.benchmark-export.read",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "Benchmark dataset export stays on the same protected portal audience while the backend controls the allowed export formats."
+  },
+  {
+    credential: "cloudflare_access_jwt",
     endpointId: "portal.runs.list",
     mode: "browser_direct",
     origin: "portal_browser",

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -80,6 +80,33 @@ export const apiEndpointCatalog = [
   {
     access: "approved_helper_or_higher",
     audience: "portal",
+    id: "portal.benchmarks.list",
+    method: "GET",
+    path: "/portal/benchmarks",
+    purpose:
+      "Return the benchmark dataset index read model for approved portal users browsing benchmark performance slices."
+  },
+  {
+    access: "approved_helper_or_higher",
+    audience: "portal",
+    id: "portal.benchmark-dataset.read",
+    method: "GET",
+    path: "/portal/benchmarks/:packageId/dataset",
+    purpose:
+      "Return one benchmark package dataset with run, job, attempt, and verdict summaries for portal analysis."
+  },
+  {
+    access: "approved_helper_or_higher",
+    audience: "portal",
+    id: "portal.benchmark-export.read",
+    method: "GET",
+    path: "/portal/benchmarks/:packageId/export",
+    purpose:
+      "Export one benchmark package dataset in the requested operator-facing format without bypassing the portal read-model boundary."
+  },
+  {
+    access: "approved_helper_or_higher",
+    audience: "portal",
     id: "portal.runs.list",
     method: "GET",
     path: "/portal/runs",

--- a/packages/shared/src/contracts/api-endpoint-schema-contract.ts
+++ b/packages/shared/src/contracts/api-endpoint-schema-contract.ts
@@ -15,6 +15,10 @@ import {
   portalAdminUserRevokeInputSchema
 } from "../schemas/portal-admin.js";
 import {
+  portalBenchmarkDatasetParamsSchema,
+  portalBenchmarkDatasetResponseSchema,
+  portalBenchmarkExportQuerySchema,
+  portalBenchmarksListResponseSchema,
   portalLaunchViewResponseSchema,
   portalRunDetailParamsSchema,
   portalRunDetailResponseSchema,
@@ -104,6 +108,24 @@ export const apiEndpointSchemaContract = {
     querySchema: null,
     requestBodySchema: null,
     responseBodySchema: portalProfileResponseSchema
+  },
+  "portal.benchmarks.list": {
+    paramsSchema: null,
+    querySchema: null,
+    requestBodySchema: null,
+    responseBodySchema: portalBenchmarksListResponseSchema
+  },
+  "portal.benchmark-dataset.read": {
+    paramsSchema: portalBenchmarkDatasetParamsSchema,
+    querySchema: null,
+    requestBodySchema: null,
+    responseBodySchema: portalBenchmarkDatasetResponseSchema
+  },
+  "portal.benchmark-export.read": {
+    paramsSchema: portalBenchmarkDatasetParamsSchema,
+    querySchema: portalBenchmarkExportQuerySchema,
+    requestBodySchema: null,
+    responseBodySchema: null
   },
   "portal.runs.list": {
     paramsSchema: null,

--- a/packages/shared/test/api-contract-parity.test.js
+++ b/packages/shared/test/api-contract-parity.test.js
@@ -35,6 +35,8 @@ describe("shared api catalog parity", () => {
     expect(apiEndpointSchemaContract["portal.access-request.create"].requestBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.access-request.read"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.profile.read"].responseBodySchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.benchmarks.list"].responseBodySchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.benchmark-dataset.read"].paramsSchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.profile.link-intent.create"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["admin.problem9-offline-ingest.create"].requestBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["internal.worker.claim"].responseBodySchema).not.toBeNull();
@@ -56,5 +58,10 @@ describe("shared api catalog parity", () => {
       requestBodySchema: null,
       responseBodySchema: null
     });
+
+    expect(apiEndpointSchemaContract["portal.benchmark-export.read"].paramsSchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.benchmark-export.read"].querySchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.benchmark-export.read"].requestBodySchema).toBeNull();
+    expect(apiEndpointSchemaContract["portal.benchmark-export.read"].responseBodySchema).toBeNull();
   });
 });


### PR DESCRIPTION
﻿## Summary
- add the missing benchmark portal endpoints to the shared API endpoint catalog
- add matching portal-browser boundary entries for those endpoints
- add matching endpoint-schema registry bindings and parity assertions

## Testing
- bun run test:shared
- bun run build

Closes #1023
