### PR TITLE
Narrow branded auth origin trust

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -27,7 +27,9 @@ CLOUDFLARE_GLOBAL_API_KEY=replace-with-a-cloudflare-global-api-key-when-not-usin
 CLOUDFLARE_ACCOUNT_ID=replace-with-your-cloudflare-account-id
 
 # Optional local runtime overrides. Expand only for deliberate local testing.
-CORS_ALLOWED_ORIGINS=https://auth.paretoproof.com,https://portal.paretoproof.com
+# Set CORS_ALLOW_LOCALHOST=true when previewing loopback-mapped branded auth hosts
+# against the local API finalize-submit boundary.
+CORS_ALLOWED_ORIGINS=https://portal.paretoproof.com
 CORS_ALLOW_LOCALHOST=false
 
 # Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them.

--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -71,11 +71,8 @@ function normalizeTeamDomain(teamDomain: string) {
   return teamDomain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
 }
 
-function usesBrandedFinalizeRelayAudiences(routePath: string) {
-  return (
-    routePath === "/portal/session/finalize" ||
-    routePath === "/portal/session/finalize/submit"
-  );
+function usesBrandedFinalizeRelayAudiences(method: string, routePath: string) {
+  return method === "POST" && routePath === "/portal/session/finalize/submit";
 }
 
 export function readCookieValue(cookieHeader: string | undefined, name: string) {
@@ -273,7 +270,7 @@ export function createCloudflareAccessVerifier(options: {
 }
 
 export function selectCloudflareAccessVerifier(
-  request: Pick<FastifyRequest, "raw" | "routeOptions">,
+  request: Pick<FastifyRequest, "method" | "raw" | "routeOptions">,
   verifiers: CloudflareAccessVerifierSet
 ) {
   const routePath = request.routeOptions?.url ?? request.raw.url ?? "";
@@ -282,7 +279,7 @@ export function selectCloudflareAccessVerifier(
     return verifiers.internal;
   }
 
-  if (usesBrandedFinalizeRelayAudiences(routePath)) {
+  if (usesBrandedFinalizeRelayAudiences(request.method, routePath)) {
     return verifiers.brandedRelay;
   }
 

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -44,7 +44,26 @@ function readBrandedAuthOrigins() {
 }
 
 function usesBrandedFinalizeSubmitCorsBoundary(method: string, routePath: string) {
-  return method === "POST" && routePath === "/portal/session/finalize/submit";
+  return (
+    routePath === "/portal/session/finalize/submit" &&
+    (method === "POST" || method === "OPTIONS")
+  );
+}
+
+export function readCorsRoutePath(routePath: string | undefined, rawUrl: string | undefined) {
+  if (routePath && routePath !== "*") {
+    return routePath;
+  }
+
+  if (!rawUrl || rawUrl === "*") {
+    return routePath ?? "";
+  }
+
+  try {
+    return new URL(rawUrl, "http://localhost").pathname;
+  } catch {
+    return rawUrl.split("?")[0] ?? rawUrl;
+  }
 }
 
 export function isAllowedCorsOrigin(options: {
@@ -94,7 +113,10 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
 
   await app.register(cors, {
     delegator(request, callback) {
-      const routePath = request.routeOptions.url ?? request.raw.url ?? "";
+      const routePath = readCorsRoutePath(
+        request.routeOptions.url,
+        request.raw.url
+      );
 
       callback(null, {
         credentials: true,

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -15,23 +15,70 @@ import {
 } from "../middleware/rate-limit.js";
 import {
   createTrustedMutationOriginHook,
+  isAllowedLocalBrandedAuthOrigin,
   isAllowedLocalOrigin,
   normalizeOrigin
 } from "./trusted-mutation-origin.js";
 
-function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
+export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
+  const brandedAuthOrigins = new Set(readBrandedAuthOrigins());
   const baselineOrigins = [
-    "https://auth.paretoproof.com",
-    "https://github.auth.paretoproof.com",
-    "https://google.auth.paretoproof.com",
     "https://portal.paretoproof.com"
   ];
 
   return [
     ...new Set(
-      [...baselineOrigins, ...runtimeEnv.corsAllowedOrigins].map(normalizeOrigin)
+      [...baselineOrigins, ...runtimeEnv.corsAllowedOrigins]
+        .map(normalizeOrigin)
+        .filter((origin) => !brandedAuthOrigins.has(origin))
     )
   ];
+}
+
+function readBrandedAuthOrigins() {
+  return [
+    "https://auth.paretoproof.com",
+    "https://github.auth.paretoproof.com",
+    "https://google.auth.paretoproof.com"
+  ];
+}
+
+function usesBrandedFinalizeSubmitCorsBoundary(method: string, routePath: string) {
+  return method === "POST" && routePath === "/portal/session/finalize/submit";
+}
+
+export function isAllowedCorsOrigin(options: {
+  allowLocalhostCors: boolean;
+  allowedOrigins: string[];
+  brandedAuthOrigins: string[];
+  method: string;
+  origin: string;
+  routePath: string;
+}) {
+  const normalizedOrigin = normalizeOrigin(options.origin);
+
+  if (options.allowedOrigins.includes(normalizedOrigin)) {
+    return true;
+  }
+
+  if (options.allowLocalhostCors && isAllowedLocalOrigin(normalizedOrigin)) {
+    return true;
+  }
+
+  if (
+    !usesBrandedFinalizeSubmitCorsBoundary(options.method, options.routePath)
+  ) {
+    return false;
+  }
+
+  if (options.brandedAuthOrigins.includes(normalizedOrigin)) {
+    return true;
+  }
+
+  return (
+    options.allowLocalhostCors &&
+    isAllowedLocalBrandedAuthOrigin(normalizedOrigin)
+  );
 }
 
 export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
@@ -42,27 +89,38 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
   const requireAccess = createAccessGuard(db);
   const rateLimitPreHandlers = createRateLimitPreHandlers(createInMemoryRateLimiter());
   const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
+  const brandedAuthOrigins = readBrandedAuthOrigins();
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
 
   await app.register(cors, {
-    credentials: true,
-    origin(origin, callback) {
-      if (!origin) {
-        callback(null, true);
-        return;
-      }
+    delegator(request, callback) {
+      const routePath = request.routeOptions.url ?? request.raw.url ?? "";
 
-      const normalizedOrigin = normalizeOrigin(origin);
+      callback(null, {
+        credentials: true,
+        origin(origin, originCallback) {
+          if (!origin) {
+            originCallback(null, true);
+            return;
+          }
 
-      if (
-        allowedOrigins.includes(normalizedOrigin) ||
-        (allowLocalhostCors && isAllowedLocalOrigin(normalizedOrigin))
-      ) {
-        callback(null, true);
-        return;
-      }
+          if (
+            isAllowedCorsOrigin({
+              allowLocalhostCors,
+              allowedOrigins,
+              brandedAuthOrigins,
+              method: request.method,
+              origin,
+              routePath
+            })
+          ) {
+            originCallback(null, true);
+            return;
+          }
 
-      callback(new Error("origin_not_allowed"), false);
+          originCallback(new Error("origin_not_allowed"), false);
+        }
+      });
     }
   });
   await app.register(formbody);
@@ -70,7 +128,8 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: allowLocalhostCors,
-      allowedOrigins
+      allowedOrigins,
+      brandedAuthOrigins
     })
   );
 

--- a/apps/api/src/server/trusted-mutation-origin.ts
+++ b/apps/api/src/server/trusted-mutation-origin.ts
@@ -12,6 +12,26 @@ export function isAllowedLocalOrigin(origin: string) {
   return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin);
 }
 
+const localBrandedAuthHosts = new Set([
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com"
+]);
+
+export function isAllowedLocalBrandedAuthOrigin(origin: string) {
+  try {
+    const parsedOrigin = new URL(origin);
+
+    return (
+      parsedOrigin.protocol === "http:" &&
+      parsedOrigin.port.length > 0 &&
+      localBrandedAuthHosts.has(parsedOrigin.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function shouldEnforceTrustedMutationOrigin(method: string, routePath: string) {
   return (
     method !== "GET" &&
@@ -21,9 +41,14 @@ export function shouldEnforceTrustedMutationOrigin(method: string, routePath: st
   );
 }
 
+function allowsBrandedFinalizeSubmitOrigin(method: string, routePath: string) {
+  return method === "POST" && routePath === "/portal/session/finalize/submit";
+}
+
 export function createTrustedMutationOriginHook(options: {
   allowLocalhostOrigins: boolean;
   allowedOrigins: string[];
+  brandedAuthOrigins?: string[];
 }) {
   return (
     request: FastifyRequest,
@@ -49,8 +74,22 @@ export function createTrustedMutationOriginHook(options: {
       return;
     }
 
+    const brandedAuthOrigins = options.brandedAuthOrigins ?? [];
+    const brandedAuthOrigin = brandedAuthOrigins.includes(requestOrigin);
     const originAllowed =
-      options.allowedOrigins.includes(requestOrigin) ||
+      (
+        options.allowedOrigins.includes(requestOrigin) &&
+        !brandedAuthOrigin
+      ) ||
+      (
+        brandedAuthOrigin &&
+        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)
+      ) ||
+      (
+        options.allowLocalhostOrigins &&
+        isAllowedLocalBrandedAuthOrigin(requestOrigin) &&
+        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)
+      ) ||
       (options.allowLocalhostOrigins && isAllowedLocalOrigin(requestOrigin));
 
     if (!originAllowed) {

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isAllowedCorsOrigin,
+  readAllowedCorsOrigins
+} from "../src/server/build-server.ts";
+
+test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allowlist", () => {
+  const origins = readAllowedCorsOrigins({
+    corsAllowedOrigins: [
+      "https://portal.preview.paretoproof.com",
+      "https://github.auth.paretoproof.com"
+    ]
+  } as never);
+
+  assert.deepEqual(origins, [
+    "https://portal.paretoproof.com",
+    "https://portal.preview.paretoproof.com"
+  ]);
+  assert.equal(origins.includes("https://auth.paretoproof.com"), false);
+  assert.equal(origins.includes("https://github.auth.paretoproof.com"), false);
+  assert.equal(origins.includes("https://google.auth.paretoproof.com"), false);
+});
+
+test("isAllowedCorsOrigin keeps branded finalize callers scoped to POST finalize-submit", () => {
+  const allowedOrigins = [
+    "https://portal.paretoproof.com"
+  ];
+  const brandedAuthOrigins = [
+    "https://auth.paretoproof.com",
+    "https://github.auth.paretoproof.com",
+    "https://google.auth.paretoproof.com"
+  ];
+
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: false,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "POST",
+      origin: "https://github.auth.paretoproof.com",
+      routePath: "/portal/session/finalize/submit"
+    }),
+    true
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: false,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "POST",
+      origin: "https://github.auth.paretoproof.com",
+      routePath: "/portal/profile"
+    }),
+    false
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: true,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "POST",
+      origin: "http://github.auth.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit"
+    }),
+    true
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: false,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "POST",
+      origin: "http://github.auth.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit"
+    }),
+    false
+  );
+});

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   isAllowedCorsOrigin,
+  readCorsRoutePath,
   readAllowedCorsOrigins
 } from "../src/server/build-server.ts";
 
@@ -22,7 +23,18 @@ test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allow
   assert.equal(origins.includes("https://google.auth.paretoproof.com"), false);
 });
 
