### PR TITLE
Add worker pool and worker instance persistence for internal worker control

### DIFF
--- a/apps/api/drizzle/0014_even_miracleman.sql
+++ b/apps/api/drizzle/0014_even_miracleman.sql
@@ -1,0 +1,41 @@
+CREATE TYPE "public"."worker_instance_lifecycle_state" AS ENUM('registering', 'ready', 'claiming', 'running', 'draining', 'unhealthy', 'recovering', 'terminated');--> statement-breakpoint
+CREATE TYPE "public"."worker_pool_rollout_class" AS ENUM('stable', 'canary', 'quarantine');--> statement-breakpoint
+ALTER TYPE "public"."audit_subject_kind" ADD VALUE 'worker_pool';--> statement-breakpoint
+ALTER TYPE "public"."audit_subject_kind" ADD VALUE 'worker_instance';--> statement-breakpoint
+ALTER TYPE "public"."audit_subject_kind" ADD VALUE 'worker_incident';--> statement-breakpoint
+ALTER TYPE "public"."audit_subject_kind" ADD VALUE 'worker_rollout';--> statement-breakpoint
+CREATE TABLE "worker_instances" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"worker_id" text NOT NULL,
+	"worker_pool_definition_id" uuid NOT NULL,
+	"worker_runtime" "worker_runtime" NOT NULL,
+	"worker_version" text NOT NULL,
+	"current_lifecycle_state" "worker_instance_lifecycle_state" DEFAULT 'ready' NOT NULL,
+	"first_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_claim_at" timestamp with time zone,
+	"last_heartbeat_at" timestamp with time zone,
+	"last_lease_activity_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "worker_pool_definitions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"worker_pool" text NOT NULL,
+	"worker_runtime" "worker_runtime" NOT NULL,
+	"default_rollout_class" "worker_pool_rollout_class" DEFAULT 'stable' NOT NULL,
+	"ownership_summary" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "worker_job_leases" ADD COLUMN "worker_instance_id" uuid;--> statement-breakpoint
+ALTER TABLE "worker_instances" ADD CONSTRAINT "worker_instances_worker_pool_definition_id_worker_pool_definitions_id_fk" FOREIGN KEY ("worker_pool_definition_id") REFERENCES "public"."worker_pool_definitions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "worker_instances_worker_id_unique" ON "worker_instances" USING btree ("worker_id");--> statement-breakpoint
+CREATE INDEX "worker_instances_pool_state_idx" ON "worker_instances" USING btree ("worker_pool_definition_id","current_lifecycle_state");--> statement-breakpoint
+CREATE INDEX "worker_instances_last_heartbeat_at_idx" ON "worker_instances" USING btree ("last_heartbeat_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "worker_pool_definitions_worker_pool_unique" ON "worker_pool_definitions" USING btree ("worker_pool");--> statement-breakpoint
+CREATE INDEX "worker_pool_definitions_worker_runtime_idx" ON "worker_pool_definitions" USING btree ("worker_runtime");--> statement-breakpoint
+ALTER TABLE "worker_job_leases" ADD CONSTRAINT "worker_job_leases_worker_instance_id_worker_instances_id_fk" FOREIGN KEY ("worker_instance_id") REFERENCES "public"."worker_instances"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "worker_job_leases_worker_instance_id_idx" ON "worker_job_leases" USING btree ("worker_instance_id");

--- a/apps/api/drizzle/meta/0014_snapshot.json
+++ b/apps/api/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,3914 @@
+{
+  "id": "a3baabff-beb6-4ec1-ae40-b5d440699801",
+  "prevId": "458fecfb-bb3c-4325-ad12-60a0ccebe8ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_requests": {
+      "name": "access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_kind": {
+          "name": "request_kind",
+          "type": "access_request_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'access_request'"
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "access_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "access_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_identity_provider": {
+          "name": "requested_identity_provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_identity_subject": {
+          "name": "requested_identity_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_requests_email_idx": {
+          "name": "access_requests_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_requested_identity_subject_idx": {
+          "name": "access_requests_requested_identity_subject_idx",
+          "columns": [
+            {
+              "expression": "requested_identity_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_identity_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_status_idx": {
+          "name": "access_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_active_pending_email_unique": {
+          "name": "access_requests_active_pending_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"access_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_requests_requested_by_user_id_users_id_fk": {
+          "name": "access_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "access_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "access_requests_reviewed_by_user_id_users_id_fk": {
+          "name": "access_requests_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "access_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artifact_class_id": {
+          "name": "artifact_class_id",
+          "type": "artifact_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_scope": {
+          "name": "owner_scope",
+          "type": "artifact_owner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_for_ingest": {
+          "name": "required_for_ingest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "artifact_storage_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_name": {
+          "name": "bucket_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix_family": {
+          "name": "prefix_family",
+          "type": "artifact_prefix_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_etag": {
+          "name": "provider_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "artifact_lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_detected_at": {
+          "name": "missing_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifacts_storage_locator_unique": {
+          "name": "artifacts_storage_locator_unique",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_attempt_relative_path_unique": {
+          "name": "artifacts_attempt_relative_path_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"artifacts\".\"attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_run_id_idx": {
+          "name": "artifacts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_attempt_id_lifecycle_state_idx": {
+          "name": "artifacts_attempt_id_lifecycle_state_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_run_id_artifact_class_idx": {
+          "name": "artifacts_run_id_artifact_class_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_manifest_digest_idx": {
+          "name": "artifacts_manifest_digest_idx",
+          "columns": [
+            {
+              "expression": "artifact_manifest_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_sha256_idx": {
+          "name": "artifacts_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_run_id_runs_id_fk": {
+          "name": "artifacts_run_id_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_job_id_jobs_id_fk": {
+          "name": "artifacts_job_id_jobs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_attempt_id_attempts_id_fk": {
+          "name": "artifacts_attempt_id_attempts_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attempt_id": {
+          "name": "source_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "attempt_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_result": {
+          "name": "verifier_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_digest": {
+          "name": "benchmark_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_package_digest": {
+          "name": "prompt_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_protocol_version": {
+          "name": "prompt_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_family": {
+          "name": "provider_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_snapshot_id": {
+          "name": "model_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_profile": {
+          "name": "tool_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_revision": {
+          "name": "harness_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_version": {
+          "name": "verifier_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_digest": {
+          "name": "candidate_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_digest": {
+          "name": "verdict_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_digest": {
+          "name": "environment_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_classification": {
+          "name": "failure_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifier_verdict": {
+          "name": "verifier_verdict",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_summary": {
+          "name": "usage_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_run_id_idx": {
+          "name": "attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_job_id_idx": {
+          "name": "attempts_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_state_idx": {
+          "name": "attempts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_source_attempt_id_unique": {
+          "name": "attempts_source_attempt_id_unique",
+          "columns": [
+            {
+              "expression": "source_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_bundle_digest_unique": {
+          "name": "attempts_bundle_digest_unique",
+          "columns": [
+            {
+              "expression": "bundle_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_run_id_runs_id_fk": {
+          "name": "attempts_run_id_runs_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_job_id_jobs_id_fk": {
+          "name": "attempts_job_id_jobs_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "audit_actor_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "audit_subject_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "audit_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_created_at_idx": {
+          "name": "audit_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_event_id_idx": {
+          "name": "audit_events_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_target_user_id_idx": {
+          "name": "audit_events_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_events_target_user_id_users_id_fk": {
+          "name": "audit_events_target_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_releases": {
+      "name": "benchmark_releases",
+      "schema": "",
+      "columns": {
+        "benchmark_release_id": {
+          "name": "benchmark_release_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_label": {
+          "name": "release_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "benchmark_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "benchmark_release_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_only'"
+        },
+        "methodology_artifact_refs": {
+          "name": "methodology_artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_artifact_refs": {
+          "name": "summary_artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_payload": {
+          "name": "summary_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "benchmark_releases_benchmark_version_id_idx": {
+          "name": "benchmark_releases_benchmark_version_id_idx",
+          "columns": [
+            {
+              "expression": "benchmark_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_public_version_unique": {
+          "name": "benchmark_releases_public_version_unique",
+          "columns": [
+            {
+              "expression": "benchmark_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"benchmark_releases\".\"status\" = 'published' and \"benchmark_releases\".\"visibility\" = 'public'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_status_idx": {
+          "name": "benchmark_releases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_status_visibility_published_at_idx": {
+          "name": "benchmark_releases_status_visibility_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "benchmark_releases_benchmark_version_id_benchmark_versions_benchmark_version_id_fk": {
+          "name": "benchmark_releases_benchmark_version_id_benchmark_versions_benchmark_version_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "benchmark_versions",
+          "columnsFrom": [
+            "benchmark_version_id"
+          ],
+          "columnsTo": [
+            "benchmark_version_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "benchmark_releases_approved_by_user_id_users_id_fk": {
+          "name": "benchmark_releases_approved_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "benchmark_releases_created_by_user_id_users_id_fk": {
+          "name": "benchmark_releases_created_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_versions": {
+      "name": "benchmark_versions",
+      "schema": "",
+      "columns": {
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_freeze_id": {
+          "name": "package_freeze_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_version": {
+          "name": "package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_digest": {
+          "name": "package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_family": {
+          "name": "benchmark_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_label": {
+          "name": "scope_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_set_definition": {
+          "name": "item_set_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launchability": {
+          "name": "launchability",
+          "type": "benchmark_version_launchability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_only'"
+        },
+        "display_label": {
+          "name": "display_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "benchmark_versions_launchability_idx": {
+          "name": "benchmark_versions_launchability_idx",
+          "columns": [
+            {
+              "expression": "launchability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_versions_package_digest_idx": {
+          "name": "benchmark_versions_package_digest_idx",
+          "columns": [
+            {
+              "expression": "package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "benchmark_versions_package_freeze_id_package_freezes_id_fk": {
+          "name": "benchmark_versions_package_freeze_id_package_freezes_id_fk",
+          "tableFrom": "benchmark_versions",
+          "tableTo": "package_freezes",
+          "columnsFrom": [
+            "package_freeze_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "benchmark_versions_created_by_user_id_users_id_fk": {
+          "name": "benchmark_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_link_intents": {
+      "name": "identity_link_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_provider": {
+          "name": "target_provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_path": {
+          "name": "redirect_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_link_intents_active_user_provider_unique": {
+          "name": "identity_link_intents_active_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"identity_link_intents\".\"used_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_link_intents_expires_at_idx": {
+          "name": "identity_link_intents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_link_intents_user_id_idx": {
+          "name": "identity_link_intents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_link_intents_user_id_users_id_fk": {
+          "name": "identity_link_intents_user_id_users_id_fk",
+          "tableFrom": "identity_link_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "job_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_run_id_idx": {
+          "name": "jobs_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_state_idx": {
+          "name": "jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_source_job_id_idx": {
+          "name": "jobs_source_job_id_idx",
+          "columns": [
+            {
+              "expression": "source_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_run_id_runs_id_fk": {
+          "name": "jobs_run_id_runs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_freezes": {
+      "name": "package_freezes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repo_sync_record_id": {
+          "name": "repo_sync_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "math_package_candidate_id": {
+          "name": "math_package_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_version": {
+          "name": "package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_digest": {
+          "name": "package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_family": {
+          "name": "benchmark_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_commit_sha": {
+          "name": "repo_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_tree_path": {
+          "name": "repo_tree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "package_freeze_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_freezes_repo_sync_record_id_unique": {
+          "name": "package_freezes_repo_sync_record_id_unique",
+          "columns": [
+            {
+              "expression": "repo_sync_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "package_freezes_package_digest_unique": {
+          "name": "package_freezes_package_digest_unique",
+          "columns": [
+            {
+              "expression": "package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "package_freezes_math_package_candidate_id_idx": {
+          "name": "package_freezes_math_package_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "math_package_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_freezes_repo_sync_record_id_repo_sync_records_id_fk": {
+          "name": "package_freezes_repo_sync_record_id_repo_sync_records_id_fk",
+          "tableFrom": "package_freezes",
+          "tableTo": "repo_sync_records",
+          "columnsFrom": [
+            "repo_sync_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "package_freezes_created_by_user_id_users_id_fk": {
+          "name": "package_freezes_created_by_user_id_users_id_fk",
+          "tableFrom": "package_freezes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_sync_records": {
+      "name": "repo_sync_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "math_package_candidate_id": {
+          "name": "math_package_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_repo_path": {
+          "name": "target_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_sha": {
+          "name": "merge_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "repo_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by_user_id": {
+          "name": "last_updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repo_sync_records_status_idx": {
+          "name": "repo_sync_records_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_sync_records_math_package_candidate_id_idx": {
+          "name": "repo_sync_records_math_package_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "math_package_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_sync_records_repo_pr_unique": {
+          "name": "repo_sync_records_repo_pr_unique",
+          "columns": [
+            {
+              "expression": "repo_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"repo_sync_records\".\"pull_request_number\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_sync_records_recorded_by_user_id_users_id_fk": {
+          "name": "repo_sync_records_recorded_by_user_id_users_id_fk",
+          "tableFrom": "repo_sync_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repo_sync_records_last_updated_by_user_id_users_id_fk": {
+          "name": "repo_sync_records_last_updated_by_user_id_users_id_fk",
+          "tableFrom": "repo_sync_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "last_updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_grants": {
+      "name": "role_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "access_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_grants_active_user_unique": {
+          "name": "role_grants_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"role_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_grants_user_id_idx": {
+          "name": "role_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_grants_role_idx": {
+          "name": "role_grants_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_grants_user_id_users_id_fk": {
+          "name": "role_grants_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_grants_granted_by_user_id_users_id_fk": {
+          "name": "role_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "role_grants_revoked_by_user_id_users_id_fk": {
+          "name": "role_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single_run'"
+        },
+        "state": {
+          "name": "state",
+          "type": "run_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_id": {
+          "name": "benchmark_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_version": {
+          "name": "benchmark_package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_digest": {
+          "name": "benchmark_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_item_id": {
+          "name": "benchmark_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_protocol_version": {
+          "name": "prompt_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_package_digest": {
+          "name": "prompt_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_profile": {
+          "name": "tool_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_revision": {
+          "name": "harness_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_version": {
+          "name": "verifier_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_family": {
+          "name": "provider_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_snapshot_id": {
+          "name": "model_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_digest": {
+          "name": "environment_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_config_digest": {
+          "name": "run_config_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_source_run_id_unique": {
+          "name": "runs_source_run_id_unique",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_bundle_digest_unique": {
+          "name": "runs_bundle_digest_unique",
+          "columns": [
+            {
+              "expression": "bundle_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_state_idx": {
+          "name": "runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_verdict_class_idx": {
+          "name": "runs_verdict_class_idx",
+          "columns": [
+            {
+              "expression": "verdict_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_benchmark_digest_idx": {
+          "name": "runs_benchmark_digest_idx",
+          "columns": [
+            {
+              "expression": "benchmark_package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_run_config_digest_idx": {
+          "name": "runs_run_config_digest_idx",
+          "columns": [
+            {
+              "expression": "run_config_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_identity_id_idx": {
+          "name": "sessions_identity_id_idx",
+          "columns": [
+            {
+              "expression": "identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_identity_owner_fk": {
+          "name": "sessions_identity_owner_fk",
+          "tableFrom": "sessions",
+          "tableTo": "user_identities",
+          "columnsFrom": [
+            "identity_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_identities": {
+      "name": "user_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_identities_provider_subject_unique": {
+          "name": "user_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_id_user_id_unique": {
+          "name": "user_identities_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_user_id_idx": {
+          "name": "user_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_users_id_fk": {
+          "name": "user_identities_user_id_users_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_attempt_events": {
+      "name": "worker_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "worker_execution_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "worker_execution_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_attempt_events_attempt_sequence_unique": {
+          "name": "worker_attempt_events_attempt_sequence_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_attempt_events_attempt_recorded_at_idx": {
+          "name": "worker_attempt_events_attempt_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_attempt_events_lease_id_idx": {
+          "name": "worker_attempt_events_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_attempt_events_run_id_runs_id_fk": {
+          "name": "worker_attempt_events_run_id_runs_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_job_id_jobs_id_fk": {
+          "name": "worker_attempt_events_job_id_jobs_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_attempt_id_attempts_id_fk": {
+          "name": "worker_attempt_events_attempt_id_attempts_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_lease_id_worker_job_leases_id_fk": {
+          "name": "worker_attempt_events_lease_id_worker_job_leases_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "worker_job_leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_instances": {
+      "name": "worker_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_pool_definition_id": {
+          "name": "worker_pool_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_lifecycle_state": {
+          "name": "current_lifecycle_state",
+          "type": "worker_instance_lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_claim_at": {
+          "name": "last_claim_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_lease_activity_at": {
+          "name": "last_lease_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_instances_worker_id_unique": {
+          "name": "worker_instances_worker_id_unique",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_instances_pool_state_idx": {
+          "name": "worker_instances_pool_state_idx",
+          "columns": [
+            {
+              "expression": "worker_pool_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_instances_last_heartbeat_at_idx": {
+          "name": "worker_instances_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_instances_worker_pool_definition_id_worker_pool_definitions_id_fk": {
+          "name": "worker_instances_worker_pool_definition_id_worker_pool_definitions_id_fk",
+          "tableFrom": "worker_instances",
+          "tableTo": "worker_pool_definitions",
+          "columnsFrom": [
+            "worker_pool_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_job_leases": {
+      "name": "worker_job_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_pool": {
+          "name": "worker_pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_interval_seconds": {
+          "name": "heartbeat_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_timeout_seconds": {
+          "name": "heartbeat_timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_hash": {
+          "name": "job_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_expires_at": {
+          "name": "job_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_scopes": {
+          "name": "job_token_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_job_leases_active_job_unique": {
+          "name": "worker_job_leases_active_job_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"worker_job_leases\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_active_attempt_unique": {
+          "name": "worker_job_leases_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"worker_job_leases\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_job_token_hash_unique": {
+          "name": "worker_job_leases_job_token_hash_unique",
+          "columns": [
+            {
+              "expression": "job_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_run_id_idx": {
+          "name": "worker_job_leases_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_job_id_idx": {
+          "name": "worker_job_leases_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_attempt_id_idx": {
+          "name": "worker_job_leases_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_worker_instance_id_idx": {
+          "name": "worker_job_leases_worker_instance_id_idx",
+          "columns": [
+            {
+              "expression": "worker_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_lease_expires_at_idx": {
+          "name": "worker_job_leases_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_job_leases_run_id_runs_id_fk": {
+          "name": "worker_job_leases_run_id_runs_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_job_id_jobs_id_fk": {
+          "name": "worker_job_leases_job_id_jobs_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_attempt_id_attempts_id_fk": {
+          "name": "worker_job_leases_attempt_id_attempts_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_worker_instance_id_worker_instances_id_fk": {
+          "name": "worker_job_leases_worker_instance_id_worker_instances_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "worker_instances",
+          "columnsFrom": [
+            "worker_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_pool_definitions": {
+      "name": "worker_pool_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_pool": {
+          "name": "worker_pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_rollout_class": {
+          "name": "default_rollout_class",
+          "type": "worker_pool_rollout_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "ownership_summary": {
+          "name": "ownership_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_pool_definitions_worker_pool_unique": {
+          "name": "worker_pool_definitions_worker_pool_unique",
+          "columns": [
+            {
+              "expression": "worker_pool",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_pool_definitions_worker_runtime_idx": {
+          "name": "worker_pool_definitions_worker_runtime_idx",
+          "columns": [
+            {
+              "expression": "worker_runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_request_kind": {
+      "name": "access_request_kind",
+      "schema": "public",
+      "values": [
+        "access_request",
+        "identity_recovery"
+      ]
+    },
+    "public.access_request_status": {
+      "name": "access_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.access_role": {
+      "name": "access_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "collaborator",
+        "helper"
+      ]
+    },
+    "public.artifact_class": {
+      "name": "artifact_class",
+      "schema": "public",
+      "values": [
+        "run_manifest",
+        "package_reference",
+        "prompt_package",
+        "candidate_source",
+        "verdict_record",
+        "compiler_output",
+        "compiler_diagnostics",
+        "verifier_output",
+        "environment_snapshot",
+        "usage_summary",
+        "execution_trace"
+      ]
+    },
+    "public.artifact_lifecycle_state": {
+      "name": "artifact_lifecycle_state",
+      "schema": "public",
+      "values": [
+        "registered",
+        "available",
+        "missing",
+        "quarantined",
+        "deleted"
+      ]
+    },
+    "public.artifact_owner_scope": {
+      "name": "artifact_owner_scope",
+      "schema": "public",
+      "values": [
+        "run_attempt",
+        "benchmark_version",
+        "run_export"
+      ]
+    },
+    "public.artifact_prefix_family": {
+      "name": "artifact_prefix_family",
+      "schema": "public",
+      "values": [
+        "run_artifacts",
+        "run_logs",
+        "run_traces",
+        "run_bundles",
+        "benchmark_source",
+        "benchmark_reports"
+      ]
+    },
+    "public.artifact_storage_provider": {
+      "name": "artifact_storage_provider",
+      "schema": "public",
+      "values": [
+        "cloudflare_r2"
+      ]
+    },
+    "public.attempt_state": {
+      "name": "attempt_state",
+      "schema": "public",
+      "values": [
+        "prepared",
+        "active",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.audit_actor_kind": {
+      "name": "audit_actor_kind",
+      "schema": "public",
+      "values": [
+        "portal_user",
+        "internal_service",
+        "system_bootstrap"
+      ]
+    },
+    "public.audit_severity": {
+      "name": "audit_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.audit_subject_kind": {
+      "name": "audit_subject_kind",
+      "schema": "public",
+      "values": [
+        "access_request",
+        "benchmark_release",
+        "benchmark_version",
+        "benchmark_workflow",
+        "role_grant",
+        "run",
+        "user_identity",
+        "worker_pool",
+        "worker_instance",
+        "worker_incident",
+        "worker_rollout"
+      ]
+    },
+    "public.benchmark_release_status": {
+      "name": "benchmark_release_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "published"
+      ]
+    },
+    "public.benchmark_release_visibility": {
+      "name": "benchmark_release_visibility",
+      "schema": "public",
+      "values": [
+        "internal_only",
+        "held_out",
+        "public"
+      ]
+    },
+    "public.benchmark_version_launchability": {
+      "name": "benchmark_version_launchability",
+      "schema": "public",
+      "values": [
+        "internal_only",
+        "launchable"
+      ]
+    },
+    "public.evaluation_verdict_class": {
+      "name": "evaluation_verdict_class",
+      "schema": "public",
+      "values": [
+        "pass",
+        "fail",
+        "invalid_result"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "cloudflare_one_time_pin",
+        "cloudflare_github",
+        "cloudflare_google"
+      ]
+    },
+    "public.job_state": {
+      "name": "job_state",
+      "schema": "public",
+      "values": [
+        "queued",
+        "claimed",
+        "running",
+        "cancel_requested",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.package_freeze_status": {
+      "name": "package_freeze_status",
+      "schema": "public",
+      "values": [
+        "active"
+      ]
+    },
+    "public.repo_sync_status": {
+      "name": "repo_sync_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "pr_open",
+        "merged",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.run_kind": {
+      "name": "run_kind",
+      "schema": "public",
+      "values": [
+        "full_benchmark",
+        "benchmark_slice",
+        "single_run",
+        "repeated_n"
+      ]
+    },
+    "public.run_state": {
+      "name": "run_state",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "running",
+        "cancel_requested",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.worker_execution_event_kind": {
+      "name": "worker_execution_event_kind",
+      "schema": "public",
+      "values": [
+        "attempt_started",
+        "compile_started",
+        "compile_succeeded",
+        "compile_failed",
+        "compile_repair_requested",
+        "compile_repair_applied",
+        "verifier_started",
+        "verifier_passed",
+        "verifier_failed",
+        "verifier_repair_requested",
+        "verifier_repair_applied",
+        "budget_exhausted",
+        "artifact_manifest_written",
+        "bundle_finalized"
+      ]
+    },
+    "public.worker_execution_phase": {
+      "name": "worker_execution_phase",
+      "schema": "public",
+      "values": [
+        "prepare",
+        "generate",
+        "tool",
+        "compile",
+        "verify",
+        "finalize",
+        "cancel"
+      ]
+    },
+    "public.worker_instance_lifecycle_state": {
+      "name": "worker_instance_lifecycle_state",
+      "schema": "public",
+      "values": [
+        "registering",
+        "ready",
+        "claiming",
+        "running",
+        "draining",
+        "unhealthy",
+        "recovering",
+        "terminated"
+      ]
+    },
+    "public.worker_pool_rollout_class": {
+      "name": "worker_pool_rollout_class",
+      "schema": "public",
+      "values": [
+        "stable",
+        "canary",
+        "quarantine"
+      ]
+    },
+    "public.worker_runtime": {
+      "name": "worker_runtime",
+      "schema": "public",
+      "values": [
+        "local_docker",
+        "modal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775810400000,
       "tag": "0013_sharp_puck",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1775814000000,
+      "tag": "0014_even_miracleman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -57,7 +57,11 @@ export const auditSubjectKindEnum = pgEnum("audit_subject_kind", [
   "benchmark_workflow",
   "role_grant",
   "run",
-  "user_identity"
+  "user_identity",
+  "worker_pool",
+  "worker_instance",
+  "worker_incident",
+  "worker_rollout"
 ]);
 
 export const auditSeverityEnum = pgEnum("audit_severity", [
@@ -151,6 +155,26 @@ export const workerRuntimeEnum = pgEnum("worker_runtime", [
   "local_docker",
   "modal"
 ]);
+
+export const workerPoolRolloutClassEnum = pgEnum("worker_pool_rollout_class", [
+  "stable",
+  "canary",
+  "quarantine"
+]);
+
+export const workerInstanceLifecycleStateEnum = pgEnum(
+  "worker_instance_lifecycle_state",
+  [
+    "registering",
+    "ready",
+    "claiming",
+    "running",
+    "draining",
+    "unhealthy",
+    "recovering",
+    "terminated"
+  ]
+);
 
 export const repoSyncStatusEnum = pgEnum("repo_sync_status", [
   "proposed",
@@ -376,6 +400,72 @@ export const auditEvents = pgTable(
     createdAtIndex: index("audit_events_created_at_idx").on(table.createdAt),
     eventIdIndex: index("audit_events_event_id_idx").on(table.eventId),
     targetUserIdIndex: index("audit_events_target_user_id_idx").on(table.targetUserId)
+  })
+);
+
+export const workerPoolDefinitions = pgTable(
+  "worker_pool_definitions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    workerPool: text("worker_pool").notNull(),
+    workerRuntime: workerRuntimeEnum("worker_runtime").notNull(),
+    defaultRolloutClass: workerPoolRolloutClassEnum("default_rollout_class")
+      .default("stable")
+      .notNull(),
+    ownershipSummary: text("ownership_summary"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+  },
+  (table) => ({
+    workerPoolUnique: uniqueIndex("worker_pool_definitions_worker_pool_unique").on(
+      table.workerPool
+    ),
+    runtimeIndex: index("worker_pool_definitions_worker_runtime_idx").on(table.workerRuntime)
+  })
+);
+
+export const workerInstances = pgTable(
+  "worker_instances",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    workerId: text("worker_id").notNull(),
+    workerPoolDefinitionId: uuid("worker_pool_definition_id")
+      .notNull()
+      .references(() => workerPoolDefinitions.id),
+    workerRuntime: workerRuntimeEnum("worker_runtime").notNull(),
+    workerVersion: text("worker_version").notNull(),
+    currentLifecycleState: workerInstanceLifecycleStateEnum("current_lifecycle_state")
+      .default("ready")
+      .notNull(),
+    firstSeenAt: timestamp("first_seen_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    lastClaimAt: timestamp("last_claim_at", { withTimezone: true }),
+    lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
+    lastLeaseActivityAt: timestamp("last_lease_activity_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull()
+  },
+  (table) => ({
+    workerIdUnique: uniqueIndex("worker_instances_worker_id_unique").on(table.workerId),
+    poolStateIndex: index("worker_instances_pool_state_idx").on(
+      table.workerPoolDefinitionId,
+      table.currentLifecycleState
+    ),
+    lastHeartbeatAtIndex: index("worker_instances_last_heartbeat_at_idx").on(
+      table.lastHeartbeatAt
+    )
   })
 );
 
@@ -753,6 +843,9 @@ export const workerJobLeases = pgTable(
     attemptId: uuid("attempt_id")
       .notNull()
       .references(() => attempts.id, { onDelete: "cascade" }),
+    workerInstanceId: uuid("worker_instance_id").references(() => workerInstances.id, {
+      onDelete: "set null"
+    }),
     workerId: text("worker_id").notNull(),
     workerPool: text("worker_pool").notNull(),
     workerRuntime: workerRuntimeEnum("worker_runtime").notNull(),
@@ -784,6 +877,9 @@ export const workerJobLeases = pgTable(
     runIndex: index("worker_job_leases_run_id_idx").on(table.runId),
     jobIndex: index("worker_job_leases_job_id_idx").on(table.jobId),
     attemptIndex: index("worker_job_leases_attempt_id_idx").on(table.attemptId),
+    workerInstanceIndex: index("worker_job_leases_worker_instance_id_idx").on(
+      table.workerInstanceId
+    ),
     leaseExpiryIndex: index("worker_job_leases_lease_expires_at_idx").on(table.leaseExpiresAt)
   })
 );

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -312,7 +312,7 @@ async function upsertWorkerPoolDefinition(
   request: Pick<WorkerClaimRequest, "workerPool" | "workerRuntime">,
   now: Date
 ) {
-  const [workerPoolDefinition] = await tx
+  const [insertedWorkerPoolDefinition] = await tx
     .insert(workerPoolDefinitions)
     .values({
       defaultRolloutClass: "stable",
@@ -320,21 +320,37 @@ async function upsertWorkerPoolDefinition(
       workerPool: request.workerPool,
       workerRuntime: request.workerRuntime
     })
-    .onConflictDoUpdate({
-      target: workerPoolDefinitions.workerPool,
-      set: {
-        updatedAt: now
-      }
-    })
+    .onConflictDoNothing()
     .returning({
       id: workerPoolDefinitions.id
     });
 
-  if (!workerPoolDefinition) {
+  if (insertedWorkerPoolDefinition) {
+    return insertedWorkerPoolDefinition.id;
+  }
+
+  const [existingWorkerPoolDefinition] = await tx
+    .select({
+      id: workerPoolDefinitions.id,
+      workerRuntime: workerPoolDefinitions.workerRuntime
+    })
+    .from(workerPoolDefinitions)
+    .where(eq(workerPoolDefinitions.workerPool, request.workerPool))
+    .limit(1);
+
+  if (!existingWorkerPoolDefinition) {
     throw new Error("Failed to persist the worker pool definition.");
   }
 
-  return workerPoolDefinition.id;
+  if (existingWorkerPoolDefinition.workerRuntime !== request.workerRuntime) {
+    throw createConflictError(
+      "worker_pool_runtime_mismatch",
+      `Worker pool ${request.workerPool} is already registered for runtime ${existingWorkerPoolDefinition.workerRuntime}.`,
+      "workerRuntime"
+    );
+  }
+
+  return existingWorkerPoolDefinition.id;
 }
 
 async function upsertWorkerInstance(
@@ -1544,6 +1560,8 @@ export function createInternalWorkerControlService(db: DbClient) {
           });
 
         if (renewedLeases.length === 0) {
+          await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+
           return {
             acknowledgedEventSequence,
             cancelRequested: false,

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -38,7 +38,9 @@ import {
   jobs,
   runs,
   workerAttemptEvents,
-  workerJobLeases
+  workerInstances,
+  workerJobLeases,
+  workerPoolDefinitions
 } from "../db/schema.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
@@ -70,6 +72,7 @@ type DbClient = ReturnTypeOfCreateDbClient;
 type SelectExecutor = Pick<DbClient, "select">;
 type ReadExecutor = Pick<DbClient, "select">;
 type ReadWriteExecutor = Pick<DbClient, "select" | "update">;
+type MutationExecutor = Pick<DbClient, "insert" | "select" | "update">;
 
 type CandidateClaimRow = {
   authMode: Problem9HostedAuthMode;
@@ -108,6 +111,7 @@ type LeaseStateRow = {
   revokedAt: Date | null;
   runState: typeof runs.$inferSelect.state;
   verifierVerdict: Record<string, unknown>;
+  workerInstanceId: string | null;
   verdictDigest: string;
 };
 
@@ -303,6 +307,208 @@ function createJobTokenExpiry(now: Date) {
   return addSeconds(now, heartbeatTimeoutSeconds);
 }
 
+async function upsertWorkerPoolDefinition(
+  tx: MutationExecutor,
+  request: Pick<WorkerClaimRequest, "workerPool" | "workerRuntime">,
+  now: Date
+) {
+  const [workerPoolDefinition] = await tx
+    .insert(workerPoolDefinitions)
+    .values({
+      defaultRolloutClass: "stable",
+      updatedAt: now,
+      workerPool: request.workerPool,
+      workerRuntime: request.workerRuntime
+    })
+    .onConflictDoUpdate({
+      target: workerPoolDefinitions.workerPool,
+      set: {
+        updatedAt: now,
+        workerRuntime: request.workerRuntime
+      }
+    })
+    .returning({
+      id: workerPoolDefinitions.id
+    });
+
+  if (!workerPoolDefinition) {
+    throw new Error("Failed to persist the worker pool definition.");
+  }
+
+  return workerPoolDefinition.id;
+}
+
+async function upsertWorkerInstance(
+  tx: MutationExecutor,
+  options: {
+    currentLifecycleState: typeof workerInstances.$inferSelect.currentLifecycleState;
+    lastClaimAt?: Date;
+    lastHeartbeatAt?: Date;
+    lastLeaseActivityAt?: Date;
+    now: Date;
+    workerId: string;
+    workerPoolDefinitionId: string;
+    workerRuntime: typeof workerInstances.$inferSelect.workerRuntime;
+    workerVersion: string;
+  }
+) {
+  const [workerInstance] = await tx
+    .insert(workerInstances)
+    .values({
+      currentLifecycleState: options.currentLifecycleState,
+      lastSeenAt: options.now,
+      updatedAt: options.now,
+      workerId: options.workerId,
+      workerPoolDefinitionId: options.workerPoolDefinitionId,
+      workerRuntime: options.workerRuntime,
+      workerVersion: options.workerVersion,
+      ...(options.lastClaimAt !== undefined ? { lastClaimAt: options.lastClaimAt } : {}),
+      ...(options.lastHeartbeatAt !== undefined
+        ? { lastHeartbeatAt: options.lastHeartbeatAt }
+        : {}),
+      ...(options.lastLeaseActivityAt !== undefined
+        ? { lastLeaseActivityAt: options.lastLeaseActivityAt }
+        : {})
+    })
+    .onConflictDoUpdate({
+      target: workerInstances.workerId,
+      set: {
+        currentLifecycleState: options.currentLifecycleState,
+        lastSeenAt: options.now,
+        updatedAt: options.now,
+        workerPoolDefinitionId: options.workerPoolDefinitionId,
+        workerRuntime: options.workerRuntime,
+        workerVersion: options.workerVersion,
+        ...(options.lastClaimAt !== undefined ? { lastClaimAt: options.lastClaimAt } : {}),
+        ...(options.lastHeartbeatAt !== undefined
+          ? { lastHeartbeatAt: options.lastHeartbeatAt }
+          : {}),
+        ...(options.lastLeaseActivityAt !== undefined
+          ? { lastLeaseActivityAt: options.lastLeaseActivityAt }
+          : {})
+      }
+    })
+    .returning({
+      id: workerInstances.id
+    });
+
+  if (!workerInstance) {
+    throw new Error("Failed to persist the worker instance.");
+  }
+
+  return workerInstance.id;
+}
+
+async function touchWorkerInstanceHeartbeat(
+  tx: ReadWriteExecutor,
+  workerInstanceId: string | null,
+  now: Date
+) {
+  if (!workerInstanceId) {
+    return;
+  }
+
+  await tx
+    .update(workerInstances)
+    .set({
+      currentLifecycleState: "running",
+      lastHeartbeatAt: now,
+      lastLeaseActivityAt: now,
+      lastSeenAt: now,
+      updatedAt: now
+    })
+    .where(eq(workerInstances.id, workerInstanceId));
+}
+
+async function reconcileWorkerInstanceLifecycle(
+  tx: ReadWriteExecutor,
+  workerInstanceId: string | null,
+  now: Date
+) {
+  if (!workerInstanceId) {
+    return;
+  }
+
+  const [activeLease] = await tx
+    .select({
+      leaseId: workerJobLeases.id
+    })
+    .from(workerJobLeases)
+    .where(
+      and(
+        eq(workerJobLeases.workerInstanceId, workerInstanceId),
+        isNull(workerJobLeases.revokedAt),
+        gt(workerJobLeases.leaseExpiresAt, now)
+      )
+    )
+    .limit(1);
+
+  await tx
+    .update(workerInstances)
+    .set({
+      currentLifecycleState: activeLease ? "running" : "ready",
+      lastSeenAt: now,
+      updatedAt: now
+    })
+    .where(eq(workerInstances.id, workerInstanceId));
+}
+
+async function reconcileWorkerInstanceLifecycles(
+  tx: ReadWriteExecutor,
+  workerInstanceIds: Array<string | null>,
+  now: Date
+) {
+  const uniqueWorkerInstanceIds = [...new Set(workerInstanceIds.filter((id): id is string => !!id))];
+
+  if (uniqueWorkerInstanceIds.length === 0) {
+    return;
+  }
+
+  const activeLeaseRows = await tx
+    .select({
+      workerInstanceId: workerJobLeases.workerInstanceId
+    })
+    .from(workerJobLeases)
+    .where(
+      and(
+        inArray(workerJobLeases.workerInstanceId, uniqueWorkerInstanceIds),
+        isNull(workerJobLeases.revokedAt),
+        gt(workerJobLeases.leaseExpiresAt, now)
+      )
+    );
+
+  const activeWorkerInstanceIds = new Set(
+    activeLeaseRows
+      .map((row) => row.workerInstanceId)
+      .filter((id): id is string => !!id)
+  );
+  const readyWorkerInstanceIds = uniqueWorkerInstanceIds.filter(
+    (workerInstanceId) => !activeWorkerInstanceIds.has(workerInstanceId)
+  );
+
+  if (readyWorkerInstanceIds.length > 0) {
+    await tx
+      .update(workerInstances)
+      .set({
+        currentLifecycleState: "ready",
+        lastSeenAt: now,
+        updatedAt: now
+      })
+      .where(inArray(workerInstances.id, readyWorkerInstanceIds));
+  }
+
+  if (activeWorkerInstanceIds.size > 0) {
+    await tx
+      .update(workerInstances)
+      .set({
+        currentLifecycleState: "running",
+        lastSeenAt: now,
+        updatedAt: now
+      })
+      .where(inArray(workerInstances.id, [...activeWorkerInstanceIds]));
+  }
+}
+
 async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
   const staleLeases = await tx
     .select({
@@ -341,12 +547,18 @@ async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
       )
     )
     .returning({
-      leaseRowId: workerJobLeases.id
+      workerInstanceId: workerJobLeases.workerInstanceId
     });
 
   if (revokedLeases.length === 0) {
     return;
   }
+
+  await reconcileWorkerInstanceLifecycles(
+    tx,
+    revokedLeases.map((lease) => lease.workerInstanceId),
+    now
+  );
 }
 
 function normalizeRelativePath(relativePath: string) {
@@ -489,6 +701,7 @@ async function loadLeaseState(
       revokedAt: workerJobLeases.revokedAt,
       runState: runs.state,
       verifierVerdict: attempts.verifierVerdict,
+      workerInstanceId: workerJobLeases.workerInstanceId,
       verdictDigest: attempts.verdictDigest
     })
     .from(workerJobLeases)
@@ -1102,12 +1315,24 @@ export function createInternalWorkerControlService(db: DbClient) {
       return db.transaction(async (tx) => {
         await revokeExpiredUnstartedLeases(tx, new Date());
         const candidate = await selectNextClaimCandidate(tx);
+        const now = new Date();
+        const workerPoolDefinitionId = await upsertWorkerPoolDefinition(tx, request, now);
+        const workerInstanceId = await upsertWorkerInstance(tx, {
+          currentLifecycleState:
+            candidate || request.activeJobCount > 0 ? "running" : "ready",
+          lastClaimAt: candidate ? now : undefined,
+          lastLeaseActivityAt: candidate ? now : undefined,
+          now,
+          workerId: request.workerId,
+          workerPoolDefinitionId,
+          workerRuntime: request.workerRuntime,
+          workerVersion: request.workerVersion
+        });
 
         if (!candidate) {
           return buildIdleClaimResponse();
         }
 
-        const now = new Date();
         const leaseExpiresAt = addSeconds(now, heartbeatTimeoutSeconds);
         const jobTokenExpiresAt = createJobTokenExpiry(now);
         const { token, tokenHash } = issueJobToken();
@@ -1124,6 +1349,7 @@ export function createInternalWorkerControlService(db: DbClient) {
             jobTokenScopes: [...issuedJobTokenScopes],
             leaseExpiresAt,
             runId: candidate.runRowId,
+            workerInstanceId,
             workerId: request.workerId,
             workerPool: request.workerPool,
             workerRuntime: request.workerRuntime,
@@ -1233,6 +1459,8 @@ export function createInternalWorkerControlService(db: DbClient) {
             })
             .where(eq(workerJobLeases.id, authContext.leaseRowId));
 
+          await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+
           return {
             acknowledgedEventSequence,
             cancelRequested: false,
@@ -1259,6 +1487,8 @@ export function createInternalWorkerControlService(db: DbClient) {
             })
             .where(eq(workerJobLeases.id, authContext.leaseRowId));
 
+          await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+
           return {
             acknowledgedEventSequence,
             cancelRequested: false,
@@ -1279,6 +1509,8 @@ export function createInternalWorkerControlService(db: DbClient) {
               updatedAt: now
             })
             .where(eq(workerJobLeases.id, authContext.leaseRowId));
+
+          await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
 
           return {
             acknowledgedEventSequence,
@@ -1325,6 +1557,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           } satisfies WorkerHeartbeatResponse;
         }
 
+        await touchWorkerInstanceHeartbeat(tx, lease.workerInstanceId, now);
         await promoteExecutionToRunning(tx, authContext, lease, now);
 
         return {
@@ -1680,6 +1913,8 @@ export function createInternalWorkerControlService(db: DbClient) {
           updatedAt: leaseFenceAt
         });
 
+        await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+
         return {
           acceptedAt: now.toISOString(),
           attemptState: "succeeded",
@@ -1790,6 +2025,8 @@ export function createInternalWorkerControlService(db: DbClient) {
           revokedAt: leaseFenceAt,
           updatedAt: leaseFenceAt
         });
+
+        await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
 
         return {
           acceptedAt: now.toISOString(),

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -323,8 +323,7 @@ async function upsertWorkerPoolDefinition(
     .onConflictDoUpdate({
       target: workerPoolDefinitions.workerPool,
       set: {
-        updatedAt: now,
-        workerRuntime: request.workerRuntime
+        updatedAt: now
       }
     })
     .returning({
@@ -491,7 +490,6 @@ async function reconcileWorkerInstanceLifecycles(
       .update(workerInstances)
       .set({
         currentLifecycleState: "ready",
-        lastSeenAt: now,
         updatedAt: now
       })
       .where(inArray(workerInstances.id, readyWorkerInstanceIds));
@@ -502,7 +500,6 @@ async function reconcileWorkerInstanceLifecycles(
       .update(workerInstances)
       .set({
         currentLifecycleState: "running",
-        lastSeenAt: now,
         updatedAt: now
       })
       .where(inArray(workerInstances.id, [...activeWorkerInstanceIds]));

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -471,14 +471,24 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
             values(values: Record<string, unknown>) {
               insertCalls.push({ target, values });
 
-              if (insertCalls.length < 3) {
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              if (insertCalls.length === 2) {
                 return {
                   onConflictDoUpdate() {
                     return {
                       returning() {
-                        return Promise.resolve([
-                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
-                        ]);
+                        return Promise.resolve([{ id: "worker-instance-1" }]);
                       }
                     };
                   }
@@ -1631,14 +1641,24 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
             values(values: Record<string, unknown>) {
               insertCalls.push({ target, values });
 
-              if (insertCalls.length < 3) {
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              if (insertCalls.length === 2) {
                 return {
                   onConflictDoUpdate() {
                     return {
                       returning() {
-                        return Promise.resolve([
-                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
-                        ]);
+                        return Promise.resolve([{ id: "worker-instance-1" }]);
                       }
                     };
                   }
@@ -1787,14 +1807,24 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
             values(values: Record<string, unknown>) {
               insertCalls.push(values);
 
-              if (insertCalls.length < 3) {
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              if (insertCalls.length === 2) {
                 return {
                   onConflictDoUpdate() {
                     return {
                       returning() {
-                        return Promise.resolve([
-                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
-                        ]);
+                        return Promise.resolve([{ id: "worker-instance-1" }]);
                       }
                     };
                   }
@@ -1889,13 +1919,23 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
             values(values: Record<string, unknown>) {
               insertCalls.push(values);
 
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
               return {
                 onConflictDoUpdate() {
                   return {
                     returning() {
-                      return Promise.resolve([
-                        { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
-                      ]);
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
                     }
                   };
                 }
@@ -1924,10 +1964,10 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
   assert.equal(query.params.length, 0);
 });
 
-test("claim preserves the stored worker pool runtime on pool definition conflicts", async () => {
-  let capturedPoolConflictSet: Record<string, unknown> | null = null;
+test("claim reuses existing worker pool definitions without hot-row updates", async () => {
   let selectCount = 0;
   let insertCount = 0;
+  let poolInsertUsedConflictDoNothing = false;
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
       const tx = {
@@ -1943,6 +1983,21 @@ test("claim preserves the stored worker pool runtime on pool definition conflict
                   },
                   where() {
                     return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 3) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([{ id: "pool-def-1", workerRuntime: "modal" }]);
                   }
                 };
               }
@@ -1979,17 +2034,25 @@ test("claim preserves the stored worker pool runtime on pool definition conflict
 
           return {
             values() {
-              return {
-                onConflictDoUpdate(options: { set: Record<string, unknown> }) {
-                  if (insertCount === 1) {
-                    capturedPoolConflictSet = options.set;
-                  }
+              if (insertCount === 1) {
+                return {
+                  onConflictDoNothing() {
+                    poolInsertUsedConflictDoNothing = true;
 
+                    return {
+                      returning() {
+                        return Promise.resolve([]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
                   return {
                     returning() {
-                      return Promise.resolve([
-                        { id: insertCount === 1 ? "pool-def-1" : "worker-instance-1" }
-                      ]);
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
                     }
                   };
                 }
@@ -2007,11 +2070,109 @@ test("claim preserves the stored worker pool runtime on pool definition conflict
   const response = await control.claim(buildClaimRequest());
 
   assert.equal(response.leaseStatus, "idle");
-  assert.equal(selectCount, 2);
+  assert.equal(selectCount, 3);
   assert.equal(insertCount, 2);
-  assert.ok(capturedPoolConflictSet);
-  assert.equal(capturedPoolConflictSet?.updatedAt instanceof Date, true);
-  assert.equal(Object.hasOwn(capturedPoolConflictSet!, "workerRuntime"), false);
+  assert.equal(poolInsertUsedConflictDoNothing, true);
+});
+
+test("claim rejects worker runtime mismatches against existing pool definitions", async () => {
+  let selectCount = 0;
+  let insertCount = 0;
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  leftJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  orderBy() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    { id: "pool-def-1", workerRuntime: "local_docker" }
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          insertCount += 1;
+
+          return {
+            values() {
+              return {
+                onConflictDoNothing() {
+                  return {
+                    returning() {
+                      return Promise.resolve([]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("runtime mismatches should reject before any updates");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+
+  await assert.rejects(
+    () => control.claim(buildClaimRequest()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_pool_runtime_mismatch"
+  );
+
+  assert.equal(selectCount, 3);
+  assert.equal(insertCount, 1);
 });
 
 test("reportEvent rejects submissions whose lease is revoked after the initial read", async () => {
@@ -2484,37 +2645,55 @@ test("heartbeat rotates the job token while extending the lease", async () => {
 
 test("heartbeat returns expired when lease renewal loses the race with recovery revocation", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
       const tx = {
         select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      {
+                        artifactManifestDigest: "a".repeat(64),
+                        attemptState: "prepared",
+                        bundleDigest: "b".repeat(64),
+                        candidateDigest: "c".repeat(64),
+                        heartbeatTimeoutSeconds: 180,
+                        jobState: "claimed",
+                        lastEventSequence: 2,
+                        leaseExpiresAt: new Date(Date.now() + 60_000),
+                        revokedAt: null,
+                        runState: "queued",
+                        verifierVerdict: {},
+                        workerInstanceId: "worker-instance-1",
+                        verdictDigest: "d".repeat(64)
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
           return {
             from() {
               return {
-                innerJoin() {
-                  return this;
-                },
                 where() {
                   return this;
                 },
                 limit() {
-                  return Promise.resolve([
-                    {
-                      artifactManifestDigest: "a".repeat(64),
-                      attemptState: "prepared",
-                      bundleDigest: "b".repeat(64),
-                      candidateDigest: "c".repeat(64),
-                      heartbeatTimeoutSeconds: 180,
-                      jobState: "claimed",
-                      lastEventSequence: 2,
-                      leaseExpiresAt: new Date(Date.now() + 60_000),
-                      revokedAt: null,
-                      runState: "queued",
-                      verifierVerdict: {},
-                      workerInstanceId: "worker-instance-1",
-                      verdictDigest: "d".repeat(64)
-                    }
-                  ]);
+                  return Promise.resolve([]);
                 }
               };
             }
@@ -2553,5 +2732,7 @@ test("heartbeat returns expired when lease renewal loses the race with recovery 
     leaseExpiresAt: null,
     leaseStatus: "expired"
   });
-  assert.equal(updateCalls.length, 1);
+  assert.equal(selectCount, 2);
+  assert.equal(updateCalls.length, 2);
+  assert.equal(updateCalls[1]?.currentLifecycleState, "ready");
 });

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -525,6 +525,7 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
   assert.equal(updateCalls.length, 4);
   assert.equal(updateCalls[0].values.revokedAt instanceof Date, true);
   assert.equal(updateCalls[1].values.currentLifecycleState, "ready");
+  assert.equal(Object.hasOwn(updateCalls[1].values, "lastSeenAt"), false);
   assert.equal(updateCalls[2].values.state, "claimed");
   assert.equal(updateCalls[3].values.state, "running");
   assert.equal(
@@ -1671,6 +1672,7 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
   assert.equal(updateCalls.length, 4);
   assert.equal(updateCalls[0].values.revokedAt instanceof Date, true);
   assert.equal(updateCalls[1].values.currentLifecycleState, "ready");
+  assert.equal(Object.hasOwn(updateCalls[1].values, "lastSeenAt"), false);
   assert.equal(updateCalls[2].values.state, "claimed");
   assert.equal(updateCalls[3].values.state, "running");
   assert.equal(
@@ -1824,6 +1826,7 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
   assert.equal(updateCalls.length, 3);
   assert.equal(updateCalls[0].revokedAt instanceof Date, true);
   assert.equal(updateCalls[1].currentLifecycleState, "ready");
+  assert.equal(Object.hasOwn(updateCalls[1], "lastSeenAt"), false);
   assert.equal(updateCalls[2].state, "claimed");
   assert.equal(updateCalls.some((call) => call.state === "queued"), false);
 });
@@ -1919,6 +1922,96 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
   assert.match(query.sql, /"worker_job_leases"\."revoked_at" is null/i);
   assert.doesNotMatch(query.sql, /"worker_job_leases"\."lease_expires_at"/i);
   assert.equal(query.params.length, 0);
+});
+
+test("claim preserves the stored worker pool runtime on pool definition conflicts", async () => {
+  let capturedPoolConflictSet: Record<string, unknown> | null = null;
+  let selectCount = 0;
+  let insertCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("idle claims should not issue updates");
+        },
+        insert() {
+          insertCount += 1;
+
+          return {
+            values() {
+              return {
+                onConflictDoUpdate(options: { set: Record<string, unknown> }) {
+                  if (insertCount === 1) {
+                    capturedPoolConflictSet = options.set;
+                  }
+
+                  return {
+                    returning() {
+                      return Promise.resolve([
+                        { id: insertCount === 1 ? "pool-def-1" : "worker-instance-1" }
+                      ]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.equal(response.leaseStatus, "idle");
+  assert.equal(selectCount, 2);
+  assert.equal(insertCount, 2);
+  assert.ok(capturedPoolConflictSet);
+  assert.equal(capturedPoolConflictSet?.updatedAt instanceof Date, true);
+  assert.equal(Object.hasOwn(capturedPoolConflictSet!, "workerRuntime"), false);
 });
 
 test("reportEvent rejects submissions whose lease is revoked after the initial read", async () => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -244,6 +244,7 @@ function buildLeaseStateRow(overrides: Partial<Record<string, unknown>> = {}) {
     revokedAt: null,
     runState: "running",
     verifierVerdict: null,
+    workerInstanceId: null,
     verdictDigest: null,
     ...overrides
   };
@@ -352,6 +353,10 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
     target: unknown;
     values: Record<string, unknown>;
   }> = [];
+  const insertCalls: Array<{
+    target: unknown;
+    values: Record<string, unknown>;
+  }> = [];
   let selectCount = 0;
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
@@ -367,7 +372,24 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
                     return this;
                   },
                   where() {
-                    return Promise.resolve([{ leaseRowId: "lease-row-1" }]);
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-1"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
                   }
                 };
               }
@@ -430,15 +452,39 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
                   return this;
                 },
                 returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        workerInstanceId: "stale-worker-instance-1"
+                      }
+                    ]);
+                  }
+
                   return Promise.resolve([{ leaseRowId: "lease-row-1" }]);
                 }
               };
             }
           };
         },
-        insert() {
+        insert(target: unknown) {
           return {
-            values() {
+            values(values: Record<string, unknown>) {
+              insertCalls.push({ target, values });
+
+              if (insertCalls.length < 3) {
+                return {
+                  onConflictDoUpdate() {
+                    return {
+                      returning() {
+                        return Promise.resolve([
+                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
+                        ]);
+                      }
+                    };
+                  }
+                };
+              }
+
               return {
                 returning() {
                   return Promise.resolve([{ id: "lease-row-2" }]);
@@ -471,11 +517,16 @@ test("POST /internal/worker/claims reclaims stale unstarted work without queued 
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().leaseStatus, "active");
   assert.equal(response.json().workerJob?.jobId, "job-1");
-  assert.equal(selectCount, 2);
-  assert.equal(updateCalls.length, 3);
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 3);
+  assert.equal(insertCalls[0]?.values.workerPool, "modal-dev");
+  assert.equal(insertCalls[1]?.values.currentLifecycleState, "running");
+  assert.equal(insertCalls[2]?.values.workerInstanceId, "worker-instance-1");
+  assert.equal(updateCalls.length, 4);
   assert.equal(updateCalls[0].values.revokedAt instanceof Date, true);
-  assert.equal(updateCalls[1].values.state, "claimed");
-  assert.equal(updateCalls[2].values.state, "running");
+  assert.equal(updateCalls[1].values.currentLifecycleState, "ready");
+  assert.equal(updateCalls[2].values.state, "claimed");
+  assert.equal(updateCalls[3].values.state, "running");
   assert.equal(
     updateCalls.some((call) => call.values.state === "queued"),
     false
@@ -1472,6 +1523,10 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
     target: unknown;
     values: Record<string, unknown>;
   }> = [];
+  const insertCalls: Array<{
+    target: unknown;
+    values: Record<string, unknown>;
+  }> = [];
   let selectCount = 0;
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
@@ -1487,7 +1542,24 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
                     return this;
                   },
                   where() {
-                    return Promise.resolve([{ leaseRowId: "lease-row-1" }]);
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-1"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
                   }
                 };
               }
@@ -1540,11 +1612,11 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
                 },
                 returning() {
                   if (updateCalls.length === 1) {
-                    return Promise.resolve([{ jobRowId: "job-row-1" }]);
-                  }
-
-                  if (updateCalls.length === 2) {
-                    return Promise.resolve([{ runRowId: "run-row-1" }]);
+                    return Promise.resolve([
+                      {
+                        workerInstanceId: "stale-worker-instance-1"
+                      }
+                    ]);
                   }
 
                   return Promise.resolve([{ id: "job-row-1" }]);
@@ -1553,9 +1625,25 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
             }
           };
         },
-        insert() {
+        insert(target: unknown) {
           return {
-            values() {
+            values(values: Record<string, unknown>) {
+              insertCalls.push({ target, values });
+
+              if (insertCalls.length < 3) {
+                return {
+                  onConflictDoUpdate() {
+                    return {
+                      returning() {
+                        return Promise.resolve([
+                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
+                        ]);
+                      }
+                    };
+                  }
+                };
+              }
+
               return {
                 returning() {
                   return Promise.resolve([{ id: "lease-row-2" }]);
@@ -1575,11 +1663,16 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
 
   assert.equal(response.leaseStatus, "active");
   assert.equal(response.workerJob?.jobId, "job-1");
-  assert.equal(selectCount, 2);
-  assert.equal(updateCalls.length, 3);
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 3);
+  assert.equal(insertCalls[0]?.values.workerPool, "modal-dev");
+  assert.equal(insertCalls[1]?.values.currentLifecycleState, "running");
+  assert.equal(insertCalls[2]?.values.workerInstanceId, "worker-instance-1");
+  assert.equal(updateCalls.length, 4);
   assert.equal(updateCalls[0].values.revokedAt instanceof Date, true);
-  assert.equal(updateCalls[1].values.state, "claimed");
-  assert.equal(updateCalls[2].values.state, "running");
+  assert.equal(updateCalls[1].values.currentLifecycleState, "ready");
+  assert.equal(updateCalls[2].values.state, "claimed");
+  assert.equal(updateCalls[3].values.state, "running");
   assert.equal(
     updateCalls.some((call) => call.values.state === "queued"),
     false
@@ -1588,6 +1681,7 @@ test("claim fences stale unstarted leases and reclaims work without queued rewin
 
 test("stale-lease recovery does not rewind durable job or run state", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
   let selectCount = 0;
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
@@ -1603,7 +1697,24 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
                     return this;
                   },
                   where() {
-                    return Promise.resolve([{ leaseRowId: "lease-row-1" }]);
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-2"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
                   }
                 };
               }
@@ -1656,11 +1767,11 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
                 },
                 returning() {
                   if (updateCalls.length === 1) {
-                    return Promise.resolve([{ jobRowId: "job-row-1" }]);
-                  }
-
-                  if (updateCalls.length === 2) {
-                    return Promise.resolve([{ runRowId: "run-row-1" }]);
+                    return Promise.resolve([
+                      {
+                        workerInstanceId: "stale-worker-instance-2"
+                      }
+                    ]);
                   }
 
                   return Promise.resolve([{ id: "job-row-1" }]);
@@ -1671,7 +1782,23 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
         },
         insert() {
           return {
-            values() {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length < 3) {
+                return {
+                  onConflictDoUpdate() {
+                    return {
+                      returning() {
+                        return Promise.resolve([
+                          { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
+                        ]);
+                      }
+                    };
+                  }
+                };
+              }
+
               return {
                 returning() {
                   return Promise.resolve([{ id: "lease-row-2" }]);
@@ -1690,16 +1817,20 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
   const response = await control.claim(buildClaimRequest());
 
   assert.equal(response.leaseStatus, "active");
-  assert.equal(selectCount, 2);
-  assert.equal(updateCalls.length, 2);
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 3);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "running");
+  assert.equal(insertCalls[2]?.workerInstanceId, "worker-instance-1");
+  assert.equal(updateCalls.length, 3);
   assert.equal(updateCalls[0].revokedAt instanceof Date, true);
-  assert.equal(updateCalls[1].state, "claimed");
+  assert.equal(updateCalls[1].currentLifecycleState, "ready");
+  assert.equal(updateCalls[2].state, "claimed");
   assert.equal(updateCalls.some((call) => call.state === "queued"), false);
 });
 
 test("claim keeps any still-unrevoked lease row blocking candidate selection", async () => {
   let capturedLeaseJoin: SQL | null = null;
-  let insertCalled = false;
+  const insertCalls: Array<Record<string, unknown>> = [];
   let updateCalled = false;
   let selectCount = 0;
   const fakeDb = {
@@ -1751,8 +1882,23 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
           throw new Error("claim should stay idle when a prior lease row is still unrevoked");
         },
         insert() {
-          insertCalled = true;
-          throw new Error("claim should not insert a new lease while an older row is still unrevoked");
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([
+                        { id: insertCalls.length === 1 ? "pool-def-1" : "worker-instance-1" }
+                      ]);
+                    }
+                  };
+                }
+              };
+            }
+          };
         }
       };
 
@@ -1767,7 +1913,9 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
   assert.equal(response.leaseStatus, "idle");
   assert.equal(selectCount, 2);
   assert.equal(updateCalled, false);
-  assert.equal(insertCalled, false);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[0]?.workerPool, "modal-dev");
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
   assert.match(query.sql, /"worker_job_leases"\."revoked_at" is null/i);
   assert.doesNotMatch(query.sql, /"worker_job_leases"\."lease_expires_at"/i);
   assert.equal(query.params.length, 0);
@@ -2195,6 +2343,7 @@ test("heartbeat rotates the job token while extending the lease", async () => {
                       revokedAt: null,
                       runState: "queued",
                       verifierVerdict: {},
+                      workerInstanceId: "worker-instance-1",
                       verdictDigest: "d".repeat(64)
                     }
                   ]);
@@ -2233,9 +2382,11 @@ test("heartbeat rotates the job token while extending the lease", async () => {
   assert.notEqual(response.jobToken, "job-token-1");
   assert.ok(response.jobTokenExpiresAt);
   assert.equal(typeof updateCalls[0].jobTokenHash, "string");
-  assert.equal(updateCalls[1].state, "running");
-  assert.equal(updateCalls[2].state, "active");
-  assert.equal(updateCalls[3].state, "running");
+  assert.equal(updateCalls[1].currentLifecycleState, "running");
+  assert.equal(updateCalls[1].lastHeartbeatAt instanceof Date, true);
+  assert.equal(updateCalls[2].state, "running");
+  assert.equal(updateCalls[3].state, "active");
+  assert.equal(updateCalls[4].state, "running");
 });
 
 test("heartbeat returns expired when lease renewal loses the race with recovery revocation", async () => {
@@ -2267,6 +2418,7 @@ test("heartbeat returns expired when lease renewal loses the race with recovery 
                       revokedAt: null,
                       runState: "queued",
                       verifierVerdict: {},
+                      workerInstanceId: "worker-instance-1",
                       verdictDigest: "d".repeat(64)
                     }
                   ]);

--- a/packages/shared/src/schemas/audit-event.ts
+++ b/packages/shared/src/schemas/audit-event.ts
@@ -13,7 +13,11 @@ export const auditSubjectKindSchema = z.enum([
   "benchmark_workflow",
   "role_grant",
   "run",
-  "user_identity"
+  "user_identity",
+  "worker_pool",
+  "worker_instance",
+  "worker_incident",
+  "worker_rollout"
 ]);
 
 export const auditSeveritySchema = z.enum(["info", "warning", "critical"]);

--- a/packages/shared/src/types/audit-event.ts
+++ b/packages/shared/src/types/audit-event.ts
@@ -7,7 +7,11 @@ export type AuditSubjectKind =
   | "benchmark_workflow"
   | "role_grant"
   | "run"
-  | "user_identity";
+  | "user_identity"
+  | "worker_pool"
+  | "worker_instance"
+  | "worker_incident"
+  | "worker_rollout";
 
 export type AuditSeverity = "info" | "warning" | "critical";
 


### PR DESCRIPTION
Related to #947

## Summary
- add `worker_pool_definitions` and `worker_instances` tables plus Drizzle migration metadata for the first hosted-worker Neon persistence slice
- attach `worker_instance_id` to `worker_job_leases` and expand shared audit subject kinds for upcoming worker pool, worker instance, incident, and rollout events
- persist worker pool and worker instance records during worker claims and reconcile worker lifecycle state during stale-lease recovery, heartbeat renewal, result submission, and failure submission
- add regression coverage for stale lease recovery, worker-instance lifecycle reconciliation, and heartbeat lifecycle updates

## Testing
- `bun run build:shared`
- `bun test test/*.test.ts`
- `bunx tsc --noEmit -p tsconfig.json`

## Scope
- part of #947
- intentionally limited to the worker control-plane schema foundation for this first slice
- does not yet add worker incidents, worker rollouts, or public reporting tables/read models