### PR TITLE
Fix shared portal route-id drift guards

### DIFF
--- a/apps/web/src/components/portal-freshness-card.tsx
+++ b/apps/web/src/components/portal-freshness-card.tsx
@@ -1,4 +1,4 @@
-import { getPortalLiveViewFreshness } from "@paretoproof/shared";
+import { getPortalLiveViewFreshness, type PortalRouteId } from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import {
   describePortalFreshness,
@@ -10,7 +10,7 @@ type PortalFreshnessCardProps = {
   isRefreshing?: boolean;
   lastUpdatedAt: string | null;
   onRefresh?: () => void;
-  routeId: string;
+  routeId: PortalRouteId;
 };
 
 export function PortalFreshnessCard({

--- a/apps/web/src/lib/portal-freshness.ts
+++ b/apps/web/src/lib/portal-freshness.ts
@@ -1,6 +1,7 @@
 import {
   getPortalLiveViewFreshness,
-  type PortalLiveViewFreshnessEntry
+  type PortalLiveViewFreshnessEntry,
+  type PortalRouteId
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -9,7 +10,7 @@ export type PortalFreshnessState = "fresh" | "manual" | "planned" | "stale";
 type UsePortalPollingOptions = {
   enabled?: boolean;
   onPoll: () => Promise<void>;
-  routeId: string;
+  routeId: PortalRouteId;
 };
 
 export function canPortalRefreshOnDemand(policy: PortalLiveViewFreshnessEntry | null) {

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -3,6 +3,7 @@ import {
   portalRunsSortOptions,
   type PortalBenchmarkExportFormat,
   type EvaluationVerdictClass,
+  type PortalRouteId,
   type PortalRunsLifecycleBucket,
   type PortalLaunchViewResponse,
   type PortalRunDetailResponse,
@@ -44,7 +45,7 @@ import { buildPortalUrl } from "../lib/surface";
 import { useCompactLayout } from "../lib/use-compact-layout";
 
 type PortalBenchmarkOpsSurfaceProps = {
-  activeRouteId: string;
+  activeRouteId: PortalRouteId;
   activeSectionId: "launch" | "runs" | "workers";
   activeRunId: string | null;
   pathname: string;
@@ -436,7 +437,7 @@ export function PortalBenchmarkOpsSurface({
 }
 
 type SurfaceProps<TData> = {
-  activeRouteId: string;
+  activeRouteId: PortalRouteId;
   loadState: LoadState<TData>;
   onRefresh: () => Promise<void>;
 };

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -4,10 +4,11 @@ import {
   getPortalLiveViewFreshness,
   getPortalSectionsForRoles,
   type EvaluationVerdictClass,
-  type RunLifecycleState,
   type PortalActionDefinition,
   type PortalRole,
-  type PortalSectionDefinition
+  type PortalRouteId,
+  type PortalSectionDefinition,
+  type RunLifecycleState
 } from "@paretoproof/shared";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { AppIcon, type AppIconName } from "../components/app-icon";
@@ -40,8 +41,10 @@ type PortalNavGroup = {
   sections: PortalSectionDefinition[];
 };
 
-const portalRoutePathById = new Map(
-  appRouteAccessMatrix.map((entry) => [entry.id, entry.path])
+const portalRoutePathById = new Map<PortalRouteId, string>(
+  appRouteAccessMatrix
+    .filter((entry) => entry.surface === "portal")
+    .map((entry) => [entry.id, entry.path] as [PortalRouteId, string])
 );
 const localPortalStateParamKeys = ["surface", "access", "email", "roles", "reason"] as const;
 
@@ -199,7 +202,7 @@ function getPortalNavGroups(sections: PortalSectionDefinition[]): PortalNavGroup
 
 function resolveActiveSection(
   pathname: string,
-  matchedRouteId: string | null,
+  matchedRouteId: PortalRouteId | null,
   sections: PortalSectionDefinition[]
 ) {
   if (pathname.startsWith("/runs/")) {
@@ -262,7 +265,8 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     activeSection?.id === "workers";
   const overviewRouteActive = activeSection?.id === "overview";
   const activeSectionHref = activeSection ? getSectionHref(activeSection) : "/";
-  const activeRouteId = matchedPortalRoute?.id ?? activeSection?.routeId ?? "portal.home";
+  const activeRouteId: PortalRouteId =
+    matchedPortalRoute?.id ?? activeSection?.routeId ?? "portal.home";
   const activeFreshnessPolicy = useMemo(
     () => getPortalLiveViewFreshness(activeRouteId),
     [activeRouteId]

--- a/packages/shared/src/contracts/portal-actions.ts
+++ b/packages/shared/src/contracts/portal-actions.ts
@@ -1,5 +1,6 @@
 import type { PortalActionDefinition, PortalActionId } from "../types/portal-actions.js";
 import type { PortalRole } from "../types/portal-navigation.js";
+import type { PortalRouteId } from "../types/route-access.js";
 
 type PortalActionBlueprint = {
   collaboratorState: PortalActionDefinition["state"];
@@ -9,7 +10,7 @@ type PortalActionBlueprint = {
   helperState: PortalActionDefinition["state"];
   helperVisible: boolean;
   id: PortalActionId;
-  routeId: string;
+  routeId: PortalRouteId;
   title: string;
 };
 

--- a/packages/shared/src/contracts/portal-live-freshness.ts
+++ b/packages/shared/src/contracts/portal-live-freshness.ts
@@ -1,4 +1,5 @@
 import type { PortalLiveViewFreshnessEntry } from "../types/portal-live-freshness.js";
+import type { PortalRouteId } from "../types/route-access.js";
 
 export const portalLiveViewFreshnessCatalog = [
   {
@@ -75,7 +76,7 @@ export const portalLiveViewFreshnessCatalog = [
   }
 ] satisfies PortalLiveViewFreshnessEntry[];
 
-export function getPortalLiveViewFreshness(routeId: string) {
+export function getPortalLiveViewFreshness(routeId: PortalRouteId) {
   return (
     portalLiveViewFreshnessCatalog.find((entry) => entry.routeId === routeId) ?? null
   );

--- a/packages/shared/src/contracts/route-access.ts
+++ b/packages/shared/src/contracts/route-access.ts
@@ -1,8 +1,13 @@
-import type { AppRouteMatrixEntry } from "../types/route-access.js";
-import type { AppSurface } from "../types/route-access.js";
+import type { AppRouteMatrixEntry, AppSurface } from "../types/route-access.js";
+
+function defineAppRouteEntry<TSurface extends AppSurface>(
+  entry: AppRouteMatrixEntry<TSurface>
+) {
+  return entry;
+}
 
 export const appRouteAccessMatrix = [
-  {
+  defineAppRouteEntry({
     access: "public",
     host: "paretoproof.com",
     id: "public.home",
@@ -10,8 +15,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "public_site",
     summary: "Marketing home and public project overview."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "public",
     host: "paretoproof.com",
     id: "public.project",
@@ -19,8 +24,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "public_site",
     summary: "Compact project pack for mission, contributor path, and contact rules."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "public",
     host: "paretoproof.com",
     id: "public.benchmarks",
@@ -28,8 +33,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "public_site",
     summary: "Public benchmark listing and methodology context."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "public",
     host: "paretoproof.com",
     id: "public.benchmark-report",
@@ -37,8 +42,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "public_site",
     summary: "Published benchmark report and aggregate public results."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "portal_authenticated",
     host: "portal.paretoproof.com",
     id: "portal.home",
@@ -46,8 +51,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "public_home",
     surface: "portal",
     summary: "Authenticated portal landing page after Cloudflare Access."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "access_request_required_only",
     host: "portal.paretoproof.com",
     id: "portal.access-request",
@@ -55,8 +60,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Contributor request screen for authenticated identities that have never been reviewed."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "approved_helper_or_higher",
     host: "portal.paretoproof.com",
     id: "portal.profile",
@@ -64,8 +69,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_pending",
     surface: "portal",
     summary: "Editable contributor profile details and linked Access identities."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "pending_only",
     host: "portal.paretoproof.com",
     id: "portal.pending",
@@ -73,8 +78,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_home",
     surface: "portal",
     summary: "Pending approval holding page after the user is identified."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "denied_only",
     host: "portal.paretoproof.com",
     id: "portal.denied",
@@ -82,8 +87,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Access denied page for rejected or insufficiently provisioned users."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "approved_helper_or_higher",
     host: "portal.paretoproof.com",
     id: "portal.runs",
@@ -91,8 +96,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_pending",
     surface: "portal",
     summary: "Read-only run listing for approved helpers and higher."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "approved_helper_or_higher",
     host: "portal.paretoproof.com",
     id: "portal.run-detail",
@@ -100,8 +105,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_pending",
     surface: "portal",
     summary: "Run detail page with status, events, and artifacts."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "approved_collaborator_or_higher",
     host: "portal.paretoproof.com",
     id: "portal.launch-run",
@@ -109,8 +114,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Run launch flow for collaborators and admins."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "approved_collaborator_or_higher",
     host: "portal.paretoproof.com",
     id: "portal.workers",
@@ -118,8 +123,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Worker fleet and queue overview for collaborators and admins."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "admin_only",
     host: "portal.paretoproof.com",
     id: "portal.admin.access-requests",
@@ -127,8 +132,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Manual contributor approval screen for portal admins."
-  },
-  {
+  }),
+  defineAppRouteEntry({
     access: "admin_only",
     host: "portal.paretoproof.com",
     id: "portal.admin.users",
@@ -136,8 +141,8 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Role management and contributor state inspection for admins."
-  }
-] satisfies AppRouteMatrixEntry[];
+  })
+] as const;
 
 export function matchesAppRoutePath(routePath: string, pathname: string) {
   if (routePath === pathname) {
@@ -160,10 +165,13 @@ export function matchesAppRoutePath(routePath: string, pathname: string) {
   });
 }
 
-export function findAppRouteBySurface(surface: AppSurface, pathname: string) {
-  return (
-    appRouteAccessMatrix.find(
-      (entry) => entry.surface === surface && matchesAppRoutePath(entry.path, pathname)
-    ) ?? null
+export function findAppRouteBySurface<TSurface extends AppSurface>(
+  surface: TSurface,
+  pathname: string
+) {
+  const matchingEntry = appRouteAccessMatrix.find(
+    (entry) => entry.surface === surface && matchesAppRoutePath(entry.path, pathname)
   );
+
+  return (matchingEntry as AppRouteMatrixEntry<TSurface> | undefined) ?? null;
 }

--- a/packages/shared/src/types/portal-actions.ts
+++ b/packages/shared/src/types/portal-actions.ts
@@ -1,4 +1,5 @@
 import type { PortalRole } from "./portal-navigation.js";
+import type { PortalRouteId } from "./route-access.js";
 
 export type PortalActionId =
   | "review_runs"
@@ -13,7 +14,7 @@ export type PortalActionDefinition = {
   description: string;
   disabledReason?: string;
   id: PortalActionId;
-  routeId: string;
+  routeId: PortalRouteId;
   state: PortalActionState;
   title: string;
   visibleTo: PortalRole[];

--- a/packages/shared/src/types/portal-live-freshness.ts
+++ b/packages/shared/src/types/portal-live-freshness.ts
@@ -1,10 +1,12 @@
+import type { PortalRouteId } from "./route-access.js";
+
 export type PortalLiveViewMode = "manual" | "polling";
 
 export type PortalLiveViewFreshnessEntry = {
   description: string;
   mode: PortalLiveViewMode;
   pollIntervalMs: number | null;
-  routeId: string;
+  routeId: PortalRouteId;
   staleAfterMs: number | null;
   title: string;
 };

--- a/packages/shared/src/types/portal-navigation.ts
+++ b/packages/shared/src/types/portal-navigation.ts
@@ -1,3 +1,5 @@
+import type { PortalRouteId } from "./route-access.js";
+
 export type PortalRole = "admin" | "collaborator" | "helper";
 
 export type PortalSectionId =
@@ -18,7 +20,7 @@ export type PortalSectionDefinition = {
   description: string;
   id: PortalSectionId;
   navLabel: string;
-  routeId: string;
+  routeId: PortalRouteId;
   summary: string;
   visibility: PortalSectionVisibility;
 };

--- a/packages/shared/src/types/route-access.ts
+++ b/packages/shared/src/types/route-access.ts
@@ -1,5 +1,12 @@
 export type AppSurface = "public_site" | "portal";
 
+export type PublicRouteId = `public.${string}`;
+export type PortalRouteId = `portal.${string}`;
+export type AppRouteId = PublicRouteId | PortalRouteId;
+
+export type AppRouteIdForSurface<TSurface extends AppSurface> =
+  TSurface extends "portal" ? PortalRouteId : PublicRouteId;
+
 export type RouteAccessLevel =
   | "public"
   | "portal_authenticated"
@@ -16,12 +23,12 @@ export type RouteRedirectTarget =
   | "portal_pending"
   | "portal_denied";
 
-export type AppRouteMatrixEntry = {
+export type AppRouteMatrixEntry<TSurface extends AppSurface = AppSurface> = {
   access: RouteAccessLevel;
   host: string;
-  id: string;
+  id: AppRouteIdForSurface<TSurface>;
   path: string;
   redirectIfDenied: RouteRedirectTarget;
-  surface: AppSurface;
+  surface: TSurface;
   summary: string;
 };

--- a/packages/shared/test/route-access.test.js
+++ b/packages/shared/test/route-access.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
   findAppRouteBySurface,
-  matchesAppRoutePath
+  matchesAppRoutePath,
+  appRouteAccessMatrix,
+  getPortalActionsForRoles,
+  portalLiveViewFreshnessCatalog,
+  portalSectionDefinitions
 } from "../dist/index.js";
 
 describe("route ownership matrix helpers", () => {
@@ -24,5 +28,33 @@ describe("route ownership matrix helpers", () => {
     expect(findAppRouteBySurface("portal", "/runs/run-123")?.id).toBe(
       "portal.run-detail"
     );
+  });
+
+  it("keeps portal route-linked catalogs aligned with the portal route matrix", () => {
+    expect(
+      appRouteAccessMatrix.every((entry) =>
+        entry.surface === "portal"
+          ? entry.id.startsWith("portal.")
+          : entry.id.startsWith("public.")
+      )
+    ).toBe(true);
+
+    const portalRouteIds = appRouteAccessMatrix
+      .filter((entry) => entry.surface === "portal")
+      .map((entry) => entry.id);
+    const navigationRouteIds = portalSectionDefinitions.map((section) => section.routeId);
+    const freshnessRouteIds = portalLiveViewFreshnessCatalog.map((entry) => entry.routeId);
+    const actionRouteIds = getPortalActionsForRoles(["admin"]).map((action) => action.routeId);
+    const coveredRouteIds = new Set([...navigationRouteIds, ...freshnessRouteIds]);
+
+    expect(new Set(navigationRouteIds).size).toBe(navigationRouteIds.length);
+    expect(new Set(freshnessRouteIds).size).toBe(freshnessRouteIds.length);
+    expect(new Set(actionRouteIds).size).toBe(actionRouteIds.length);
+    expect(navigationRouteIds.every((routeId) => portalRouteIds.includes(routeId))).toBe(true);
+    expect(freshnessRouteIds.every((routeId) => portalRouteIds.includes(routeId))).toBe(true);
+    expect(actionRouteIds.every((routeId) => portalRouteIds.includes(routeId))).toBe(true);
+    expect(
+      portalRouteIds.filter((routeId) => !coveredRouteIds.has(routeId)).sort()
+    ).toEqual(["portal.access-request", "portal.denied", "portal.pending"]);
   });
 });


### PR DESCRIPTION
## Summary
- add typed shared route-id contracts for portal route-linked catalogs and direct web consumers
- enforce per-row route matrix surface/id coupling and type portal portal-action route IDs
- add shared parity coverage for navigation, freshness, actions, and route-matrix surface/id prefix alignment

## Testing
- bun run test:shared
- bun run typecheck:web
- bun run build

Closes #990