### PR TITLE
docs(problem9): clarify axiom safety contract

### DIFF
--- a/benchmarks/firstproof/problem9/README.md
+++ b/benchmarks/firstproof/problem9/README.md
@@ -28,3 +28,14 @@ reference proof:
 
 This keeps the immutable package honest while preserving deterministic local
 materialization and verifier behavior.
+
+## Axiom safety model
+
+- `Statement.lean` intentionally exports `axiom problem9` as the stable theorem
+  header.
+- The checked-in axiom is not accepted as benchmark proof evidence.
+- The runtime keeps the checked-in benchmark package read-only and writes model
+  output only to `FirstProof/Problem9/Candidate.lean`.
+- Importing `FirstProof.Problem9.Gold` is invalid.
+- Passing runs must match the canonical theorem target and clear the
+  no-axioms check for `FirstProof.Problem9.problem9`.

--- a/docs/problem9-benchmark-target-baseline.md
+++ b/docs/problem9-benchmark-target-baseline.md
@@ -35,6 +35,17 @@ The checked-in package must keep these layers aligned:
 That arrangement keeps the package-local default build on the same path as the
 canonical statement contract.
 
+## Axiom safety contract
+
+- `Statement.lean` intentionally exports `axiom problem9` as the stable theorem
+  header.
+- The checked-in axiom is not accepted as benchmark proof evidence.
+- The runtime keeps the checked-in benchmark package read-only and writes model
+  output only to `FirstProof/Problem9/Candidate.lean`.
+- Importing `FirstProof.Problem9.Gold` is invalid.
+- Passing runs must match the canonical theorem target and clear the
+  no-axioms check for `FirstProof.Problem9.problem9`.
+
 ## Package shape
 
 The benchmark remains one immutable package version with:

--- a/infra/scripts/check-problem9-package-cohesion.mjs
+++ b/infra/scripts/check-problem9-package-cohesion.mjs
@@ -1,14 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
-import { hasExpectedCanonicalModules } from "./lib/problem9-package-cohesion.mjs";
+import {
+  hasExpectedAxiomSafetyNarrative,
+  hasExpectedCanonicalModules
+} from "./lib/problem9-package-cohesion.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 const benchmarkRoot = path.join(repoRoot, "benchmarks", "firstproof", "problem9");
 
 const benchmarkPackagePath = path.join(benchmarkRoot, "benchmark-package.json");
 const lakefilePath = path.join(benchmarkRoot, "lakefile.toml");
+const benchmarkReadmePath = path.join(benchmarkRoot, "README.md");
 const statementPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Statement.lean");
 const goldPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Gold.lean");
