### PR TITLE
fix(api): bind portal identities by provider and subject

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -10,6 +10,7 @@ DATABASE_URL=postgres://user:password@host:5432/paretoproof
 # Owner-ops config. Only set these when you are intentionally running owner workflows.
 MIGRATION_DATABASE_URL=postgres://user:password@host:5432/paretoproof
 OWNER_EMAIL=owner@example.com
+OWNER_IDENTITY_PROVIDER=cloudflare_google
 
 # App runtime config for local Cloudflare Access parity and internal worker auth.
 CF_ACCESS_TEAM_DOMAIN=paretoproof.cloudflareaccess.com

--- a/apps/api/drizzle/0013_sharp_puck.sql
+++ b/apps/api/drizzle/0013_sharp_puck.sql
@@ -1,0 +1,4 @@
+DROP INDEX "user_identities_provider_subject_unique";--> statement-breakpoint
+CREATE UNIQUE INDEX "user_identities_provider_subject_unique" ON "user_identities" USING btree ("provider","provider_subject");--> statement-breakpoint
+DROP INDEX "access_requests_requested_identity_subject_idx";--> statement-breakpoint
+CREATE INDEX "access_requests_requested_identity_subject_idx" ON "access_requests" USING btree ("requested_identity_provider","requested_identity_subject");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775116800000,
       "tag": "0012_frozen_stilt_man",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1775810400000,
+      "tag": "0013_sharp_puck",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/scripts/bootstrap-owner-admin.ts
+++ b/apps/api/scripts/bootstrap-owner-admin.ts
@@ -1,9 +1,11 @@
 import postgres from "postgres";
