### PR TITLE
fix(problem9): bind benchmark provenance metadata

### DIFF
--- a/apps/api/src/lib/problem9-offline-ingest.ts
+++ b/apps/api/src/lib/problem9-offline-ingest.ts
@@ -751,6 +751,7 @@ function computeBenchmarkPackageDigest(manifest: Problem9BenchmarkPackageManifes
       packageId: manifest.packageId,
       packageRoot: manifest.packageRoot,
       packageVersion: manifest.packageVersion,
+      ...(manifest.sourceMetadata ? { sourceMetadata: manifest.sourceMetadata } : {}),
       sourceManifestDigest: manifest.sourceManifestDigest,
       sourceSchemaVersion: "1"
     })

--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -23,6 +24,7 @@ async function readJsonFile<TValue>(filePath: string): Promise<TValue> {
 }
 
 async function buildOfflineIngestRequest(options: {
+  legacyBenchmarkManifest?: boolean;
   result: "pass" | "fail";
 }): Promise<{
   request: Problem9OfflineIngestRequest;
@@ -34,6 +36,11 @@ async function buildOfflineIngestRequest(options: {
       outputRoot: path.join(tempRoot, "benchmark-package")
     })
   ).outputRoot;
+
+  if (options.legacyBenchmarkManifest) {
+    await rewriteBenchmarkManifestForLegacyCompatibility(benchmarkPackageRoot);
+  }
+
   const promptPackageRoot = path.join(tempRoot, "prompt-package");
   const candidateSourcePath = path.join(tempRoot, "candidate.lean");
   const compilerDiagnosticsPath = path.join(tempRoot, "compiler-diagnostics.json");
@@ -245,6 +252,24 @@ test("buildProblem9OfflineIngestPlan preserves failure metadata for canonical fa
   assert.equal(plan.attempt.failureClassification?.failureFamily, "compile");
 });
 
+test("buildProblem9OfflineIngestPlan accepts legacy v1 bundles without sourceMetadata", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    legacyBenchmarkManifest: true,
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const plan = buildProblem9OfflineIngestPlan(request);
+
+  assert.equal(plan.run.state, "succeeded");
+  assert.equal(plan.job.state, "completed");
+  assert.equal(plan.attempt.state, "succeeded");
+  assert.equal(request.bundle.benchmarkPackage.sourceMetadata, undefined);
+});
+
 test("buildProblem9OfflineIngestPlan rejects digest mismatches", async (t) => {
   const { request, tempRoot } = await buildOfflineIngestRequest({
     result: "pass"
@@ -427,3 +452,60 @@ test("POST /portal/admin/offline-ingest/problem9-run-bundles maps duplicate run 
     error: "offline_ingest_duplicate_run"
   });
 });
+
+async function rewriteBenchmarkManifestForLegacyCompatibility(
+  benchmarkPackageRoot: string
+): Promise<void> {
+  const manifestPath = path.join(benchmarkPackageRoot, "benchmark-package.json");
+  const manifest = await readJsonFile<Record<string, unknown>>(manifestPath);
+
+  delete manifest.sourceMetadata;
+  manifest.lanePolicy = {
+    primaryLane: "lean422_exact",
+    supportedLanes: ["lean422_exact", "lean424_interop"]
+  };
+  manifest.packageDigest = computeLegacyBenchmarkPackageDigest(manifest);
+
+  await writeFile(manifestPath, `${JSON.stringify(sortJsonValue(manifest), null, 2)}\n`, "utf8");
+}
+
+function computeLegacyBenchmarkPackageDigest(manifest: Record<string, unknown>): string {
+  return sha256Text(
+    JSON.stringify(
+      sortJsonValue({
+        benchmarkFamily: manifest.benchmarkFamily,
+        benchmarkItemId: manifest.benchmarkItemId,
+        canonicalModules: manifest.canonicalModules,
+        fileHashes: manifest.hashes,
+        lanePolicy: manifest.lanePolicy,
+        packageId: manifest.packageId,
+        packageRoot: manifest.packageRoot,
+        packageVersion: manifest.packageVersion,
+        sourceManifestDigest: manifest.sourceManifestDigest,
+        sourceSchemaVersion: "1"
+      }),
+      null,
+      2
+    )
+  );
+}
+
+function sha256Text(text: string): string {
+  return createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex");
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+    );
+  }
+
+  return value;
+}

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -54,7 +54,28 @@ const benchmarkPackageManifestSchema = z.object({
   }),
   packageDigest: sha256Schema,
   packageId: z.literal("firstproof/Problem9"),