+const targetBaselinePath = path.join(repoRoot, "docs", "problem9-benchmark-target-baseline.md");
 
 const expectedCanonicalModules = {
   statement: "FirstProof.Problem9.Statement",
@@ -26,8 +31,10 @@ function fail(message) {
 
 const benchmarkPackage = JSON.parse(readText(benchmarkPackagePath));
 const lakefile = readText(lakefilePath);
+const benchmarkReadme = readText(benchmarkReadmePath);
 const statementSource = readText(statementPath);
 const goldSource = readText(goldPath);
+const targetBaseline = readText(targetBaselinePath);
 
 if (!hasExpectedCanonicalModules(benchmarkPackage.canonicalModules, expectedCanonicalModules)) {
   fail(
@@ -75,4 +82,12 @@ if (!/theorem\s+problem9_gold\s*\(n\s*:\s*Nat\)\s*:\s*problem9_target n\s*:=\s*b
   fail(
     "Gold.lean must prove problem9_target n instead of restating the proposition independently"
   );
+}
+
+if (!hasExpectedAxiomSafetyNarrative(benchmarkReadme, "## Axiom safety model")) {
+  fail("README.md must explain the Problem 9 axiom safety model");
+}
+
+if (!hasExpectedAxiomSafetyNarrative(targetBaseline, "## Axiom safety contract")) {
+  fail("docs/problem9-benchmark-target-baseline.md must explain the Problem 9 axiom safety model");
 }

--- a/infra/scripts/lib/problem9-package-cohesion.mjs
+++ b/infra/scripts/lib/problem9-package-cohesion.mjs
@@ -18,3 +18,89 @@ export function hasExpectedCanonicalModules(actual, expected) {
     })
   );
 }
+
+const requiredAxiomSafetyNarrativeFragments = [
+  "statement.lean intentionally exports axiom problem9 as the stable theorem header.",
+  "the checked-in axiom is not accepted as benchmark proof evidence.",
+  "the runtime keeps the checked-in benchmark package read-only and writes model output only to firstproof/problem9/candidate.lean.",
+  "importing firstproof.problem9.gold is invalid.",
+  "passing runs must match the canonical theorem target and clear the no-axioms check for firstproof.problem9.problem9."
+];
+
+function normalizeNarrativeText(text) {
+  return text
+    .replace(/[`*_]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function extractMarkdownSection(text, heading) {
+  if (typeof text !== "string" || typeof heading !== "string") {
+    return null;
+  }
+
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const headingIndex = lines.findIndex((line) => line.trim() === heading);
+
+  if (headingIndex === -1) {
+    return null;
+  }
+
+  const sectionLines = [];
+
+  for (let index = headingIndex + 1; index < lines.length; index += 1) {
+    const currentLine = lines[index];
+
+    if (currentLine?.startsWith("## ")) {
+      break;
+    }
+
+    sectionLines.push(currentLine ?? "");
+  }
+
+  return sectionLines;
+}
+
+export function hasExpectedAxiomSafetyNarrative(text, heading) {
+  const sectionLines = extractMarkdownSection(text, heading);
+
+  if (!sectionLines) {
+    return false;
+  }
+
+  const contentLines = sectionLines.map((line) => line.trim()).filter((line) => line.length > 0);
+  const bulletLines = [];
+  let currentBullet = null;
+
+  for (const line of contentLines) {
+    if (line.startsWith("- ")) {
+      if (currentBullet !== null) {
+        bulletLines.push(normalizeNarrativeText(currentBullet));
+      }
+
+      currentBullet = line.slice(2);
+      continue;
+    }
+
+    if (currentBullet === null) {
+      return false;
+    }
+
+    currentBullet = `${currentBullet} ${line}`;
+  }
+
+  if (currentBullet !== null) {
+    bulletLines.push(normalizeNarrativeText(currentBullet));
+  }
+
+  if (bulletLines.length !== requiredAxiomSafetyNarrativeFragments.length) {
+    return false;
+  }
+
+  return (
+    requiredAxiomSafetyNarrativeFragments.every(
+      (fragment, index) => bulletLines[index] === fragment
+    )
+  );
+}

--- a/infra/scripts/test/problem9-package-cohesion.test.mjs
+++ b/infra/scripts/test/problem9-package-cohesion.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hasExpectedCanonicalModules } from "../lib/problem9-package-cohesion.mjs";
+import {
+  hasExpectedAxiomSafetyNarrative,
+  hasExpectedCanonicalModules
+} from "../lib/problem9-package-cohesion.mjs";
 
 const expectedCanonicalModules = {
   statement: "FirstProof.Problem9.Statement",
@@ -44,6 +47,53 @@ test("hasExpectedCanonicalModules rejects missing or mismatched module bindings"
       },
       expectedCanonicalModules
     ),
+    false
+  );
+});
+
+test("hasExpectedAxiomSafetyNarrative accepts the required Problem 9 safety model", () => {
+  assert.equal(
+    hasExpectedAxiomSafetyNarrative(`
+      ## Axiom safety contract
+
+      - Statement.lean intentionally exports axiom problem9 as the stable theorem header.
+      - The checked-in axiom is not accepted as benchmark proof evidence.
+      - The runtime keeps the checked-in benchmark package read-only and writes model
+        output only to FirstProof/Problem9/Candidate.lean.
+      - Importing FirstProof.Problem9.Gold is invalid.
+      - Passing runs must match the canonical theorem target and clear the
+        no-axioms check for FirstProof.Problem9.problem9.
+    `, "## Axiom safety contract"),
+    true
+  );
+});
+
+test("hasExpectedAxiomSafetyNarrative rejects incomplete explanations", () => {
+  assert.equal(
+    hasExpectedAxiomSafetyNarrative(`
+      ## Axiom safety model
+
+      - Statement.lean keeps the theorem header stable and Gold.lean carries the
+        repository proof.
+    `, "## Axiom safety model"),
+    false
+  );
+});
+
+test("hasExpectedAxiomSafetyNarrative rejects contradictory safety claims", () => {
+  assert.equal(
+    hasExpectedAxiomSafetyNarrative(`
+      ## Axiom safety model
+
+      - Statement.lean intentionally exports axiom problem9 as the stable theorem header.
+      - The checked-in axiom is not accepted as benchmark proof evidence.
+      - The runtime keeps the checked-in benchmark package read-only and writes model
+        output only to FirstProof/Problem9/Candidate.lean.
+      - Importing FirstProof.Problem9.Gold is invalid.
+      - Passing runs must match the canonical theorem target and clear the
+        no-axioms check for FirstProof.Problem9.problem9.
+      Models may also edit Statement.lean directly if they want.
+    `, "## Axiom safety model"),
     false
   );
 });


### PR DESCRIPTION
## Summary
- document the canonical Problem 9 axiom-safety contract in the benchmark README and baseline doc
- extend the existing Problem 9 cohesion guard to require an exact canonical axiom-safety section in both docs
- add regression coverage for the new section parser so contradictory or incomplete sections fail the check

## Verification
- bun run check:problem9-package-cohesion
- bun test apps/worker/test/problem9-attempt.test.ts
- bun run build

Closes #992