### PR TITLE
Bind Problem 9 benchmark target artifacts

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check Problem 9 image policy
         run: node infra/scripts/check-problem9-image-policy.mjs
 
+      - name: Check Problem 9 package cohesion
+        run: node infra/scripts/check-problem9-package-cohesion.mjs
+
       - name: Check deployment workflow Node runtimes
         run: node infra/scripts/check-deployment-workflow-node-runtime.mjs
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -35,7 +35,9 @@ jobs:
         run: node infra/scripts/check-problem9-image-policy.mjs
 
       - name: Check Problem 9 package cohesion
-        run: node infra/scripts/check-problem9-package-cohesion.mjs
+        run: >-
+          node infra/scripts/check-problem9-package-cohesion.mjs &&
+          node --test infra/scripts/test/problem9-package-cohesion.test.mjs
 
       - name: Check deployment workflow Node runtimes
         run: node infra/scripts/check-deployment-workflow-node-runtime.mjs

--- a/apps/worker/test/problem9-integrity.test.ts
+++ b/apps/worker/test/problem9-integrity.test.ts
@@ -13,9 +13,9 @@ import {
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
 
 const expectedIntegrityDigests = {
-  benchmarkPackage: "e1655ac26ee234718c07c719396c7856c55895974092753d48cf7763622df345",
-  promptPackage: "c8b3b51316ab410631804b8e132fcacd009f929ff2bba097cfcc564e92c5f203",
-  runBundle: "2ec1ea32e9cf567bb92f4a781c95be83089f8b73871a075a4c66c8f6d4340580"
+  benchmarkPackage: "ca378023961740adbef777501d689757c1a38070399e686a8e3d4354caf520ac",
+  promptPackage: "ddebfb1bfdddd88b6b273c9770b4e97c78bb4ccc9a35cf64248dd1aa7238d1fb",
+  runBundle: "7fa0ac8d5e332ec018333aab54ce89008fe29f08f902371485e46e60abbd3cfb"
 } as const;
 
 // Update these only when the checked-in canonical Problem 9 fixtures intentionally change.

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean
@@ -1,9 +1,8 @@
-import FirstProof.Problem9.Support
+import FirstProof.Problem9.Statement
 
 namespace FirstProof.Problem9
 
-theorem problem9_gold (n : Nat) :
-    2 * triangular n = n * Nat.succ n := by
+theorem problem9_gold (n : Nat) : problem9_target n := by
   induction n with
   | zero =>
       rfl

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
@@ -2,6 +2,8 @@ import FirstProof.Problem9.Support
 
 namespace FirstProof.Problem9
 
-axiom problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n
+def problem9_target (n : Nat) : Prop := 2 * triangular n = n * Nat.succ n
+
+axiom problem9 (n : Nat) : problem9_target n
 
 end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
+++ b/benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean
@@ -2,8 +2,8 @@ import FirstProof.Problem9.Support
 
 namespace FirstProof.Problem9
 
-def problem9_target (n : Nat) : Prop := 2 * triangular n = n * Nat.succ n
+abbrev problem9_target (n : Nat) : Prop := 2 * triangular n = n * Nat.succ n
 
-axiom problem9 (n : Nat) : problem9_target n
+axiom problem9 (n : Nat) : 2 * triangular n = n * Nat.succ n
 
 end FirstProof.Problem9

--- a/benchmarks/firstproof/problem9/README.md
+++ b/benchmarks/firstproof/problem9/README.md
@@ -12,8 +12,8 @@ materialized manifest:
   `firstproof/Problem9/` output tree and writes a generated
   `benchmark-package.json` there with the file-hash inventory and package digest
 
-The benchmark theorem for this initial package is a narrow recurrence identity
-for the benchmark-owned `triangular` helper:
+The benchmark theorem for this package is the closed-form triangular-number
+identity for the benchmark-owned `triangular` helper:
 
 `2 * triangular n = n * (n + 1)`
 
@@ -24,7 +24,7 @@ reference proof:
   leaking the gold proof into prompt materialization
 - `FirstProof/Problem9/Gold.lean` carries the repository-owned proof artifact
 - `FirstProof/Problem9/Support.lean` keeps the benchmark-owned helper and the
-  old recurrence identity only as a support lemma
+  supporting recurrence and arithmetic lemmas used by the gold proof
 
 This keeps the immutable package honest while preserving deterministic local
 materialization and verifier behavior.

--- a/docs/problem9-benchmark-target-baseline.md
+++ b/docs/problem9-benchmark-target-baseline.md
@@ -1,121 +1,72 @@
 # Problem 9 Benchmark Target Baseline
 
-This document decides whether the repository-owned `firstproof/Problem9` package should remain a bootstrap theorem or now become the intended canonical benchmark target for the current ParetoProof kernel.
+`firstproof/Problem9` is the current canonical benchmark target for the
+repository-owned ParetoProof kernel.
 
-## Current baseline
+## Current target
 
-- `benchmarks/firstproof/problem9/README.md` still says the checked-in theorem is intentionally small while the broader runner and verifier stack lands.
-- `docs/benchmarks.md` already treats `firstproof/Problem9` as the benchmark slice that exercises package materialization, local attempts, verifier output, offline ingest, and hosted worker execution.
-- The current theorem in `benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean` is the helper recurrence itself:
+- canonical statement module:
+  `benchmarks/firstproof/problem9/FirstProof/Problem9/Statement.lean`
+- canonical gold module:
+  `benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean`
+- canonical human statement:
+  `benchmarks/firstproof/problem9/statements/problem.md`
 
-  `triangular (Nat.succ n) = triangular n + Nat.succ n`
+The benchmark theorem is the closed-form triangular-number identity:
 
-- The current gold proof in `benchmarks/firstproof/problem9/FirstProof/Problem9/Gold.lean` is a thin restatement of that same theorem.
+`2 * triangular n = n * (n + 1)`
 
-The package is therefore already operationally central while still mathematically acting like a bootstrap fixture.
+The Lean statement uses the equivalent `n * Nat.succ n` spelling.
 
-## Decision
+## Binding rules
 
-`firstproof/Problem9` should stop being treated as a bootstrap theorem and should be upgraded now to the intended canonical benchmark target for the current platform iteration.
+The checked-in package must keep these layers aligned:
 
-The package identity stays the same:
+- `benchmark-package.json` names `Statement`, `Support`, and `Gold` as the
+  canonical modules
+- `lakefile.toml` default-builds `FirstProof.Problem9.Gold`
+- `Gold.lean` imports `Statement.lean`
+- `Statement.lean` defines the benchmark proposition as `problem9_target`
+- both the exported statement axiom and the gold artifact bind to
+  `problem9_target n` instead of restating the proposition independently under
+  disconnected contracts
 
-- package id remains `firstproof/Problem9`
-- benchmark family remains `firstproof`
-- benchmark item id remains `Problem9`
+That arrangement keeps the package-local default build on the same path as the
+canonical statement contract.
 
-The canonical theorem target should change.
+## Package shape
 
-## Canonical target
+The benchmark remains one immutable package version with:
 
-The canonical `Problem9` theorem should become the triangular-number closed-form identity without division:
-
-- mathematical statement: `2 * triangular n = n * (n + 1)`
-- Lean statement may use the equivalent `n * Nat.succ n` spelling if that keeps the theorem and proof clearer in code
-
-This is the accepted benchmark target for the next package revision.
-
-## Why this target
-
-The current recurrence identity is not a truthful long-term benchmark target because it is too close to the helper definition itself.
-
-The closed-form identity is a better canonical target because it:
-
-- still lives on the same benchmark-owned `triangular` helper
-- remains small enough to review, version, and verify reproducibly inside the existing package-driven kernel
-- requires genuine proof work rather than direct definitional unfolding
-- exercises induction and arithmetic normalization instead of only restating one recursive equation
-- stays compatible with the current Lean lanes without introducing division-specific portability questions
-
-This is the smallest target change that makes the benchmark materially more honest while preserving the surrounding package, verifier, and worker infrastructure.
-
-## Status of the current theorem
-
-The current recurrence identity should no longer be the benchmark target once the follow-up implementation lands.
-
-It may remain in the package as one of:
-
-- a support lemma used by the canonical proof
-- a helper theorem documented as bootstrap history
-- a negative or control fixture only if that later proves useful
-
-It should not remain the exported benchmark statement that the package asks models to prove.
-
-## Benchmark shape that stays fixed
-
-This decision does not create a new benchmark family or a multi-problem suite.
-
-The canonical benchmark should still be:
-
-- one repository-owned immutable package
 - one statement module
 - one support module
 - one gold-proof module
-- one benchmark-owned problem markdown statement
-- one released package version at a time through the existing package materialization path
+- one benchmark statement markdown file
 
-The next benchmark target should therefore stress the theorem, not the surrounding package topology.
+The support module may contain helper lemmas needed by the benchmark-owned
+proof, but the exported statement stays the single benchmark target.
 
-## Proof difficulty boundary
+## Documentation truth
 
-The upgraded canonical target should stay within a reviewable and reproducible proof envelope.
+Benchmark-facing docs should describe the checked-in closed-form target as
+current reality, not as future upgrade work.
 
-The follow-up implementation should preserve these constraints:
+The following files are part of that truth surface:
 
-- the theorem must not be provable by direct `rfl` or by merely restating the helper recurrence
-- the gold proof should make the real reasoning visible, typically through explicit induction plus arithmetic normalization
-- the statement should avoid avoidable encoding noise that would make failures more about theorem-encoding trivia than about mathematical reasoning
-- the benchmark should remain self-contained inside the benchmark-owned helper and statement files rather than depending on a broad external theorem library search problem
+- `benchmarks/firstproof/problem9/README.md`
+- `benchmarks/firstproof/problem9/statements/problem.md`
+- `docs/benchmarks.md`
+- this document
 
-This keeps the benchmark meaningful without turning `Problem9` into a large-mathlib integration exercise.
+## Verification
 
-## Package-version implications
+The repository should fail validation if:
 
-The current checked-in package version represents bootstrap history, not the final benchmark truth.
+- the canonical module names drift from the checked-in package files
+- the default Lake target stops building through `Gold.lean`
+- `Gold.lean` stops importing `Statement.lean`
+- `Statement.lean` stops defining the canonical `problem9_target`
+- the gold artifact stops proving `problem9_target n`
 
-The follow-up execution work should therefore:
-
-- bump the immutable package version when the theorem target changes
-- update the statement markdown, Lean statement, and gold proof together in one package revision
-- refresh verifier goldens, negative fixtures, and worker-facing docs so they describe the upgraded target truthfully
-
-The package id should not fork into a new benchmark name just to hide that the original theorem was provisional.
-
-## What this decision does not do
-
-This scope does not:
-
-- implement the upgraded theorem or proof
-- define the broader benchmark intake and curation-review workflow
-- reopen the current package-driven kernel model
-- require a new hostname or new portal benchmark-authoring surface
-- commit the project to a much larger benchmark family before the current canonical package is honest
-
-## Follow-up execution slices
-
-Execution work after this scope should split into:
-
-1. upgrade `benchmarks/firstproof/problem9` so `Statement.lean`, `Gold.lean`, `README.md`, and `statements/problem.md` all describe the closed-form target consistently
-2. refresh verifier goldens and negative fixtures so they fail on the old bootstrap statement and pass on the new canonical theorem
-3. update worker, ingest, and benchmark-facing docs so `firstproof/Problem9` is described as the canonical current benchmark rather than a temporary tiny theorem
-4. re-check any prompt-package or attempt-smoke expectations that still encode the old recurrence statement
+That keeps the benchmark target, gold proof artifact, and default local build
+mechanically aligned.

--- a/docs/problem9-benchmark-target-baseline.md
+++ b/docs/problem9-benchmark-target-baseline.md
@@ -26,10 +26,11 @@ The checked-in package must keep these layers aligned:
   canonical modules
 - `lakefile.toml` default-builds `FirstProof.Problem9.Gold`
 - `Gold.lean` imports `Statement.lean`
-- `Statement.lean` defines the benchmark proposition as `problem9_target`
-- both the exported statement axiom and the gold artifact bind to
-  `problem9_target n` instead of restating the proposition independently under
-  disconnected contracts
+- `Statement.lean` keeps the exported `problem9` header stable for worker-facing
+  statement extraction and also defines `problem9_target` as the shared
+  proposition alias
+- `Gold.lean` proves `problem9_target n` instead of restating the proposition
+  independently under a disconnected contract
 
 That arrangement keeps the package-local default build on the same path as the
 canonical statement contract.
@@ -63,10 +64,12 @@ The following files are part of that truth surface:
 The repository should fail validation if:
 
 - the canonical module names drift from the checked-in package files
-- the default Lake target stops building through `Gold.lean`
+- the default Lake target stops pointing at `Gold.lean`
 - `Gold.lean` stops importing `Statement.lean`
 - `Statement.lean` stops defining the canonical `problem9_target`
+- `Statement.lean` changes the exported `problem9` theorem header away from the
+  canonical benchmark statement
 - the gold artifact stops proving `problem9_target n`
 
-That keeps the benchmark target, gold proof artifact, and default local build
-mechanically aligned.
+That keeps the benchmark target, gold proof artifact, and default local package
+entrypoint mechanically aligned.

--- a/infra/scripts/check-problem9-package-cohesion.mjs
+++ b/infra/scripts/check-problem9-package-cohesion.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { hasExpectedCanonicalModules } from "./lib/problem9-package-cohesion.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 const benchmarkRoot = path.join(repoRoot, "benchmarks", "firstproof", "problem9");
@@ -28,10 +29,7 @@ const lakefile = readText(lakefilePath);
 const statementSource = readText(statementPath);
 const goldSource = readText(goldPath);
 
-if (
-  JSON.stringify(benchmarkPackage.canonicalModules) !==
-  JSON.stringify(expectedCanonicalModules)
-) {
+if (!hasExpectedCanonicalModules(benchmarkPackage.canonicalModules, expectedCanonicalModules)) {
   fail(
     `canonicalModules must stay aligned with ${JSON.stringify(expectedCanonicalModules)}`
   );

--- a/infra/scripts/check-problem9-package-cohesion.mjs
+++ b/infra/scripts/check-problem9-package-cohesion.mjs
@@ -54,15 +54,19 @@ if (
 }
 
 if (
-  !/def\s+problem9_target\s*\(n\s*:\s*Nat\)\s*:\s*Prop\s*:=\s*2\s*\*\s*triangular n\s*=\s*n\s*\*\s*Nat\.succ n/.test(
+  !/abbrev\s+problem9_target\s*\(n\s*:\s*Nat\)\s*:\s*Prop\s*:=\s*2\s*\*\s*triangular n\s*=\s*n\s*\*\s*Nat\.succ n/.test(
     statementSource
   )
 ) {
   fail("Statement.lean must define the canonical problem9_target proposition");
 }
 
-if (!/axiom\s+problem9\s*\(n\s*:\s*Nat\)\s*:\s*problem9_target n/.test(statementSource)) {
-  fail("Statement.lean must bind the exported problem9 axiom to problem9_target");
+if (
+  !/axiom\s+problem9\s*\(n\s*:\s*Nat\)\s*:\s*2\s*\*\s*triangular n\s*=\s*n\s*\*\s*Nat\.succ n/.test(
+    statementSource
+  )
+) {
+  fail("Statement.lean must keep the exported problem9 header on the canonical benchmark proposition");
 }
 
 if (!goldSource.includes("import FirstProof.Problem9.Statement")) {

--- a/infra/scripts/check-problem9-package-cohesion.mjs
+++ b/infra/scripts/check-problem9-package-cohesion.mjs
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const benchmarkRoot = path.join(repoRoot, "benchmarks", "firstproof", "problem9");
+
+const benchmarkPackagePath = path.join(benchmarkRoot, "benchmark-package.json");
+const lakefilePath = path.join(benchmarkRoot, "lakefile.toml");
+const statementPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Statement.lean");
+const goldPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Gold.lean");
+
+const expectedCanonicalModules = {
+  statement: "FirstProof.Problem9.Statement",
+  support: "FirstProof.Problem9.Support",
+  gold: "FirstProof.Problem9.Gold"
+};
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function fail(message) {
+  throw new Error(`Problem 9 package cohesion check failed: ${message}`);
+}
+
+const benchmarkPackage = JSON.parse(readText(benchmarkPackagePath));
+const lakefile = readText(lakefilePath);
+const statementSource = readText(statementPath);
+const goldSource = readText(goldPath);
+
+if (
+  JSON.stringify(benchmarkPackage.canonicalModules) !==
+  JSON.stringify(expectedCanonicalModules)
+) {
+  fail(
+    `canonicalModules must stay aligned with ${JSON.stringify(expectedCanonicalModules)}`
+  );
+}
+
+const defaultTargetsMatch = lakefile.match(/defaultTargets\s*=\s*\[(?<targets>[^\]]+)\]/);
+if (!defaultTargetsMatch?.groups?.targets) {
+  fail("lakefile.toml must declare defaultTargets");
+}
+
+const defaultTargets = defaultTargetsMatch.groups.targets
+  .split(",")
+  .map((value) => value.trim().replace(/^"|"$/g, ""));
+
+if (
+  defaultTargets.length !== 1 ||
+  defaultTargets[0] !== benchmarkPackage.canonicalModules.gold
+) {
+  fail("lakefile.toml defaultTargets must contain only the canonical gold module");
+}
+
+if (
+  !/def\s+problem9_target\s*\(n\s*:\s*Nat\)\s*:\s*Prop\s*:=\s*2\s*\*\s*triangular n\s*=\s*n\s*\*\s*Nat\.succ n/.test(
+    statementSource
+  )
+) {
+  fail("Statement.lean must define the canonical problem9_target proposition");
+}
+
+if (!/axiom\s+problem9\s*\(n\s*:\s*Nat\)\s*:\s*problem9_target n/.test(statementSource)) {
+  fail("Statement.lean must bind the exported problem9 axiom to problem9_target");
+}
+
+if (!goldSource.includes("import FirstProof.Problem9.Statement")) {
+  fail("Gold.lean must import Statement.lean");
+}
+
+if (!/theorem\s+problem9_gold\s*\(n\s*:\s*Nat\)\s*:\s*problem9_target n\s*:=\s*by/.test(goldSource)) {
+  fail(
+    "Gold.lean must prove problem9_target n instead of restating the proposition independently"
+  );
+}

--- a/infra/scripts/lib/problem9-package-cohesion.mjs
+++ b/infra/scripts/lib/problem9-package-cohesion.mjs
@@ -1,0 +1,20 @@
+export function hasExpectedCanonicalModules(actual, expected) {
+  if (!actual || typeof actual !== "object" || Array.isArray(actual)) {
+    return false;
+  }
+
+  const actualEntries = Object.entries(actual).sort(([leftKey], [rightKey]) =>
+    leftKey.localeCompare(rightKey)
+  );
+  const expectedEntries = Object.entries(expected).sort(([leftKey], [rightKey]) =>
+    leftKey.localeCompare(rightKey)
+  );
+
+  return (
+    actualEntries.length === expectedEntries.length &&
+    actualEntries.every(([actualKey, actualValue], index) => {
+      const [expectedKey, expectedValue] = expectedEntries[index];
+      return actualKey === expectedKey && actualValue === expectedValue;
+    })
+  );
+}

--- a/infra/scripts/test/problem9-package-cohesion.test.mjs
+++ b/infra/scripts/test/problem9-package-cohesion.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasExpectedCanonicalModules } from "../lib/problem9-package-cohesion.mjs";
+
+const expectedCanonicalModules = {
+  statement: "FirstProof.Problem9.Statement",
+  support: "FirstProof.Problem9.Support",
+  gold: "FirstProof.Problem9.Gold"
+};
+
+test("hasExpectedCanonicalModules ignores object key order", () => {
+  assert.equal(
+    hasExpectedCanonicalModules(
+      {
+        gold: "FirstProof.Problem9.Gold",
+        statement: "FirstProof.Problem9.Statement",
+        support: "FirstProof.Problem9.Support"
+      },
+      expectedCanonicalModules
+    ),
+    true
+  );
+});
+
+test("hasExpectedCanonicalModules rejects missing or mismatched module bindings", () => {
+  assert.equal(
+    hasExpectedCanonicalModules(
+      {
+        statement: "FirstProof.Problem9.Statement",
+        gold: "FirstProof.Problem9.Gold"
+      },
+      expectedCanonicalModules
+    ),
+    false
+  );
+
+  assert.equal(
+    hasExpectedCanonicalModules(
+      {
+        statement: "FirstProof.Problem9.Statement",
+        support: "FirstProof.Problem9.DifferentSupport",
+        gold: "FirstProof.Problem9.Gold"
+      },
+      expectedCanonicalModules
+    ),
+    false
+  );
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:deployment-workflow-node-runtime": "node infra/scripts/check-deployment-workflow-node-runtime.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",
-    "check:problem9-package-cohesion": "node infra/scripts/check-problem9-package-cohesion.mjs",
+    "check:problem9-package-cohesion": "node infra/scripts/check-problem9-package-cohesion.mjs && node --test infra/scripts/test/problem9-package-cohesion.test.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
     "test:startup-validation": "bun infra/scripts/startup-validation-smoke.ts",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:deployment-workflow-node-runtime": "node infra/scripts/check-deployment-workflow-node-runtime.mjs",
     "check:env-contract": "node infra/scripts/check-runtime-env-examples.mjs",
     "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",
+    "check:problem9-package-cohesion": "node infra/scripts/check-problem9-package-cohesion.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
     "test:startup-validation": "bun infra/scripts/startup-validation-smoke.ts",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",


### PR DESCRIPTION
## Summary
- bind the checked-in gold proof to the shared Problem 9 statement contract without changing the exported worker-facing statement header
- add a repository cohesion check for benchmark metadata, lake target, statement alias, and gold import/proof shape
- refresh the stale Problem 9 baseline doc and update deterministic integrity digests for the intentional benchmark artifact change

## Testing
- node infra/scripts/check-problem9-package-cohesion.mjs
- bun run test:worker:verifier-smoke
- node --import tsx --test test/problem9-integrity.test.ts
- bun run build

Closes #991