### PR TITLE
fix(api): make runtime config authoritative

### DIFF
--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { FastifyRequest } from "fastify";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { normalizeOptionalEmail } from "../lib/email.js";
-import { parseApiRuntimeEnv } from "../config/runtime.js";
+import { parseApiRuntimeEnv, type ApiRuntimeEnv } from "../config/runtime.js";
 import type { PortalIdentityProvider } from "@paretoproof/shared";
 
 type CloudflareAccessTokenClaims = JWTPayload & {
@@ -22,8 +22,8 @@ export type VerifiedAccessLinkIntent = {
   intentId: string;
 };
 
-function readAccessProviderStateSecret() {
-  return process.env.ACCESS_PROVIDER_STATE_SECRET;
+function readAccessProviderStateSecret(secret?: string) {
+  return secret ?? process.env.ACCESS_PROVIDER_STATE_SECRET;
 }
 
 function createSignedAccessValue(value: string, secret: string, maxAgeSeconds = 600) {
@@ -66,6 +66,15 @@ export type CloudflareAccessVerifierSet = {
   internal: CloudflareAccessVerifier;
   portal: CloudflareAccessVerifier;
 };
+
+export type CloudflareAccessRuntimeConfig = Pick<
+  ApiRuntimeEnv,
+  | "accessProviderStateSecret"
+  | "brandedAccessAudiences"
+  | "internalAccessAudience"
+  | "portalAccessAudience"
+  | "teamDomain"
+>;
 
 function normalizeTeamDomain(teamDomain: string) {
   return teamDomain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
@@ -137,12 +146,15 @@ function verifySignedAccessCookie(
 
 export function verifyAccessProviderHint(
   cookieHeader: string | undefined,
-  expectedSubject?: string
+  options?: {
+    expectedSubject?: string;
+    secret?: string;
+  }
 ) {
   const verifiedCookie = verifySignedAccessCookie(
     cookieHeader,
     "PortalAccessProvider",
-    readAccessProviderStateSecret()
+    readAccessProviderStateSecret(options?.secret)
   );
   const parsedPayload = verifiedCookie?.payload
     ? parseVerifiedProviderHintPayload(verifiedCookie.payload)
@@ -152,18 +164,27 @@ export function verifyAccessProviderHint(
     return null;
   }
 
-  if (parsedPayload.boundSubject && expectedSubject && parsedPayload.boundSubject !== expectedSubject) {
+  if (
+    parsedPayload.boundSubject &&
+    options?.expectedSubject &&
+    parsedPayload.boundSubject !== options.expectedSubject
+  ) {
     return null;
   }
 
   return parsedPayload.provider;
 }
 
-export function verifyAccessLinkIntent(cookieHeader: string | undefined) {
+export function verifyAccessLinkIntent(
+  cookieHeader: string | undefined,
+  options?: {
+    secret?: string;
+  }
+) {
   const verifiedCookie = verifySignedAccessCookie(
     cookieHeader,
     "PortalLinkIntent",
-    readAccessProviderStateSecret()
+    readAccessProviderStateSecret(options?.secret)
   );
 
   if (!verifiedCookie?.payload) {
@@ -205,9 +226,10 @@ export function buildSignedAccessCookie(
   options?: {
     maxAgeSeconds?: number;
     sameSite?: "Strict" | "Lax";
+    secret?: string;
   }
 ) {
-  const secret = readAccessProviderStateSecret();
+  const secret = readAccessProviderStateSecret(options?.secret);
 
   if (!secret) {
     throw new Error("ACCESS_PROVIDER_STATE_SECRET is not configured.");
@@ -288,6 +310,12 @@ export function selectCloudflareAccessVerifier(
 
 export function createCloudflareAccessVerifierSetFromEnv() {
   const runtimeEnv = parseApiRuntimeEnv();
+  return createCloudflareAccessVerifierSet(runtimeEnv);
+}
+
+export function createCloudflareAccessVerifierSet(
+  runtimeEnv: CloudflareAccessRuntimeConfig
+) {
   const brandedRelayAudiences = [
     runtimeEnv.portalAccessAudience,
     ...runtimeEnv.brandedAccessAudiences

--- a/apps/api/src/auth/portal-access-session.ts
+++ b/apps/api/src/auth/portal-access-session.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { and, eq, gt, isNull } from "drizzle-orm";
 import type { FastifyRequest } from "fastify";
-import { parseApiRuntimeEnv } from "../config/runtime.js";
+import { parseApiRuntimeEnv, type ApiRuntimeEnv } from "../config/runtime.js";
 import { sessions, userIdentities } from "../db/schema.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 import type { CloudflareAccessIdentity } from "./cloudflare-access.js";
@@ -26,8 +26,8 @@ function getPortalAccessSessionExpiry(now = Date.now()) {
   return new Date(now + portalAccessSessionMaxAgeSeconds * 1000);
 }
 
-function buildCloudflareAccessIssuer() {
-  return `https://${parseApiRuntimeEnv().teamDomain}`;
+function buildCloudflareAccessIssuer(teamDomain?: string) {
+  return `https://${teamDomain ?? parseApiRuntimeEnv().teamDomain}`;
 }
 
 export function buildPortalAccessSessionCookie(token: string) {
@@ -99,7 +99,10 @@ export async function createPortalAccessSession(
 
 export async function resolvePortalAccessSession(
   db: ReturnTypeOfCreateDbClient,
-  cookieHeader: string | undefined
+  cookieHeader: string | undefined,
+  options?: {
+    teamDomain?: ApiRuntimeEnv["teamDomain"];
+  }
 ): Promise<ResolvedPortalAccessSession | null> {
   const token = readPortalAccessSessionToken(cookieHeader);
 
@@ -130,7 +133,7 @@ export async function resolvePortalAccessSession(
 
   const identity: CloudflareAccessIdentity = {
     email: sessionRow.identity.providerEmail ?? sessionRow.identity.user.email,
-    issuer: buildCloudflareAccessIssuer(),
+    issuer: buildCloudflareAccessIssuer(options?.teamDomain),
     provider: sessionRow.identity.provider,
     subject: sessionRow.identity.providerSubject
   };

--- a/apps/api/src/auth/require-access.ts
+++ b/apps/api/src/auth/require-access.ts
@@ -3,6 +3,7 @@ import type { HookHandlerDoneFunction } from "fastify/types/hooks";
 import type { AccessRbacContext } from "./resolve-access-rbac-context.js";
 import { resolveAccessRbacContext } from "./resolve-access-rbac-context.js";
 import {
+  createCloudflareAccessVerifierSet,
   createCloudflareAccessVerifierSetFromEnv,
   readAccessJwtAssertion,
   selectCloudflareAccessVerifier,
@@ -14,6 +15,7 @@ import {
   resolvePortalAccessSession,
   type ResolvedPortalAccessSession
 } from "./portal-access-session.js";
+import type { ApiRuntimeEnv } from "../config/runtime.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 type RouteAccessRequirement =
@@ -38,9 +40,15 @@ export function isAccessAssertionVerificationError(error: unknown) {
 
 export function resolveAccessIdentityProvider(
   identity: Pick<CloudflareAccessIdentity, "provider" | "subject">,
-  cookieHeader: string | undefined
+  cookieHeader: string | undefined,
+  options?: {
+    accessProviderStateSecret?: string;
+  }
 ) {
-  return verifyAccessProviderHint(cookieHeader, identity.subject) ?? identity.provider;
+  return verifyAccessProviderHint(cookieHeader, {
+    expectedSubject: identity.subject,
+    secret: options?.accessProviderStateSecret
+  }) ?? identity.provider;
 }
 
 declare module "fastify" {
@@ -82,7 +90,11 @@ function isAllowed(context: AccessRbacContext, requirement: RouteAccessRequireme
 async function resolveRequestAccess(
   db: ReturnTypeOfCreateDbClient,
   verifiers: CloudflareAccessVerifierSet,
-  request: FastifyRequest
+  request: FastifyRequest,
+  options?: {
+    accessProviderStateSecret?: string;
+    teamDomain?: string;
+  }
 ) {
   if (request.accessRbacContext) {
     return request.accessRbacContext;
@@ -95,7 +107,9 @@ async function resolveRequestAccess(
 
   if (!assertion) {
     if (routePath.startsWith("/portal/")) {
-      const cachedSession = await resolvePortalAccessSession(db, cookieHeader);
+      const cachedSession = await resolvePortalAccessSession(db, cookieHeader, {
+        teamDomain: options?.teamDomain
+      });
 
       if (cachedSession) {
         request.accessIdentity = cachedSession.identity;
@@ -120,7 +134,9 @@ async function resolveRequestAccess(
 
   identity = {
     ...identity,
-    provider: resolveAccessIdentityProvider(identity, cookieHeader)
+    provider: resolveAccessIdentityProvider(identity, cookieHeader, {
+      accessProviderStateSecret: options?.accessProviderStateSecret
+    })
   };
 
   const context = await resolveAccessRbacContext(db, identity);
@@ -132,15 +148,28 @@ async function resolveRequestAccess(
   return context;
 }
 
-export function createAccessResolver(db: ReturnTypeOfCreateDbClient) {
-  const verifiers = createCloudflareAccessVerifierSetFromEnv();
+export type AccessResolverOptions = {
+  accessProviderStateSecret?: string;
+  teamDomain?: string;
+  verifiers?: CloudflareAccessVerifierSet;
+};
 
-  return (request: FastifyRequest) => resolveRequestAccess(db, verifiers, request);
+export function createAccessResolver(
+  db: ReturnTypeOfCreateDbClient,
+  options?: AccessResolverOptions
+) {
+  const verifiers = options?.verifiers ?? createCloudflareAccessVerifierSetFromEnv();
+
+  return (request: FastifyRequest) =>
+    resolveRequestAccess(db, verifiers, request, options);
 }
 
 // Access proves identity at the edge, but the backend still decides whether that caller may use its DB-backed routes.
-export function createAccessGuard(db: ReturnTypeOfCreateDbClient) {
-  const resolveAccess = createAccessResolver(db);
+export function createAccessGuard(
+  db: ReturnTypeOfCreateDbClient,
+  options?: AccessResolverOptions
+) {
+  const resolveAccess = createAccessResolver(db, options);
 
   return (requirement: RouteAccessRequirement) => {
     return (
@@ -180,5 +209,18 @@ export function createAccessGuard(db: ReturnTypeOfCreateDbClient) {
           done(error);
         });
     };
+  };
+}
+
+export function runtimeEnvToAccessResolverOptions(
+  runtimeEnv: Pick<
+    ApiRuntimeEnv,
+    "accessProviderStateSecret" | "brandedAccessAudiences" | "internalAccessAudience" | "portalAccessAudience" | "teamDomain"
+  >
+): Required<AccessResolverOptions> {
+  return {
+    accessProviderStateSecret: runtimeEnv.accessProviderStateSecret,
+    teamDomain: runtimeEnv.teamDomain,
+    verifiers: createCloudflareAccessVerifierSet(runtimeEnv)
   };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,18 +1,27 @@
 import { parseApiRuntimeEnv } from "./config/runtime.js";
 import { buildServer } from "./server/build-server.js";
 
-const start = async () => {
-  const runtimeEnv = parseApiRuntimeEnv();
-  const app = await buildServer(runtimeEnv);
+export async function startApiServer(options?: {
+  buildApiServer?: typeof buildServer;
+  exit?: (code: number) => void;
+  parseRuntimeEnv?: typeof parseApiRuntimeEnv;
+}) {
+  let app: Awaited<ReturnType<typeof buildServer>> | null = null;
 
   try {
+    const runtimeEnv = (options?.parseRuntimeEnv ?? parseApiRuntimeEnv)();
+    app = await (options?.buildApiServer ?? buildServer)(runtimeEnv);
     await app.listen({ host: runtimeEnv.host, port: runtimeEnv.port });
   } catch (error) {
-    app.log.error(error);
-    process.exit(1);
+    if (app) {
+      app.log.error(error);
+    } else {
+      console.error(error);
+    }
+    (options?.exit ?? process.exit)(1);
   }
-};
+}
 
-if (process.env.NODE_ENV !== "test") {
-  void start();
+if (import.meta.main && process.env.NODE_ENV !== "test") {
+  void startApiServer();
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseApiRuntimeEnv } from "./config/runtime.js";
 import { buildServer } from "./server/build-server.js";
 
@@ -22,6 +24,22 @@ export async function startApiServer(options?: {
   }
 }
 
-if (import.meta.main && process.env.NODE_ENV !== "test") {
+export function isExecutedAsMainModule(options?: {
+  entryPointPath?: string;
+  moduleUrl?: string;
+}) {
+  const entryPointPath = options?.entryPointPath ?? process.argv[1];
+
+  if (!entryPointPath) {
+    return false;
+  }
+
+  return (
+    resolve(fileURLToPath(options?.moduleUrl ?? import.meta.url)) ===
+    resolve(entryPointPath)
+  );
+}
+
+if (process.env.NODE_ENV !== "test" && isExecutedAsMainModule()) {
   void startApiServer();
 }

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -4,15 +4,29 @@ import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 export function registerHealthRoute(
   app: FastifyInstance,
   options?: {
+    checkReadiness?: () => Promise<void>;
     rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
   }
 ) {
   app.get("/health", {
     preHandler: options?.rateLimitPreHandlers?.public
-  }, async () => {
-    return {
-      ok: true,
-      service: "api"
-    };
+  }, async (request, reply) => {
+    try {
+      await options?.checkReadiness?.();
+
+      return {
+        ok: true,
+        service: "api"
+      };
+    } catch (error) {
+      request.log.error({ err: error }, "Health readiness check failed.");
+      reply.code(503);
+
+      return {
+        error: "service_unavailable",
+        ok: false,
+        service: "api"
+      };
+    }
   });
 }

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -53,7 +53,8 @@ import {
 } from "../auth/portal-access-session.js";
 import {
   createAccessResolver,
-  isAccessAssertionVerificationError
+  isAccessAssertionVerificationError,
+  type AccessResolverOptions
 } from "../auth/require-access.js";
 import { resolveAccessRbacContext } from "../auth/resolve-access-rbac-context.js";
 import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
@@ -376,12 +377,19 @@ export function registerPortalRoutes(
   db: ReturnTypeOfCreateDbClient,
   requireAccess: ReturnTypeOfCreateAccessGuard,
   options?: {
+    accessProviderStateSecret?: string;
+    accessResolverOptions?: AccessResolverOptions;
     portalBenchmarkOpsReadModels?: PortalBenchmarkOpsReadModelService;
     rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
     resolvePortalAccess?: ReturnType<typeof createAccessResolver>;
   }
 ) {
-  const resolvePortalAccess = options?.resolvePortalAccess ?? createAccessResolver(db);
+  const accessResolverOptions = options?.accessResolverOptions;
+  const accessProviderStateSecret =
+    options?.accessProviderStateSecret ??
+    accessResolverOptions?.accessProviderStateSecret;
+  const resolvePortalAccess =
+    options?.resolvePortalAccess ?? createAccessResolver(db, accessResolverOptions);
   const portalBenchmarkOpsReadModels =
     options?.portalBenchmarkOpsReadModels ?? createPortalBenchmarkOpsReadModelService(db);
   const harnessRegistry = createHarnessRegistryService();
@@ -421,8 +429,13 @@ export function registerPortalRoutes(
         null
     );
     const portalUrl = new URL(redirectPath, "https://portal.paretoproof.com");
-    const linkIntent = verifyAccessLinkIntent(cookieHeader);
-    const providerHint = verifyAccessProviderHint(cookieHeader, identity?.subject);
+    const linkIntent = verifyAccessLinkIntent(cookieHeader, {
+      secret: accessProviderStateSecret
+    });
+    const providerHint = verifyAccessProviderHint(cookieHeader, {
+      expectedSubject: identity?.subject,
+      secret: accessProviderStateSecret
+    });
     let resolvedAccessContext = accessContext;
 
     if (identity && linkIntent) {
@@ -520,7 +533,10 @@ export function registerPortalRoutes(
         ? buildSignedAccessCookie(
             "PortalAccessProvider",
             `${providerHint}|${identity.subject}`,
-            { maxAgeSeconds: 24 * 60 * 60 }
+            {
+              maxAgeSeconds: 24 * 60 * 60,
+              secret: accessProviderStateSecret
+            }
           )
         : clearSignedAccessCookie("PortalAccessProvider"),
       clearSignedAccessCookie("PortalLinkIntent")
@@ -548,7 +564,7 @@ export function registerPortalRoutes(
       typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
 
     // Cross-site GETs must not be enough to consume a pending identity-link intent.
-    if (verifyAccessLinkIntent(cookieHeader)) {
+    if (verifyAccessLinkIntent(cookieHeader, { secret: accessProviderStateSecret })) {
       handlePortalSessionRetryRedirect(request, reply);
       return;
     }
@@ -1196,7 +1212,9 @@ export function registerPortalRoutes(
 
       reply.header(
         "set-cookie",
-        buildSignedAccessCookie("PortalLinkIntent", intent.id)
+        buildSignedAccessCookie("PortalLinkIntent", intent.id, {
+          secret: accessProviderStateSecret
+        })
       );
 
       return {

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -1,8 +1,12 @@
 import cors from "@fastify/cors";
 import formbody from "@fastify/formbody";
+import { sql } from "drizzle-orm";
 import Fastify from "fastify";
 import type { ApiRuntimeEnv } from "../config/runtime.js";
-import { createAccessGuard } from "../auth/require-access.js";
+import {
+  createAccessGuard,
+  runtimeEnvToAccessResolverOptions
+} from "../auth/require-access.js";
 import { createDbClient } from "../db/client.js";
 import { registerAdminRoutes } from "../routes/admin.js";
 import { registerBenchmarkWorkflowRoutes } from "../routes/benchmark-workflow.js";
@@ -20,6 +24,7 @@ import {
   isAllowedLocalOrigin,
   normalizeOrigin
 } from "./trusted-mutation-origin.js";
+import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
   const brandedAuthOrigins = new Set(readBrandedAuthOrigins());
@@ -101,16 +106,32 @@ export function isAllowedCorsOrigin(options: {
   );
 }
 
-export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
+type BuildServerOptions = {
+  checkReadiness?: () => Promise<void>;
+  createDbClient?: (connectionString: string) => ReturnTypeOfCreateDbClient;
+};
+
+function createDatabaseReadinessCheck(db: ReturnTypeOfCreateDbClient) {
+  return async () => {
+    await db.execute(sql`select 1`);
+  };
+}
+
+export async function buildServer(
+  runtimeEnv: ApiRuntimeEnv,
+  options?: BuildServerOptions
+) {
   const app = Fastify({
     logger: true
   });
-  const db = createDbClient(runtimeEnv.databaseUrl);
-  const requireAccess = createAccessGuard(db);
+  const db = (options?.createDbClient ?? createDbClient)(runtimeEnv.databaseUrl);
+  const accessResolverOptions = runtimeEnvToAccessResolverOptions(runtimeEnv);
+  const requireAccess = createAccessGuard(db, accessResolverOptions);
   const rateLimitPreHandlers = createRateLimitPreHandlers(createInMemoryRateLimiter());
   const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
   const brandedAuthOrigins = readBrandedAuthOrigins();
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
+  const checkReadiness = options?.checkReadiness ?? createDatabaseReadinessCheck(db);
 
   await app.register(cors, {
     delegator(request, callback) {
@@ -157,9 +178,12 @@ export async function buildServer(runtimeEnv: ApiRuntimeEnv) {
   );
 
   registerHealthRoute(app, {
+    checkReadiness,
     rateLimitPreHandlers
   });
   registerPortalRoutes(app, db, requireAccess, {
+    accessProviderStateSecret: runtimeEnv.accessProviderStateSecret,
+    accessResolverOptions,
     rateLimitPreHandlers
   });
   registerAdminRoutes(app, db, requireAccess, {

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { parseApiRuntimeEnv } from "../src/config/runtime.ts";
 import {
+  buildServer,
   isAllowedCorsOrigin,
   readCorsRoutePath,
   readAllowedCorsOrigins
@@ -124,4 +126,90 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
     }),
     false
   );
+});
+
+test("buildServer keeps the parsed runtime contract authoritative during boot and health checks", async (t) => {
+  const originalEnv = {
+    ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
+    CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
+    CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN
+  };
+
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-secret";
+  process.env.CF_ACCESS_BRANDED_AUDS = "wrong-branded-audience";
+  process.env.CF_ACCESS_PORTAL_AUD = "wrong-portal-audience";
+  process.env.CF_ACCESS_TEAM_DOMAIN = "wrong-team.example";
+
+  let readinessChecks = 0;
+  const app = await buildServer(
+    parseApiRuntimeEnv({
+      ACCESS_PROVIDER_STATE_SECRET: "runtime-secret",
+      CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+      CF_ACCESS_PORTAL_AUD: "portal-audience",
+      CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+      DATABASE_URL: "postgres://localhost:5432/paretoproof",
+      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+    }),
+    {
+      createDbClient: () => ({
+        execute: async () => {
+          readinessChecks += 1;
+        }
+      }) as never
+    }
+  );
+
+  t.after(async () => {
+    Object.assign(process.env, originalEnv);
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    ok: true,
+    service: "api"
+  });
+  assert.equal(readinessChecks, 1);
+});
+
+test("buildServer maps default DB readiness failures to 503 health responses", async (t) => {
+  const app = await buildServer(
+    parseApiRuntimeEnv({
+      ACCESS_PROVIDER_STATE_SECRET: "runtime-secret",
+      CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+      CF_ACCESS_PORTAL_AUD: "portal-audience",
+      CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+      DATABASE_URL: "postgres://localhost:5432/paretoproof",
+      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+    }),
+    {
+      createDbClient: () => ({
+        execute: async () => {
+          throw new Error("database_unreachable");
+        }
+      }) as never
+    }
+  );
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), {
+    error: "service_unavailable",
+    ok: false,
+    service: "api"
+  });
 });

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -53,14 +53,18 @@ test("PortalAccessProvider verification continues to use ACCESS_PROVIDER_STATE_S
     );
 
     assert.equal(
-      verifyAccessProviderHint(providerCookie, "subject-1"),
+      verifyAccessProviderHint(providerCookie, {
+        expectedSubject: "subject-1"
+      }),
       "cloudflare_google"
     );
 
     process.env.PORTAL_SESSION_SECRET = "wrong-session-secret";
 
     assert.equal(
-      verifyAccessProviderHint(providerCookie, "subject-1"),
+      verifyAccessProviderHint(providerCookie, {
+        expectedSubject: "subject-1"
+      }),
       "cloudflare_google"
     );
   } finally {
@@ -69,22 +73,50 @@ test("PortalAccessProvider verification continues to use ACCESS_PROVIDER_STATE_S
   }
 });
 
+test("PortalAccessProvider verification can use a runtime-provided secret without reparsing process.env", () => {
+  const originalProviderSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-provider-secret";
+
+  try {
+    const providerCookie = buildSignedAccessCookie(
+      "PortalAccessProvider",
+      "cloudflare_google|subject-1",
+      {
+        secret: "runtime-provider-secret"
+      }
+    );
+
+    assert.equal(
+      verifyAccessProviderHint(providerCookie, {
+        expectedSubject: "subject-1",
+        secret: "runtime-provider-secret"
+      }),
+      "cloudflare_google"
+    );
+    assert.equal(
+      verifyAccessProviderHint(providerCookie, {
+        expectedSubject: "subject-1",
+        secret: "wrong-provider-secret"
+      }),
+      null
+    );
+  } finally {
+    process.env.ACCESS_PROVIDER_STATE_SECRET = originalProviderSecret;
+  }
+});
+
 test("createAccessResolver accepts an opaque portal access session when the DB session lookup succeeds", async () => {
   const originalEnv = {
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
     CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
-    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
-    DATABASE_URL: process.env.DATABASE_URL,
-    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN
   };
 
-  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
-  process.env.CF_ACCESS_BRANDED_AUDS = "github-audience,google-audience";
-  process.env.CF_ACCESS_PORTAL_AUD = "portal-audience";
-  process.env.CF_ACCESS_TEAM_DOMAIN = "paretoproof.cloudflareaccess.com";
-  process.env.DATABASE_URL = "postgres://localhost:5432/paretoproof";
-  process.env.WORKER_BOOTSTRAP_TOKEN = "worker-bootstrap-token";
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-env-secret";
+  process.env.CF_ACCESS_BRANDED_AUDS = "wrong-branded-audience";
+  process.env.CF_ACCESS_PORTAL_AUD = "wrong-portal-audience";
+  process.env.CF_ACCESS_TEAM_DOMAIN = "wrong-team.example";
 
   try {
     let touchedSession = false;
@@ -140,7 +172,15 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
           }
         };
       }
-    } as never);
+    } as never, {
+      accessProviderStateSecret: "runtime-secret",
+      teamDomain: "paretoproof.cloudflareaccess.com",
+      verifiers: {
+        brandedRelay: { audiences: ["branded"] },
+        internal: { audiences: ["internal"] },
+        portal: { audiences: ["portal"] }
+      } as never
+    });
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
@@ -167,6 +207,10 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
     });
     assert.equal(request.accessIdentity?.subject, "subject-1");
     assert.equal(request.accessIdentity?.provider, "cloudflare_google");
+    assert.equal(
+      request.accessIdentity?.issuer,
+      "https://paretoproof.cloudflareaccess.com"
+    );
     assert.equal(touchedSession, true);
   } finally {
     Object.assign(process.env, originalEnv);
@@ -197,7 +241,14 @@ test("createAccessResolver gracefully rejects legacy signed portal session cooki
           findFirst: async () => null
         }
       }
-    } as never);
+    } as never, {
+      teamDomain: "paretoproof.cloudflareaccess.com",
+      verifiers: {
+        brandedRelay: { audiences: ["branded"] },
+        internal: { audiences: ["internal"] },
+        portal: { audiences: ["portal"] }
+      } as never
+    });
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
@@ -271,7 +322,14 @@ test("createAccessResolver rejects revoked opaque portal sessions", async () => 
           }
         };
       }
-    } as never);
+    } as never, {
+      teamDomain: "paretoproof.cloudflareaccess.com",
+      verifiers: {
+        brandedRelay: { audiences: ["branded"] },
+        internal: { audiences: ["internal"] },
+        portal: { audiences: ["portal"] }
+      } as never
+    });
     const request = {
       accessIdentity: null,
       accessRbacContext: null,

--- a/apps/api/test/health.test.ts
+++ b/apps/api/test/health.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { registerHealthRoute } from "../src/routes/health.ts";
+
+test("GET /health returns 200 when readiness succeeds", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerHealthRoute(app, {
+    checkReadiness: async () => {}
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    ok: true,
+    service: "api"
+  });
+});
+
+test("GET /health returns 503 when readiness fails", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerHealthRoute(app, {
+    checkReadiness: async () => {
+      throw new Error("database_unreachable");
+    }
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/health"
+  });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), {
+    error: "service_unavailable",
+    ok: false,
+    service: "api"
+  });
+});

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { startApiServer } from "../src/index.ts";
+import { isExecutedAsMainModule, startApiServer } from "../src/index.ts";
+
+test("isExecutedAsMainModule accepts relative entrypoint paths for normal CLI launches", () => {
+  assert.equal(
+    isExecutedAsMainModule({
+      entryPointPath: "src/index.ts",
+      moduleUrl: new URL("../src/index.ts", import.meta.url).toString()
+    }),
+    true
+  );
+});
 
 test("startApiServer exits when runtime parsing fails before the server is built", async () => {
   const originalConsoleError = console.error;

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { startApiServer } from "../src/index.ts";
+
+test("startApiServer exits when runtime parsing fails before the server is built", async () => {
+  const originalConsoleError = console.error;
+  const exitCodes: number[] = [];
+  const loggedErrors: unknown[] = [];
+
+  console.error = (...args: unknown[]) => {
+    loggedErrors.push(args);
+  };
+
+  try {
+    await startApiServer({
+      buildApiServer: async () => {
+        throw new Error("build should not run");
+      },
+      exit(code) {
+        exitCodes.push(code);
+      },
+      parseRuntimeEnv() {
+        throw new Error("invalid_runtime_env");
+      }
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  assert.deepEqual(exitCodes, [1]);
+  assert.equal(loggedErrors.length, 1);
+  assert.match(String(loggedErrors[0]?.[0]), /invalid_runtime_env/);
+});
+
+test("startApiServer exits when listen fails after the server is built", async () => {
+  const exitCodes: number[] = [];
+  const loggedErrors: unknown[] = [];
+
+  await startApiServer({
+    async buildApiServer() {
+      return {
+        async listen() {
+          throw new Error("listen_failed");
+        },
+        log: {
+          error(error: unknown) {
+            loggedErrors.push(error);
+          }
+        }
+      } as never;
+    },
+    exit(code) {
+      exitCodes.push(code);
+    },
+    parseRuntimeEnv() {
+      return {
+        accessProviderStateSecret: "state-secret",
+        brandedAccessAudiences: ["github-audience", "google-audience"],
+        corsAllowedOrigins: [],
+        corsAllowLocalhost: false,
+        databaseUrl: "postgres://localhost:5432/paretoproof",
+        host: "0.0.0.0",
+        internalAccessAudience: "portal-audience",
+        port: 3000,
+        portalAccessAudience: "portal-audience",
+        portalSessionSecret: "state-secret",
+        teamDomain: "paretoproof.cloudflareaccess.com",
+        workerBootstrapToken: "worker-bootstrap-token"
+      };
+    }
+  });
+
+  assert.deepEqual(exitCodes, [1]);
+  assert.equal(loggedErrors.length, 1);
+  assert.match(String(loggedErrors[0]), /listen_failed/);
+});

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -66,6 +66,58 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
   assert.equal(mutationAttempted, false);
 });
 
+test("GET /portal/session/finalize/submit honors a runtime-provided link-intent secret", async (t) => {
+  let mutationAttempted = false;
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      transaction: async () => {
+        mutationAttempted = true;
+        throw new Error("portal finalize GET should not reach the mutation path");
+      }
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      accessProviderStateSecret: "runtime-secret",
+      resolvePortalAccess: async () => ({
+        email: "person@example.com",
+        identityId: "identity-1",
+        roles: ["helper"],
+        status: "approved",
+        subject: "subject-1",
+        userId: "user-1"
+      })
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/session/finalize/submit?redirect=/profile",
+    headers: {
+      accept: "text/html",
+      cookie: buildSignedAccessCookie("PortalLinkIntent", "intent-1", {
+        secret: "runtime-secret"
+      }),
+      "cf-access-jwt-assertion": "test-assertion"
+    }
+  });
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(
+    response.headers.location,
+    "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+  );
+  assert.equal(mutationAttempted, false);
+});
+
 test("GET /portal/session/finalize/submit creates an opaque DB-backed session for approved users", async (t) => {
   let mutationAttempted = false;
   const insertedSessions: Array<typeof sessions.$inferInsert> = [];

--- a/infra/scripts/startup-validation-smoke.ts
+++ b/infra/scripts/startup-validation-smoke.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { parseApiRuntimeEnv } from "../../apps/api/src/config/runtime.ts";
+import { buildServer } from "../../apps/api/src/server/build-server.ts";
 import { parseWebRuntimeEnv } from "../../apps/web/src/lib/runtime-env.ts";
 import { parseWorkerRuntimeEnv } from "../../apps/worker/src/lib/runtime.ts";
 
@@ -35,6 +36,54 @@ await expectPass("API startup accepts the documented local runtime contract", ()
     "portal-audience"
   );
 });
+
+await expectPass(
+  "API startup uses the parsed runtime contract for boot and readiness without reparsing process.env",
+  async () => {
+    const originalEnv = {
+      ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
+      CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
+      CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
+      CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN
+    };
+
+    process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-secret";
+    process.env.CF_ACCESS_BRANDED_AUDS = "wrong-branded-audience";
+    process.env.CF_ACCESS_PORTAL_AUD = "wrong-portal-audience";
+    process.env.CF_ACCESS_TEAM_DOMAIN = "wrong-team.example";
+
+    const app = await buildServer(
+      parseApiRuntimeEnv({
+        ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+        CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+        CF_ACCESS_PORTAL_AUD: "portal-audience",
+        CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+        DATABASE_URL: "postgres://localhost:5432/paretoproof",
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+      }),
+      {
+        checkReadiness: async () => {},
+        createDbClient: () => ({}) as never
+      }
+    );
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/health"
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.json(), {
+        ok: true,
+        service: "api"
+      });
+    } finally {
+      Object.assign(process.env, originalEnv);
+      await app.close();
+    }
+  }
+);
 
 await expectFailure(
   "API startup rejects missing required worker bootstrap auth",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check:main-branch-promotion-gate": "node infra/scripts/check-main-branch-promotion-gate.mjs",
     "check:problem9-package-cohesion": "node infra/scripts/check-problem9-package-cohesion.mjs && node --test infra/scripts/test/problem9-package-cohesion.test.mjs",
     "check:problem9-image-policy": "node infra/scripts/check-problem9-image-policy.mjs",
-    "test:startup-validation": "bun infra/scripts/startup-validation-smoke.ts",
+    "test:startup-validation": "bun run build:shared && bun infra/scripts/startup-validation-smoke.ts",
     "check:trusted-local-boundary": "node infra/scripts/check-trusted-local-boundaries.mjs",
     "test:problem9-image-toolchains": "node --test infra/scripts/verify-problem9-image-toolchains.test.mjs",
     "verify:problem9-execution-image": "node infra/scripts/verify-problem9-image-toolchains.mjs --target problem9-execution",


### PR DESCRIPTION
## Summary
- thread runtime-derived auth/session configuration through API access resolution instead of reparsing process env on the boot path
- make /health use DB-backed readiness and move parse/build/listen under one startup failure path
- add regressions for default readiness wiring, startup failure handling, portal finalize cookie secrets, and startup-validation smoke coverage

## Verification
- bun run test:api
- ='1'; bun run test:startup-validation
- bun run build

Closes #996