-test("isAllowedCorsOrigin keeps branded finalize callers scoped to POST finalize-submit", () => {
+test("readCorsRoutePath falls back to the raw request URL for Fastify preflights", () => {
+  assert.equal(
+    readCorsRoutePath("*", "/portal/session/finalize/submit?redirect=%2Fprofile"),
+    "/portal/session/finalize/submit"
+  );
+  assert.equal(
+    readCorsRoutePath("/portal/profile", "/portal/profile?tab=settings"),
+    "/portal/profile"
+  );
+});
+
+test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-submit POST and OPTIONS only", () => {
   const allowedOrigins = [
     "https://portal.paretoproof.com"
   ];
@@ -48,7 +60,32 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to POST finalize
       allowLocalhostCors: false,
       allowedOrigins,
       brandedAuthOrigins,
+      method: "OPTIONS",
+      origin: "https://github.auth.paretoproof.com",
+      routePath: readCorsRoutePath(
+        "*",
+        "/portal/session/finalize/submit?redirect=%2Fprofile"
+      )
+    }),
+    true
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: false,
+      allowedOrigins,
+      brandedAuthOrigins,
       method: "POST",
+      origin: "https://github.auth.paretoproof.com",
+      routePath: "/portal/profile"
+    }),
+    false
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: false,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "OPTIONS",
       origin: "https://github.auth.paretoproof.com",
       routePath: "/portal/profile"
     }),