-  packageVersion: z.string().min(1)
+  packageVersion: z.string().min(1),
+  sourceMetadata: z
+    .object({
+      laneEvidence: z.object({
+        lean422_exact: z.literal("lean-toolchain")
+      }),
+      license: z.object({
+        file: z.literal("LICENSE"),
+        spdxId: z.literal("Apache-2.0")
+      }),
+      provenance: z.object({
+        goldModule: z.literal("FirstProof/Problem9/Gold.lean"),
+        humanStatement: z.literal("statements/problem.md"),
+        statementModule: z.literal("FirstProof/Problem9/Statement.lean"),
+        supportModule: z.literal("FirstProof/Problem9/Support.lean")
+      }),
+      regressionEvidence: z.object({
+        cohesionCheck: z.literal("bun run check:problem9-package-cohesion"),
+        integrityTest: z.literal("node --import tsx --test test/problem9-integrity.test.ts")
+      })
+    })
+    .optional()
 });
 
 const promptPackageManifestSchema = z.object({

--- a/apps/worker/src/lib/problem9-package.ts
+++ b/apps/worker/src/lib/problem9-package.ts
@@ -22,8 +22,8 @@ const sourceManifestSchema = z.object({
     support: z.string().min(1)
   }),
   lanePolicy: z.object({
-    primaryLane: z.string().min(1),
-    supportedLanes: z.array(z.string().min(1)).min(1)
+    primaryLane: z.literal("lean422_exact"),
+    supportedLanes: z.tuple([z.literal("lean422_exact")])
   }),
   materialization: z.object({
     generatedManifestPath: z.literal("benchmark-package.json"),
@@ -31,6 +31,25 @@ const sourceManifestSchema = z.object({
   }),
   packageId: z.literal("firstproof/Problem9"),
   packageVersion: z.string().min(1),
+  sourceMetadata: z.object({
+    laneEvidence: z.object({
+      lean422_exact: z.literal("lean-toolchain")
+    }),
+    license: z.object({
+      file: z.literal("LICENSE"),
+      spdxId: z.literal("Apache-2.0")
+    }),
+    provenance: z.object({
+      goldModule: z.literal("FirstProof/Problem9/Gold.lean"),
+      humanStatement: z.literal("statements/problem.md"),
+      statementModule: z.literal("FirstProof/Problem9/Statement.lean"),
+      supportModule: z.literal("FirstProof/Problem9/Support.lean")
+    }),
+    regressionEvidence: z.object({
+      cohesionCheck: z.literal("bun run check:problem9-package-cohesion"),
+      integrityTest: z.literal("node --import tsx --test test/problem9-integrity.test.ts")
+    })
+  }),
   sourceSchemaVersion: z.string().min(1)
 });
 
@@ -118,6 +137,7 @@ export async function materializeProblem9Package(
       packageId: sourceManifest.packageId,
       packageRoot: sourceManifest.materialization.packageRoot,
       packageVersion: sourceManifest.packageVersion,
+      sourceMetadata: sourceManifest.sourceMetadata,
       sourceManifestDigest,
       sourceSchemaVersion: sourceManifest.sourceSchemaVersion
     })
@@ -132,6 +152,7 @@ export async function materializeProblem9Package(
     packageRoot: sourceManifest.materialization.packageRoot,
     canonicalModules: sourceManifest.canonicalModules,
     lanePolicy: sourceManifest.lanePolicy,
+    sourceMetadata: sourceManifest.sourceMetadata,
     sourceManifestDigest,
     hashAlgorithm: "sha256",
     packageDigestMode: "metadata_plus_file_inventory_v1",

--- a/apps/worker/src/lib/problem9-prompt-package.ts
+++ b/apps/worker/src/lib/problem9-prompt-package.ts
@@ -21,6 +21,26 @@ import { z } from "zod";
 
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
 
+const problem9SourceMetadataSchema = z.object({
+  laneEvidence: z.object({
+    lean422_exact: z.literal("lean-toolchain")
+  }),
+  license: z.object({
+    file: z.literal("LICENSE"),
+    spdxId: z.literal("Apache-2.0")
+  }),
+  provenance: z.object({
+    goldModule: z.literal("FirstProof/Problem9/Gold.lean"),
+    humanStatement: z.literal("statements/problem.md"),
+    statementModule: z.literal("FirstProof/Problem9/Statement.lean"),
+    supportModule: z.literal("FirstProof/Problem9/Support.lean")
+  }),
+  regressionEvidence: z.object({
+    cohesionCheck: z.literal("bun run check:problem9-package-cohesion"),
+    integrityTest: z.literal("node --import tsx --test test/problem9-integrity.test.ts")
+  })
+});
+
 const benchmarkPackageManifestSchema = z.object({
   benchmarkFamily: z.literal("firstproof"),
   benchmarkItemId: z.literal("Problem9"),
@@ -40,6 +60,7 @@ const benchmarkPackageManifestSchema = z.object({
   packageId: z.literal("firstproof/Problem9"),
   packageRoot: z.literal("firstproof/Problem9"),
   packageVersion: z.string().min(1),
+  sourceMetadata: problem9SourceMetadataSchema.optional(),
   sourceManifestDigest: sha256Schema
 });
 
@@ -379,6 +400,9 @@ async function validateBenchmarkPackageInput(
       packageId: benchmarkManifest.packageId,
       packageRoot: benchmarkManifest.packageRoot,
       packageVersion: benchmarkManifest.packageVersion,
+      ...(benchmarkManifest.sourceMetadata
+        ? { sourceMetadata: benchmarkManifest.sourceMetadata }
+        : {}),
       sourceManifestDigest: benchmarkManifest.sourceManifestDigest,
       sourceSchemaVersion: benchmarkPackageSourceSchemaVersion
     })

--- a/apps/worker/src/lib/problem9-run-bundle.test.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
@@ -122,11 +123,40 @@ test("materialize-problem9-run-bundle rejects output roots that contain fixture 
   }
 });
 
-async function createFixtureInputs(root: string): Promise<FixturePaths> {
+test("materialize-problem9-run-bundle accepts legacy v1 benchmark manifests without sourceMetadata", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-run-bundle-"));
+
+  try {
+    const fixturePaths = await createFixtureInputs(tempRoot, {
+      legacyBenchmarkManifest: true
+    });
+    const result = runRunBundleCli({
+      fixturePaths,
+      outputRoot: path.join(tempRoot, "outputs", "legacy"),
+      result: "pass"
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+async function createFixtureInputs(
+  root: string,
+  options: {
+    legacyBenchmarkManifest?: boolean;
+  } = {}
+): Promise<FixturePaths> {
   const benchmarkOutputRoot = path.join(root, "benchmark-output");
   const benchmarkPackage = await materializeProblem9Package({
     outputRoot: benchmarkOutputRoot
   });
+
+  if (options.legacyBenchmarkManifest) {
+    await rewriteBenchmarkManifestForLegacyCompatibility(benchmarkPackage.outputRoot);
+  }
+
   const promptOutputRoot = path.join(root, "prompt-output");
   const promptDefaults = getDefaultProblem9PromptPackageOptions();
   const promptPackage = await materializeProblem9PromptPackage({
@@ -323,7 +353,7 @@ function runRunBundleCli(options: {
     args.push("--failure-classification", options.fixturePaths.failureClassificationPath);
   }
 
-  const result = spawnSync(process.execPath, args, {
+  const result = spawnSync(resolveNodeBinary(), args, {
     cwd: workerRoot,
     encoding: "utf8"
   });
@@ -350,4 +380,66 @@ async function writeNormalizedText(filePath: string, value: string): Promise<voi
 
 function normalizeText(value: string): string {
   return value.replace(/^\uFEFF/u, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+async function rewriteBenchmarkManifestForLegacyCompatibility(
+  benchmarkPackageRoot: string
+): Promise<void> {
+  const manifestPath = path.join(benchmarkPackageRoot, "benchmark-package.json");
+  const manifest = JSON.parse(await readNormalizedText(manifestPath)) as Record<string, unknown>;
+
+  delete manifest.sourceMetadata;
+  manifest.lanePolicy = {
+    primaryLane: "lean422_exact",
+    supportedLanes: ["lean422_exact", "lean424_interop"]
+  };
+  manifest.packageDigest = computeLegacyBenchmarkPackageDigest(manifest);
+
+  await writeJsonFile(manifestPath, manifest);
+}
+
+function computeLegacyBenchmarkPackageDigest(manifest: Record<string, unknown>): string {
+  return sha256Text(
+    JSON.stringify(
+      sortJsonValue({
+        benchmarkFamily: manifest.benchmarkFamily,
+        benchmarkItemId: manifest.benchmarkItemId,
+        canonicalModules: manifest.canonicalModules,
+        fileHashes: manifest.hashes,
+        lanePolicy: manifest.lanePolicy,
+        packageId: manifest.packageId,
+        packageRoot: manifest.packageRoot,
+        packageVersion: manifest.packageVersion,
+        sourceManifestDigest: manifest.sourceManifestDigest,
+        sourceSchemaVersion: "1"
+      }),
+      null,
+      2
+    )
+  );
+}
+
+function sha256Text(text: string): string {
+  return createHash("sha256").update(Buffer.from(normalizeText(text), "utf8")).digest("hex");
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+function resolveNodeBinary(): string {
+  const bunRuntime = (globalThis as { Bun?: { which(command: string): string | null } }).Bun;
+  return bunRuntime?.which("node") ?? process.execPath;
 }

--- a/apps/worker/src/lib/problem9-run-bundle.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.ts
@@ -30,6 +30,26 @@ const recordValueSchema: z.ZodType<unknown> = z.lazy(() =>
   ])
 );
 
+const problem9SourceMetadataSchema = z.object({
+  laneEvidence: z.object({
+    lean422_exact: z.literal("lean-toolchain")
+  }),
+  license: z.object({
+    file: z.literal("LICENSE"),
+    spdxId: z.literal("Apache-2.0")
+  }),
+  provenance: z.object({
+    goldModule: z.literal("FirstProof/Problem9/Gold.lean"),
+    humanStatement: z.literal("statements/problem.md"),
+    statementModule: z.literal("FirstProof/Problem9/Statement.lean"),
+    supportModule: z.literal("FirstProof/Problem9/Support.lean")
+  }),
+  regressionEvidence: z.object({
+    cohesionCheck: z.literal("bun run check:problem9-package-cohesion"),
+    integrityTest: z.literal("node --import tsx --test test/problem9-integrity.test.ts")
+  })
+});
+
 const benchmarkPackageManifestSchema = z.object({
   benchmarkFamily: z.literal("firstproof"),
   benchmarkItemId: z.literal("Problem9"),
@@ -49,6 +69,7 @@ const benchmarkPackageManifestSchema = z.object({
   packageId: z.literal("firstproof/Problem9"),
   packageRoot: z.literal("firstproof/Problem9"),
   packageVersion: z.string().min(1),
+  sourceMetadata: problem9SourceMetadataSchema.optional(),
   sourceManifestDigest: sha256Schema
 });
 
@@ -594,6 +615,9 @@ async function validateBenchmarkPackageInput(
       packageId: benchmarkManifest.packageId,
       packageRoot: benchmarkManifest.packageRoot,
       packageVersion: benchmarkManifest.packageVersion,
+      ...(benchmarkManifest.sourceMetadata
+        ? { sourceMetadata: benchmarkManifest.sourceMetadata }
+        : {}),
       sourceManifestDigest: benchmarkManifest.sourceManifestDigest,
       sourceSchemaVersion: benchmarkPackageSourceSchemaVersion
     })

--- a/apps/worker/test/problem9-integrity.test.ts
+++ b/apps/worker/test/problem9-integrity.test.ts
@@ -13,9 +13,29 @@ import {
 import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts";
 
 const expectedIntegrityDigests = {
-  benchmarkPackage: "ca378023961740adbef777501d689757c1a38070399e686a8e3d4354caf520ac",
-  promptPackage: "ddebfb1bfdddd88b6b273c9770b4e97c78bb4ccc9a35cf64248dd1aa7238d1fb",
-  runBundle: "7fa0ac8d5e332ec018333aab54ce89008fe29f08f902371485e46e60abbd3cfb"
+  benchmarkPackage: "2a613fe5717c5df32fc3c95b0cf4cbbc9a99312c0cac44948b0cd641acac8dcb",
+  promptPackage: "f0fe26f4c426b6b51d524a6bcf23331556a590d0b621f5ccc74fe416c1f7f329",
+  runBundle: "3dea5638b16d0ee293ffdf5508f66beea74a7da776149f689f599e9c5f7cb821"
+} as const;
+
+const expectedBenchmarkSourceMetadata = {
+  laneEvidence: {
+    lean422_exact: "lean-toolchain"
+  },
+  license: {
+    file: "LICENSE",
+    spdxId: "Apache-2.0"
+  },
+  provenance: {
+    goldModule: "FirstProof/Problem9/Gold.lean",
+    humanStatement: "statements/problem.md",
+    statementModule: "FirstProof/Problem9/Statement.lean",
+    supportModule: "FirstProof/Problem9/Support.lean"
+  },
+  regressionEvidence: {
+    cohesionCheck: "bun run check:problem9-package-cohesion",
+    integrityTest: "node --import tsx --test test/problem9-integrity.test.ts"
+  }
 } as const;
 
 // Update these only when the checked-in canonical Problem 9 fixtures intentionally change.
@@ -48,8 +68,20 @@ test("Problem 9 benchmark package materialization stays deterministic", async ()
 
     assert.equal(firstPackage.packageDigest, expectedIntegrityDigests.benchmarkPackage);
     assert.equal(secondPackage.packageDigest, expectedIntegrityDigests.benchmarkPackage);
+
+    const firstManifestText = await readNormalizedText(
+      path.join(firstPackage.outputRoot, "benchmark-package.json")
+    );
+    const firstManifest = JSON.parse(firstManifestText) as Record<string, unknown>;
+
+    assert.deepEqual(firstManifest.sourceMetadata, expectedBenchmarkSourceMetadata);
+    assert.deepEqual(firstManifest.lanePolicy, {
+      primaryLane: "lean422_exact",
+      supportedLanes: ["lean422_exact"]
+    });
+
     assert.equal(
-      await readNormalizedText(path.join(firstPackage.outputRoot, "benchmark-package.json")),
+      firstManifestText,
       await readNormalizedText(path.join(secondPackage.outputRoot, "benchmark-package.json"))
     );
   } finally {

--- a/benchmarks/firstproof/problem9/LICENSE
+++ b/benchmarks/firstproof/problem9/LICENSE
@@ -1,3 +1,201 @@
 Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/benchmarks/firstproof/problem9/benchmark-package.json
+++ b/benchmarks/firstproof/problem9/benchmark-package.json
@@ -12,9 +12,27 @@
   "lanePolicy": {
     "primaryLane": "lean422_exact",
     "supportedLanes": [
-      "lean422_exact",
-      "lean424_interop"
+      "lean422_exact"
     ]
+  },
+  "sourceMetadata": {
+    "license": {
+      "file": "LICENSE",
+      "spdxId": "Apache-2.0"
+    },
+    "provenance": {
+      "statementModule": "FirstProof/Problem9/Statement.lean",
+      "supportModule": "FirstProof/Problem9/Support.lean",
+      "goldModule": "FirstProof/Problem9/Gold.lean",
+      "humanStatement": "statements/problem.md"
+    },
+    "laneEvidence": {
+      "lean422_exact": "lean-toolchain"
+    },
+    "regressionEvidence": {
+      "cohesionCheck": "bun run check:problem9-package-cohesion",
+      "integrityTest": "node --import tsx --test test/problem9-integrity.test.ts"
+    }
   },
   "materialization": {
     "generatedManifestPath": "benchmark-package.json",

--- a/infra/scripts/check-problem9-package-cohesion.mjs
+++ b/infra/scripts/check-problem9-package-cohesion.mjs
@@ -1,8 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+  hasApacheTwoLicenseText,
   hasExpectedAxiomSafetyNarrative,
-  hasExpectedCanonicalModules
+  hasExpectedCanonicalModules,
+  hasExpectedLanePolicy,
+  hasExpectedProblem9SourceMetadata,
 } from "./lib/problem9-package-cohesion.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
@@ -11,6 +14,7 @@ const benchmarkRoot = path.join(repoRoot, "benchmarks", "firstproof", "problem9"
 const benchmarkPackagePath = path.join(benchmarkRoot, "benchmark-package.json");
 const lakefilePath = path.join(benchmarkRoot, "lakefile.toml");
 const benchmarkReadmePath = path.join(benchmarkRoot, "README.md");
+const licensePath = path.join(benchmarkRoot, "LICENSE");
 const statementPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Statement.lean");
 const goldPath = path.join(benchmarkRoot, "FirstProof", "Problem9", "Gold.lean");
 const targetBaselinePath = path.join(repoRoot, "docs", "problem9-benchmark-target-baseline.md");
@@ -32,6 +36,7 @@ function fail(message) {
 const benchmarkPackage = JSON.parse(readText(benchmarkPackagePath));
 const lakefile = readText(lakefilePath);
 const benchmarkReadme = readText(benchmarkReadmePath);
+const licenseText = readText(licensePath);
 const statementSource = readText(statementPath);
 const goldSource = readText(goldPath);
 const targetBaseline = readText(targetBaselinePath);
@@ -40,6 +45,14 @@ if (!hasExpectedCanonicalModules(benchmarkPackage.canonicalModules, expectedCano
   fail(
     `canonicalModules must stay aligned with ${JSON.stringify(expectedCanonicalModules)}`
   );
+}
+
+if (!hasExpectedLanePolicy(benchmarkPackage.lanePolicy)) {
+  fail("benchmark-package.json lanePolicy must keep lean422_exact as the only primary and supported lane");
+}
+
+if (!hasExpectedProblem9SourceMetadata(benchmarkPackage.sourceMetadata)) {
+  fail("benchmark-package.json sourceMetadata must match the canonical Problem 9 provenance block");
 }
 
 const defaultTargetsMatch = lakefile.match(/defaultTargets\s*=\s*\[(?<targets>[^\]]+)\]/);
@@ -90,4 +103,8 @@ if (!hasExpectedAxiomSafetyNarrative(benchmarkReadme, "## Axiom safety model")) 
 
 if (!hasExpectedAxiomSafetyNarrative(targetBaseline, "## Axiom safety contract")) {
   fail("docs/problem9-benchmark-target-baseline.md must explain the Problem 9 axiom safety model");
+}
+
+if (!hasApacheTwoLicenseText(licenseText)) {
+  fail("LICENSE must carry the full Apache 2.0 text");
 }

--- a/infra/scripts/lib/problem9-package-cohesion.mjs
+++ b/infra/scripts/lib/problem9-package-cohesion.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export function hasExpectedCanonicalModules(actual, expected) {
   if (!actual || typeof actual !== "object" || Array.isArray(actual)) {
     return false;
@@ -26,6 +28,29 @@ const requiredAxiomSafetyNarrativeFragments = [
   "importing firstproof.problem9.gold is invalid.",
   "passing runs must match the canonical theorem target and clear the no-axioms check for firstproof.problem9.problem9."
 ];
+
+const expectedProblem9SourceMetadata = {
+  laneEvidence: {
+    lean422_exact: "lean-toolchain"
+  },
+  license: {
+    file: "LICENSE",
+    spdxId: "Apache-2.0"
+  },
+  provenance: {
+    goldModule: "FirstProof/Problem9/Gold.lean",
+    humanStatement: "statements/problem.md",
+    statementModule: "FirstProof/Problem9/Statement.lean",
+    supportModule: "FirstProof/Problem9/Support.lean"
+  },
+  regressionEvidence: {
+    cohesionCheck: "bun run check:problem9-package-cohesion",
+    integrityTest: "node --import tsx --test test/problem9-integrity.test.ts"
+  }
+};
+
+const expectedApacheTwoLicenseDigest =
+  "948703bcf1cb4a2dafd21676dd01e40a58fe21bd9b425c000b9070eccb441092";
 
 function normalizeNarrativeText(text) {
   return text
@@ -62,7 +87,7 @@ function extractMarkdownSection(text, heading) {
   return sectionLines;
 }
 
-export function hasExpectedAxiomSafetyNarrative(text, heading) {
+function hasExpectedSectionBullets(text, heading, expectedBullets) {
   const sectionLines = extractMarkdownSection(text, heading);
 
   if (!sectionLines) {
@@ -94,13 +119,66 @@ export function hasExpectedAxiomSafetyNarrative(text, heading) {
     bulletLines.push(normalizeNarrativeText(currentBullet));
   }
 
-  if (bulletLines.length !== requiredAxiomSafetyNarrativeFragments.length) {
+  if (bulletLines.length !== expectedBullets.length) {
     return false;
   }
 
+  return expectedBullets.every((fragment, index) => bulletLines[index] === fragment);
+}
+
+export function hasExpectedAxiomSafetyNarrative(text, heading) {
+  return hasExpectedSectionBullets(text, heading, requiredAxiomSafetyNarrativeFragments);
+}
+
+export function hasExpectedProblem9SourceMetadata(actual) {
   return (
-    requiredAxiomSafetyNarrativeFragments.every(
-      (fragment, index) => bulletLines[index] === fragment
-    )
+    JSON.stringify(sortJsonValue(actual)) === JSON.stringify(sortJsonValue(expectedProblem9SourceMetadata))
   );
+}
+
+export function hasExpectedSupportedLanes(actual) {
+  return Array.isArray(actual) && actual.length === 1 && actual[0] === "lean422_exact";
+}
+
+export function hasExpectedLanePolicy(actual) {
+  return (
+    actual &&
+    typeof actual === "object" &&
+    actual.primaryLane === "lean422_exact" &&
+    hasExpectedSupportedLanes(actual.supportedLanes)
+  );
+}
+
+export function hasApacheTwoLicenseText(text) {
+  return sha256Text(normalizeLicenseText(text)) === expectedApacheTwoLicenseDigest;
+}
+
+function sortJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+function normalizeLicenseText(text) {
+  return text
+    .replace(/^\uFEFF/u, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function sha256Text(text) {
+  return createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex");
 }

--- a/infra/scripts/test/problem9-package-cohesion.test.mjs
+++ b/infra/scripts/test/problem9-package-cohesion.test.mjs
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  hasApacheTwoLicenseText,
   hasExpectedAxiomSafetyNarrative,
-  hasExpectedCanonicalModules
+  hasExpectedCanonicalModules,
+  hasExpectedLanePolicy,
+  hasExpectedProblem9SourceMetadata,
+  hasExpectedSupportedLanes
 } from "../lib/problem9-package-cohesion.mjs";
 
 const expectedCanonicalModules = {
@@ -47,6 +52,76 @@ test("hasExpectedCanonicalModules rejects missing or mismatched module bindings"
       },
       expectedCanonicalModules
     ),
+    false
+  );
+});
+
+test("hasExpectedSupportedLanes accepts only the repo-backed Problem 9 lane", () => {
+  assert.equal(hasExpectedSupportedLanes(["lean422_exact"]), true);
+  assert.equal(hasExpectedSupportedLanes(["lean422_exact", "lean424_interop"]), false);
+  assert.equal(hasExpectedSupportedLanes([]), false);
+});
+
+test("hasExpectedLanePolicy rejects primary-lane drift", () => {
+  assert.equal(
+    hasExpectedLanePolicy({
+      primaryLane: "lean422_exact",
+      supportedLanes: ["lean422_exact"]
+    }),
+    true
+  );
+
+  assert.equal(
+    hasExpectedLanePolicy({
+      primaryLane: "lean424_interop",
+      supportedLanes: ["lean422_exact"]
+    }),
+    false
+  );
+});
+
+test("hasExpectedProblem9SourceMetadata accepts the canonical source metadata block", () => {
+  assert.equal(
+    hasExpectedProblem9SourceMetadata({
+      regressionEvidence: {
+        integrityTest: "node --import tsx --test test/problem9-integrity.test.ts",
+        cohesionCheck: "bun run check:problem9-package-cohesion"
+      },
+      provenance: {
+        supportModule: "FirstProof/Problem9/Support.lean",
+        goldModule: "FirstProof/Problem9/Gold.lean",
+        statementModule: "FirstProof/Problem9/Statement.lean",
+        humanStatement: "statements/problem.md"
+      },
+      license: {
+        spdxId: "Apache-2.0",
+        file: "LICENSE"
+      },
+      laneEvidence: {
+        lean422_exact: "lean-toolchain"
+      }
+    }),
+    true
+  );
+});
+
+test("hasExpectedProblem9SourceMetadata rejects missing regression linkage", () => {
+  assert.equal(
+    hasExpectedProblem9SourceMetadata({
+      license: {
+        file: "LICENSE",
+        spdxId: "Apache-2.0"
+      },
+      provenance: {
+        goldModule: "FirstProof/Problem9/Gold.lean",
+        humanStatement: "statements/problem.md",
+        statementModule: "FirstProof/Problem9/Statement.lean",
+        supportModule: "FirstProof/Problem9/Support.lean"
+      },
+      laneEvidence: {
+        lean422_exact: "lean-toolchain"
+      }
+    }),
     false
   );
 });
@@ -95,5 +170,41 @@ test("hasExpectedAxiomSafetyNarrative rejects contradictory safety claims", () =
       Models may also edit Statement.lean directly if they want.
     `, "## Axiom safety model"),
     false
+  );
+});
+
+test("hasApacheTwoLicenseText rejects the old stub and accepts the full license", () => {
+  assert.equal(
+    hasApacheTwoLicenseText([
+      "Apache License",
+      "Version 2.0, January 2004",
+      "http://www.apache.org/licenses/"
+    ].join("\n")),
+    false
+  );
+
+  assert.equal(
+    hasApacheTwoLicenseText([
+      "Apache License",
+      "Version 2.0, January 2004",
+      "http://www.apache.org/licenses/",
+      "",
+      "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION",
+      "",
+      "END OF TERMS AND CONDITIONS",
+      "",
+      "APPENDIX: How to apply the Apache License to your work."
+    ].join("\n")),
+    false
+  );
+
+  assert.equal(
+    hasApacheTwoLicenseText(
+      readFileSync(
+        new URL("../../../benchmarks/firstproof/problem9/LICENSE", import.meta.url),
+        "utf8"
+      )
+    ),
+    true
   );
 });

--- a/packages/shared/src/schemas/problem9-offline-ingest.ts
+++ b/packages/shared/src/schemas/problem9-offline-ingest.ts
@@ -29,6 +29,26 @@ const recordValueSchema: z.ZodType<unknown> = z.lazy(() =>
   ])
 );
 
+const problem9SourceMetadataSchema = z.object({
+  laneEvidence: z.object({
+    lean422_exact: z.literal("lean-toolchain")
+  }),
+  license: z.object({
+    file: z.literal("LICENSE"),
+    spdxId: z.literal("Apache-2.0")
+  }),
+  provenance: z.object({
+    goldModule: z.literal("FirstProof/Problem9/Gold.lean"),
+    humanStatement: z.literal("statements/problem.md"),
+    statementModule: z.literal("FirstProof/Problem9/Statement.lean"),
+    supportModule: z.literal("FirstProof/Problem9/Support.lean")
+  }),
+  regressionEvidence: z.object({
+    cohesionCheck: z.literal("bun run check:problem9-package-cohesion"),
+    integrityTest: z.literal("node --import tsx --test test/problem9-integrity.test.ts")
+  })
+});
+
 export const problem9BenchmarkPackageManifestSchema = z.object({
   benchmarkFamily: z.literal("firstproof"),
   benchmarkItemId: z.literal("Problem9"),
@@ -49,6 +69,7 @@ export const problem9BenchmarkPackageManifestSchema = z.object({
   packageId: z.literal("firstproof/Problem9"),
   packageRoot: z.literal("firstproof/Problem9"),
   packageVersion: z.string().min(1),
+  sourceMetadata: problem9SourceMetadataSchema.optional(),
   sourceManifestDigest: sha256Schema
 });
 

--- a/packages/shared/src/types/problem9-offline-ingest.ts
+++ b/packages/shared/src/types/problem9-offline-ingest.ts
@@ -97,6 +97,25 @@ export type Problem9BenchmarkPackageManifest = {
   packageId: "firstproof/Problem9";
   packageRoot: "firstproof/Problem9";
   packageVersion: string;
+  sourceMetadata?: {
+    laneEvidence: {
+      lean422_exact: "lean-toolchain";
+    };
+    license: {
+      file: "LICENSE";
+      spdxId: "Apache-2.0";
+    };
+    provenance: {
+      goldModule: "FirstProof/Problem9/Gold.lean";
+      humanStatement: "statements/problem.md";
+      statementModule: "FirstProof/Problem9/Statement.lean";
+      supportModule: "FirstProof/Problem9/Support.lean";
+    };
+    regressionEvidence: {
+      cohesionCheck: "bun run check:problem9-package-cohesion";
+      integrityTest: "node --import tsx --test test/problem9-integrity.test.ts";
+    };
+  };
   sourceManifestDigest: string;
 };
 


### PR DESCRIPTION
﻿## Summary
- make the checked-in Problem 9 benchmark manifest carry canonical provenance, license, and regression metadata and materialize that metadata into the emitted benchmark package
- replace the package-local Apache stub with the full Apache 2.0 text and tighten the cohesion guard around lane policy, manifest metadata, and license completeness
- keep legacy v1 bundle and offline-ingest compatibility by accepting older benchmark manifests without `sourceMetadata`, with explicit worker and API regressions proving that path

## Verification
- bun run check:problem9-package-cohesion
- bun test apps/worker/src/lib/problem9-run-bundle.test.ts
- bun --cwd apps/worker test:run-bundle
- node --import tsx --test test/problem9-integrity.test.ts
- bun run test:api
- bun run build

Closes #993