-
-type CloudflareAccessUser = {
-  email: string;
-  uid: string;
-};
+import {
+  selectBootstrapOwnerAccessUser,
+  parseBootstrapOwnerIdentityProvider,
+  type BootstrapOwnerIdentityProvider,
+  type CloudflareAccessUserCandidate,
+  type CloudflareLastSeenIdentity
+} from "../src/lib/owner-identity-provider.js";
 
 type BootstrapUserRow = {
   id: string;
@@ -11,6 +13,7 @@ type BootstrapUserRow = {
 
 type ExistingIdentityRow = {
   id: string;
+  provider: BootstrapOwnerIdentityProvider | "cloudflare_one_time_pin";
   user_id: string;
 };
 
@@ -40,6 +43,10 @@ function getOwnerEmail() {
   }
 
   return email;
+}
+
+function getOwnerIdentityProvider() {
+  return parseBootstrapOwnerIdentityProvider(process.env.OWNER_IDENTITY_PROVIDER);
 }
 
 function getCloudflareHeaders(): Record<string, string> {
@@ -76,7 +83,7 @@ async function readCloudflareAccessUser(ownerEmail: string) {
     `https://api.cloudflare.com/client/v4/accounts/${accountId}/access/users`
   );
   requestUrl.searchParams.set("email", ownerEmail);
-  requestUrl.searchParams.set("per_page", "1");
+  requestUrl.searchParams.set("per_page", "50");
 
   const response = await fetch(
     requestUrl,
@@ -92,7 +99,7 @@ async function readCloudflareAccessUser(ownerEmail: string) {
   }
 
   const payload = (await response.json()) as {
-    result?: CloudflareAccessUser[];
+    result?: CloudflareAccessUserCandidate[];
     success?: boolean;
   };
 
@@ -100,22 +107,72 @@ async function readCloudflareAccessUser(ownerEmail: string) {
     throw new Error("Cloudflare Access users response was not successful.");
   }
 
-  const matchingUser = payload.result.find(
-    ({ email }) => email.toLowerCase() === ownerEmail
-  );
+  return payload.result;
+}
 
-  if (!matchingUser) {
+async function readCloudflareAccessLastSeenIdentity(userId: string) {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+
+  if (!accountId) {
     throw new Error(
-      `No Cloudflare Access user found for ${ownerEmail}. Sign into the protected portal once before bootstrapping.`
+      "CLOUDFLARE_ACCOUNT_ID is required to resolve the owner Access identity."
     );
   }
 
-  return matchingUser;
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/access/users/${encodeURIComponent(userId)}/last_seen_identity`,
+    {
+      headers: getCloudflareHeaders()
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read Cloudflare Access last seen identity: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const payload = (await response.json()) as {
+    result?: {
+      idp?: {
+        type?: string;
+      };
+      user_uuid?: string;
+    };
+    success?: boolean;
+  };
+
+  if (!payload.success || !payload.result) {
+    throw new Error("Cloudflare Access last seen identity response was not successful.");
+  }
+
+  return {
+    idpType: payload.result.idp?.type ?? null,
+    userUuid: payload.result.user_uuid ?? null
+  } satisfies CloudflareLastSeenIdentity;
 }
 
 async function main() {
   const ownerEmail = getOwnerEmail();
-  const ownerAccessUser = await readCloudflareAccessUser(ownerEmail);
+  const ownerIdentityProvider = getOwnerIdentityProvider();
+  const ownerAccessUsers = await readCloudflareAccessUser(ownerEmail);
+  const lastSeenIdentityByUserId = new Map<string, CloudflareLastSeenIdentity>();
+
+  await Promise.all(
+    ownerAccessUsers.map(async (candidate) => {
+      lastSeenIdentityByUserId.set(
+        candidate.id,
+        await readCloudflareAccessLastSeenIdentity(candidate.id)
+      );
+    })
+  );
+
+  const ownerAccessUser = selectBootstrapOwnerAccessUser(
+    ownerAccessUsers,
+    ownerEmail,
+    ownerIdentityProvider,
+    lastSeenIdentityByUserId
+  );
   const sql = postgres(getDatabaseUrl(), {
     max: 1,
     prepare: false
@@ -139,9 +196,18 @@ async function main() {
 
       // The Access users API returns the stable user uid that the portal JWT subject resolves to for the current IdP.
       const [existingIdentity] = await tx<Array<ExistingIdentityRow>>`
-        select id, user_id
+        select id, provider, user_id
         from public.user_identities
-        where provider_subject = ${ownerAccessUser.uid}
+        where provider = ${ownerIdentityProvider}
+          and provider_subject = ${ownerAccessUser.uid}
+        limit 1
+      `;
+
+      const [legacyOtpIdentity] = await tx<Array<ExistingIdentityRow>>`
+        select id, provider, user_id
+        from public.user_identities
+        where provider = ${"cloudflare_one_time_pin"}
+          and provider_subject = ${ownerAccessUser.uid}
         limit 1
       `;
 
@@ -151,7 +217,28 @@ async function main() {
         );
       }
 
-      if (!existingIdentity) {
+      if (legacyOtpIdentity && legacyOtpIdentity.user_id !== user.id) {
+        throw new Error(
+          `Legacy Cloudflare Access subject ${ownerAccessUser.uid} is already linked to a different user.`
+        );
+      }
+
+      if (existingIdentity) {
+        await tx`
+          update public.user_identities
+          set provider_email = ${ownerEmail},
+              last_seen_at = now()
+          where id = ${existingIdentity.id}
+        `;
+      } else if (legacyOtpIdentity) {
+        await tx`
+          update public.user_identities
+          set provider = ${ownerIdentityProvider},
+              provider_email = ${ownerEmail},
+              last_seen_at = now()
+          where id = ${legacyOtpIdentity.id}
+        `;
+      } else {
         await tx`
           insert into public.user_identities (
             user_id,
@@ -161,17 +248,10 @@ async function main() {
           )
           values (
             ${user.id},
-            ${"cloudflare_one_time_pin"},
+            ${ownerIdentityProvider},
             ${ownerAccessUser.uid},
             ${ownerEmail}
           )
-        `;
-      } else {
-        await tx`
-          update public.user_identities
-          set provider_email = ${ownerEmail},
-              last_seen_at = now()
-          where id = ${existingIdentity.id}
         `;
       }
 
@@ -220,6 +300,7 @@ async function main() {
             ${"critical"},
             ${user.id},
             ${JSON.stringify({
+              provider: ownerIdentityProvider,
               providerSubject: ownerAccessUser.uid,
               targetEmail: ownerEmail,
               targetUserId: user.id

--- a/apps/api/src/auth/portal-access-session.ts
+++ b/apps/api/src/auth/portal-access-session.ts
@@ -5,6 +5,7 @@ import { parseApiRuntimeEnv } from "../config/runtime.js";
 import { sessions, userIdentities } from "../db/schema.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 import type { CloudflareAccessIdentity } from "./cloudflare-access.js";
+import { matchesUserIdentityProviderSubject } from "../lib/identity-binding.js";
 import { readCookieValue } from "./cloudflare-access.js";
 import {
   resolveAccessRbacContext,
@@ -66,7 +67,15 @@ export async function createPortalAccessSession(
     )
   });
 
-  if (!linkedIdentity || linkedIdentity.providerSubject !== identity.subject) {
+  if (
+    !identity.provider ||
+    !linkedIdentity ||
+    !matchesUserIdentityProviderSubject(
+      linkedIdentity,
+      identity.provider,
+      identity.subject
+    )
+  ) {
     throw new Error("Approved portal session identity could not be resolved.");
   }
 

--- a/apps/api/src/auth/require-access.ts
+++ b/apps/api/src/auth/require-access.ts
@@ -36,6 +36,13 @@ export function isAccessAssertionVerificationError(error: unknown) {
   return error instanceof AccessAssertionVerificationError;
 }
 
+export function resolveAccessIdentityProvider(
+  identity: Pick<CloudflareAccessIdentity, "provider" | "subject">,
+  cookieHeader: string | undefined
+) {
+  return verifyAccessProviderHint(cookieHeader, identity.subject) ?? identity.provider;
+}
+
 declare module "fastify" {
   interface FastifyRequest {
     accessIdentity: CloudflareAccessIdentity | null;
@@ -113,10 +120,7 @@ async function resolveRequestAccess(
 
   identity = {
     ...identity,
-    provider: verifyAccessProviderHint(
-      cookieHeader,
-      identity.subject
-    ) ?? identity.provider
+    provider: resolveAccessIdentityProvider(identity, cookieHeader)
   };
 
   const context = await resolveAccessRbacContext(db, identity);

--- a/apps/api/src/auth/resolve-access-rbac-context.ts
+++ b/apps/api/src/auth/resolve-access-rbac-context.ts
@@ -3,12 +3,17 @@ import { createDbClient } from "../db/client.js";
 import {
   accessRequests,
   roleGrants,
-  userIdentities,
   users,
   type accessRoleEnum
 } from "../db/schema.js";
 import type { CloudflareAccessIdentity } from "./cloudflare-access.js";
+import type { PortalIdentityProvider } from "@paretoproof/shared";
 import { normalizeOptionalEmail } from "../lib/email.js";
+import {
+  buildRequestedIdentityProviderSubjectMatch,
+  buildUserIdentityProviderSubjectMatch,
+  filterUserIdentityProviderSubjectMatch
+} from "../lib/identity-binding.js";
 
 type DbClient = ReturnType<typeof createDbClient>;
 type AccessRole = (typeof accessRoleEnum.enumValues)[number];
@@ -61,6 +66,7 @@ async function getLatestAccessRequestByEmail(db: DbClient, email: string) {
 async function getPendingRecoveryRequestForSubject(
   db: DbClient,
   email: string,
+  provider: PortalIdentityProvider,
   subject: string
 ) {
   return db.query.accessRequests.findFirst({
@@ -68,7 +74,7 @@ async function getPendingRecoveryRequestForSubject(
     where: and(
       eq(accessRequests.email, email),
       eq(accessRequests.requestKind, "identity_recovery"),
-      eq(accessRequests.requestedIdentitySubject, subject),
+      buildRequestedIdentityProviderSubjectMatch(provider, subject),
       eq(accessRequests.status, "pending")
     )
   });
@@ -77,6 +83,7 @@ async function getPendingRecoveryRequestForSubject(
 async function getLatestRecoveryRequestForSubject(
   db: DbClient,
   email: string,
+  provider: PortalIdentityProvider,
   subject: string
 ) {
   return db.query.accessRequests.findFirst({
@@ -84,7 +91,7 @@ async function getLatestRecoveryRequestForSubject(
     where: and(
       eq(accessRequests.email, email),
       eq(accessRequests.requestKind, "identity_recovery"),
-      eq(accessRequests.requestedIdentitySubject, subject)
+      buildRequestedIdentityProviderSubjectMatch(provider, subject)
     )
   });
 }
@@ -94,12 +101,21 @@ export async function resolveAccessRbacContext(
   identity: CloudflareAccessIdentity
 ): Promise<AccessRbacContext> {
   const normalizedIdentityEmail = normalizeOptionalEmail(identity.email);
-  const linkedIdentity = await db.query.userIdentities.findFirst({
-    where: eq(userIdentities.providerSubject, identity.subject),
-    with: {
-      user: true
-    }
-  });
+  const linkedIdentity = identity.provider
+    ? filterUserIdentityProviderSubjectMatch(
+        await db.query.userIdentities.findFirst({
+          where: buildUserIdentityProviderSubjectMatch(
+            identity.provider,
+            identity.subject
+          ),
+          with: {
+            user: true
+          }
+        }),
+        identity.provider,
+        identity.subject
+      )
+    : null;
 
   if (linkedIdentity) {
     const roles = await getActiveRoles(db, linkedIdentity.user.id);
@@ -168,11 +184,14 @@ export async function resolveAccessRbacContext(
   const latestRequest = await getLatestAccessRequestByEmail(db, normalizedIdentityEmail);
 
   if (matchingUser && activeMatchingUserRoles.length > 0) {
-    const pendingRecoveryRequest = await getPendingRecoveryRequestForSubject(
-      db,
-      normalizedIdentityEmail,
-      identity.subject
-    );
+    const pendingRecoveryRequest = identity.provider
+      ? await getPendingRecoveryRequestForSubject(
+          db,
+          normalizedIdentityEmail,
+          identity.provider,
+          identity.subject
+        )
+      : null;
 
     if (pendingRecoveryRequest) {
       return {
@@ -184,11 +203,14 @@ export async function resolveAccessRbacContext(
       };
     }
 
-    const latestRecoveryRequest = await getLatestRecoveryRequestForSubject(
-      db,
-      normalizedIdentityEmail,
-      identity.subject
-    );
+    const latestRecoveryRequest = identity.provider
+      ? await getLatestRecoveryRequestForSubject(
+          db,
+          normalizedIdentityEmail,
+          identity.provider,
+          identity.subject
+        )
+      : null;
 
     if (
       latestRecoveryRequest &&

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -219,6 +219,7 @@ export const userIdentities = pgTable(
   },
   (table) => ({
     providerSubjectUnique: uniqueIndex("user_identities_provider_subject_unique").on(
+      table.provider,
       table.providerSubject
     ),
     idUserUnique: uniqueIndex("user_identities_id_user_id_unique").on(
@@ -285,6 +286,7 @@ export const accessRequests = pgTable(
   (table) => ({
     emailIndex: index("access_requests_email_idx").on(table.email),
     requestedIdentitySubjectIndex: index("access_requests_requested_identity_subject_idx").on(
+      table.requestedIdentityProvider,
       table.requestedIdentitySubject
     ),
     statusIndex: index("access_requests_status_idx").on(table.status),

--- a/apps/api/src/lib/identity-binding.ts
+++ b/apps/api/src/lib/identity-binding.ts
@@ -1,0 +1,74 @@
+import type { PortalIdentityProvider } from "@paretoproof/shared";
+import { and, eq } from "drizzle-orm";
+import { accessRequests, userIdentities } from "../db/schema.js";
+
+type UserIdentityLike = Pick<
+  typeof userIdentities.$inferSelect,
+  "provider" | "providerSubject"
+>;
+type AccessRequestIdentityLike = Pick<
+  typeof accessRequests.$inferSelect,
+  "requestedIdentityProvider" | "requestedIdentitySubject"
+>;
+
+export function buildUserIdentityProviderSubjectMatch(
+  provider: PortalIdentityProvider,
+  subject: string
+) {
+  return and(
+    eq(userIdentities.provider, provider),
+    eq(userIdentities.providerSubject, subject)
+  );
+}
+
+export function matchesUserIdentityProviderSubject(
+  identityRow: UserIdentityLike,
+  provider: PortalIdentityProvider,
+  subject: string
+) {
+  return (
+    identityRow.provider === provider &&
+    identityRow.providerSubject === subject
+  );
+}
+
+export function filterUserIdentityProviderSubjectMatch<T extends UserIdentityLike>(
+  identityRow: T | null | undefined,
+  provider: PortalIdentityProvider,
+  subject: string
+) {
+  return identityRow &&
+    matchesUserIdentityProviderSubject(identityRow, provider, subject)
+    ? identityRow
+    : null;
+}
+
+export function buildRequestedIdentityProviderSubjectMatch(
+  provider: PortalIdentityProvider,
+  subject: string
+) {
+  return and(
+    eq(accessRequests.requestedIdentityProvider, provider),
+    eq(accessRequests.requestedIdentitySubject, subject)
+  );
+}
+
+export function matchesRequestedIdentityProviderSubject(
+  requestRow: AccessRequestIdentityLike,
+  provider: PortalIdentityProvider,
+  subject: string
+) {
+  return (
+    requestRow.requestedIdentityProvider === provider &&
+    requestRow.requestedIdentitySubject === subject
+  );
+}
+
+export function filterRequestedIdentityProviderSubjectMatch<
+  T extends AccessRequestIdentityLike
+>(requestRow: T | null | undefined, provider: PortalIdentityProvider, subject: string) {
+  return requestRow &&
+    matchesRequestedIdentityProviderSubject(requestRow, provider, subject)
+    ? requestRow
+    : null;
+}

--- a/apps/api/src/lib/owner-identity-provider.ts
+++ b/apps/api/src/lib/owner-identity-provider.ts
@@ -1,0 +1,97 @@
+import type { PortalIdentityProvider } from "@paretoproof/shared";
+
+export type BootstrapOwnerIdentityProvider = Extract<
+  PortalIdentityProvider,
+  "cloudflare_github" | "cloudflare_google"
+>;
+
+export function parseBootstrapOwnerIdentityProvider(
+  value: string | undefined
+): BootstrapOwnerIdentityProvider {
+  if (value === "cloudflare_github" || value === "cloudflare_google") {
+    return value;
+  }
+
+  throw new Error(
+    "OWNER_IDENTITY_PROVIDER must be set to cloudflare_github or cloudflare_google when bootstrapping the owner admin user."
+  );
+}
+
+export type CloudflareAccessUserCandidate = {
+  email: string;
+  id: string;
+  uid: string;
+};
+
+export type CloudflareLastSeenIdentity = {
+  idpType: string | null;
+  userUuid: string | null;
+};
+
+export function mapCloudflareIdpTypeToPortalIdentityProvider(
+  idpType: string | undefined | null
+) {
+  const normalizedIdpType = idpType?.trim().toLowerCase() ?? null;
+
+  if (normalizedIdpType === "github") {
+    return "cloudflare_github";
+  }
+
+  if (normalizedIdpType === "google") {
+    return "cloudflare_google";
+  }
+
+  if (normalizedIdpType === "onetimepin") {
+    return "cloudflare_one_time_pin";
+  }
+
+  return null;
+}
+
+export function selectBootstrapOwnerAccessUser(
+  candidates: CloudflareAccessUserCandidate[],
+  ownerEmail: string,
+  ownerIdentityProvider: BootstrapOwnerIdentityProvider,
+  lastSeenIdentityByUserId: ReadonlyMap<string, CloudflareLastSeenIdentity>
+) {
+  const normalizedOwnerEmail = ownerEmail.trim().toLowerCase();
+  const matchingCandidates = candidates.filter(({ email, id }) => {
+    if (email.trim().toLowerCase() !== normalizedOwnerEmail) {
+      return false;
+    }
+
+    const lastSeenIdentity = lastSeenIdentityByUserId.get(id);
+
+    return (
+      Boolean(lastSeenIdentity?.userUuid) &&
+      mapCloudflareIdpTypeToPortalIdentityProvider(lastSeenIdentity?.idpType) ===
+        ownerIdentityProvider
+    );
+  });
+
+  if (matchingCandidates.length === 0) {
+    throw new Error(
+      `No Cloudflare Access user last seen via ${ownerIdentityProvider} was found for ${normalizedOwnerEmail}. Sign into the protected portal with that provider before bootstrapping.`
+    );
+  }
+
+  if (matchingCandidates.length > 1) {
+    throw new Error(
+      `Multiple Cloudflare Access users last seen via ${ownerIdentityProvider} matched ${normalizedOwnerEmail}. Resolve the ambiguity before bootstrapping.`
+    );
+  }
+
+  const [selectedUser] = matchingCandidates;
+  const selectedLastSeenIdentity = selectedUser
+    ? lastSeenIdentityByUserId.get(selectedUser.id)
+    : null;
+
+  if (!selectedUser || !selectedLastSeenIdentity?.userUuid) {
+    throw new Error("The selected Cloudflare Access user could not be resolved.");
+  }
+
+  return {
+    email: normalizedOwnerEmail,
+    uid: selectedLastSeenIdentity.userUuid
+  };
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -33,6 +33,10 @@ import {
   users
 } from "../db/schema.js";
 import { toAccessRequestSummary } from "../lib/access-request-summary.js";
+import {
+  buildUserIdentityProviderSubjectMatch,
+  filterUserIdentityProviderSubjectMatch
+} from "../lib/identity-binding.js";
 import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
@@ -320,14 +324,22 @@ async function buildRecoveryContext(
     return null;
   }
 
-  const existingIdentity = requestRow.requestedIdentitySubject
-    ? await db.query.userIdentities.findFirst({
-        where: eq(userIdentities.providerSubject, requestRow.requestedIdentitySubject),
-        with: {
-          user: true
-        }
-      })
-    : null;
+  const existingIdentity =
+    requestRow.requestedIdentityProvider && requestRow.requestedIdentitySubject
+      ? filterUserIdentityProviderSubjectMatch(
+          await db.query.userIdentities.findFirst({
+            where: buildUserIdentityProviderSubjectMatch(
+              requestRow.requestedIdentityProvider,
+              requestRow.requestedIdentitySubject
+            ),
+            with: {
+              user: true
+            }
+          }),
+          requestRow.requestedIdentityProvider,
+          requestRow.requestedIdentitySubject
+        )
+      : null;
   const activeRole = matchedUser
     ? toAdminRoleGrantSummary(findActiveRoleGrant(matchedUser.roleGrants))
     : null;
@@ -850,9 +862,16 @@ export function registerAdminRoutes(
             };
           }
 
-          const existingSubjectOwner = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.providerSubject, requestedIdentitySubject)
-          });
+          const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
+            await tx.query.userIdentities.findFirst({
+              where: buildUserIdentityProviderSubjectMatch(
+                requestedIdentityProvider,
+                requestedIdentitySubject
+              )
+            }),
+            requestedIdentityProvider,
+            requestedIdentitySubject
+          );
 
           if (existingSubjectOwner && existingSubjectOwner.userId !== targetUser.id) {
             return {
@@ -883,9 +902,16 @@ export function registerAdminRoutes(
           .where(and(eq(roleGrants.userId, targetUser.id), isNull(roleGrants.revokedAt)));
 
         if (requestRow.requestKind === "identity_recovery") {
-          const existingSubjectOwner = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.providerSubject, requestRow.requestedIdentitySubject!)
-          });
+          const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
+            await tx.query.userIdentities.findFirst({
+              where: buildUserIdentityProviderSubjectMatch(
+                requestRow.requestedIdentityProvider!,
+                requestRow.requestedIdentitySubject!
+              )
+            }),
+            requestRow.requestedIdentityProvider!,
+            requestRow.requestedIdentitySubject!
+          );
 
           if (!existingSubjectOwner) {
             await tx.insert(userIdentities).values({

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -30,6 +30,12 @@ import {
 import { toAccessRequestSummary } from "../lib/access-request-summary.js";
 import { normalizeOptionalEmail } from "../lib/email.js";
 import {
+  buildRequestedIdentityProviderSubjectMatch,
+  buildUserIdentityProviderSubjectMatch,
+  filterUserIdentityProviderSubjectMatch,
+  matchesUserIdentityProviderSubject
+} from "../lib/identity-binding.js";
+import {
   createPortalBenchmarkOpsReadModelService,
   type PortalBenchmarkOpsReadModelService
 } from "../lib/portal-benchmark-ops.js";
@@ -210,6 +216,7 @@ function buildBrandedFinalizeRelayUrl(origin: string, redirectPath: string) {
 }
 
 function toPortalProfile(options: {
+  currentProvider: (typeof userIdentities.$inferSelect)["provider"] | null;
   currentSubject: string;
   fallbackEmail: string | null;
   linkedIdentityRows: (typeof userIdentities.$inferSelect)[];
@@ -223,7 +230,13 @@ function toPortalProfile(options: {
       .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
       .map((identityRow) => ({
         createdAt: identityRow.createdAt.toISOString(),
-        current: identityRow.providerSubject === options.currentSubject,
+        current:
+          options.currentProvider !== null &&
+          matchesUserIdentityProviderSubject(
+            identityRow,
+            options.currentProvider,
+            options.currentSubject
+          ),
         id: identityRow.id,
         lastSeenAt: identityRow.lastSeenAt.toISOString(),
         provider: identityRow.provider,
@@ -323,20 +336,32 @@ function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
 
 async function loadPortalProfile(db: ReturnTypeOfCreateDbClient, options: {
   fallbackEmail: string | null;
+  identityProvider: (typeof userIdentities.$inferSelect)["provider"] | null;
   identitySubject: string;
 }) {
-  const linkedIdentity = await db.query.userIdentities.findFirst({
-    where: eq(userIdentities.providerSubject, options.identitySubject),
-    with: {
-      user: {
-        with: {
-          identities: true
-        }
-      }
-    }
-  });
+  const linkedIdentity =
+    options.identityProvider === null
+      ? null
+      : filterUserIdentityProviderSubjectMatch(
+          await db.query.userIdentities.findFirst({
+            where: buildUserIdentityProviderSubjectMatch(
+              options.identityProvider,
+              options.identitySubject
+            ),
+            with: {
+              user: {
+                with: {
+                  identities: true
+                }
+              }
+            }
+          }),
+          options.identityProvider,
+          options.identitySubject
+        );
 
   return toPortalProfile({
+    currentProvider: options.identityProvider,
     currentSubject: options.identitySubject,
     fallbackEmail: options.fallbackEmail,
     linkedIdentityRows: linkedIdentity?.user.identities ?? [],
@@ -407,16 +432,23 @@ export function registerPortalRoutes(
           return "invalid";
         }
 
-        const existingSubjectOwner = await tx.query.userIdentities.findFirst({
-          where: eq(userIdentities.providerSubject, identity.subject)
-        });
+        if (providerHint !== intentRow.targetProvider) {
+          return "provider_mismatch";
+        }
+
+        const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
+          await tx.query.userIdentities.findFirst({
+            where: buildUserIdentityProviderSubjectMatch(
+              intentRow.targetProvider,
+              identity.subject
+            )
+          }),
+          intentRow.targetProvider,
+          identity.subject
+        );
 
         if (existingSubjectOwner && existingSubjectOwner.userId !== intentRow.userId) {
           return "conflict";
-        }
-
-        if (providerHint !== intentRow.targetProvider) {
-          return "provider_mismatch";
         }
 
         const now = new Date();
@@ -681,9 +713,19 @@ export function registerPortalRoutes(
         throw new Error("Authenticated Access identity was not attached to the request.");
       }
 
-      const linkedIdentity = await db.query.userIdentities.findFirst({
-        where: eq(userIdentities.providerSubject, identity.subject)
-      });
+      const linkedIdentity =
+        identity.provider === null
+          ? null
+          : filterUserIdentityProviderSubjectMatch(
+              await db.query.userIdentities.findFirst({
+                where: buildUserIdentityProviderSubjectMatch(
+                  identity.provider,
+                  identity.subject
+                )
+              }),
+              identity.provider,
+              identity.subject
+            );
 
       const latestRequest =
         (linkedIdentity
@@ -737,6 +779,7 @@ export function registerPortalRoutes(
       return {
         profile: await loadPortalProfile(db, {
           fallbackEmail: normalizeOptionalEmail(identity.email),
+          identityProvider: identity.provider,
           identitySubject: identity.subject
         })
       };
@@ -952,12 +995,22 @@ export function registerPortalRoutes(
       throw new Error("Authenticated Access identity was not attached to the request.");
     }
 
-    const linkedIdentity = await db.query.userIdentities.findFirst({
-      where: eq(userIdentities.providerSubject, identity.subject),
-      with: {
-        user: true
-      }
-    });
+    const linkedIdentity =
+      identity.provider === null
+        ? null
+        : filterUserIdentityProviderSubjectMatch(
+            await db.query.userIdentities.findFirst({
+              where: buildUserIdentityProviderSubjectMatch(
+                identity.provider,
+                identity.subject
+              ),
+              with: {
+                user: true
+              }
+            }),
+            identity.provider,
+            identity.subject
+          );
 
     if (!linkedIdentity) {
       reply.code(409).send({
@@ -977,6 +1030,7 @@ export function registerPortalRoutes(
     return {
       profile: await loadPortalProfile(db, {
         fallbackEmail: normalizeOptionalEmail(identity.email),
+        identityProvider: identity.provider,
         identitySubject: identity.subject
       })
     };
@@ -1027,16 +1081,26 @@ export function registerPortalRoutes(
         throw new Error("Approved Access identity was not attached to the request.");
       }
 
-      const linkedIdentity = await db.query.userIdentities.findFirst({
-        where: eq(userIdentities.providerSubject, identity.subject),
-        with: {
-          user: {
-            with: {
-              identities: true
-            }
-          }
-        }
-      });
+      const linkedIdentity =
+        identity.provider === null
+          ? null
+          : filterUserIdentityProviderSubjectMatch(
+              await db.query.userIdentities.findFirst({
+                where: buildUserIdentityProviderSubjectMatch(
+                  identity.provider,
+                  identity.subject
+                ),
+                with: {
+                  user: {
+                    with: {
+                      identities: true
+                    }
+                  }
+                }
+              }),
+              identity.provider,
+              identity.subject
+            );
 
       if (!linkedIdentity) {
         reply.code(409).send({
@@ -1153,7 +1217,6 @@ export function registerPortalRoutes(
       }
 
       const accessEmail = normalizeOptionalEmail(identity.email);
-      const accessProvider = identity.provider ?? "cloudflare_one_time_pin";
 
       if (!accessEmail) {
         reply.code(400).send({
@@ -1162,13 +1225,29 @@ export function registerPortalRoutes(
         return;
       }
 
+      if (!identity.provider) {
+        reply.code(409).send({
+          error: "identity_provider_required"
+        });
+        return;
+      }
+
+      const accessProvider = identity.provider;
+
       let latestRequest;
 
       try {
         latestRequest = await db.transaction(async (tx) => {
-          const existingIdentity = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.providerSubject, identity.subject)
-          });
+          const existingIdentity = filterUserIdentityProviderSubjectMatch(
+            await tx.query.userIdentities.findFirst({
+              where: buildUserIdentityProviderSubjectMatch(
+                accessProvider,
+                identity.subject
+              )
+            }),
+            accessProvider,
+            identity.subject
+          );
 
           const linkedUser = existingIdentity
             ? await tx.query.users.findFirst({
@@ -1406,7 +1485,6 @@ export function registerPortalRoutes(
       }
 
       const accessEmail = normalizeOptionalEmail(identity.email);
-      const accessProvider = identity.provider ?? "cloudflare_one_time_pin";
 
       if (!accessEmail) {
         reply.code(400).send({
@@ -1415,13 +1493,29 @@ export function registerPortalRoutes(
         return;
       }
 
+      if (!identity.provider) {
+        reply.code(409).send({
+          error: "identity_provider_required"
+        });
+        return;
+      }
+
+      const accessProvider = identity.provider;
+
       let latestRequest;
 
       try {
         latestRequest = await db.transaction(async (tx) => {
-          const existingIdentity = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.providerSubject, identity.subject)
-          });
+          const existingIdentity = filterUserIdentityProviderSubjectMatch(
+            await tx.query.userIdentities.findFirst({
+              where: buildUserIdentityProviderSubjectMatch(
+                accessProvider,
+                identity.subject
+              )
+            }),
+            accessProvider,
+            identity.subject
+          );
 
           if (existingIdentity) {
             throw new PortalAccessRequestConflictError("identity_already_linked");

--- a/apps/api/test/admin-routes.test.ts
+++ b/apps/api/test/admin-routes.test.ts
@@ -236,6 +236,88 @@ test("GET /portal/admin/access-requests returns the richer admin read model", as
   assert.equal(payload.items[0]?.recovery?.requestedIdentityAlreadyLinked, false);
 });
 
+test("GET /portal/admin/access-requests ignores recovery identity rows from a different provider", async (t) => {
+  const reviewer = buildUser({
+    displayName: "Admin Reviewer",
+    email: "admin@paretoproof.com",
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  });
+  const matchedUser = buildUser({
+    displayName: "Researcher One"
+  });
+  const recoveryRequest = {
+    ...buildAccessRequest({
+      createdAt: new Date("2026-03-13T18:00:00.000Z"),
+      email: "recover@paretoproof.com",
+      id: "78787878-7878-4787-8787-787878787878",
+      rationale: "Lost my Google login",
+      requestKind: "identity_recovery",
+      requestedIdentityProvider: "cloudflare_google",
+      requestedIdentitySubject: "recovery-subject",
+      status: "pending"
+    }),
+    reviewedByUser: null
+  };
+  const db = {
+    query: {
+      accessRequests: {
+        findMany: async () => [recoveryRequest]
+      },
+      userIdentities: {
+        findFirst: async () => ({
+          ...buildIdentity({
+            provider: "cloudflare_github",
+            providerSubject: "recovery-subject",
+            userId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+          }),
+          user: buildUser({
+            displayName: "Different Owner",
+            email: "different@paretoproof.com",
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+          })
+        })
+      },
+      users: {
+        findFirst: async () => ({
+          ...matchedUser,
+          accessRequests: [recoveryRequest],
+          auditEventsAsTarget: [],
+          identities: [buildIdentity()],
+          roleGrants: [
+            {
+              ...buildRoleGrant(),
+              grantedByUser: reviewer,
+              revokedByUser: null
+            }
+          ],
+          sessions: [buildSession()]
+        })
+      }
+    }
+  };
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerAdminRoutes(app, db as never, createAdminAccessGuard() as never);
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/admin/access-requests"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(
+    portalAdminReadModelsContract.accessRequestListResponse.safeParse(payload).success,
+    true
+  );
+  assert.equal(payload.items[0]?.recovery?.conflictingUser, null);
+  assert.equal(payload.items[0]?.recovery?.requestedIdentityAlreadyLinked, false);
+});
+
 test("GET /portal/admin/access-requests keeps orphaned recovery requests unlinked", async (t) => {
   const orphanedRecoveryRequest = {
     ...buildAccessRequest({
@@ -920,6 +1002,8 @@ test("POST /portal/admin/access-requests/:id/approve returns a recovery-specific
           },
           userIdentities: {
             findFirst: async () => ({
+              provider: "cloudflare_google",
+              providerSubject: "recovery-conflict",
               userId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
             })
           },

--- a/apps/api/test/identity-binding.test.ts
+++ b/apps/api/test/identity-binding.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createPortalAccessSession
+} from "../src/auth/portal-access-session.ts";
+import { resolveAccessIdentityProvider } from "../src/auth/require-access.ts";
+import {
+  resolveAccessRbacContext
+} from "../src/auth/resolve-access-rbac-context.ts";
+
+test("resolveAccessIdentityProvider keeps the provider unset when no provider hint is present", () => {
+  assert.equal(
+    resolveAccessIdentityProvider(
+      {
+        provider: null,
+        subject: "otp-subject"
+      },
+      undefined
+    ),
+    null
+  );
+});
+
+test("resolveAccessRbacContext ignores subject matches from a different provider", async () => {
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async () => null
+      },
+      userIdentities: {
+        findFirst: async () => ({
+          id: "identity-1",
+          provider: "cloudflare_github",
+          providerEmail: "person@example.com",
+          providerSubject: "shared-subject",
+          user: {
+            email: "person@example.com",
+            id: "user-1"
+          }
+        })
+      },
+      users: {
+        findFirst: async () => ({
+          email: "person@example.com",
+          id: "user-1"
+        })
+      }
+    },
+    select() {
+      return {
+        from() {
+          return {
+            where: async () => [{ role: "helper" }]
+          };
+        }
+      };
+    }
+  };
+
+  const context = await resolveAccessRbacContext(db as never, {
+    email: "person@example.com",
+    issuer: "https://paretoproof.cloudflareaccess.com",
+    provider: "cloudflare_google",
+    subject: "shared-subject"
+  });
+
+  assert.deepEqual(context, {
+    email: "person@example.com",
+    reason: "identity_recovery_required",
+    status: "denied",
+    subject: "shared-subject"
+  });
+});
+
+test("resolveAccessRbacContext keeps providerless assertions unbound when the provider hint is absent", async () => {
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async () => null
+      },
+      userIdentities: {
+        findFirst: async () => {
+          throw new Error("provider-specific lookup should not run without a provider hint");
+        }
+      },
+      users: {
+        findFirst: async () => ({
+          email: "person@example.com",
+          id: "user-1"
+        })
+      }
+    },
+    select() {
+      return {
+        from() {
+          return {
+            where: async () => [{ role: "helper" }]
+          };
+        }
+      };
+    }
+  };
+
+  const context = await resolveAccessRbacContext(db as never, {
+    email: "person@example.com",
+    issuer: "https://paretoproof.cloudflareaccess.com",
+    provider: null,
+    subject: "otp-subject"
+  });
+
+  assert.deepEqual(context, {
+    email: "person@example.com",
+    reason: "identity_recovery_required",
+    status: "denied",
+    subject: "otp-subject",
+  });
+});
+
+test("resolveAccessRbacContext denies providerless assertions without probing subject-only identity matches", async () => {
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async () => null
+      },
+      userIdentities: {
+        findFirst: async () => {
+          throw new Error("provider-specific lookup should not run without a provider hint");
+        },
+        findMany: async () => {
+          throw new Error("subject-only identity scans should not run without a provider hint");
+        }
+      },
+      users: {
+        findFirst: async () => ({
+          email: "person@example.com",
+          id: "user-1"
+        })
+      }
+    },
+    select() {
+      return {
+        from() {
+          return {
+            where: async () => [{ role: "helper" }]
+          };
+        }
+      };
+    }
+  };
+
+  const context = await resolveAccessRbacContext(db as never, {
+    email: "person@example.com",
+    issuer: "https://paretoproof.cloudflareaccess.com",
+    provider: null,
+    subject: "shared-subject"
+  });
+
+  assert.deepEqual(context, {
+    email: "person@example.com",
+    reason: "identity_recovery_required",
+    status: "denied",
+    subject: "shared-subject"
+  });
+});
+
+test("createPortalAccessSession rejects approved contexts when the stored identity provider mismatches", async () => {
+  let insertedSession = false;
+  const db = {
+    insert() {
+      insertedSession = true;
+
+      return {
+        values: async () => undefined
+      };
+    },
+    query: {
+      userIdentities: {
+        findFirst: async () => ({
+          id: "identity-1",
+          provider: "cloudflare_github",
+          providerEmail: "person@example.com",
+          providerSubject: "shared-subject",
+          userId: "user-1"
+        })
+      }
+    }
+  };
+
+  await assert.rejects(
+    createPortalAccessSession(
+      db as never,
+      {
+        headers: {},
+        ip: "127.0.0.1"
+      } as never,
+      {
+        email: "person@example.com",
+        issuer: "https://paretoproof.cloudflareaccess.com",
+        provider: "cloudflare_google",
+        subject: "shared-subject"
+      },
+      {
+        email: "person@example.com",
+        identityId: "identity-1",
+        roles: ["helper"],
+        status: "approved",
+        subject: "shared-subject",
+        userId: "user-1"
+      }
+    ),
+    /Approved portal session identity could not be resolved/
+  );
+  assert.equal(insertedSession, false);
+});

--- a/apps/api/test/owner-identity-provider.test.ts
+++ b/apps/api/test/owner-identity-provider.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  mapCloudflareIdpTypeToPortalIdentityProvider,
+  parseBootstrapOwnerIdentityProvider,
+  selectBootstrapOwnerAccessUser
+} from "../src/lib/owner-identity-provider.ts";
+
+test("parseBootstrapOwnerIdentityProvider accepts the supported branded providers", () => {
+  assert.equal(
+    parseBootstrapOwnerIdentityProvider("cloudflare_github"),
+    "cloudflare_github"
+  );
+  assert.equal(
+    parseBootstrapOwnerIdentityProvider("cloudflare_google"),
+    "cloudflare_google"
+  );
+});
+
+test("parseBootstrapOwnerIdentityProvider rejects missing and legacy OTP values", () => {
+  assert.throws(
+    () => parseBootstrapOwnerIdentityProvider(undefined),
+    /OWNER_IDENTITY_PROVIDER must be set/
+  );
+  assert.throws(
+    () => parseBootstrapOwnerIdentityProvider("cloudflare_one_time_pin"),
+    /OWNER_IDENTITY_PROVIDER must be set/
+  );
+});
+
+test("mapCloudflareIdpTypeToPortalIdentityProvider maps Cloudflare last-seen IdP types", () => {
+  assert.equal(
+    mapCloudflareIdpTypeToPortalIdentityProvider("github"),
+    "cloudflare_github"
+  );
+  assert.equal(
+    mapCloudflareIdpTypeToPortalIdentityProvider("google"),
+    "cloudflare_google"
+  );
+  assert.equal(
+    mapCloudflareIdpTypeToPortalIdentityProvider("onetimepin"),
+    "cloudflare_one_time_pin"
+  );
+  assert.equal(
+    mapCloudflareIdpTypeToPortalIdentityProvider("unknown"),
+    null
+  );
+});
+
+test("selectBootstrapOwnerAccessUser requires a last-seen identity that matches the declared provider", () => {
+  const selectedUser = selectBootstrapOwnerAccessUser(
+    [
+      {
+        email: "owner@example.com",
+        id: "user-1",
+        uid: "uid-1"
+      }
+    ],
+    "owner@example.com",
+    "cloudflare_google",
+    new Map([
+      [
+        "user-1",
+        {
+          idpType: "google",
+          userUuid: "subject-1"
+        }
+      ]
+    ])
+  );
+
+  assert.deepEqual(selectedUser, {
+    email: "owner@example.com",
+    uid: "subject-1"
+  });
+
+  assert.throws(
+    () =>
+      selectBootstrapOwnerAccessUser(
+        [
+          {
+            email: "owner@example.com",
+            id: "user-1",
+            uid: "uid-1"
+          }
+        ],
+        "owner@example.com",
+        "cloudflare_google",
+        new Map([
+          [
+            "user-1",
+            {
+              idpType: "github",
+              userUuid: "subject-1"
+            }
+          ]
+        ])
+      ),
+    /last seen via cloudflare_google/
+  );
+});

--- a/apps/api/test/portal-access-identity-binding.test.ts
+++ b/apps/api/test/portal-access-identity-binding.test.ts
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import {
+  accessRequests,
+  auditEvents,
+  roleGrants,
+  userIdentities,
+  users
+} from "../src/db/schema.ts";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+function createAuthenticatedAccessGuard(
+  identityOverrides: Partial<{
+    email: string;
+    issuer: string;
+    provider: "cloudflare_google" | null;
+    subject: string;
+  }> = {}
+) {
+  return () => (
+    request: {
+      accessIdentity?: {
+        email: string;
+        issuer: string;
+        provider: "cloudflare_google" | null;
+        subject: string;
+      };
+    },
+    _reply: unknown,
+    done: () => void
+  ) => {
+    request.accessIdentity = {
+      email: "person@example.com",
+      issuer: "https://paretoproof.cloudflareaccess.com",
+      provider: "cloudflare_google",
+      subject: "shared-subject",
+      ...identityOverrides
+    };
+    done();
+  };
+}
+
+test("POST /portal/access-requests ignores subject collisions from a different provider", async (t) => {
+  const createdRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "11111111-1111-4111-8111-111111111111",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const insertedIdentityRows: Array<typeof userIdentities.$inferInsert> = [];
+  const app = Fastify();
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => {
+          values: (value: unknown) => {
+            returning?: () => Promise<unknown[]>;
+          };
+        };
+        query: {
+          accessRequests: { findFirst: () => Promise<null> };
+          userIdentities: { findFirst: () => Promise<typeof userIdentities.$inferSelect> };
+          users: { findFirst: () => Promise<null> };
+        };
+        select: () => {
+          from: (_table: unknown) => {
+            where: (_where: unknown) => Promise<Array<{ role: typeof roleGrants.$inferSelect.role }>>;
+          };
+        };
+      }) => Promise<unknown>
+    ) =>
+      callback({
+        insert(table: unknown) {
+          return {
+            values(value: unknown) {
+              if (table === users) {
+                return {
+                  returning: async () => [
+                    {
+                      email: "person@example.com",
+                      id: "22222222-2222-4222-8222-222222222222"
+                    }
+                  ]
+                };
+              }
+
+              if (table === userIdentities) {
+                insertedIdentityRows.push(value as typeof userIdentities.$inferInsert);
+                return Promise.resolve(value);
+              }
+
+              if (table === accessRequests) {
+                return {
+                  returning: async () => [createdRequest]
+                };
+              }
+
+              if (table === auditEvents) {
+                return Promise.resolve(value);
+              }
+
+              throw new Error("unexpected insert");
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async () => null
+          },
+          userIdentities: {
+            findFirst: async () => ({
+              createdAt: new Date("2026-04-10T14:30:00.000Z"),
+              id: "33333333-3333-4333-8333-333333333333",
+              lastSeenAt: new Date("2026-04-10T14:31:00.000Z"),
+              provider: "cloudflare_github",
+              providerEmail: "other@example.com",
+              providerSubject: "shared-subject",
+              userId: "44444444-4444-4444-8444-444444444444"
+            })
+          },
+          users: {
+            findFirst: async () => null
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => []
+              };
+            }
+          };
+        }
+      } as never)
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, db as never, createAuthenticatedAccessGuard(), {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need helper access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.requestKind, "access_request");
+  assert.equal(insertedIdentityRows[0]?.provider, "cloudflare_google");
+  assert.equal(insertedIdentityRows[0]?.providerSubject, "shared-subject");
+});
+
+test("POST /portal/access-recovery ignores subject collisions from a different provider", async (t) => {
+  const matchingUser = {
+    email: "person@example.com",
+    id: "22222222-2222-4222-8222-222222222222"
+  };
+  const createdRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:05:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "55555555-5555-4555-8555-555555555555",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: matchingUser.id,
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const app = Fastify();
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => {
+          values: (value: unknown) => {
+            returning?: () => Promise<unknown[]>;
+          };
+        };
+        query: {
+          accessRequests: { findFirst: () => Promise<null> };
+          userIdentities: { findFirst: () => Promise<typeof userIdentities.$inferSelect> };
+          users: { findFirst: () => Promise<typeof matchingUser> };
+        };
+        select: () => {
+          from: (_table: unknown) => {
+            where: (_where: unknown) => Promise<Array<{ role: typeof roleGrants.$inferSelect.role }>>;
+          };
+        };
+      }) => Promise<unknown>
+    ) =>
+      callback({
+        insert(table: unknown) {
+          return {
+            values(value: unknown) {
+              if (table === accessRequests) {
+                return {
+                  returning: async () => [createdRequest]
+                };
+              }
+
+              if (table === auditEvents) {
+                return Promise.resolve(value);
+              }
+
+              throw new Error("unexpected insert");
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async () => null
+          },
+          userIdentities: {
+            findFirst: async () => ({
+              createdAt: new Date("2026-04-10T14:30:00.000Z"),
+              id: "66666666-6666-4666-8666-666666666666",
+              lastSeenAt: new Date("2026-04-10T14:31:00.000Z"),
+              provider: "cloudflare_github",
+              providerEmail: "other@example.com",
+              providerSubject: "shared-subject",
+              userId: "77777777-7777-4777-8777-777777777777"
+            })
+          },
+          users: {
+            findFirst: async () => matchingUser
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => [{ role: "helper" }]
+              };
+            }
+          };
+        }
+      } as never)
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, db as never, createAuthenticatedAccessGuard(), {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need to recover my Google login"
+    },
+    url: "/portal/access-recovery"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.requestKind, "identity_recovery");
+});
+
+test("POST /portal/access-requests rejects requests whose verified provider is still unknown", async (t) => {
+  let transactionCalled = false;
+  const app = Fastify();
+  const db = {
+    transaction: async () => {
+      transactionCalled = true;
+      throw new Error("providerless access requests must fail before the transaction starts");
+    }
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    db as never,
+    createAuthenticatedAccessGuard({
+      provider: null
+    }),
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need helper access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests"
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(response.json(), {
+    error: "identity_provider_required"
+  });
+  assert.equal(transactionCalled, false);
+});
+
+test("POST /portal/access-recovery rejects requests whose verified provider is still unknown", async (t) => {
+  let transactionCalled = false;
+  const app = Fastify();
+  const db = {
+    transaction: async () => {
+      transactionCalled = true;
+      throw new Error("providerless recovery requests must fail before the transaction starts");
+    }
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    db as never,
+    createAuthenticatedAccessGuard({
+      provider: null
+    }),
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need to recover my Google login"
+    },
+    url: "/portal/access-recovery"
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(response.json(), {
+    error: "identity_provider_required"
+  });
+  assert.equal(transactionCalled, false);
+});

--- a/apps/api/test/portal-link-intent-cookie.test.ts
+++ b/apps/api/test/portal-link-intent-cookie.test.ts
@@ -45,6 +45,8 @@ test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie 
     query: {
       userIdentities: {
         findFirst: async () => ({
+          provider: "cloudflare_google",
+          providerSubject: "subject-1",
           user: {
             id: "user-1",
             identities: [

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -93,6 +93,7 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
         userIdentities: {
           findFirst: async () => ({
             id: "identity-1",
+            provider: "cloudflare_google",
             providerSubject: "subject-1",
             userId: "user-1"
           })
@@ -191,6 +192,7 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
         userIdentities: {
           findFirst: async () => ({
             id: "identity-1",
+            provider: "cloudflare_google",
             providerSubject: "subject-1",
             userId: "user-1"
           })

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import {
+  resolveAuthEntrySessionCheckAction,
+  shouldStayOnAuthEntryForProviderlessRecovery
+} from "./auth-entry.tsx";
+
+describe("shouldStayOnAuthEntryForProviderlessRecovery", () => {
+  it("keeps auth entry active when /portal/me reports providerless recovery drift", () => {
+    expect(
+      shouldStayOnAuthEntryForProviderlessRecovery({
+        access: {
+          reason: "identity_recovery_required",
+          status: "denied"
+        },
+        identity: {
+          provider: null
+        }
+      })
+    ).toBe(true);
+  });
+
+  it("does not treat ordinary approved sessions as providerless recovery drift", () => {
+    expect(
+      shouldStayOnAuthEntryForProviderlessRecovery({
+        access: {
+          status: "approved"
+        },
+        identity: {
+          provider: "cloudflare_google"
+        }
+      })
+    ).toBe(false);
+  });
+});
+
+describe("resolveAuthEntrySessionCheckAction", () => {
+  it("stays on auth entry for providerless recovery responses", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            reason: "identity_recovery_required",
+            status: "denied"
+          },
+          identity: {
+            provider: null
+          }
+        }
+      )
+    ).toBe("stay_on_auth_entry");
+  });
+
+  it("redirects to portal for ordinary successful session checks", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            status: "approved"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }
+      )
+    ).toBe("redirect_portal");
+  });
+});

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -15,6 +15,20 @@ type AuthEntryProps = {
   redirectPath: string;
 };
 
+type AuthEntrySessionCheckPayload = {
+  access: {
+    reason?:
+      | "access_request_required"
+      | "identity_recovery_required"
+      | "rejected_or_withdrawn"
+      | "unknown_identity";
+    status: "approved" | "pending" | "denied";
+  };
+  identity: {
+    provider: "cloudflare_one_time_pin" | "cloudflare_github" | "cloudflare_google" | null;
+  } | null;
+};
+
 const signInChecks = [
   "We match this provider to your existing ParetoProof account whenever possible.",
   "If your account still needs approval, we will let you know clearly before portal entry.",
@@ -42,8 +56,25 @@ export function buildAuthEntrySessionCheckRequestInit(signal: AbortSignal): Requ
   };
 }
 
-export function resolveAuthEntrySessionCheckAction(response: Pick<Response, "ok" | "status" | "type">) {
+export function shouldStayOnAuthEntryForProviderlessRecovery(
+  payload: AuthEntrySessionCheckPayload | null
+) {
+  return (
+    payload?.access.status === "denied" &&
+    payload.access.reason === "identity_recovery_required" &&
+    payload.identity?.provider === null
+  );
+}
+
+export function resolveAuthEntrySessionCheckAction(
+  response: Pick<Response, "ok" | "status" | "type">,
+  payload: AuthEntrySessionCheckPayload | null = null
+) {
   if (response.ok) {
+    if (shouldStayOnAuthEntryForProviderlessRecovery(payload)) {
+      return "stay_on_auth_entry";
+    }
+
     return "redirect_portal";
   }
 
@@ -83,7 +114,9 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
           `${apiBaseUrl}/portal/me`,
           buildAuthEntrySessionCheckRequestInit(controller.signal)
         );
-        const action = resolveAuthEntrySessionCheckAction(response);
+        const payload =
+          response.ok ? ((await response.json()) as AuthEntrySessionCheckPayload) : null;
+        const action = resolveAuthEntrySessionCheckAction(response, payload);
 
         if (action === "redirect_portal") {
           window.location.replace(portalUrl);

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -3,6 +3,10 @@ import {
   buildLocalPendingPortalUrl,
   reducePortalStateAfterAuthExpiry
 } from "./portal-bootstrap-state.ts";
+import {
+  mapPortalMutationErrorMessage,
+  shouldRestartPortalAuthForMissingProvider
+} from "./portal-bootstrap.tsx";
 
 describe("buildLocalPendingPortalUrl", () => {
   it("promotes the local access state to pending and clears denial-only params", () => {
@@ -39,5 +43,53 @@ describe("buildLocalPendingPortalUrl", () => {
     ).toEqual({
       status: "loading"
     });
+  });
+});
+
+describe("mapPortalMutationErrorMessage", () => {
+  it("surfaces a restart message when the API cannot prove the sign-in provider", () => {
+    expect(
+      mapPortalMutationErrorMessage("access_request", 409, "identity_provider_required")
+    ).toBe(
+      "The sign-in provider could not be verified. Restart from the auth entry and choose GitHub or Google again."
+    );
+  });
+
+  it("falls back to the request-specific status message for unknown API errors", () => {
+    expect(mapPortalMutationErrorMessage("identity_recovery", 500, "unexpected")).toBe(
+      "Access recovery failed with 500."
+    );
+  });
+});
+
+describe("shouldRestartPortalAuthForMissingProvider", () => {
+  it("restarts auth when the portal bootstrap sees providerless recovery drift", () => {
+    expect(
+      shouldRestartPortalAuthForMissingProvider({
+        access: {
+          email: "owner@example.com",
+          reason: "identity_recovery_required",
+          status: "denied"
+        },
+        identity: {
+          provider: null
+        }
+      })
+    ).toBe(true);
+  });
+
+  it("does not restart auth for ordinary linked recovery flows", () => {
+    expect(
+      shouldRestartPortalAuthForMissingProvider({
+        access: {
+          email: "owner@example.com",
+          reason: "identity_recovery_required",
+          status: "denied"
+        },
+        identity: {
+          provider: "cloudflare_google"
+        }
+      })
+    ).toBe(false);
   });
 });

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -33,6 +33,15 @@ type PortalMeResponse = {
       | "unknown_identity";
     status: "approved" | "pending" | "denied";
   };
+  identity: {
+    provider: "cloudflare_one_time_pin" | "cloudflare_github" | "cloudflare_google" | null;
+  } | null;
+};
+
+type PortalMutationAction = "access_request" | "identity_recovery";
+
+type PortalMutationErrorPayload = {
+  error?: string;
 };
 
 function parseDeniedReason(
@@ -108,6 +117,46 @@ function formatPortalBootstrapError(error: unknown) {
 
   return "The portal could not finish loading right now. Try again in a moment.";
 }
+
+export function mapPortalMutationErrorMessage(
+  action: PortalMutationAction,
+  status: number,
+  errorCode: string | null
+) {
+  if (errorCode === "identity_provider_required") {
+    return "The sign-in provider could not be verified. Restart from the auth entry and choose GitHub or Google again.";
+  }
+
+  return action === "access_request"
+    ? `Access request failed with ${status}.`
+    : `Access recovery failed with ${status}.`;
+}
+
+async function readPortalMutationErrorMessage(
+  response: Pick<Response, "json" | "status">,
+  action: PortalMutationAction
+) {
+  let errorCode: string | null = null;
+
+  try {
+    errorCode = ((await response.json()) as PortalMutationErrorPayload).error ?? null;
+  } catch {
+    errorCode = null;
+  }
+
+  return mapPortalMutationErrorMessage(action, response.status, errorCode);
+}
+
+export function shouldRestartPortalAuthForMissingProvider(
+  payload: PortalMeResponse
+) {
+  return (
+    payload.access.status === "denied" &&
+    payload.access.reason === "identity_recovery_required" &&
+    payload.identity?.provider === null
+  );
+}
+
 export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
@@ -171,6 +220,11 @@ export function PortalBootstrap() {
         }
 
         const payload = (await response.json()) as PortalMeResponse;
+
+        if (shouldRestartPortalAuthForMissingProvider(payload)) {
+          setState({ status: "unauthenticated" });
+          return;
+        }
 
         if (payload.access.status === "approved") {
           setState({
@@ -264,7 +318,7 @@ export function PortalBootstrap() {
     });
 
     if (!response.ok) {
-      throw new Error(`Access request failed with ${response.status}.`);
+      throw new Error(await readPortalMutationErrorMessage(response, "access_request"));
     }
 
     setState({
@@ -296,7 +350,7 @@ export function PortalBootstrap() {
     });
 
     if (!response.ok) {
-      throw new Error(`Access recovery failed with ${response.status}.`);
+      throw new Error(await readPortalMutationErrorMessage(response, "identity_recovery"));
     }
 
     setState({

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -129,12 +129,16 @@ Use this mode for `bun run bootstrap:owner-admin:api` and related owner-only set
 - Required env:
   - `MIGRATION_DATABASE_URL` or `DATABASE_URL`
   - `OWNER_EMAIL`
+  - `OWNER_IDENTITY_PROVIDER`
   - `CLOUDFLARE_ACCOUNT_ID`
   - either `CLOUDFLARE_API_TOKEN`, or `CLOUDFLARE_EMAIL` together with `CLOUDFLARE_GLOBAL_API_KEY`
 - Optional env: none
 - Secret env:
   - database credential used for the bootstrap
   - Cloudflare credential used for the bootstrap
+- Notes:
+  - `OWNER_IDENTITY_PROVIDER` must be `cloudflare_github` or `cloudflare_google`
+  - rerunning the bootstrap migrates a legacy `cloudflare_one_time_pin` owner identity for the same Access subject onto the declared provider
 - Do not treat as normal startup:
   - these owner-only values are not required for routine API serving
 

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -21,6 +21,7 @@ const checks = [
       { name: "DATABASE_URL", commented: false },
       { name: "MIGRATION_DATABASE_URL", commented: false },
       { name: "OWNER_EMAIL", commented: false },
+      { name: "OWNER_IDENTITY_PROVIDER", commented: false },
       { name: "CF_ACCESS_TEAM_DOMAIN", commented: false },
       { name: "CF_ACCESS_PORTAL_AUD", commented: false },
       { name: "CF_ACCESS_BRANDED_AUDS", commented: false },


### PR DESCRIPTION
## Summary
- scope portal/API identity binding to provider plus subject across auth, portal, admin, and session paths
- stop providerless assertions from auto-binding, require a verified provider for access request and recovery mutations, and keep auth entry on the provider chooser when the provider hint is missing
- migrate owner bootstrap off legacy OTP identities by selecting the declared provider via Cloudflare last-seen identity and documenting the new owner bootstrap contract

## Testing
- bun run test:api
- bun test apps/web/src/routes/portal-bootstrap.test.js apps/web/src/routes/auth-entry.test.js
- bun run build
- bun run test:startup-validation *(fails in this environment because Docker Desktop is unavailable: the local Docker worker startup smoke cannot connect to //./pipe/dockerDesktopLinuxEngine)*

Closes #995