@@ -60,6 +97,17 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to POST finalize
       allowedOrigins,
       brandedAuthOrigins,
       method: "POST",
+      origin: "http://github.auth.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit"
+    }),
+    true
+  );
+  assert.equal(
+    isAllowedCorsOrigin({
+      allowLocalhostCors: true,
+      allowedOrigins,
+      brandedAuthOrigins,
+      method: "OPTIONS",
       origin: "http://github.auth.paretoproof.com:4371",
       routePath: "/portal/session/finalize/submit"
     }),

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -295,7 +295,7 @@ test("createAccessResolver rejects revoked opaque portal sessions", async () => 
   }
 });
 
-test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on the relay audiences", () => {
+test("selectCloudflareAccessVerifier keeps branded relay audiences only on POST finalize-submit", () => {
   const verifiers = {
     brandedRelay: { audiences: ["portal-aud", "github-aud", "google-aud"] },
     internal: { audiences: ["internal-aud"] },
@@ -305,6 +305,7 @@ test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on th
   assert.equal(
     selectCloudflareAccessVerifier(
       {
+        method: "POST",
         raw: {
           url: "/portal/session/finalize"
         },
@@ -314,11 +315,12 @@ test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on th
       } as never,
       verifiers as never
     ),
-    verifiers.brandedRelay
+    verifiers.portal
   );
   assert.equal(
     selectCloudflareAccessVerifier(
       {
+        method: "POST",
         raw: {
           url: "/portal/session/finalize/submit"
         },
@@ -333,6 +335,22 @@ test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on th
   assert.equal(
     selectCloudflareAccessVerifier(
       {
+        method: "GET",
+        raw: {
+          url: "/portal/session/finalize/submit"
+        },
+        routeOptions: {
+          url: "/portal/session/finalize/submit"
+        }
+      } as never,
+      verifiers as never
+    ),
+    verifiers.portal
+  );
+  assert.equal(
+    selectCloudflareAccessVerifier(
+      {
+        method: "GET",
         raw: {
           url: "/portal/me"
         },
@@ -347,6 +365,7 @@ test("selectCloudflareAccessVerifier keeps the branded finalize boundaries on th
   assert.equal(
     selectCloudflareAccessVerifier(
       {
+        method: "POST",
         raw: {
           url: "/internal/worker/claims"
         },

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -14,7 +14,8 @@ test("trusted mutation origin hook rejects state-changing portal requests withou
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"]
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: []
     })
   );
 
@@ -45,7 +46,8 @@ test("trusted mutation origin hook rejects state-changing portal requests from u
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"]
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: []
     })
   );
 
@@ -80,7 +82,8 @@ test("trusted mutation origin hook also protects admin role revocation mutations
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"]
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: []
     })
   );
 
@@ -114,7 +117,8 @@ test("trusted mutation origin hook also protects portal-admin offline ingest mut
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"]
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: []
     })
   );
 
@@ -148,7 +152,8 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"]
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: []
     })
   );
 
@@ -181,7 +186,7 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
   });
 });
 
