### PR TITLE
fix(shared): clear terminal-only benchmark ops fields

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -155,9 +155,7 @@ function buildRunListItem(options: {
 }): PortalRunListItem {
   const latestJob = [...options.jobRows].sort(compareByCreatedAtDesc)[0] ?? null;
   const latestAttempt = [...options.attemptRows].sort(compareByCreatedAtDesc)[0] ?? null;
-  const terminal = isTerminalRunState(options.runRow.state);
-
-  return {
+  const baseItem = {
     authMode: options.runRow.authMode,
     benchmarkItemId: options.runRow.benchmarkItemId,
     benchmarkLabel: getBenchmarkLabel(options.runRow),
@@ -165,13 +163,6 @@ function buildRunListItem(options: {
     benchmarkPackageId: options.runRow.benchmarkPackageId,
     benchmarkPackageVersion: options.runRow.benchmarkPackageVersion,
     benchmarkVersionId: getBenchmarkVersionId(options.runRow),
-    completedAt: terminal ? options.runRow.completedAt.toISOString() : null,
-    durationMs: terminal
-      ? Math.max(
-          options.runRow.completedAt.getTime() - options.runRow.createdAt.getTime(),
-          0
-        )
-      : null,
     failure: getFailureSummary(options.runRow),
     laneId: options.runRow.laneId,
     latestAttemptId: latestAttempt?.sourceAttemptId ?? null,
@@ -194,24 +185,56 @@ function buildRunListItem(options: {
     runKind: options.runRow.runKind,
     runLifecycleBucket: getRunLifecycleBucket(options.runRow.state),
     runMode: options.runRow.runMode,
-    runState: options.runRow.state,
     startedAt: options.runRow.createdAt.toISOString(),
-    toolProfile: options.runRow.toolProfile,
-    verdictClass: terminal ? options.runRow.verdictClass : null
+    toolProfile: options.runRow.toolProfile
+  };
+
+  if (isTerminalRunState(options.runRow.state)) {
+    return {
+      ...baseItem,
+      completedAt: options.runRow.completedAt.toISOString(),
+      durationMs: Math.max(
+        options.runRow.completedAt.getTime() - options.runRow.createdAt.getTime(),
+        0
+      ),
+      runState: options.runRow.state,
+      verdictClass: options.runRow.verdictClass
+    };
+  }
+
+  return {
+    ...baseItem,
+    completedAt: null,
+    durationMs: null,
+    runState: options.runRow.state,
+    verdictClass: null
   };
 }
 
 function buildJobSummary(runRow: RunRow, jobRow: JobRow): PortalRunJobSummary {
-  const terminal = isTerminalJobState(jobRow.state);
-  return {
-    completedAt: terminal ? jobRow.completedAt.toISOString() : null,
+  const baseSummary = {
     failure: getFailureSummary(jobRow),
     jobId: jobRow.sourceJobId,
     runId: runRow.sourceRunId,
-    startedAt: jobRow.createdAt.toISOString(),
+    startedAt: jobRow.createdAt.toISOString()
+  };
+
+  if (isTerminalJobState(jobRow.state)) {
+    return {
+      ...baseSummary,
+      completedAt: jobRow.completedAt.toISOString(),
+      state: jobRow.state,
+      stopReason: jobRow.stopReason,
+      verdictClass: jobRow.verdictClass
+    };
+  }
+
+  return {
+    ...baseSummary,
+    completedAt: null,
     state: jobRow.state,
-    stopReason: terminal ? jobRow.stopReason : null,
-    verdictClass: terminal ? jobRow.verdictClass : null
+    stopReason: null,
+    verdictClass: null
   };
 }
 
@@ -220,18 +243,32 @@ function buildAttemptSummary(
   attemptRow: AttemptRow,
   jobById: Map<string, JobRow>
 ): PortalRunAttemptSummary {
-  const terminal = isTerminalAttemptState(attemptRow.state);
-  return {
+  const baseSummary = {
     attemptId: attemptRow.sourceAttemptId,
-    completedAt: terminal ? attemptRow.completedAt.toISOString() : null,
     failure: getFailureSummary(attemptRow),
     jobId: jobById.get(attemptRow.jobId)?.sourceJobId ?? null,
     runId: runRow.sourceRunId,
-    startedAt: attemptRow.createdAt.toISOString(),
+    startedAt: attemptRow.createdAt.toISOString()
+  };
+
+  if (isTerminalAttemptState(attemptRow.state)) {
+    return {
+      ...baseSummary,
+      completedAt: attemptRow.completedAt.toISOString(),
+      state: attemptRow.state,
+      stopReason: attemptRow.stopReason,
+      verdictClass: attemptRow.verdictClass,
+      verifierResult: attemptRow.verifierResult
+    };
+  }
+
+  return {
+    ...baseSummary,
+    completedAt: null,
     state: attemptRow.state,
-    stopReason: terminal ? attemptRow.stopReason : null,
-    verdictClass: terminal ? attemptRow.verdictClass : null,
-    verifierResult: terminal ? attemptRow.verifierResult : null
+    stopReason: null,
+    verdictClass: null,
+    verifierResult: null
   };
 }
 

--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -92,15 +92,21 @@ const terminalRunStates = ["succeeded", "failed", "cancelled"] as const;
 const terminalJobStates = ["completed", "failed", "cancelled"] as const;
 const terminalAttemptStates = ["succeeded", "failed", "cancelled"] as const;
 
-function isTerminalRunState(state: RunRow["state"]) {
+function isTerminalRunState(
+  state: RunRow["state"]
+): state is (typeof terminalRunStates)[number] {
   return (terminalRunStates as ReadonlyArray<RunRow["state"]>).includes(state);
 }
 
-function isTerminalJobState(state: JobRow["state"]) {
+function isTerminalJobState(
+  state: JobRow["state"]
+): state is (typeof terminalJobStates)[number] {
   return (terminalJobStates as ReadonlyArray<JobRow["state"]>).includes(state);
 }
 
-function isTerminalAttemptState(state: AttemptRow["state"]) {
+function isTerminalAttemptState(
+  state: AttemptRow["state"]
+): state is (typeof terminalAttemptStates)[number] {
   return (terminalAttemptStates as ReadonlyArray<AttemptRow["state"]>).includes(state);
 }
 

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -572,6 +572,61 @@ test("GET /portal/runs rejects invalid benchmark-ops query params", async (t) =>
   assert.equal(response.json().error, "invalid_portal_runs_query");
 });
 
+test("GET /portal/runs accepts non-terminal rows without invented terminal fields", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["helper"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService({
+        getRunsList: async (query) => ({
+          ...buildRunsListResponse(query),
+          items: [
+            {
+              ...buildRunsListResponse(query).items[0],
+              completedAt: null,
+              durationMs: null,
+              runLifecycleBucket: "active",
+              runState: "running",
+              verdictClass: null
+            }
+          ],
+          summary: {
+            activeRuns: 1,
+            failedRuns: 0,
+            returnedCount: 1,
+            totalMatches: 1,
+            verdictCounts: {
+              fail: 0,
+              invalid_result: 0,
+              pass: 0
+            }
+          }
+        })
+      }),
+      resolvePortalAccess: createResolvePortalAccessStub(["helper"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/runs"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = portalBenchmarkOpsReadModelsContract.runsListResponse.parse(response.json());
+  assert.equal(payload.items[0]?.completedAt, null);
+  assert.equal(payload.items[0]?.durationMs, null);
+  assert.equal(payload.items[0]?.verdictClass, null);
+  assert.equal(payload.summary.verdictCounts.pass, 0);
+});
+
 test("GET /portal/benchmarks returns a contract-valid package summary list", async (t) => {
   const app = Fastify();
 

--- a/apps/api/test/run-control-state-parity.test.ts
+++ b/apps/api/test/run-control-state-parity.test.ts
@@ -8,7 +8,9 @@ import {
   offlineIngestAttemptLifecycleStates,
   offlineIngestJobLifecycleStates,
   offlineIngestRunLifecycleStates,
+  portalRunJobSummarySchema,
   portalRunAttemptSummarySchema,
+  portalRunListItemSchema,
   problem9OfflineIngestResponseSchema,
   runKindCatalog,
   runKindValues,
@@ -29,6 +31,13 @@ import {
   runKindEnum,
   runStateEnum
 } from "../src/db/schema.ts";
+
+function collectUnionStateOptions(
+  schema: { options: Array<{ shape: Record<string, { options: readonly string[] }> }> },
+  key: string
+) {
+  return schema.options.flatMap((option) => [...(option.shape[key]?.options ?? [])]);
+}
 
 test("shared lifecycle catalogs, response schemas, and API Postgres enums stay in parity", () => {
   assert.deepEqual(runKindCatalog.map((entry) => entry.id), [...runKindValues]);
@@ -63,8 +72,16 @@ test("shared lifecycle catalogs, response schemas, and API Postgres enums stay i
   assert.deepEqual(attemptStateEnum.enumValues, [...attemptLifecycleStates]);
 
   assert.deepEqual(
-    portalRunAttemptSummarySchema.shape.state.options,
-    [...attemptLifecycleStates]
+    collectUnionStateOptions(portalRunListItemSchema, "runState").sort(),
+    [...runLifecycleStates].sort()
+  );
+  assert.deepEqual(
+    collectUnionStateOptions(portalRunJobSummarySchema, "state").sort(),
+    [...jobLifecycleStates].sort()
+  );
+  assert.deepEqual(
+    collectUnionStateOptions(portalRunAttemptSummarySchema, "state").sort(),
+    [...attemptLifecycleStates].sort()
   );
 
   assert.deepEqual(

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -111,12 +111,12 @@ describe("buildRunsCsv", () => {
     expect(csv).toContain("\"'  =SUM(\"\"a\"\",\"\"b\"\")\"");
   });
 
-  it("leaves terminal-only run fields blank for active and pending rows", () => {
+  it("leaves terminal-only run fields blank for non-terminal rows", () => {
     const csv = buildRunsCsv([
       {
         authMode: "oidc",
         benchmarkItemId: "item-2",
-        benchmarkLabel: "problem9 core",
+        benchmarkLabel: "problem9 active",
         benchmarkPackageDigest: "sha256:def",
         benchmarkPackageId: "problem9",
         benchmarkPackageVersion: "2026.03",
@@ -150,9 +150,7 @@ describe("buildRunsCsv", () => {
       }
     ]);
 
-    expect(csv).toContain(
-      "PP-319,job-2,attempt-2,problem9@2026.03,gpt-oss,GPT OSS,running,Running,active,Active,,,,,2026-03-13T19:58:00.000Z,,"
-    );
+    expect(csv).toContain("PP-319,job-2,attempt-2,problem9@2026.03,gpt-oss,GPT OSS,running,Running,active,Active,,,,,2026-03-13T19:58:00.000Z,,");
   });
 });
 
@@ -246,6 +244,85 @@ describe("benchmark dataset exports", () => {
     expect(csv).toContain("benchmarkPackageId,benchmarkVersions,runId");
     expect(csv).toContain("problem9,2026.03,PP-318,succeeded,pass,openai");
     expect(csv).toContain("job-1,attempt-1,succeeded,pass,accepted");
+  });
+
+  it("keeps non-terminal dataset fields blank until a run or attempt finishes", () => {
+    const csv = buildPortalBenchmarkDatasetCsv({
+      attempts: [
+        {
+          attemptId: "attempt-2",
+          completedAt: null,
+          failure: { code: null, family: null, summary: null },
+          jobId: "job-2",
+          runId: "PP-319",
+          startedAt: "2026-03-13T19:58:30.000Z",
+          state: "active",
+          stopReason: null,
+          verdictClass: null,
+          verifierResult: null
+        }
+      ],
+      benchmark: {
+        benchmarkLabel: "problem9 @ 2026.03",
+        benchmarkPackageId: "problem9",
+        laneIds: ["problem9-default"],
+        latestRunId: null,
+        modelConfigIds: ["gpt-oss"],
+        providerFamilies: ["openai"],
+        versions: ["2026.03"]
+      },
+      jobs: [],
+      runs: [
+        {
+          authMode: "oidc",
+          benchmarkItemId: "item-2",
+          benchmarkLabel: "problem9 active",
+          benchmarkPackageDigest: "sha256:def",
+          benchmarkPackageId: "problem9",
+          benchmarkPackageVersion: "2026.03",
+          benchmarkVersionId: "problem9@2026.03",
+          completedAt: null,
+          durationMs: null,
+          failure: { code: null, family: null, summary: null },
+          laneId: "lane-2",
+          latestAttemptId: "attempt-2",
+          latestJobId: "job-2",
+          lineage: {
+            attemptCount: 1,
+            attemptIds: ["attempt-2"],
+            jobCount: 1,
+            jobIds: ["job-2"],
+            latestAttemptId: "attempt-2",
+            latestJobId: "job-2"
+          },
+          modelConfigId: "gpt-oss",
+          modelConfigLabel: "GPT OSS",
+          modelSnapshotId: "gpt-oss-2026-03-13",
+          providerFamily: "openai",
+          runId: "PP-319",
+          runKind: "single_run",
+          runLifecycleBucket: "active",
+          runMode: "eval",
+          runState: "running",
+          startedAt: "2026-03-13T19:58:00.000Z",
+          toolProfile: "lean4-proof",
+          verdictClass: null
+        }
+      ],
+      summary: {
+        attemptCount: 1,
+        jobCount: 1,
+        latestCompletedAt: null,
+        runCount: 1,
+        verdictCounts: {
+          fail: 0,
+          invalid_result: 0,
+          pass: 0
+        }
+      }
+    });
+
+    expect(csv).toContain("PP-319,running,,openai,gpt-oss,2026-03-13T19:58:00.000Z,,,job-2,attempt-2,active,,,");
   });
 });
 

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -1,14 +1,43 @@
 import { z } from "zod";
 import {
-  attemptLifecycleStateSchema,
   evaluationVerdictClassSchema,
-  jobLifecycleStateSchema,
   runKindSchema,
   runLifecycleStateSchema
 } from "./run-control.js";
 import { runControlPolicySchema, runKindConcurrencyOverrideSchema } from "./run-governance.js";
 
 const timestampSchema = z.string().min(1);
+const portalTerminalRunLifecycleStateSchema = z.enum([
+  "succeeded",
+  "failed",
+  "cancelled"
+]);
+const portalNonTerminalRunLifecycleStateSchema = z.enum([
+  "created",
+  "queued",
+  "running",
+  "cancel_requested"
+]);
+const portalTerminalJobLifecycleStateSchema = z.enum([
+  "completed",
+  "failed",
+  "cancelled"
+]);
+const portalNonTerminalJobLifecycleStateSchema = z.enum([
+  "queued",
+  "claimed",
+  "running",
+  "cancel_requested"
+]);
+const portalTerminalAttemptLifecycleStateSchema = z.enum([
+  "succeeded",
+  "failed",
+  "cancelled"
+]);
+const portalNonTerminalAttemptLifecycleStateSchema = z.enum([
+  "prepared",
+  "active"
+]);
 
 function csvArraySchema<TItem extends z.ZodTypeAny>(itemSchema: TItem) {
   return z.preprocess((value) => {
@@ -85,7 +114,7 @@ export const portalRunLineageSummarySchema = z.object({
   latestJobId: z.string().nullable()
 });
 
-export const portalRunListItemSchema = z.object({
+const portalRunListItemBaseSchema = z.object({
   authMode: z.string(),
   benchmarkItemId: z.string(),
   benchmarkLabel: z.string(),
@@ -93,8 +122,6 @@ export const portalRunListItemSchema = z.object({
   benchmarkPackageId: z.string(),
   benchmarkPackageVersion: z.string(),
   benchmarkVersionId: z.string(),
-  completedAt: timestampSchema.nullable(),
-  durationMs: z.number().int().nonnegative().nullable(),
   failure: portalRunFailureSummarySchema,
   laneId: z.string(),
   latestAttemptId: z.string().nullable(),
@@ -108,11 +135,24 @@ export const portalRunListItemSchema = z.object({
   runKind: runKindSchema,
   runLifecycleBucket: portalRunsLifecycleBucketSchema,
   runMode: z.string(),
-  runState: runLifecycleStateSchema,
   startedAt: timestampSchema,
-  toolProfile: z.string(),
-  verdictClass: evaluationVerdictClassSchema.nullable()
+  toolProfile: z.string()
 });
+
+export const portalRunListItemSchema = z.union([
+  portalRunListItemBaseSchema.extend({
+    completedAt: timestampSchema,
+    durationMs: z.number().int().nonnegative(),
+    runState: portalTerminalRunLifecycleStateSchema,
+    verdictClass: evaluationVerdictClassSchema
+  }),
+  portalRunListItemBaseSchema.extend({
+    completedAt: z.null(),
+    durationMs: z.null(),
+    runState: portalNonTerminalRunLifecycleStateSchema,
+    verdictClass: z.null()
+  })
+]);
 
 export const portalRunsProviderFilterOptionSchema = z.object({
   count: z.number().int().nonnegative(),
@@ -160,29 +200,52 @@ export const portalRunTimelineEntrySchema = z.object({
   state: z.string().nullable()
 });
 
-export const portalRunJobSummarySchema = z.object({
-  completedAt: timestampSchema.nullable(),
+const portalRunJobSummaryBaseSchema = z.object({
   failure: portalRunFailureSummarySchema,
   jobId: z.string().nullable(),
   runId: z.string(),
-  startedAt: timestampSchema,
-  state: jobLifecycleStateSchema,
-  stopReason: z.string().nullable(),
-  verdictClass: evaluationVerdictClassSchema.nullable()
+  startedAt: timestampSchema
 });
 
-export const portalRunAttemptSummarySchema = z.object({
+export const portalRunJobSummarySchema = z.union([
+  portalRunJobSummaryBaseSchema.extend({
+    completedAt: timestampSchema,
+    state: portalTerminalJobLifecycleStateSchema,
+    stopReason: z.string(),
+    verdictClass: evaluationVerdictClassSchema
+  }),
+  portalRunJobSummaryBaseSchema.extend({
+    completedAt: z.null(),
+    state: portalNonTerminalJobLifecycleStateSchema,
+    stopReason: z.null(),
+    verdictClass: z.null()
+  })
+]);
+
+const portalRunAttemptSummaryBaseSchema = z.object({
   attemptId: z.string(),
-  completedAt: timestampSchema.nullable(),
   failure: portalRunFailureSummarySchema,
   jobId: z.string().nullable(),
   runId: z.string(),
-  startedAt: timestampSchema,
-  state: attemptLifecycleStateSchema,
-  stopReason: z.string().nullable(),
-  verdictClass: evaluationVerdictClassSchema.nullable(),
-  verifierResult: z.string().nullable()
+  startedAt: timestampSchema
 });
+
+export const portalRunAttemptSummarySchema = z.union([
+  portalRunAttemptSummaryBaseSchema.extend({
+    completedAt: timestampSchema,
+    state: portalTerminalAttemptLifecycleStateSchema,
+    stopReason: z.string(),
+    verdictClass: evaluationVerdictClassSchema,
+    verifierResult: z.string()
+  }),
+  portalRunAttemptSummaryBaseSchema.extend({
+    completedAt: z.null(),
+    state: portalNonTerminalAttemptLifecycleStateSchema,
+    stopReason: z.null(),
+    verdictClass: z.null(),
+    verifierResult: z.null()
+  })
+]);
 
 export const portalRunArtifactSummarySchema = z.object({
   artifactClassId: z.string(),

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -89,7 +89,17 @@ export type PortalRunLineageSummary = {
   latestJobId: string | null;
 };
 
-export type PortalRunListItem = {
+export type PortalTerminalRunLifecycleState = Extract<
+  RunLifecycleState,
+  "succeeded" | "failed" | "cancelled"
+>;
+
+export type PortalNonTerminalRunLifecycleState = Exclude<
+  RunLifecycleState,
+  PortalTerminalRunLifecycleState
+>;
+
+type PortalRunListItemBase = {
   authMode: string;
   benchmarkItemId: string;
   benchmarkLabel: string;
@@ -97,8 +107,6 @@ export type PortalRunListItem = {
   benchmarkPackageId: string;
   benchmarkPackageVersion: string;
   benchmarkVersionId: string;
-  completedAt: string | null;
-  durationMs: number | null;
   failure: PortalRunFailureSummary;
   laneId: string;
   latestAttemptId: string | null;
@@ -112,11 +120,25 @@ export type PortalRunListItem = {
   runKind: RunKind;
   runLifecycleBucket: PortalRunsLifecycleBucket;
   runMode: string;
-  runState: RunLifecycleState;
   startedAt: string;
   toolProfile: string;
-  verdictClass: EvaluationVerdictClass | null;
 };
+
+export type PortalTerminalRunListItem = PortalRunListItemBase & {
+  completedAt: string;
+  durationMs: number;
+  runState: PortalTerminalRunLifecycleState;
+  verdictClass: EvaluationVerdictClass;
+};
+
+export type PortalNonTerminalRunListItem = PortalRunListItemBase & {
+  completedAt: null;
+  durationMs: null;
+  runState: PortalNonTerminalRunLifecycleState;
+  verdictClass: null;
+};
+
+export type PortalRunListItem = PortalTerminalRunListItem | PortalNonTerminalRunListItem;
 
 export type PortalRunsListResponse = {
   filters: PortalRunsAvailableFilters;
@@ -139,29 +161,78 @@ export type PortalRunTimelineEntry = {
   state: string | null;
 };
 
-export type PortalRunJobSummary = {
-  completedAt: string | null;
+export type PortalTerminalJobLifecycleState = Extract<
+  JobLifecycleState,
+  "completed" | "failed" | "cancelled"
+>;
+
+export type PortalNonTerminalJobLifecycleState = Exclude<
+  JobLifecycleState,
+  PortalTerminalJobLifecycleState
+>;
+
+type PortalRunJobSummaryBase = {
   failure: PortalRunFailureSummary;
   jobId: string | null;
   runId: string;
   startedAt: string;
-  state: JobLifecycleState;
-  stopReason: string | null;
-  verdictClass: EvaluationVerdictClass | null;
 };
 
-export type PortalRunAttemptSummary = {
+export type PortalTerminalRunJobSummary = PortalRunJobSummaryBase & {
+  completedAt: string;
+  state: PortalTerminalJobLifecycleState;
+  stopReason: string;
+  verdictClass: EvaluationVerdictClass;
+};
+
+export type PortalNonTerminalRunJobSummary = PortalRunJobSummaryBase & {
+  completedAt: null;
+  state: PortalNonTerminalJobLifecycleState;
+  stopReason: null;
+  verdictClass: null;
+};
+
+export type PortalRunJobSummary =
+  | PortalTerminalRunJobSummary
+  | PortalNonTerminalRunJobSummary;
+
+export type PortalTerminalAttemptLifecycleState = Extract<
+  AttemptLifecycleState,
+  "succeeded" | "failed" | "cancelled"
+>;
+
+export type PortalNonTerminalAttemptLifecycleState = Exclude<
+  AttemptLifecycleState,
+  PortalTerminalAttemptLifecycleState
+>;
+
+type PortalRunAttemptSummaryBase = {
   attemptId: string;
-  completedAt: string | null;
   failure: PortalRunFailureSummary;
   jobId: string | null;
   runId: string;
   startedAt: string;
-  state: AttemptLifecycleState;
-  stopReason: string | null;
-  verdictClass: EvaluationVerdictClass | null;
-  verifierResult: string | null;
 };
+
+export type PortalTerminalRunAttemptSummary = PortalRunAttemptSummaryBase & {
+  completedAt: string;
+  state: PortalTerminalAttemptLifecycleState;
+  stopReason: string;
+  verdictClass: EvaluationVerdictClass;
+  verifierResult: string;
+};
+
+export type PortalNonTerminalRunAttemptSummary = PortalRunAttemptSummaryBase & {
+  completedAt: null;
+  state: PortalNonTerminalAttemptLifecycleState;
+  stopReason: null;
+  verdictClass: null;
+  verifierResult: null;
+};
+
+export type PortalRunAttemptSummary =
+  | PortalTerminalRunAttemptSummary
+  | PortalNonTerminalRunAttemptSummary;
 
 export type PortalRunArtifactSummary = {
   artifactClassId: string;

--- a/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
+++ b/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   portalBenchmarkDatasetResponseSchema,
+  portalRunAttemptSummarySchema,
+  portalRunJobSummarySchema,
+  portalRunListItemSchema,
   portalRunsListResponseSchema
 } from "../dist/index.js";
 
@@ -40,7 +43,87 @@ const baseRunItem = {
 };
 
 describe("portal benchmark-ops lifecycle contracts", () => {
-  it("allows active and pending runs to omit terminal-only fields", () => {
+  it("accepts non-terminal runs with null terminal-only fields", () => {
+    const parsed = portalRunListItemSchema.parse({
+      ...baseRunItem,
+      completedAt: null,
+      durationMs: null,
+      latestAttemptId: null,
+      latestJobId: null,
+      lineage: {
+        attemptCount: 0,
+        attemptIds: [],
+        jobCount: 0,
+        jobIds: [],
+        latestAttemptId: null,
+        latestJobId: null
+      },
+      runId: "PP-321",
+      runLifecycleBucket: "pending",
+      runState: "queued",
+      verdictClass: null
+    });
+
+    expect(parsed.completedAt).toBeNull();
+    expect(parsed.durationMs).toBeNull();
+    expect(parsed.verdictClass).toBeNull();
+  });
+
+  it("rejects non-terminal runs with invented terminal verdict data", () => {
+    const parsed = portalRunListItemSchema.safeParse({
+      ...baseRunItem,
+      completedAt: "2026-03-13T16:18:00.000Z",
+      durationMs: 0,
+      latestAttemptId: null,
+      latestJobId: null,
+      lineage: {
+        attemptCount: 0,
+        attemptIds: [],
+        jobCount: 0,
+        jobIds: [],
+        latestAttemptId: null,
+        latestJobId: null
+      },
+      runId: "PP-321",
+      runLifecycleBucket: "pending",
+      runState: "queued",
+      verdictClass: "pass"
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts non-terminal job and attempt summaries with null terminal-only fields", () => {
+    const job = portalRunJobSummarySchema.parse({
+      completedAt: null,
+      failure: { code: null, family: null, summary: null },
+      jobId: "job-1",
+      runId: "PP-319",
+      startedAt: "2026-03-13T15:50:39.000Z",
+      state: "running",
+      stopReason: null,
+      verdictClass: null
+    });
+    const attempt = portalRunAttemptSummarySchema.parse({
+      attemptId: "attempt-1",
+      completedAt: null,
+      failure: { code: null, family: null, summary: null },
+      jobId: "job-1",
+      runId: "PP-319",
+      startedAt: "2026-03-13T15:50:39.000Z",
+      state: "active",
+      stopReason: null,
+      verdictClass: null,
+      verifierResult: null
+    });
+
+    expect(job.completedAt).toBeNull();
+    expect(job.stopReason).toBeNull();
+    expect(attempt.completedAt).toBeNull();
+    expect(attempt.verifierResult).toBeNull();
+  });
+
+  it("allows active and pending runs to omit terminal-only fields in the list response", () => {
     const parsed = portalRunsListResponseSchema.parse({
       filters: {
         modelConfigs: [],
@@ -114,7 +197,7 @@ describe("portal benchmark-ops lifecycle contracts", () => {
     expect(parsed.items[1].verdictClass).toBeNull();
   });
 
-  it("allows non-terminal attempt and job summaries to omit terminal-only fields", () => {
+  it("allows non-terminal attempt and job summaries to omit terminal-only fields in dataset responses", () => {
     const parsed = portalBenchmarkDatasetResponseSchema.parse({
       attempts: [
         {


### PR DESCRIPTION
﻿## Summary
- stop exposing terminal-only run, job, and attempt fields on active or pending benchmark-ops records
- update the API serializer and local web benchmark-ops surface to emit nulls for non-terminal state
- add shared, API, and web regression coverage for the new lifecycle contract shape

## Testing
- bun run test:shared
- bun run test:api
- bun test apps/web/src/lib/portal-benchmark-ops.test.js
- bun run build

Closes #989
