### PR TITLE
fix(shared): remove fake terminal fields from benchmark ops

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -88,6 +88,22 @@ function getRunLifecycleBucket(runState: RunRow["state"]): PortalRunsLifecycleBu
   );
 }
 
+const terminalRunStates = ["succeeded", "failed", "cancelled"] as const;
+const terminalJobStates = ["completed", "failed", "cancelled"] as const;
+const terminalAttemptStates = ["succeeded", "failed", "cancelled"] as const;
+
+function isTerminalRunState(state: RunRow["state"]) {
+  return (terminalRunStates as ReadonlyArray<RunRow["state"]>).includes(state);
+}
+
+function isTerminalJobState(state: JobRow["state"]) {
+  return (terminalJobStates as ReadonlyArray<JobRow["state"]>).includes(state);
+}
+
+function isTerminalAttemptState(state: AttemptRow["state"]) {
+  return (terminalAttemptStates as ReadonlyArray<AttemptRow["state"]>).includes(state);
+}
+
 function compareByCreatedAtDesc<T extends { createdAt: Date }>(left: T, right: T) {
   return right.createdAt.getTime() - left.createdAt.getTime();
 }
@@ -139,6 +155,7 @@ function buildRunListItem(options: {
 }): PortalRunListItem {
   const latestJob = [...options.jobRows].sort(compareByCreatedAtDesc)[0] ?? null;
   const latestAttempt = [...options.attemptRows].sort(compareByCreatedAtDesc)[0] ?? null;
+  const terminal = isTerminalRunState(options.runRow.state);
 
   return {
     authMode: options.runRow.authMode,
@@ -148,11 +165,13 @@ function buildRunListItem(options: {
     benchmarkPackageId: options.runRow.benchmarkPackageId,
     benchmarkPackageVersion: options.runRow.benchmarkPackageVersion,
     benchmarkVersionId: getBenchmarkVersionId(options.runRow),
-    completedAt: options.runRow.completedAt.toISOString(),
-    durationMs: Math.max(
-      options.runRow.completedAt.getTime() - options.runRow.createdAt.getTime(),
-      0
-    ),
+    completedAt: terminal ? options.runRow.completedAt.toISOString() : null,
+    durationMs: terminal
+      ? Math.max(
+          options.runRow.completedAt.getTime() - options.runRow.createdAt.getTime(),
+          0
+        )
+      : null,
     failure: getFailureSummary(options.runRow),
     laneId: options.runRow.laneId,
     latestAttemptId: latestAttempt?.sourceAttemptId ?? null,
@@ -178,20 +197,21 @@ function buildRunListItem(options: {
     runState: options.runRow.state,
     startedAt: options.runRow.createdAt.toISOString(),
     toolProfile: options.runRow.toolProfile,
-    verdictClass: options.runRow.verdictClass
+    verdictClass: terminal ? options.runRow.verdictClass : null
   };
 }
 
 function buildJobSummary(runRow: RunRow, jobRow: JobRow): PortalRunJobSummary {
+  const terminal = isTerminalJobState(jobRow.state);
   return {
-    completedAt: jobRow.completedAt.toISOString(),
+    completedAt: terminal ? jobRow.completedAt.toISOString() : null,
     failure: getFailureSummary(jobRow),
     jobId: jobRow.sourceJobId,
     runId: runRow.sourceRunId,
     startedAt: jobRow.createdAt.toISOString(),
     state: jobRow.state,
-    stopReason: jobRow.stopReason,
-    verdictClass: jobRow.verdictClass
+    stopReason: terminal ? jobRow.stopReason : null,
+    verdictClass: terminal ? jobRow.verdictClass : null
   };
 }
 
@@ -200,17 +220,18 @@ function buildAttemptSummary(
   attemptRow: AttemptRow,
   jobById: Map<string, JobRow>
 ): PortalRunAttemptSummary {
+  const terminal = isTerminalAttemptState(attemptRow.state);
   return {
     attemptId: attemptRow.sourceAttemptId,
-    completedAt: attemptRow.completedAt.toISOString(),
+    completedAt: terminal ? attemptRow.completedAt.toISOString() : null,
     failure: getFailureSummary(attemptRow),
     jobId: jobById.get(attemptRow.jobId)?.sourceJobId ?? null,
     runId: runRow.sourceRunId,
     startedAt: attemptRow.createdAt.toISOString(),
     state: attemptRow.state,
-    stopReason: attemptRow.stopReason,
-    verdictClass: attemptRow.verdictClass,
-    verifierResult: attemptRow.verifierResult
+    stopReason: terminal ? attemptRow.stopReason : null,
+    verdictClass: terminal ? attemptRow.verdictClass : null,
+    verifierResult: terminal ? attemptRow.verifierResult : null
   };
 }
 
@@ -269,6 +290,9 @@ function buildTimeline(options: {
   jobRows: JobRow[];
   runRow: RunRow;
 }): PortalRunTimelineEntry[] {
+  const runStateOccurredAt = isTerminalRunState(options.runRow.state)
+    ? options.runRow.completedAt
+    : options.runRow.updatedAt;
   const timeline: PortalRunTimelineEntry[] = [
     {
       label: "Run record created",
@@ -279,7 +303,7 @@ function buildTimeline(options: {
     },
     {
       label: `Run ${getRunLifecycleStateLabel(options.runRow.state).toLowerCase()}`,
-      occurredAt: options.runRow.completedAt.toISOString(),
+      occurredAt: runStateOccurredAt.toISOString(),
       scope: "run",
       sourceId: options.runRow.sourceRunId,
       state: options.runRow.state
@@ -287,6 +311,9 @@ function buildTimeline(options: {
   ];
 
   for (const jobRow of options.jobRows) {
+    const jobStateOccurredAt = isTerminalJobState(jobRow.state)
+      ? jobRow.completedAt
+      : jobRow.updatedAt;
     timeline.push({
       label: "Job started",
       occurredAt: jobRow.createdAt.toISOString(),
@@ -296,7 +323,7 @@ function buildTimeline(options: {
     });
     timeline.push({
       label: `Job ${getJobLifecycleStateLabel(jobRow.state).toLowerCase()}`,
-      occurredAt: jobRow.completedAt.toISOString(),
+      occurredAt: jobStateOccurredAt.toISOString(),
       scope: "job",
       sourceId: jobRow.sourceJobId,
       state: jobRow.state
@@ -304,6 +331,9 @@ function buildTimeline(options: {
   }
 
   for (const attemptRow of options.attemptById.values()) {
+    const attemptStateOccurredAt = isTerminalAttemptState(attemptRow.state)
+      ? attemptRow.completedAt
+      : attemptRow.updatedAt;
     timeline.push({
       label: "Attempt started",
       occurredAt: attemptRow.createdAt.toISOString(),
@@ -313,7 +343,7 @@ function buildTimeline(options: {
     });
     timeline.push({
       label: `Attempt ${getAttemptLifecycleStateLabel(attemptRow.state).toLowerCase()}`,
-      occurredAt: attemptRow.completedAt.toISOString(),
+      occurredAt: attemptStateOccurredAt.toISOString(),
       scope: "attempt",
       sourceId: attemptRow.sourceAttemptId,
       state: attemptRow.state
@@ -401,13 +431,33 @@ async function loadRunIdsForSourceAttemptId(
 function buildRunOrderBy(sortId: PortalRunsListQuery["sort"]) {
   switch (sortId) {
     case "finished_at_desc":
-      return [desc(runs.completedAt), desc(runs.createdAt)] as const;
+      return [
+        desc(
+          sql`case when ${runs.state} in ('succeeded', 'failed', 'cancelled') then ${runs.completedAt} end`
+        ),
+        desc(runs.createdAt)
+      ] as const;
     case "duration_desc":
-      return [desc(sql`${runs.completedAt} - ${runs.createdAt}`), desc(runs.createdAt)] as const;
+      return [
+        desc(
+          sql`case when ${runs.state} in ('succeeded', 'failed', 'cancelled')
+            then extract(epoch from ${runs.completedAt} - ${runs.createdAt})
+          end`
+        ),
+        desc(runs.createdAt)
+      ] as const;
     case "run_state_asc":
       return [runs.state, runs.sourceRunId] as const;
     case "verdict_asc":
-      return [runs.verdictClass, runs.sourceRunId] as const;
+      return [
+        sql`case
+          when ${runs.state} not in ('succeeded', 'failed', 'cancelled') then 99
+          when ${runs.verdictClass} = 'pass' then 0
+          when ${runs.verdictClass} = 'fail' then 1
+          else 2
+        end`,
+        runs.sourceRunId
+      ] as const;
     case "started_at_desc":
     default:
       return [desc(runs.createdAt), desc(runs.completedAt)] as const;
@@ -434,6 +484,21 @@ function incrementVerdictCounts(
   verdictClass: RunRow["verdictClass"]
 ) {
   verdictCounts[verdictClass] += 1;
+}
+
+function getLatestTerminalCompletedAt<T extends { completedAt: Date; state: string }>(
+  rows: T[],
+  isTerminalState: (state: T["state"]) => boolean
+) {
+  const timestamps = rows
+    .filter((row) => isTerminalState(row.state))
+    .map((row) => row.completedAt.getTime());
+
+  if (timestamps.length === 0) {
+    return null;
+  }
+
+  return new Date(Math.max(...timestamps)).toISOString();
 }
 
 function listSortedUnique(values: string[]) {
@@ -529,17 +594,22 @@ export function createPortalBenchmarkOpsReadModelService(
       for (const runRow of runRows) {
         const existing = benchmarks.get(runRow.benchmarkPackageId);
         const attemptCount = attemptCountsByRunId.get(runRow.id) ?? 0;
+        const completedAt = isTerminalRunState(runRow.state)
+          ? runRow.completedAt.toISOString()
+          : null;
 
         if (!existing) {
           const verdictCounts = createEmptyVerdictCounts();
-          incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+          if (runRow.state === "succeeded" || runRow.state === "failed" || runRow.state === "cancelled") {
+            incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+          }
           benchmarks.set(runRow.benchmarkPackageId, {
             attemptCount,
             benchmarkLabel: getBenchmarkPackageLabel(runRow.benchmarkPackageId, [
               runRow.benchmarkPackageVersion
             ]),
             benchmarkPackageId: runRow.benchmarkPackageId,
-            latestCompletedAt: runRow.completedAt.toISOString(),
+            latestCompletedAt: completedAt,
             latestRunId: runRow.sourceRunId,
             modelConfigIds: [runRow.modelConfigId],
             providerFamilies: [runRow.providerFamily],
@@ -552,10 +622,12 @@ export function createPortalBenchmarkOpsReadModelService(
 
         existing.attemptCount += attemptCount;
         existing.runCount += 1;
-        incrementVerdictCounts(existing.verdictCounts, runRow.verdictClass);
+        if (runRow.state === "succeeded" || runRow.state === "failed" || runRow.state === "cancelled") {
+          incrementVerdictCounts(existing.verdictCounts, runRow.verdictClass);
+        }
 
-        if (!existing.latestCompletedAt) {
-          existing.latestCompletedAt = runRow.completedAt.toISOString();
+        if (!existing.latestCompletedAt && completedAt) {
+          existing.latestCompletedAt = completedAt;
           existing.latestRunId = runRow.sourceRunId;
         }
 
@@ -622,7 +694,9 @@ export function createPortalBenchmarkOpsReadModelService(
       const latestRun = runRows[0] ?? null;
 
       for (const runRow of runRows) {
-        incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+        if (isTerminalRunState(runRow.state)) {
+          incrementVerdictCounts(verdictCounts, runRow.verdictClass);
+        }
       }
 
       return {
@@ -667,7 +741,7 @@ export function createPortalBenchmarkOpsReadModelService(
         summary: {
           attemptCount: attemptRows.length,
           jobCount: jobRows.length,
-          latestCompletedAt: latestRun?.completedAt.toISOString() ?? null,
+          latestCompletedAt: getLatestTerminalCompletedAt(runRows, isTerminalRunState),
           runCount: runRows.length,
           verdictCounts
         }
@@ -692,7 +766,12 @@ export function createPortalBenchmarkOpsReadModelService(
       }
 
       if (query.verdict.length > 0) {
-        runConditions.push(inArray(runs.verdictClass, query.verdict));
+        runConditions.push(
+          and(
+            inArray(runs.state, [...terminalRunStates]),
+            inArray(runs.verdictClass, query.verdict)
+          )!
+        );
       }
 
       if (query.runKind) {

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -127,6 +127,92 @@ function buildRunsListResponse(
   };
 }
 
+test("shared benchmark-ops contracts allow null terminal fields for non-terminal rows", () => {
+  const parsed = portalBenchmarkOpsReadModelsContract.runsListResponse.parse({
+    filters: {
+      modelConfigs: [],
+      providerFamilies: []
+    },
+    items: [
+      {
+        authMode: "machine_api_key",
+        benchmarkItemId: "item-2",
+        benchmarkLabel: "problem9 @ 2026.03",
+        benchmarkPackageDigest: "b".repeat(64),
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: null,
+        durationMs: null,
+        failure: {
+          code: null,
+          family: null,
+          summary: null
+        },
+        laneId: "problem9-default",
+        latestAttemptId: "attempt-2",
+        latestJobId: "job-2",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-2"],
+          jobCount: 1,
+          jobIds: ["job-2"],
+          latestAttemptId: "attempt-2",
+          latestJobId: "job-2"
+        },
+        modelConfigId: "gpt-oss",
+        modelConfigLabel: "gpt-oss",
+        modelSnapshotId: "gpt-oss-2026-03-13",
+        providerFamily: "openai",
+        runId: "PP-319",
+        runKind: "single_run",
+        runLifecycleBucket: "active",
+        runMode: "bounded_agentic_attempt",
+        runState: "running",
+        startedAt: "2026-03-13T19:58:00.000Z",
+        toolProfile: "workspace_edit_limited",
+        verdictClass: null
+      }
+    ],
+    query: {
+      attemptId: null,
+      authMode: null,
+      benchmarkPackageDigest: null,
+      benchmarkPackageId: null,
+      benchmarkPackageVersion: null,
+      failureCode: null,
+      failureFamily: null,
+      jobId: null,
+      lifecycleBucket: null,
+      limit: 25,
+      modelConfigId: null,
+      providerFamily: null,
+      q: null,
+      runId: null,
+      runLifecycle: [],
+      runMode: null,
+      runKind: null,
+      sort: "started_at_desc",
+      toolProfile: null,
+      verdict: []
+    },
+    summary: {
+      activeRuns: 1,
+      failedRuns: 0,
+      returnedCount: 1,
+      totalMatches: 1,
+      verdictCounts: {
+        fail: 0,
+        invalid_result: 0,
+        pass: 0
+      }
+    }
+  });
+
+  assert.equal(parsed.items[0]?.completedAt, null);
+  assert.equal(parsed.items[0]?.verdictClass, null);
+});
+
 function buildRunDetailResponse(): PortalRunDetailResponse {
   return {
     artifacts: [],

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -110,6 +110,50 @@ describe("buildRunsCsv", () => {
     expect(csv).toContain("'\t=family,'+code");
     expect(csv).toContain("\"'  =SUM(\"\"a\"\",\"\"b\"\")\"");
   });
+
+  it("leaves terminal-only run fields blank for active and pending rows", () => {
+    const csv = buildRunsCsv([
+      {
+        authMode: "oidc",
+        benchmarkItemId: "item-2",
+        benchmarkLabel: "problem9 core",
+        benchmarkPackageDigest: "sha256:def",
+        benchmarkPackageId: "problem9",
+        benchmarkPackageVersion: "2026.03",
+        benchmarkVersionId: "problem9@2026.03",
+        completedAt: null,
+        durationMs: null,
+        failure: { code: null, family: null, summary: null },
+        laneId: "lane-2",
+        latestAttemptId: "attempt-2",
+        latestJobId: "job-2",
+        lineage: {
+          attemptCount: 1,
+          attemptIds: ["attempt-2"],
+          jobCount: 1,
+          jobIds: ["job-2"],
+          latestAttemptId: "attempt-2",
+          latestJobId: "job-2"
+        },
+        modelConfigId: "gpt-oss",
+        modelConfigLabel: "GPT OSS",
+        modelSnapshotId: "gpt-oss-2026-03-13",
+        providerFamily: "openai",
+        runId: "PP-319",
+        runKind: "single_run",
+        runLifecycleBucket: "active",
+        runMode: "eval",
+        runState: "running",
+        startedAt: "2026-03-13T19:58:00.000Z",
+        toolProfile: "lean4-proof",
+        verdictClass: null
+      }
+    ]);
+
+    expect(csv).toContain(
+      "PP-319,job-2,attempt-2,problem9@2026.03,gpt-oss,GPT OSS,running,Running,active,Active,,,,,2026-03-13T19:58:00.000Z,,"
+    );
+  });
 });
 
 describe("benchmark dataset exports", () => {

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -57,6 +57,18 @@ const portalVerdictOrder: Record<EvaluationVerdictClass, number> = {
   pass: 0
 };
 
+function compareNullableTimestampDesc(left: string | null, right: string | null) {
+  return Date.parse(right ?? "") - Date.parse(left ?? "");
+}
+
+function getDurationSortValue(durationMs: number | null) {
+  return durationMs ?? Number.NEGATIVE_INFINITY;
+}
+
+function getVerdictSortValue(verdictClass: EvaluationVerdictClass | null) {
+  return verdictClass === null ? Number.POSITIVE_INFINITY : portalVerdictOrder[verdictClass];
+}
+
 export const defaultPortalRunsQuery: PortalRunsListQuery = {
   attemptId: null,
   authMode: null,
@@ -128,8 +140,8 @@ const localRunItems: PortalRunListItem[] = [
     benchmarkPackageId: "problem9-core",
     benchmarkPackageVersion: "2026.03.11",
     benchmarkVersionId: "problem9-core@2026.03.11",
-    completedAt: "2026-03-13T16:06:00.000Z",
-    durationMs: 921000,
+    completedAt: null,
+    durationMs: null,
     failure: { code: null, family: null, summary: null },
     laneId: "induction-search",
     latestAttemptId: "ATT-319-2",
@@ -153,7 +165,7 @@ const localRunItems: PortalRunListItem[] = [
     runState: "running",
     startedAt: "2026-03-13T15:50:39.000Z",
     toolProfile: "lean4-proof",
-    verdictClass: "pass"
+    verdictClass: null
   },
   {
     authMode: "service_token",
@@ -202,8 +214,8 @@ const localRunItems: PortalRunListItem[] = [
     benchmarkPackageId: "problem9-core",
     benchmarkPackageVersion: "2026.03.11",
     benchmarkVersionId: "problem9-core@2026.03.11",
-    completedAt: "2026-03-13T16:18:00.000Z",
-    durationMs: 0,
+    completedAt: null,
+    durationMs: null,
     failure: { code: null, family: null, summary: null },
     laneId: "axiom-slice",
     latestAttemptId: null,
@@ -227,7 +239,7 @@ const localRunItems: PortalRunListItem[] = [
     runState: "queued",
     startedAt: "2026-03-13T16:18:00.000Z",
     toolProfile: "lean4-proof",
-    verdictClass: "pass"
+    verdictClass: null
   }
 ];
 
@@ -350,27 +362,27 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
       },
       {
         attemptId: "ATT-319-2",
-        completedAt: "2026-03-13T16:06:00.000Z",
+        completedAt: null,
         failure: { code: null, family: null, summary: null },
         jobId: "JOB-319-2",
         runId: "PP-319",
         startedAt: "2026-03-13T15:50:39.000Z",
         state: "active",
-        stopReason: "still_running",
-        verdictClass: "pass",
-        verifierResult: "pending"
+        stopReason: null,
+        verdictClass: null,
+        verifierResult: null
       }
     ],
     jobs: [
       {
-        completedAt: "2026-03-13T16:06:00.000Z",
+        completedAt: null,
         failure: { code: null, family: null, summary: null },
         jobId: "JOB-319-2",
         runId: "PP-319",
         startedAt: "2026-03-13T15:50:39.000Z",
         state: "running",
-        stopReason: "still_running",
-        verdictClass: "pass"
+        stopReason: null,
+        verdictClass: null
       }
     ],
     recentWorkerEvents: [
@@ -725,8 +737,12 @@ function createEmptyVerdictCounts() {
 
 function incrementVerdictCounts(
   verdictCounts: Record<EvaluationVerdictClass, number>,
-  verdictClass: EvaluationVerdictClass
+  verdictClass: EvaluationVerdictClass | null
 ) {
+  if (verdictClass === null) {
+    return;
+  }
+
   verdictCounts[verdictClass] += 1;
 }
 
@@ -745,7 +761,7 @@ function getBenchmarkPackageLabel(packageId: string, versions: string[]) {
 function buildLocalBenchmarkDataset(packageId: string): PortalBenchmarkDatasetResponse {
   const runs = localRunItems
     .filter((item) => item.benchmarkPackageId === packageId)
-    .sort((left, right) => Date.parse(right.completedAt) - Date.parse(left.completedAt));
+    .sort((left, right) => compareNullableTimestampDesc(left.completedAt, right.completedAt));
 
   if (runs.length === 0) {
     throw new Error(`Benchmark package ${packageId} was not found.`);
@@ -776,13 +792,13 @@ function buildLocalBenchmarkDataset(packageId: string): PortalBenchmarkDatasetRe
     },
     jobs,
     runs,
-    summary: {
-      attemptCount: attempts.length,
-      jobCount: jobs.length,
-      latestCompletedAt: runs[0]?.completedAt ?? null,
-      runCount: runs.length,
-      verdictCounts
-    }
+      summary: {
+        attemptCount: attempts.length,
+        jobCount: jobs.length,
+        latestCompletedAt: runs.find((run) => run.completedAt !== null)?.completedAt ?? null,
+        runCount: runs.length,
+        verdictCounts
+      }
   };
 }
 
@@ -817,6 +833,15 @@ function buildLocalBenchmarksListResponse(): PortalBenchmarksListResponse {
     existing.runCount += 1;
     incrementVerdictCounts(existing.verdictCounts, run.verdictClass);
 
+    if (
+      run.completedAt !== null &&
+      (existing.latestCompletedAt === null ||
+        Date.parse(run.completedAt) > Date.parse(existing.latestCompletedAt))
+    ) {
+      existing.latestCompletedAt = run.completedAt;
+      existing.latestRunId = run.runId;
+    }
+
     if (!existing.modelConfigIds.includes(run.modelConfigId)) {
       existing.modelConfigIds.push(run.modelConfigId);
     }
@@ -842,7 +867,7 @@ function buildLocalBenchmarksListResponse(): PortalBenchmarksListResponse {
           versions
         };
       })
-      .sort((left, right) => Date.parse(right.latestCompletedAt ?? "") - Date.parse(left.latestCompletedAt ?? ""))
+      .sort((left, right) => compareNullableTimestampDesc(left.latestCompletedAt, right.latestCompletedAt))
   };
 }
 
@@ -915,7 +940,10 @@ function matchesPortalRunsQuery(item: PortalRunListItem, query: PortalRunsListQu
     return false;
   }
 
-  if (query.verdict.length > 0 && !query.verdict.includes(item.verdictClass)) {
+  if (
+    query.verdict.length > 0 &&
+    (item.verdictClass === null || !query.verdict.includes(item.verdictClass))
+  ) {
     return false;
   }
 
@@ -996,13 +1024,13 @@ function sortPortalRuns(items: PortalRunListItem[], sortId: PortalRunsSortId) {
   return [...items].sort((left, right) => {
     switch (sortId) {
       case "finished_at_desc":
-        return Date.parse(right.completedAt) - Date.parse(left.completedAt);
+        return compareNullableTimestampDesc(left.completedAt, right.completedAt);
       case "duration_desc":
-        return right.durationMs - left.durationMs;
+        return getDurationSortValue(right.durationMs) - getDurationSortValue(left.durationMs);
       case "run_state_asc":
         return portalRunLifecycleStateOrder[left.runState] - portalRunLifecycleStateOrder[right.runState];
       case "verdict_asc":
-        return portalVerdictOrder[left.verdictClass] - portalVerdictOrder[right.verdictClass];
+        return getVerdictSortValue(left.verdictClass) - getVerdictSortValue(right.verdictClass);
       case "started_at_desc":
       default:
         return Date.parse(right.startedAt) - Date.parse(left.startedAt);
@@ -1155,13 +1183,13 @@ export function buildRunsCsv(items: PortalRunListItem[]) {
     getRunLifecycleStateLabel(item.runState),
     item.runLifecycleBucket,
     getPortalRunsLifecycleBucketLabel(item.runLifecycleBucket),
-    item.verdictClass,
-    evaluationVerdictLabels[item.verdictClass],
+    item.verdictClass ?? "",
+    item.verdictClass ? evaluationVerdictLabels[item.verdictClass] : "",
     item.failure.family ?? "",
     item.failure.code ?? "",
     item.startedAt,
-    item.completedAt,
-    String(item.durationMs)
+    item.completedAt ?? "",
+    item.durationMs === null ? "" : String(item.durationMs)
   ]);
 
   return [portalResultsExportHeaders, ...rows]
@@ -1211,12 +1239,12 @@ export function buildPortalBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetRe
       dataset.benchmark.versions.join("|"),
       run.runId,
       run.runState,
-      run.verdictClass,
+      run.verdictClass ?? "",
       run.providerFamily,
       run.modelConfigId,
       run.startedAt,
-      run.completedAt,
-      String(run.durationMs),
+      run.completedAt ?? "",
+      run.durationMs === null ? "" : String(run.durationMs),
       attempt?.jobId ?? run.latestJobId ?? "",
       attempt?.attemptId ?? "",
       attempt?.state ?? "",

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -83,7 +83,11 @@ function formatTimestamp(timestamp: string) {
   });
 }
 
-function formatDuration(durationMs: number) {
+function formatDuration(durationMs: number | null) {
+  if (durationMs === null) {
+    return "In progress";
+  }
+
   if (durationMs <= 0) {
     return "Queued";
   }
@@ -92,6 +96,10 @@ function formatDuration(durationMs: number) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}m ${seconds}s`;
+}
+
+function getVerdictLabel(verdict: EvaluationVerdictClass | null) {
+  return verdict ? evaluationVerdictLabels[verdict] : "In progress";
 }
 
 function formatRunKind(value: string) {
@@ -548,9 +556,13 @@ function PortalRunsSurface({
                 <p className="portal-run-card-title">{item.benchmarkLabel}</p>
                 <p className="portal-run-card-meta">{item.modelConfigLabel}</p>
                 <div className="portal-run-card-footer">
-                  <span className={`portal-verdict-badge portal-verdict-${item.verdictClass}`}>
-                    {evaluationVerdictLabels[item.verdictClass]}
-                  </span>
+                  {item.verdictClass ? (
+                    <span className={`portal-verdict-badge portal-verdict-${item.verdictClass}`}>
+                      {evaluationVerdictLabels[item.verdictClass]}
+                    </span>
+                  ) : (
+                    <span className="role-chip role-chip-muted">In progress</span>
+                  )}
                   <span className="portal-run-card-timestamp">
                     {formatTimestamp(item.startedAt)}
                   </span>
@@ -581,9 +593,13 @@ function PortalRunsSurface({
                 <span className={`portal-state-badge portal-state-${item.runState}`}>
                   {runLifecycleStateLabels[item.runState]}
                 </span>
-                <span className={`portal-verdict-badge portal-verdict-${item.verdictClass}`}>
-                  {evaluationVerdictLabels[item.verdictClass]}
-                </span>
+                {item.verdictClass ? (
+                  <span className={`portal-verdict-badge portal-verdict-${item.verdictClass}`}>
+                    {evaluationVerdictLabels[item.verdictClass]}
+                  </span>
+                ) : (
+                  <span className="role-chip role-chip-muted">In progress</span>
+                )}
               </div>
             ))}
           </div>
@@ -1153,7 +1169,7 @@ function PortalRunDetailSurface({
               </article>
               <article className="portal-summary-card">
                 <span>Verdict</span>
-                <strong>{evaluationVerdictLabels[detail.item.verdictClass]}</strong>
+                <strong>{getVerdictLabel(detail.item.verdictClass)}</strong>
                 <small>{detail.item.failure.summary ?? "No terminal failure summary."}</small>
               </article>
             </div>

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -93,8 +93,8 @@ export const portalRunListItemSchema = z.object({
   benchmarkPackageId: z.string(),
   benchmarkPackageVersion: z.string(),
   benchmarkVersionId: z.string(),
-  completedAt: timestampSchema,
-  durationMs: z.number().int().nonnegative(),
+  completedAt: timestampSchema.nullable(),
+  durationMs: z.number().int().nonnegative().nullable(),
   failure: portalRunFailureSummarySchema,
   laneId: z.string(),
   latestAttemptId: z.string().nullable(),
@@ -111,7 +111,7 @@ export const portalRunListItemSchema = z.object({
   runState: runLifecycleStateSchema,
   startedAt: timestampSchema,
   toolProfile: z.string(),
-  verdictClass: evaluationVerdictClassSchema
+  verdictClass: evaluationVerdictClassSchema.nullable()
 });
 
 export const portalRunsProviderFilterOptionSchema = z.object({
@@ -161,27 +161,27 @@ export const portalRunTimelineEntrySchema = z.object({
 });
 
 export const portalRunJobSummarySchema = z.object({
-  completedAt: timestampSchema,
+  completedAt: timestampSchema.nullable(),
   failure: portalRunFailureSummarySchema,
   jobId: z.string().nullable(),
   runId: z.string(),
   startedAt: timestampSchema,
   state: jobLifecycleStateSchema,
-  stopReason: z.string(),
-  verdictClass: evaluationVerdictClassSchema
+  stopReason: z.string().nullable(),
+  verdictClass: evaluationVerdictClassSchema.nullable()
 });
 
 export const portalRunAttemptSummarySchema = z.object({
   attemptId: z.string(),
-  completedAt: timestampSchema,
+  completedAt: timestampSchema.nullable(),
   failure: portalRunFailureSummarySchema,
   jobId: z.string().nullable(),
   runId: z.string(),
   startedAt: timestampSchema,
   state: attemptLifecycleStateSchema,
-  stopReason: z.string(),
-  verdictClass: evaluationVerdictClassSchema,
-  verifierResult: z.string()
+  stopReason: z.string().nullable(),
+  verdictClass: evaluationVerdictClassSchema.nullable(),
+  verifierResult: z.string().nullable()
 });
 
 export const portalRunArtifactSummarySchema = z.object({

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -97,8 +97,8 @@ export type PortalRunListItem = {
   benchmarkPackageId: string;
   benchmarkPackageVersion: string;
   benchmarkVersionId: string;
-  completedAt: string;
-  durationMs: number;
+  completedAt: string | null;
+  durationMs: number | null;
   failure: PortalRunFailureSummary;
   laneId: string;
   latestAttemptId: string | null;
@@ -115,7 +115,7 @@ export type PortalRunListItem = {
   runState: RunLifecycleState;
   startedAt: string;
   toolProfile: string;
-  verdictClass: EvaluationVerdictClass;
+  verdictClass: EvaluationVerdictClass | null;
 };
 
 export type PortalRunsListResponse = {
@@ -140,27 +140,27 @@ export type PortalRunTimelineEntry = {
 };
 
 export type PortalRunJobSummary = {
-  completedAt: string;
+  completedAt: string | null;
   failure: PortalRunFailureSummary;
   jobId: string | null;
   runId: string;
   startedAt: string;
   state: JobLifecycleState;
-  stopReason: string;
-  verdictClass: EvaluationVerdictClass;
+  stopReason: string | null;
+  verdictClass: EvaluationVerdictClass | null;
 };
 
 export type PortalRunAttemptSummary = {
   attemptId: string;
-  completedAt: string;
+  completedAt: string | null;
   failure: PortalRunFailureSummary;
   jobId: string | null;
   runId: string;
   startedAt: string;
   state: AttemptLifecycleState;
-  stopReason: string;
-  verdictClass: EvaluationVerdictClass;
-  verifierResult: string;
+  stopReason: string | null;
+  verdictClass: EvaluationVerdictClass | null;
+  verifierResult: string | null;
 };
 
 export type PortalRunArtifactSummary = {

--- a/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
+++ b/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+import {
+  portalBenchmarkDatasetResponseSchema,
+  portalRunsListResponseSchema
+} from "../dist/index.js";
+
+const baseRunItem = {
+  authMode: "machine_api_key",
+  benchmarkItemId: "item-1",
+  benchmarkLabel: "problem9 @ 2026.03",
+  benchmarkPackageDigest: "a".repeat(64),
+  benchmarkPackageId: "problem9",
+  benchmarkPackageVersion: "2026.03",
+  benchmarkVersionId: "problem9@2026.03",
+  failure: {
+    code: null,
+    family: null,
+    summary: null
+  },
+  laneId: "problem9-default",
+  latestAttemptId: "attempt-1",
+  latestJobId: "job-1",
+  lineage: {
+    attemptCount: 1,
+    attemptIds: ["attempt-1"],
+    jobCount: 1,
+    jobIds: ["job-1"],
+    latestAttemptId: "attempt-1",
+    latestJobId: "job-1"
+  },
+  modelConfigId: "gpt-oss",
+  modelConfigLabel: "gpt-oss",
+  modelSnapshotId: "gpt-oss-2026-03-13",
+  providerFamily: "openai",
+  runId: "PP-318",
+  runKind: "single_run",
+  runMode: "bounded_agentic_attempt",
+  startedAt: "2026-03-13T19:58:00.000Z",
+  toolProfile: "workspace_edit_limited"
+};
+
+describe("portal benchmark-ops lifecycle contracts", () => {
+  it("allows active and pending runs to omit terminal-only fields", () => {
+    const parsed = portalRunsListResponseSchema.parse({
+      filters: {
+        modelConfigs: [],
+        providerFamilies: []
+      },
+      items: [
+        {
+          ...baseRunItem,
+          completedAt: null,
+          durationMs: null,
+          runLifecycleBucket: "active",
+          runState: "running",
+          verdictClass: null
+        },
+        {
+          ...baseRunItem,
+          completedAt: null,
+          durationMs: null,
+          latestAttemptId: null,
+          latestJobId: null,
+          lineage: {
+            attemptCount: 0,
+            attemptIds: [],
+            jobCount: 0,
+            jobIds: [],
+            latestAttemptId: null,
+            latestJobId: null
+          },
+          runId: "PP-319",
+          runLifecycleBucket: "pending",
+          runState: "queued",
+          verdictClass: null
+        }
+      ],
+      query: {
+        attemptId: null,
+        authMode: null,
+        benchmarkPackageDigest: null,
+        benchmarkPackageId: null,
+        benchmarkPackageVersion: null,
+        failureCode: null,
+        failureFamily: null,
+        jobId: null,
+        lifecycleBucket: null,
+        limit: 25,
+        modelConfigId: null,
+        providerFamily: null,
+        q: null,
+        runId: null,
+        runLifecycle: [],
+        runMode: null,
+        runKind: null,
+        sort: "started_at_desc",
+        toolProfile: null,
+        verdict: []
+      },
+      summary: {
+        activeRuns: 1,
+        failedRuns: 0,
+        returnedCount: 2,
+        totalMatches: 2,
+        verdictCounts: {
+          fail: 0,
+          invalid_result: 0,
+          pass: 0
+        }
+      }
+    });
+
+    expect(parsed.items[0].completedAt).toBeNull();
+    expect(parsed.items[1].verdictClass).toBeNull();
+  });
+
+  it("allows non-terminal attempt and job summaries to omit terminal-only fields", () => {
+    const parsed = portalBenchmarkDatasetResponseSchema.parse({
+      attempts: [
+        {
+          attemptId: "attempt-1",
+          completedAt: null,
+          failure: {
+            code: null,
+            family: null,
+            summary: null
+          },
+          jobId: "job-1",
+          runId: "PP-318",
+          startedAt: "2026-03-13T19:58:30.000Z",
+          state: "active",
+          stopReason: null,
+          verdictClass: null,
+          verifierResult: null
+        }
+      ],
+      benchmark: {
+        benchmarkLabel: "problem9 @ 2026.03",
+        benchmarkPackageId: "problem9",
+        laneIds: ["problem9-default"],
+        latestRunId: "PP-318",
+        modelConfigIds: ["gpt-oss"],
+        providerFamilies: ["openai"],
+        versions: ["2026.03"]
+      },
+      jobs: [
+        {
+          completedAt: null,
+          failure: {
+            code: null,
+            family: null,
+            summary: null
+          },
+          jobId: "job-1",
+          runId: "PP-318",
+          startedAt: "2026-03-13T19:58:10.000Z",
+          state: "running",
+          stopReason: null,
+          verdictClass: null
+        }
+      ],
+      runs: [
+        {
+          ...baseRunItem,
+          completedAt: null,
+          durationMs: null,
+          runLifecycleBucket: "active",
+          runState: "running",
+          verdictClass: null
+        }
+      ],
+      summary: {
+        attemptCount: 1,
+        jobCount: 1,
+        latestCompletedAt: null,
+        runCount: 1,
+        verdictCounts: {
+          fail: 0,
+          invalid_result: 0,
+          pass: 0
+        }
+      }
+    });
+
+    expect(parsed.attempts[0].stopReason).toBeNull();
+    expect(parsed.jobs[0].verdictClass).toBeNull();
+  });
+});


### PR DESCRIPTION
﻿## Summary
- make benchmark-ops run, job, and attempt terminal-only fields nullable in the shared contract
- normalize the API read model so active and pending records stop leaking fake terminal timestamps, verdicts, and stop reasons
- update portal fixtures, exports, and rendering to show in-progress records without fake terminal data

## Testing
- bun run test:shared
- bun --cwd apps/api test test/portal-benchmark-ops.test.ts
- bun test apps/web/src/lib/portal-benchmark-ops.test.js
- bun run build

Closes #989