-test("trusted mutation origin hook allows branded auth POSTs to the finalize relay and finalize submit handoff", async (t) => {
+test("trusted mutation origin hook only allows branded auth POSTs on the finalize-submit handoff boundary", async (t) => {
   const app = Fastify();
 
   t.after(async () => {
@@ -197,12 +202,18 @@ test("trusted mutation origin hook allows branded auth POSTs to the finalize rel
         "https://github.auth.paretoproof.com",
         "https://google.auth.paretoproof.com",
         "https://portal.paretoproof.com"
+      ],
+      brandedAuthOrigins: [
+        "https://auth.paretoproof.com",
+        "https://github.auth.paretoproof.com",
+        "https://google.auth.paretoproof.com"
       ]
     })
   );
 
   app.post("/portal/session/finalize", async () => ({ ok: true }));
   app.post("/portal/session/finalize/submit", async () => ({ ok: true }));
+  app.post("/portal/profile", async () => ({ ok: true }));
 
   const finalizeResponse = await app.inject({
     method: "POST",
@@ -226,12 +237,82 @@ test("trusted mutation origin hook allows branded auth POSTs to the finalize rel
     }
   });
 
-  assert.equal(finalizeResponse.statusCode, 200);
+  const profileResponse = await app.inject({
+    method: "POST",
+    payload: {
+      displayName: "Ada"
+    },
+    url: "/portal/profile",
+    headers: {
+      origin: "https://github.auth.paretoproof.com"
+    }
+  });
+
+  assert.equal(finalizeResponse.statusCode, 403);
   assert.deepEqual(finalizeResponse.json(), {
-    ok: true
+    error: "trusted_origin_not_allowed"
   });
   assert.equal(submitResponse.statusCode, 200);
   assert.deepEqual(submitResponse.json(), {
     ok: true
+  });
+  assert.equal(profileResponse.statusCode, 403);
+  assert.deepEqual(profileResponse.json(), {
+    error: "trusted_origin_not_allowed"
+  });
+});
+
+test("trusted mutation origin hook only allows loopback-mapped branded auth origins on finalize-submit when localhost mode is enabled", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: true,
+      allowedOrigins: ["https://portal.paretoproof.com"],
+      brandedAuthOrigins: [
+        "https://auth.paretoproof.com",
+        "https://github.auth.paretoproof.com",
+        "https://google.auth.paretoproof.com"
+      ]
+    })
+  );
+
+  app.post("/portal/session/finalize/submit", async () => ({ ok: true }));
+  app.post("/portal/profile", async () => ({ ok: true }));
+
+  const finalizeResponse = await app.inject({
+    method: "POST",
+    payload: {
+      redirect: "/profile"
+    },
+    url: "/portal/session/finalize/submit",
+    headers: {
+      origin: "http://github.auth.paretoproof.com:4371"
+    }
+  });
+
+  const profileResponse = await app.inject({
+    method: "POST",
+    payload: {
+      displayName: "Ada"
+    },
+    url: "/portal/profile",
+    headers: {
+      origin: "http://github.auth.paretoproof.com:4371"
+    }
+  });
+
+  assert.equal(finalizeResponse.statusCode, 200);
+  assert.deepEqual(finalizeResponse.json(), {
+    ok: true
+  });
+  assert.equal(profileResponse.statusCode, 403);
+  assert.deepEqual(profileResponse.json(), {
+    error: "trusted_origin_not_allowed"
   });
 });

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,5 +8,5 @@ Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline for browser env versus hosted auth-entry secrets
 - use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages auth-entry runtime checklists
-- the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production completion stays on `/api/access/finalize`, while local loopback-branded previews can still use the local API finalize route directly
+- the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production completion stays on `/api/access/finalize`, while local loopback-branded previews target the local API finalize-submit route directly when the local API is running with localhost origin exceptions enabled
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -74,7 +74,7 @@ describe("buildPortalUrl", () => {
     setWindowUrl("http://github.auth.paretoproof.com:4371/");
 
     expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize?redirect=%2Fprofile"
+      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
     );
   });
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -255,7 +255,7 @@ export function buildAccessFinalizeUrl(targetPath = "/") {
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
 
   if (isLocalOrigin()) {
-    const completionUrl = new URL("/portal/session/finalize", getApiBaseUrl());
+    const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
 
     if (normalizedTargetPath !== "/") {
       completionUrl.searchParams.set("redirect", normalizedTargetPath);

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -74,6 +74,7 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
 - Notes:
   - `CF_ACCESS_INTERNAL_AUD` falls back to the portal audience when omitted
   - `CF_ACCESS_BRANDED_AUDS` is the comma-separated allowlist of branded provider-host Access audiences accepted only on the finalize-submit handoff boundary
+  - set `CORS_ALLOW_LOCALHOST=true` when you need loopback-mapped branded auth hosts such as `http://github.auth.paretoproof.com:<port>` or `http://google.auth.paretoproof.com:<port>` to post directly to the local API finalize-submit boundary during auth-flow previews
   - `HOST` defaults to `0.0.0.0`
   - `PORT` defaults to `3000`
 


### PR DESCRIPTION
## Summary\n- restrict branded auth trust to POST /portal/session/finalize/submit instead of broader portal mutations\n- remove branded auth hosts from the general API CORS allowlist while preserving the finalize-submit exception in the live server wiring\n- align the local/web finalize helper and local runtime docs with the scoped finalize-submit boundary\n\n## Testing\n- un run test:api\n- un test src/lib/surface.test.js\n- un run build\n- un run test:startup-validation *(fails in this environment because the local Docker daemon is unavailable)*\n\nCloses #994