### PR TITLE
fix(api): remove hard-coded portal origin and cookie assumptions

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,6 +33,17 @@ CLOUDFLARE_ACCOUNT_ID=replace-with-your-cloudflare-account-id
 CORS_ALLOWED_ORIGINS=https://portal.paretoproof.com
 CORS_ALLOW_LOCALHOST=false
 
+# Optional non-prod portal/auth origin overrides. Leave unset for the canonical
+# hosted paretoproof.com surface pair.
+# PORTAL_PUBLIC_ORIGIN=https://portal.preview.paretoproof.com
+# AUTH_PUBLIC_ORIGIN=https://auth.preview.paretoproof.com
+# BRANDED_AUTH_ORIGINS=https://auth.preview.paretoproof.com,https://github.auth.preview.paretoproof.com,https://google.auth.preview.paretoproof.com
+
+# Optional portal/auth coordination cookie overrides. When unset, the API
+# derives a shared cookie domain and Secure posture from the configured origins.
+# ACCESS_COOKIE_DOMAIN=.preview.paretoproof.com
+# ACCESS_COOKIE_SECURE=true
+
 # Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them.
 # CF_INTERNAL_API_SERVICE_TOKEN_ID=
 # CF_INTERNAL_API_SERVICE_TOKEN_SECRET=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "fastify": "latest",
     "jose": "^6.2.0",
     "postgres": "latest",
+    "tldts": "^7.0.17",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/api/src/auth/cloudflare-access.ts
+++ b/apps/api/src/auth/cloudflare-access.ts
@@ -2,7 +2,11 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { FastifyRequest } from "fastify";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { normalizeOptionalEmail } from "../lib/email.js";
-import { parseApiRuntimeEnv, type ApiRuntimeEnv } from "../config/runtime.js";
+import {
+  resolveApiOriginRuntimeConfig,
+  parseApiRuntimeEnv,
+  type ApiRuntimeEnv,
+} from "../config/runtime.js";
 import type { PortalIdentityProvider } from "@paretoproof/shared";
 
 type CloudflareAccessTokenClaims = JWTPayload & {
@@ -26,10 +30,16 @@ function readAccessProviderStateSecret(secret?: string) {
   return secret ?? process.env.ACCESS_PROVIDER_STATE_SECRET;
 }
 
-function createSignedAccessValue(value: string, secret: string, maxAgeSeconds = 600) {
+function createSignedAccessValue(
+  value: string,
+  secret: string,
+  maxAgeSeconds = 600,
+) {
   const expiresAt = Math.floor(Date.now() / 1000) + maxAgeSeconds;
   const payload = `${value}.${expiresAt}`;
-  const signature = createHmac("sha256", secret).update(payload).digest("base64url");
+  const signature = createHmac("sha256", secret)
+    .update(payload)
+    .digest("base64url");
 
   return `${payload}.${signature}`;
 }
@@ -37,10 +47,7 @@ function createSignedAccessValue(value: string, secret: string, maxAgeSeconds = 
 function parseVerifiedProviderHintPayload(payload: string) {
   const [provider, ...subjectParts] = payload.split("|");
 
-  if (
-    provider !== "cloudflare_github" &&
-    provider !== "cloudflare_google"
-  ) {
+  if (provider !== "cloudflare_github" && provider !== "cloudflare_google") {
     return null;
   }
 
@@ -48,7 +55,7 @@ function parseVerifiedProviderHintPayload(payload: string) {
 
   return {
     boundSubject,
-    provider
+    provider,
   } satisfies {
     boundSubject: string | null;
     provider: PortalIdentityProvider;
@@ -84,7 +91,10 @@ function usesBrandedFinalizeRelayAudiences(method: string, routePath: string) {
   return method === "POST" && routePath === "/portal/session/finalize/submit";
 }
 
-export function readCookieValue(cookieHeader: string | undefined, name: string) {
+export function readCookieValue(
+  cookieHeader: string | undefined,
+  name: string,
+) {
   if (!cookieHeader) {
     return null;
   }
@@ -103,7 +113,7 @@ export function readCookieValue(cookieHeader: string | undefined, name: string) 
 function verifySignedAccessCookie(
   cookieHeader: string | undefined,
   cookieName: string,
-  secret: string | undefined
+  secret: string | undefined,
 ) {
   const rawValue = readCookieValue(cookieHeader, cookieName);
 
@@ -122,12 +132,17 @@ function verifySignedAccessCookie(
 
   const expiresAtNumber = Number.parseInt(expiresAt, 10);
 
-  if (!Number.isFinite(expiresAtNumber) || expiresAtNumber < Math.floor(Date.now() / 1000)) {
+  if (
+    !Number.isFinite(expiresAtNumber) ||
+    expiresAtNumber < Math.floor(Date.now() / 1000)
+  ) {
     return null;
   }
 
   const payload = `${payloadParts.join(".")}.${expiresAt}`;
-  const expectedSignature = createHmac("sha256", secret).update(payload).digest("base64url");
+  const expectedSignature = createHmac("sha256", secret)
+    .update(payload)
+    .digest("base64url");
   const providedSignature = Buffer.from(signature);
   const expectedSignatureBuffer = Buffer.from(expectedSignature);
 
@@ -140,7 +155,7 @@ function verifySignedAccessCookie(
 
   return {
     expiresAt: expiresAtNumber,
-    payload: payloadParts.join(".")
+    payload: payloadParts.join("."),
   };
 }
 
@@ -149,12 +164,12 @@ export function verifyAccessProviderHint(
   options?: {
     expectedSubject?: string;
     secret?: string;
-  }
+  },
 ) {
   const verifiedCookie = verifySignedAccessCookie(
     cookieHeader,
     "PortalAccessProvider",
-    readAccessProviderStateSecret(options?.secret)
+    readAccessProviderStateSecret(options?.secret),
   );
   const parsedPayload = verifiedCookie?.payload
     ? parseVerifiedProviderHintPayload(verifiedCookie.payload)
@@ -179,12 +194,12 @@ export function verifyAccessLinkIntent(
   cookieHeader: string | undefined,
   options?: {
     secret?: string;
-  }
+  },
 ) {
   const verifiedCookie = verifySignedAccessCookie(
     cookieHeader,
     "PortalLinkIntent",
-    readAccessProviderStateSecret(options?.secret)
+    readAccessProviderStateSecret(options?.secret),
   );
 
   if (!verifiedCookie?.payload) {
@@ -193,7 +208,7 @@ export function verifyAccessLinkIntent(
 
   return {
     expiresAt: verifiedCookie.expiresAt,
-    intentId: verifiedCookie.payload
+    intentId: verifiedCookie.payload,
   } satisfies VerifiedAccessLinkIntent;
 }
 
@@ -202,21 +217,28 @@ function buildSignedCookie(
   value: string,
   secret: string,
   options?: {
+    cookieDomain?: string;
     maxAgeSeconds?: number;
     sameSite?: "Strict" | "Lax";
-  }
+    secure?: boolean;
+  },
 ) {
+  const defaultOriginRuntimeConfig = resolveApiOriginRuntimeConfig();
   const maxAgeSeconds = options?.maxAgeSeconds ?? 600;
   const sameSite = options?.sameSite ?? "Strict";
+  const cookieDomain =
+    options?.cookieDomain ?? defaultOriginRuntimeConfig.accessCookieDomain;
+  const secure =
+    options?.secure ?? defaultOriginRuntimeConfig.accessCookieSecure;
 
   return [
     `${name}=${createSignedAccessValue(value, secret, maxAgeSeconds)}`,
-    "Domain=.paretoproof.com",
+    ...(cookieDomain ? [`Domain=${cookieDomain}`] : []),
     "Path=/",
     `SameSite=${sameSite}`,
     `Max-Age=${maxAgeSeconds}`,
-    "Secure",
-    "HttpOnly"
+    ...(secure ? ["Secure"] : []),
+    "HttpOnly",
   ].join("; ");
 }
 
@@ -224,10 +246,12 @@ export function buildSignedAccessCookie(
   name: "PortalAccessProvider" | "PortalLinkIntent",
   value: string,
   options?: {
+    cookieDomain?: string;
     maxAgeSeconds?: number;
     sameSite?: "Strict" | "Lax";
     secret?: string;
-  }
+    secure?: boolean;
+  },
 ) {
   const secret = readAccessProviderStateSecret(options?.secret);
 
@@ -238,7 +262,7 @@ export function buildSignedAccessCookie(
   return buildSignedCookie(name, value, secret, options);
 }
 export function readAccessJwtAssertion(
-  request: Pick<FastifyRequest, "headers">
+  request: Pick<FastifyRequest, "headers">,
 ) {
   const assertion = request.headers["cf-access-jwt-assertion"];
 
@@ -246,7 +270,10 @@ export function readAccessJwtAssertion(
     return assertion;
   }
 
-  const cookieHeader = typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+  const cookieHeader =
+    typeof request.headers.cookie === "string"
+      ? request.headers.cookie
+      : undefined;
   const cookieAssertion = readCookieValue(cookieHeader, "CF_Authorization");
 
   return cookieAssertion && cookieAssertion.length > 0 ? cookieAssertion : null;
@@ -258,9 +285,7 @@ export function createCloudflareAccessVerifier(options: {
 }): CloudflareAccessVerifier {
   const normalizedTeamDomain = normalizeTeamDomain(options.teamDomain);
   const issuer = `https://${normalizedTeamDomain}`;
-  const jwks = createRemoteJWKSet(
-    new URL(`${issuer}/cdn-cgi/access/certs`)
-  );
+  const jwks = createRemoteJWKSet(new URL(`${issuer}/cdn-cgi/access/certs`));
 
   return {
     audiences: [...options.audiences],
@@ -271,13 +296,13 @@ export function createCloudflareAccessVerifier(options: {
         jwks,
         {
           audience: options.audiences,
-          issuer
-        }
+          issuer,
+        },
       );
 
       if (!payload.sub) {
         throw new Error(
-          "Cf-Access-Jwt-Assertion is missing the subject claim."
+          "Cf-Access-Jwt-Assertion is missing the subject claim.",
         );
       }
 
@@ -285,15 +310,15 @@ export function createCloudflareAccessVerifier(options: {
         email: normalizeOptionalEmail(payload.email),
         issuer,
         provider: null,
-        subject: payload.sub
+        subject: payload.sub,
       };
-    }
+    },
   };
 }
 
 export function selectCloudflareAccessVerifier(
   request: Pick<FastifyRequest, "method" | "raw" | "routeOptions">,
-  verifiers: CloudflareAccessVerifierSet
+  verifiers: CloudflareAccessVerifierSet,
 ) {
   const routePath = request.routeOptions?.url ?? request.raw.url ?? "";
 
@@ -314,25 +339,25 @@ export function createCloudflareAccessVerifierSetFromEnv() {
 }
 
 export function createCloudflareAccessVerifierSet(
-  runtimeEnv: CloudflareAccessRuntimeConfig
+  runtimeEnv: CloudflareAccessRuntimeConfig,
 ) {
   const brandedRelayAudiences = [
     runtimeEnv.portalAccessAudience,
-    ...runtimeEnv.brandedAccessAudiences
+    ...runtimeEnv.brandedAccessAudiences,
   ];
 
   return {
     brandedRelay: createCloudflareAccessVerifier({
       audiences: [...new Set(brandedRelayAudiences)],
-      teamDomain: runtimeEnv.teamDomain
+      teamDomain: runtimeEnv.teamDomain,
     }),
     internal: createCloudflareAccessVerifier({
       audiences: [runtimeEnv.internalAccessAudience],
-      teamDomain: runtimeEnv.teamDomain
+      teamDomain: runtimeEnv.teamDomain,
     }),
     portal: createCloudflareAccessVerifier({
       audiences: [runtimeEnv.portalAccessAudience],
-      teamDomain: runtimeEnv.teamDomain
-    })
+      teamDomain: runtimeEnv.teamDomain,
+    }),
   };
 }

--- a/apps/api/src/auth/portal-access-session.ts
+++ b/apps/api/src/auth/portal-access-session.ts
@@ -1,7 +1,11 @@
 import { createHash, randomBytes } from "node:crypto";
 import { and, eq, gt, isNull } from "drizzle-orm";
 import type { FastifyRequest } from "fastify";
-import { parseApiRuntimeEnv, type ApiRuntimeEnv } from "../config/runtime.js";
+import {
+  resolveApiOriginRuntimeConfig,
+  parseApiRuntimeEnv,
+  type ApiRuntimeEnv,
+} from "../config/runtime.js";
 import { sessions, userIdentities } from "../db/schema.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 import type { CloudflareAccessIdentity } from "./cloudflare-access.js";
@@ -9,7 +13,7 @@ import { matchesUserIdentityProviderSubject } from "../lib/identity-binding.js";
 import { readCookieValue } from "./cloudflare-access.js";
 import {
   resolveAccessRbacContext,
-  type AccessRbacContext
+  type AccessRbacContext,
 } from "./resolve-access-rbac-context.js";
 
 export const portalAccessSessionCookieName = "PortalAccessSession";
@@ -30,15 +34,27 @@ function buildCloudflareAccessIssuer(teamDomain?: string) {
   return `https://${teamDomain ?? parseApiRuntimeEnv().teamDomain}`;
 }
 
-export function buildPortalAccessSessionCookie(token: string) {
+export function buildPortalAccessSessionCookie(
+  token: string,
+  options?: {
+    cookieDomain?: string;
+    secure?: boolean;
+  },
+) {
+  const defaultOriginRuntimeConfig = resolveApiOriginRuntimeConfig();
+  const cookieDomain =
+    options?.cookieDomain ?? defaultOriginRuntimeConfig.accessCookieDomain;
+  const secure =
+    options?.secure ?? defaultOriginRuntimeConfig.accessCookieSecure;
+
   return [
     `${portalAccessSessionCookieName}=${token}`,
-    "Domain=.paretoproof.com",
+    ...(cookieDomain ? [`Domain=${cookieDomain}`] : []),
     "Path=/",
     "SameSite=Lax",
     `Max-Age=${portalAccessSessionMaxAgeSeconds}`,
-    "Secure",
-    "HttpOnly"
+    ...(secure ? ["Secure"] : []),
+    "HttpOnly",
   ].join("; ");
 }
 
@@ -58,13 +74,13 @@ export async function createPortalAccessSession(
   db: ReturnTypeOfCreateDbClient,
   request: Pick<FastifyRequest, "headers" | "ip">,
   identity: CloudflareAccessIdentity,
-  context: Extract<AccessRbacContext, { status: "approved" }>
+  context: Extract<AccessRbacContext, { status: "approved" }>,
 ) {
   const linkedIdentity = await db.query.userIdentities.findFirst({
     where: and(
       eq(userIdentities.id, context.identityId),
-      eq(userIdentities.userId, context.userId)
-    )
+      eq(userIdentities.userId, context.userId),
+    ),
   });
 
   if (
@@ -73,7 +89,7 @@ export async function createPortalAccessSession(
     !matchesUserIdentityProviderSubject(
       linkedIdentity,
       identity.provider,
-      identity.subject
+      identity.subject,
     )
   ) {
     throw new Error("Approved portal session identity could not be resolved.");
@@ -91,7 +107,7 @@ export async function createPortalAccessSession(
       typeof request.headers["user-agent"] === "string"
         ? request.headers["user-agent"]
         : null,
-    userId: context.userId
+    userId: context.userId,
   });
 
   return token;
@@ -102,7 +118,7 @@ export async function resolvePortalAccessSession(
   cookieHeader: string | undefined,
   options?: {
     teamDomain?: ApiRuntimeEnv["teamDomain"];
-  }
+  },
 ): Promise<ResolvedPortalAccessSession | null> {
   const token = readPortalAccessSessionToken(cookieHeader);
 
@@ -115,10 +131,10 @@ export async function resolvePortalAccessSession(
     with: {
       identity: {
         with: {
-          user: true
-        }
-      }
-    }
+          user: true,
+        },
+      },
+    },
   });
 
   if (!sessionRow || !sessionRow.identity) {
@@ -135,34 +151,34 @@ export async function resolvePortalAccessSession(
     email: sessionRow.identity.providerEmail ?? sessionRow.identity.user.email,
     issuer: buildCloudflareAccessIssuer(options?.teamDomain),
     provider: sessionRow.identity.provider,
-    subject: sessionRow.identity.providerSubject
+    subject: sessionRow.identity.providerSubject,
   };
   const context = await resolveAccessRbacContext(db, identity);
 
   await db
     .update(sessions)
     .set({
-      lastSeenAt: now
+      lastSeenAt: now,
     })
     .where(
       and(
         eq(sessions.id, sessionRow.id),
         gt(sessions.expiresAt, now),
-        isNull(sessions.revokedAt)
-      )
+        isNull(sessions.revokedAt),
+      ),
     );
 
   return {
     context,
     identity,
     sessionId: sessionRow.id,
-    token
+    token,
   };
 }
 
 export async function revokePortalAccessSession(
   db: ReturnTypeOfCreateDbClient,
-  cookieHeader: string | undefined
+  cookieHeader: string | undefined,
 ) {
   const token = readPortalAccessSessionToken(cookieHeader);
 
@@ -174,17 +190,17 @@ export async function revokePortalAccessSession(
   const [revokedSession] = await db
     .update(sessions)
     .set({
-      revokedAt: now
+      revokedAt: now,
     })
     .where(
       and(
         eq(sessions.tokenHash, hashPortalAccessSessionToken(token)),
         gt(sessions.expiresAt, now),
-        isNull(sessions.revokedAt)
-      )
+        isNull(sessions.revokedAt),
+      ),
     )
     .returning({
-      id: sessions.id
+      id: sessions.id,
     });
 
   return Boolean(revokedSession);

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { getPublicSuffix } from "tldts";
 import { z } from "zod";
 
 function normalizeOptionalEnvValue(value: unknown) {
@@ -209,7 +210,23 @@ function deriveAccessCookieDomain(origins: string[]) {
     sharedLabels.unshift(label);
   }
 
-  return sharedLabels.length >= 2 ? `.${sharedLabels.join(".")}` : undefined;
+  if (sharedLabels.length < 2) {
+    return undefined;
+  }
+
+  const candidateDomain = sharedLabels.join(".");
+
+  if (
+    hostnames.some(
+      (hostname) =>
+        getPublicSuffix(hostname, { allowPrivateDomains: true }) ===
+        candidateDomain,
+    )
+  ) {
+    return undefined;
+  }
+
+  return `.${candidateDomain}`;
 }
 
 function deriveAccessCookieSecure(origins: string[]) {

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { z } from "zod";
 
 function normalizeOptionalEnvValue(value: unknown) {
@@ -10,8 +11,10 @@ function normalizeOptionalEnvValue(value: unknown) {
   return trimmedValue.length > 0 ? trimmedValue : undefined;
 }
 
-const trimmedOptionalStringSchema = z
-  .preprocess(normalizeOptionalEnvValue, z.string().trim().optional());
+const trimmedOptionalStringSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z.string().trim().optional(),
+);
 
 const requiredTrimmedStringSchema = z
   .string()
@@ -25,17 +28,242 @@ const portSchema = z.preprocess(
     .int("must be an integer")
     .min(0, "must be at least 0")
     .max(65535, "must be at most 65535")
-    .optional()
+    .optional(),
 );
 
 const optionalBooleanStringSchema = z.preprocess(
   normalizeOptionalEnvValue,
-  z.enum(["true", "false"]).optional()
+  z.enum(["true", "false"]).optional(),
 );
+
+function normalizeConfiguredOrigin(value: string, context: z.RefinementCtx) {
+  let parsedOrigin: URL;
+
+  try {
+    parsedOrigin = new URL(value);
+  } catch {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must be a valid http or https origin",
+    });
+    return z.NEVER;
+  }
+
+  if (parsedOrigin.protocol !== "http:" && parsedOrigin.protocol !== "https:") {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must use http or https",
+    });
+    return z.NEVER;
+  }
+
+  if (
+    parsedOrigin.username.length > 0 ||
+    parsedOrigin.password.length > 0 ||
+    parsedOrigin.pathname !== "/" ||
+    parsedOrigin.search.length > 0 ||
+    parsedOrigin.hash.length > 0
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must be an origin without path, search, or hash",
+    });
+    return z.NEVER;
+  }
+
+  return parsedOrigin.origin;
+}
+
+const trimmedOptionalOriginSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z
+    .string()
+    .trim()
+    .transform((value, context) => normalizeConfiguredOrigin(value, context))
+    .optional(),
+);
+
+const trimmedOptionalOriginListSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z
+    .string()
+    .trim()
+    .transform((value, context) => {
+      const normalizedOrigins: string[] = [];
+
+      for (const rawOrigin of value.split(",")) {
+        const trimmedOrigin = rawOrigin.trim();
+
+        if (!trimmedOrigin) {
+          continue;
+        }
+
+        const normalizedOrigin = normalizeConfiguredOrigin(
+          trimmedOrigin,
+          context,
+        );
+
+        if (normalizedOrigin === z.NEVER) {
+          return z.NEVER;
+        }
+
+        normalizedOrigins.push(normalizedOrigin);
+      }
+
+      return [...new Set(normalizedOrigins)];
+    })
+    .optional(),
+);
+
+function normalizeConfiguredCookieDomain(
+  value: string,
+  context: z.RefinementCtx,
+) {
+  const normalizedDomain = value.trim().replace(/^\.+/, "").toLowerCase();
+
+  if (
+    normalizedDomain.length === 0 ||
+    normalizedDomain.includes("/") ||
+    normalizedDomain.includes(":") ||
+    normalizedDomain.includes(" ")
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must be a bare cookie domain without scheme, port, or path",
+    });
+    return z.NEVER;
+  }
+
+  if (!normalizedDomain.includes(".") || isIP(normalizedDomain) !== 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must be a hostname suffix, not localhost or an IP address",
+    });
+    return z.NEVER;
+  }
+
+  return `.${normalizedDomain}`;
+}
+
+const trimmedOptionalCookieDomainSchema = z.preprocess(
+  normalizeOptionalEnvValue,
+  z
+    .string()
+    .trim()
+    .transform((value, context) =>
+      normalizeConfiguredCookieDomain(value, context),
+    )
+    .optional(),
+);
+
+export const defaultApiPortalPublicOrigin = "https://portal.paretoproof.com";
+export const defaultApiAuthPublicOrigin = "https://auth.paretoproof.com";
+
+function buildBrandedAuthOrigin(
+  authPublicOrigin: string,
+  providerPrefix: "github" | "google",
+) {
+  const authUrl = new URL(authPublicOrigin);
+  authUrl.hostname = `${providerPrefix}.${authUrl.hostname}`;
+  return authUrl.origin;
+}
+
+export function deriveDefaultBrandedAuthOrigins(authPublicOrigin: string) {
+  return [
+    authPublicOrigin,
+    buildBrandedAuthOrigin(authPublicOrigin, "github"),
+    buildBrandedAuthOrigin(authPublicOrigin, "google"),
+  ];
+}
+
+function deriveAccessCookieDomain(origins: string[]) {
+  const hostnames = [
+    ...new Set(origins.map((origin) => new URL(origin).hostname.toLowerCase())),
+  ];
+
+  if (
+    hostnames.length === 0 ||
+    hostnames.some(
+      (hostname) => hostname === "localhost" || isIP(hostname) !== 0,
+    )
+  ) {
+    return undefined;
+  }
+
+  const splitHostnames = hostnames.map((hostname) => hostname.split("."));
+  const shortestLength = Math.min(
+    ...splitHostnames.map((labels) => labels.length),
+  );
+  const sharedLabels: string[] = [];
+
+  for (let offset = 1; offset <= shortestLength; offset += 1) {
+    const label = splitHostnames[0]?.at(-offset);
+
+    if (
+      !label ||
+      splitHostnames.some((labels) => labels.at(-offset) !== label)
+    ) {
+      break;
+    }
+
+    sharedLabels.unshift(label);
+  }
+
+  return sharedLabels.length >= 2 ? `.${sharedLabels.join(".")}` : undefined;
+}
+
+function deriveAccessCookieSecure(origins: string[]) {
+  return origins.every((origin) => new URL(origin).protocol === "https:");
+}
+
+export type ApiOriginRuntimeConfig = {
+  accessCookieDomain?: string;
+  accessCookieSecure: boolean;
+  authPublicOrigin: string;
+  brandedAuthOrigins: string[];
+  corsAllowLocalhost: boolean;
+  portalPublicOrigin: string;
+};
+
+export function resolveApiOriginRuntimeConfig(
+  config?: Partial<ApiOriginRuntimeConfig>,
+): ApiOriginRuntimeConfig {
+  const authPublicOrigin =
+    config?.authPublicOrigin ?? defaultApiAuthPublicOrigin;
+  const portalPublicOrigin =
+    config?.portalPublicOrigin ?? defaultApiPortalPublicOrigin;
+  const brandedAuthOrigins = [
+    ...new Set(
+      [
+        authPublicOrigin,
+        ...(config?.brandedAuthOrigins ??
+          deriveDefaultBrandedAuthOrigins(authPublicOrigin)),
+      ]
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0),
+    ),
+  ];
+  const cookieOrigins = [portalPublicOrigin, ...brandedAuthOrigins];
+
+  return {
+    accessCookieDomain:
+      config?.accessCookieDomain ?? deriveAccessCookieDomain(cookieOrigins),
+    accessCookieSecure:
+      config?.accessCookieSecure ?? deriveAccessCookieSecure(cookieOrigins),
+    authPublicOrigin,
+    brandedAuthOrigins,
+    corsAllowLocalhost: config?.corsAllowLocalhost ?? false,
+    portalPublicOrigin,
+  };
+}
 
 const rawApiRuntimeEnvSchema = z
   .object({
     ACCESS_PROVIDER_STATE_SECRET: requiredTrimmedStringSchema,
+    ACCESS_COOKIE_DOMAIN: trimmedOptionalCookieDomainSchema,
+    ACCESS_COOKIE_SECURE: optionalBooleanStringSchema,
+    AUTH_PUBLIC_ORIGIN: trimmedOptionalOriginSchema,
+    BRANDED_AUTH_ORIGINS: trimmedOptionalOriginListSchema,
     CF_ACCESS_AUD: trimmedOptionalStringSchema,
     CF_ACCESS_BRANDED_AUDS: requiredTrimmedStringSchema,
     CF_ACCESS_INTERNAL_AUD: trimmedOptionalStringSchema,
@@ -47,22 +275,27 @@ const rawApiRuntimeEnvSchema = z
     HOST: trimmedOptionalStringSchema,
     NODE_ENV: trimmedOptionalStringSchema,
     PORT: portSchema,
+    PORTAL_PUBLIC_ORIGIN: trimmedOptionalOriginSchema,
     PORTAL_SESSION_SECRET: trimmedOptionalStringSchema,
-    WORKER_BOOTSTRAP_TOKEN: requiredTrimmedStringSchema
+    WORKER_BOOTSTRAP_TOKEN: requiredTrimmedStringSchema,
   })
   .superRefine((env, context) => {
     if (!(env.CF_ACCESS_PORTAL_AUD ?? env.CF_ACCESS_AUD)) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: "CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required",
-        path: ["CF_ACCESS_PORTAL_AUD"]
+        path: ["CF_ACCESS_PORTAL_AUD"],
       });
     }
   });
 
 export type ApiRuntimeEnv = {
   accessProviderStateSecret: string;
+  accessCookieDomain?: string;
+  accessCookieSecure: boolean;
+  authPublicOrigin: string;
   brandedAccessAudiences: string[];
+  brandedAuthOrigins: string[];
   corsAllowedOrigins: string[];
   corsAllowLocalhost: boolean;
   databaseUrl: string;
@@ -71,6 +304,7 @@ export type ApiRuntimeEnv = {
   nodeEnv?: string;
   port: number;
   portalAccessAudience: string;
+  portalPublicOrigin: string;
   portalSessionSecret: string;
   teamDomain: string;
   workerBootstrapToken: string;
@@ -80,7 +314,8 @@ function formatApiRuntimeEnvIssues(issues: z.ZodIssue[]) {
   return issues
     .map((issue) => {
       const field = issue.path[0];
-      const message = issue.message === "Required" ? "is required" : issue.message;
+      const message =
+        issue.message === "Required" ? "is required" : issue.message;
 
       if (typeof field !== "string") {
         return message;
@@ -107,27 +342,33 @@ function normalizeAccessAudienceList(value: string | undefined) {
     return [];
   }
 
-  return [...new Set(
-    value
-      .split(",")
-      .map((audience) => audience.trim())
-      .filter((audience) => audience.length > 0)
-  )];
+  return [
+    ...new Set(
+      value
+        .split(",")
+        .map((audience) => audience.trim())
+        .filter((audience) => audience.length > 0),
+    ),
+  ];
 }
 
 export function parseApiRuntimeEnv(
-  rawEnv: Partial<Record<string, string | undefined>> = process.env
+  rawEnv: Partial<Record<string, string | undefined>> = process.env,
 ): ApiRuntimeEnv {
   const parsed = rawApiRuntimeEnvSchema.safeParse(rawEnv);
 
   if (!parsed.success) {
     throw new Error(
-      `Invalid API runtime environment: ${formatApiRuntimeEnvIssues(parsed.error.issues)}`
+      `Invalid API runtime environment: ${formatApiRuntimeEnvIssues(parsed.error.issues)}`,
     );
   }
 
   const {
     ACCESS_PROVIDER_STATE_SECRET,
+    ACCESS_COOKIE_DOMAIN,
+    ACCESS_COOKIE_SECURE,
+    AUTH_PUBLIC_ORIGIN,
+    BRANDED_AUTH_ORIGINS,
     CF_ACCESS_AUD,
     CF_ACCESS_BRANDED_AUDS,
     CF_ACCESS_INTERNAL_AUD,
@@ -139,26 +380,43 @@ export function parseApiRuntimeEnv(
     HOST,
     NODE_ENV,
     PORT,
+    PORTAL_PUBLIC_ORIGIN,
     PORTAL_SESSION_SECRET,
-    WORKER_BOOTSTRAP_TOKEN
+    WORKER_BOOTSTRAP_TOKEN,
   } = parsed.data;
 
   const portalAccessAudience = CF_ACCESS_PORTAL_AUD ?? CF_ACCESS_AUD!;
+  const originRuntimeConfig = resolveApiOriginRuntimeConfig({
+    accessCookieDomain: ACCESS_COOKIE_DOMAIN,
+    accessCookieSecure:
+      ACCESS_COOKIE_SECURE === undefined
+        ? undefined
+        : ACCESS_COOKIE_SECURE === "true",
+    authPublicOrigin: AUTH_PUBLIC_ORIGIN,
+    brandedAuthOrigins: BRANDED_AUTH_ORIGINS,
+    corsAllowLocalhost: CORS_ALLOW_LOCALHOST === "true",
+    portalPublicOrigin: PORTAL_PUBLIC_ORIGIN,
+  });
 
   return {
     accessProviderStateSecret: ACCESS_PROVIDER_STATE_SECRET,
+    accessCookieDomain: originRuntimeConfig.accessCookieDomain,
+    accessCookieSecure: originRuntimeConfig.accessCookieSecure,
+    authPublicOrigin: originRuntimeConfig.authPublicOrigin,
     brandedAccessAudiences: normalizeAccessAudienceList(CF_ACCESS_BRANDED_AUDS),
+    brandedAuthOrigins: originRuntimeConfig.brandedAuthOrigins,
     corsAllowedOrigins: normalizeCorsAllowedOrigins(CORS_ALLOWED_ORIGINS),
-    corsAllowLocalhost: CORS_ALLOW_LOCALHOST === "true",
+    corsAllowLocalhost: originRuntimeConfig.corsAllowLocalhost,
     databaseUrl: DATABASE_URL,
     host: HOST ?? "0.0.0.0",
     internalAccessAudience: CF_ACCESS_INTERNAL_AUD ?? portalAccessAudience,
     nodeEnv: NODE_ENV,
     port: PORT === undefined ? 3000 : Number(PORT),
     portalAccessAudience,
+    portalPublicOrigin: originRuntimeConfig.portalPublicOrigin,
     portalSessionSecret: PORTAL_SESSION_SECRET ?? ACCESS_PROVIDER_STATE_SECRET,
     teamDomain: CF_ACCESS_TEAM_DOMAIN,
-    workerBootstrapToken: WORKER_BOOTSTRAP_TOKEN
+    workerBootstrapToken: WORKER_BOOTSTRAP_TOKEN,
   };
 }
 

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -143,6 +143,17 @@ function normalizeConfiguredCookieDomain(
     return z.NEVER;
   }
 
+  if (
+    getPublicSuffix(normalizedDomain, { allowPrivateDomains: true }) ===
+    normalizedDomain
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "must not be a public suffix cookie domain",
+    });
+    return z.NEVER;
+  }
+
   return `.${normalizedDomain}`;
 }
 
@@ -217,11 +228,8 @@ function deriveAccessCookieDomain(origins: string[]) {
   const candidateDomain = sharedLabels.join(".");
 
   if (
-    hostnames.some(
-      (hostname) =>
-        getPublicSuffix(hostname, { allowPrivateDomains: true }) ===
-        candidateDomain,
-    )
+    getPublicSuffix(candidateDomain, { allowPrivateDomains: true }) ===
+    candidateDomain
   ) {
     return undefined;
   }

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -11,14 +11,14 @@ import {
   portalRunsListQuerySchema,
   type PortalBenchmarkDatasetResponse,
   type PortalProfile,
-  type PortalProfileLinkIntent
+  type PortalProfileLinkIntent,
 } from "@paretoproof/shared";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import type {
   FastifyInstance,
   FastifyReply,
   FastifyRequest,
-  preHandlerHookHandler
+  preHandlerHookHandler,
 } from "fastify";
 import {
   accessRequests,
@@ -26,7 +26,7 @@ import {
   identityLinkIntents,
   roleGrants,
   userIdentities,
-  users
+  users,
 } from "../db/schema.js";
 import { toAccessRequestSummary } from "../lib/access-request-summary.js";
 import { normalizeOptionalEmail } from "../lib/email.js";
@@ -34,32 +34,40 @@ import {
   buildRequestedIdentityProviderSubjectMatch,
   buildUserIdentityProviderSubjectMatch,
   filterUserIdentityProviderSubjectMatch,
-  matchesUserIdentityProviderSubject
+  matchesUserIdentityProviderSubject,
 } from "../lib/identity-binding.js";
 import {
   createPortalBenchmarkOpsReadModelService,
-  type PortalBenchmarkOpsReadModelService
+  type PortalBenchmarkOpsReadModelService,
 } from "../lib/portal-benchmark-ops.js";
 import { createHarnessRegistryService } from "../lib/harness-registry.js";
 import {
   buildSignedAccessCookie,
   verifyAccessProviderHint,
-  verifyAccessLinkIntent
+  verifyAccessLinkIntent,
 } from "../auth/cloudflare-access.js";
 import {
   buildPortalAccessSessionCookie,
   createPortalAccessSession,
-  revokePortalAccessSession
+  revokePortalAccessSession,
 } from "../auth/portal-access-session.js";
 import {
   createAccessResolver,
   isAccessAssertionVerificationError,
-  type AccessResolverOptions
+  type AccessResolverOptions,
 } from "../auth/require-access.js";
 import { resolveAccessRbacContext } from "../auth/resolve-access-rbac-context.js";
+import {
+  resolveApiOriginRuntimeConfig,
+  type ApiRuntimeEnv,
+} from "../config/runtime.js";
 import type { createRateLimitPreHandlers } from "../middleware/rate-limit.js";
 import type { ReturnTypeOfCreateAccessGuard } from "../types/access-guard.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
+import {
+  isAllowedBrandedAuthOrigin,
+  normalizeOrigin,
+} from "../server/trusted-mutation-origin.js";
 
 class PortalAccessRequestConflictError extends Error {
   constructor(message: string) {
@@ -99,42 +107,73 @@ function createSubmittedAuditPayload(options: {
     actorUserId: options.actorUserId,
     requestKind: options.requestKind,
     requestedRole: options.requestedRole,
-    targetEmail: options.targetEmail
+    targetEmail: options.targetEmail,
   };
 }
 
-function sanitizePortalRedirectPath(rawRedirectPath: string | null) {
+type PortalRouteRuntimeConfig = Pick<
+  ApiRuntimeEnv,
+  | "accessCookieDomain"
+  | "accessCookieSecure"
+  | "authPublicOrigin"
+  | "brandedAuthOrigins"
+  | "corsAllowLocalhost"
+  | "portalPublicOrigin"
+>;
+
+function sanitizePortalRedirectPath(
+  rawRedirectPath: string | null,
+  portalPublicOrigin: string,
+) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
   }
 
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) || rawRedirectPath.startsWith("//")) {
+  if (
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) ||
+    rawRedirectPath.startsWith("//")
+  ) {
     return "/";
   }
 
   try {
     const candidateUrl = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      "https://portal.paretoproof.com"
+      portalPublicOrigin,
     );
 
-    if (candidateUrl.origin !== "https://portal.paretoproof.com") {
+    if (candidateUrl.origin !== portalPublicOrigin) {
       return "/";
     }
 
-    return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/";
+    return (
+      `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` ||
+      "/"
+    );
   } catch {
     return "/";
   }
 }
 
 function clearSignedAccessCookie(
-  name: "PortalAccessProvider" | "PortalLinkIntent" | "PortalAccessSession"
+  name: "PortalAccessProvider" | "PortalLinkIntent" | "PortalAccessSession",
+  runtimeConfig: PortalRouteRuntimeConfig,
 ) {
-  return `${name}=; Domain=.paretoproof.com; Path=/; SameSite=Strict; Max-Age=0; Secure; HttpOnly`;
+  return [
+    `${name}=`,
+    ...(runtimeConfig.accessCookieDomain
+      ? [`Domain=${runtimeConfig.accessCookieDomain}`]
+      : []),
+    "Path=/",
+    "SameSite=Strict",
+    "Max-Age=0",
+    ...(runtimeConfig.accessCookieSecure ? ["Secure"] : []),
+    "HttpOnly",
+  ].join("; ");
 }
 
 function buildPortalAuthStartUrl(options: {
+  authPublicOrigin: string;
   provider: "cloudflare_github" | "cloudflare_google";
   redirectPath: string;
 }) {
@@ -142,7 +181,7 @@ function buildPortalAuthStartUrl(options: {
     options.provider === "cloudflare_github"
       ? "/api/access/start/github"
       : "/api/access/start/google",
-    "https://auth.paretoproof.com"
+    options.authPublicOrigin,
   );
 
   if (options.redirectPath !== "/") {
@@ -154,8 +193,11 @@ function buildPortalAuthStartUrl(options: {
   return authUrl.toString();
 }
 
-function buildPortalAuthRetryUrl(redirectPath: string) {
-  const authUrl = new URL("https://auth.paretoproof.com");
+function buildPortalAuthRetryUrl(
+  redirectPath: string,
+  authPublicOrigin: string,
+) {
+  const authUrl = new URL(authPublicOrigin);
 
   if (redirectPath !== "/") {
     authUrl.searchParams.set("redirect", redirectPath);
@@ -166,13 +208,10 @@ function buildPortalAuthRetryUrl(redirectPath: string) {
   return authUrl.toString();
 }
 
-const brandedAuthHosts = new Set([
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com"
-]);
-
-function readTrustedBrandedAuthOrigin(request: FastifyRequest) {
+function readTrustedBrandedAuthOrigin(
+  request: FastifyRequest,
+  runtimeConfig: PortalRouteRuntimeConfig,
+) {
   const originHeader =
     typeof request.headers.origin === "string" ? request.headers.origin : null;
 
@@ -180,8 +219,14 @@ function readTrustedBrandedAuthOrigin(request: FastifyRequest) {
     try {
       const originUrl = new URL(originHeader);
 
-      if (originUrl.protocol === "https:" && brandedAuthHosts.has(originUrl.hostname)) {
-        return originUrl.origin;
+      if (
+        isAllowedBrandedAuthOrigin({
+          allowLocalhostOrigins: runtimeConfig.corsAllowLocalhost,
+          brandedAuthOrigins: runtimeConfig.brandedAuthOrigins,
+          origin: originUrl.origin,
+        })
+      ) {
+        return normalizeOrigin(originUrl.origin);
       }
     } catch {
       return null;
@@ -189,7 +234,9 @@ function readTrustedBrandedAuthOrigin(request: FastifyRequest) {
   }
 
   const refererHeader =
-    typeof request.headers.referer === "string" ? request.headers.referer : null;
+    typeof request.headers.referer === "string"
+      ? request.headers.referer
+      : null;
 
   if (!refererHeader) {
     return null;
@@ -198,8 +245,14 @@ function readTrustedBrandedAuthOrigin(request: FastifyRequest) {
   try {
     const refererUrl = new URL(refererHeader);
 
-    if (refererUrl.protocol === "https:" && brandedAuthHosts.has(refererUrl.hostname)) {
-      return refererUrl.origin;
+    if (
+      isAllowedBrandedAuthOrigin({
+        allowLocalhostOrigins: runtimeConfig.corsAllowLocalhost,
+        brandedAuthOrigins: runtimeConfig.brandedAuthOrigins,
+        origin: refererUrl.origin,
+      })
+    ) {
+      return normalizeOrigin(refererUrl.origin);
     }
   } catch {
     return null;
@@ -228,9 +281,12 @@ function toPortalProfile(options: {
   return {
     createdAt: options.userRow?.createdAt.toISOString() ?? null,
     displayName: options.userRow?.displayName ?? null,
-    email: options.userRow?.email ?? normalizeOptionalEmail(options.fallbackEmail),
+    email:
+      options.userRow?.email ?? normalizeOptionalEmail(options.fallbackEmail),
     identities: [...options.linkedIdentityRows]
-      .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
+      .sort(
+        (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+      )
       .map((identityRow) => ({
         createdAt: identityRow.createdAt.toISOString(),
         current:
@@ -238,15 +294,15 @@ function toPortalProfile(options: {
           matchesUserIdentityProviderSubject(
             identityRow,
             options.currentProvider,
-            options.currentSubject
+            options.currentSubject,
           ),
         id: identityRow.id,
         lastSeenAt: identityRow.lastSeenAt.toISOString(),
         provider: identityRow.provider,
-        providerEmail: identityRow.providerEmail
+        providerEmail: identityRow.providerEmail,
       })),
     linkedUserId: options.userRow?.id ?? null,
-    updatedAt: options.userRow?.updatedAt.toISOString() ?? null
+    updatedAt: options.userRow?.updatedAt.toISOString() ?? null,
   };
 }
 
@@ -261,7 +317,10 @@ function escapeCsvValue(value: string) {
 }
 
 function sanitizeExportFilenameSegment(value: string) {
-  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "benchmark";
+  return (
+    value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") ||
+    "benchmark"
+  );
 }
 
 function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
@@ -297,7 +356,7 @@ function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
     "verifierResult",
     "failureFamily",
     "failureCode",
-    "failureSummary"
+    "failureSummary",
   ];
   const rows = dataset.runs.flatMap((run) => {
     const attempts = attemptsByRunId.get(run.runId) ?? [null];
@@ -320,7 +379,7 @@ function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
       attempt?.verifierResult ?? "",
       attempt?.failure.family ?? run.failure.family ?? "",
       attempt?.failure.code ?? run.failure.code ?? "",
-      attempt?.failure.summary ?? run.failure.summary ?? ""
+      attempt?.failure.summary ?? run.failure.summary ?? "",
     ]);
   });
 
@@ -337,11 +396,14 @@ function buildBenchmarkDatasetCsv(dataset: PortalBenchmarkDatasetResponse) {
     .join("\n");
 }
 
-async function loadPortalProfile(db: ReturnTypeOfCreateDbClient, options: {
-  fallbackEmail: string | null;
-  identityProvider: (typeof userIdentities.$inferSelect)["provider"] | null;
-  identitySubject: string;
-}) {
+async function loadPortalProfile(
+  db: ReturnTypeOfCreateDbClient,
+  options: {
+    fallbackEmail: string | null;
+    identityProvider: (typeof userIdentities.$inferSelect)["provider"] | null;
+    identitySubject: string;
+  },
+) {
   const linkedIdentity =
     options.identityProvider === null
       ? null
@@ -349,18 +411,18 @@ async function loadPortalProfile(db: ReturnTypeOfCreateDbClient, options: {
           await db.query.userIdentities.findFirst({
             where: buildUserIdentityProviderSubjectMatch(
               options.identityProvider,
-              options.identitySubject
+              options.identitySubject,
             ),
             with: {
               user: {
                 with: {
-                  identities: true
-                }
-              }
-            }
+                  identities: true,
+                },
+              },
+            },
           }),
           options.identityProvider,
-          options.identitySubject
+          options.identitySubject,
         );
 
   return toPortalProfile({
@@ -368,7 +430,7 @@ async function loadPortalProfile(db: ReturnTypeOfCreateDbClient, options: {
     currentSubject: options.identitySubject,
     fallbackEmail: options.fallbackEmail,
     linkedIdentityRows: linkedIdentity?.user.identities ?? [],
-    userRow: linkedIdentity?.user ?? null
+    userRow: linkedIdentity?.user ?? null,
   });
 }
 
@@ -377,23 +439,39 @@ export function registerPortalRoutes(
   db: ReturnTypeOfCreateDbClient,
   requireAccess: ReturnTypeOfCreateAccessGuard,
   options?: {
+    accessCookieDomain?: ApiRuntimeEnv["accessCookieDomain"];
+    accessCookieSecure?: ApiRuntimeEnv["accessCookieSecure"];
     accessProviderStateSecret?: string;
     accessResolverOptions?: AccessResolverOptions;
+    allowLocalhostOrigins?: ApiRuntimeEnv["corsAllowLocalhost"];
+    authPublicOrigin?: ApiRuntimeEnv["authPublicOrigin"];
+    brandedAuthOrigins?: ApiRuntimeEnv["brandedAuthOrigins"];
     portalBenchmarkOpsReadModels?: PortalBenchmarkOpsReadModelService;
+    portalPublicOrigin?: ApiRuntimeEnv["portalPublicOrigin"];
     rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
     resolvePortalAccess?: ReturnType<typeof createAccessResolver>;
-  }
+  },
 ) {
   const accessResolverOptions = options?.accessResolverOptions;
   const accessProviderStateSecret =
     options?.accessProviderStateSecret ??
     accessResolverOptions?.accessProviderStateSecret;
   const resolvePortalAccess =
-    options?.resolvePortalAccess ?? createAccessResolver(db, accessResolverOptions);
+    options?.resolvePortalAccess ??
+    createAccessResolver(db, accessResolverOptions);
   const portalBenchmarkOpsReadModels =
-    options?.portalBenchmarkOpsReadModels ?? createPortalBenchmarkOpsReadModelService(db);
+    options?.portalBenchmarkOpsReadModels ??
+    createPortalBenchmarkOpsReadModelService(db);
   const harnessRegistry = createHarnessRegistryService();
   const rateLimitPreHandlers = options?.rateLimitPreHandlers;
+  const runtimeConfig = resolveApiOriginRuntimeConfig({
+    accessCookieDomain: options?.accessCookieDomain,
+    accessCookieSecure: options?.accessCookieSecure,
+    authPublicOrigin: options?.authPublicOrigin,
+    brandedAuthOrigins: options?.brandedAuthOrigins,
+    corsAllowLocalhost: options?.allowLocalhostOrigins,
+    portalPublicOrigin: options?.portalPublicOrigin,
+  });
   const withAuthenticatedRateLimit = (guard: preHandlerHookHandler) =>
     rateLimitPreHandlers?.authenticated
       ? [guard, rateLimitPreHandlers.authenticated]
@@ -401,22 +479,30 @@ export function registerPortalRoutes(
 
   const handlePortalSessionRetryRedirect = (
     request: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
     const redirectPath = sanitizePortalRedirectPath(
-      (request.query as { redirect?: string } | undefined)?.redirect ?? null
+      (request.query as { redirect?: string } | undefined)?.redirect ?? null,
+      runtimeConfig.portalPublicOrigin,
     );
 
-    reply.header("set-cookie", clearSignedAccessCookie("PortalAccessSession"));
-    reply.redirect(buildPortalAuthRetryUrl(redirectPath));
+    reply.header(
+      "set-cookie",
+      clearSignedAccessCookie("PortalAccessSession", runtimeConfig),
+    );
+    reply.redirect(
+      buildPortalAuthRetryUrl(redirectPath, runtimeConfig.authPublicOrigin),
+    );
   };
 
   const handlePortalSessionCompletion = async (
     request: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
     const cookieHeader =
-      typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+      typeof request.headers.cookie === "string"
+        ? request.headers.cookie
+        : undefined;
     const identity = request.accessIdentity;
     const accessContext = request.accessRbacContext;
     const parsedBody =
@@ -426,25 +512,30 @@ export function registerPortalRoutes(
     const redirectPath = sanitizePortalRedirectPath(
       parsedBody?.redirect ??
         (request.query as { redirect?: string } | undefined)?.redirect ??
-        null
+        null,
+      runtimeConfig.portalPublicOrigin,
     );
-    const portalUrl = new URL(redirectPath, "https://portal.paretoproof.com");
+    const portalUrl = new URL(redirectPath, runtimeConfig.portalPublicOrigin);
     const linkIntent = verifyAccessLinkIntent(cookieHeader, {
-      secret: accessProviderStateSecret
+      secret: accessProviderStateSecret,
     });
     const providerHint = verifyAccessProviderHint(cookieHeader, {
       expectedSubject: identity?.subject,
-      secret: accessProviderStateSecret
+      secret: accessProviderStateSecret,
     });
     let resolvedAccessContext = accessContext;
 
     if (identity && linkIntent) {
       const linkStatus = await db.transaction(async (tx) => {
         const intentRow = await tx.query.identityLinkIntents.findFirst({
-          where: eq(identityLinkIntents.id, linkIntent.intentId)
+          where: eq(identityLinkIntents.id, linkIntent.intentId),
         });
 
-        if (!intentRow || intentRow.usedAt || intentRow.expiresAt.getTime() <= Date.now()) {
+        if (
+          !intentRow ||
+          intentRow.usedAt ||
+          intentRow.expiresAt.getTime() <= Date.now()
+        ) {
           return "invalid";
         }
 
@@ -456,14 +547,17 @@ export function registerPortalRoutes(
           await tx.query.userIdentities.findFirst({
             where: buildUserIdentityProviderSubjectMatch(
               intentRow.targetProvider,
-              identity.subject
-            )
+              identity.subject,
+            ),
           }),
           intentRow.targetProvider,
-          identity.subject
+          identity.subject,
         );
 
-        if (existingSubjectOwner && existingSubjectOwner.userId !== intentRow.userId) {
+        if (
+          existingSubjectOwner &&
+          existingSubjectOwner.userId !== intentRow.userId
+        ) {
           return "conflict";
         }
 
@@ -474,14 +568,14 @@ export function registerPortalRoutes(
             provider: intentRow.targetProvider,
             providerEmail: normalizeOptionalEmail(identity.email),
             providerSubject: identity.subject,
-            userId: intentRow.userId
+            userId: intentRow.userId,
           });
         } else {
           await tx
             .update(userIdentities)
             .set({
               lastSeenAt: now,
-              providerEmail: normalizeOptionalEmail(identity.email)
+              providerEmail: normalizeOptionalEmail(identity.email),
             })
             .where(eq(userIdentities.id, existingSubjectOwner.id));
         }
@@ -489,7 +583,7 @@ export function registerPortalRoutes(
         await tx
           .update(identityLinkIntents)
           .set({
-            usedAt: now
+            usedAt: now,
           })
           .where(eq(identityLinkIntents.id, intentRow.id));
 
@@ -500,11 +594,11 @@ export function registerPortalRoutes(
           payload: {
             identityProvider: intentRow.targetProvider,
             identitySubject: identity.subject,
-            targetUserId: intentRow.userId
+            targetUserId: intentRow.userId,
           },
           severity: "critical",
           subjectKind: "user_identity",
-          targetUserId: intentRow.userId
+          targetUserId: intentRow.userId,
         });
 
         return "linked";
@@ -525,21 +619,27 @@ export function registerPortalRoutes(
               db,
               request,
               identity,
-              resolvedAccessContext
-            )
+              resolvedAccessContext,
+            ),
+            {
+              cookieDomain: runtimeConfig.accessCookieDomain,
+              secure: runtimeConfig.accessCookieSecure,
+            },
           )
-        : clearSignedAccessCookie("PortalAccessSession"),
+        : clearSignedAccessCookie("PortalAccessSession", runtimeConfig),
       identity && providerHint
         ? buildSignedAccessCookie(
             "PortalAccessProvider",
             `${providerHint}|${identity.subject}`,
             {
+              cookieDomain: runtimeConfig.accessCookieDomain,
               maxAgeSeconds: 24 * 60 * 60,
-              secret: accessProviderStateSecret
-            }
+              secret: accessProviderStateSecret,
+              secure: runtimeConfig.accessCookieSecure,
+            },
           )
-        : clearSignedAccessCookie("PortalAccessProvider"),
-      clearSignedAccessCookie("PortalLinkIntent")
+        : clearSignedAccessCookie("PortalAccessProvider", runtimeConfig),
+      clearSignedAccessCookie("PortalLinkIntent", runtimeConfig),
     ];
 
     reply.header("set-cookie", responseCookies);
@@ -549,7 +649,7 @@ export function registerPortalRoutes(
       request.headers.accept.includes("application/json")
     ) {
       return reply.send({
-        redirectTo: portalUrl.toString()
+        redirectTo: portalUrl.toString(),
       });
     }
 
@@ -558,13 +658,19 @@ export function registerPortalRoutes(
 
   const handlePortalSessionFinalizeGet = async (
     request: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
     const cookieHeader =
-      typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+      typeof request.headers.cookie === "string"
+        ? request.headers.cookie
+        : undefined;
 
     // Cross-site GETs must not be enough to consume a pending identity-link intent.
-    if (verifyAccessLinkIntent(cookieHeader, { secret: accessProviderStateSecret })) {
+    if (
+      verifyAccessLinkIntent(cookieHeader, {
+        secret: accessProviderStateSecret,
+      })
+    ) {
       handlePortalSessionRetryRedirect(request, reply);
       return;
     }
@@ -590,7 +696,7 @@ export function registerPortalRoutes(
 
   const handlePortalSessionFinalizeSubmit = async (
     request: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
     const parsedBody =
       typeof request.body === "object" && request.body !== null
@@ -599,42 +705,53 @@ export function registerPortalRoutes(
     const redirectPath = sanitizePortalRedirectPath(
       parsedBody?.redirect ??
         (request.query as { redirect?: string } | undefined)?.redirect ??
-        null
+        null,
+      runtimeConfig.portalPublicOrigin,
     );
 
     try {
       const accessContext = await resolvePortalAccess(request);
 
       if (!accessContext) {
-        const brandedOrigin = readTrustedBrandedAuthOrigin(request);
+        const brandedOrigin = readTrustedBrandedAuthOrigin(
+          request,
+          runtimeConfig,
+        );
 
         if (brandedOrigin) {
-          reply.code(307).header(
-            "location",
-            buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath)
-          );
+          reply
+            .code(307)
+            .header(
+              "location",
+              buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath),
+            );
           return reply.send();
         }
 
         reply.code(401).send({
-          error: "access_assertion_required"
+          error: "access_assertion_required",
         });
         return;
       }
     } catch (error) {
       if (isAccessAssertionVerificationError(error)) {
-        const brandedOrigin = readTrustedBrandedAuthOrigin(request);
+        const brandedOrigin = readTrustedBrandedAuthOrigin(
+          request,
+          runtimeConfig,
+        );
 
         if (brandedOrigin) {
-          reply.code(307).header(
-            "location",
-            buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath)
-          );
+          reply
+            .code(307)
+            .header(
+              "location",
+              buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath),
+            );
           return reply.send();
         }
 
         reply.code(401).send({
-          error: "invalid_access_assertion"
+          error: "invalid_access_assertion",
         });
         return;
       }
@@ -649,76 +766,104 @@ export function registerPortalRoutes(
     "/portal/me",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
     async (request) => {
       return {
         identity: request.accessIdentity,
-        access: request.accessRbacContext
+        access: request.accessRbacContext,
       };
-    }
+    },
   );
 
-  app.get("/portal/session/complete", {
-    preHandler: rateLimitPreHandlers?.public
-  }, handlePortalSessionRetryRedirect);
-  app.get("/portal/session/finalize", {
-    preHandler: rateLimitPreHandlers?.public
-  }, handlePortalSessionRetryRedirect);
-  app.get("/portal/session/finalize/submit", {
-    preHandler: rateLimitPreHandlers?.public
-  }, handlePortalSessionFinalizeGet);
+  app.get(
+    "/portal/session/complete",
+    {
+      preHandler: rateLimitPreHandlers?.public,
+    },
+    handlePortalSessionRetryRedirect,
+  );
+  app.get(
+    "/portal/session/finalize",
+    {
+      preHandler: rateLimitPreHandlers?.public,
+    },
+    handlePortalSessionRetryRedirect,
+  );
+  app.get(
+    "/portal/session/finalize/submit",
+    {
+      preHandler: rateLimitPreHandlers?.public,
+    },
+    handlePortalSessionFinalizeGet,
+  );
 
   app.post(
     "/portal/session/complete",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
-    handlePortalSessionCompletion
+    handlePortalSessionCompletion,
   );
 
   app.post(
     "/portal/session/finalize",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
-    handlePortalSessionCompletion
+    handlePortalSessionCompletion,
   );
 
   app.post(
     "/portal/session/finalize/submit",
     {
-      preHandler: rateLimitPreHandlers?.public
+      preHandler: rateLimitPreHandlers?.public,
     },
-    handlePortalSessionFinalizeSubmit
+    handlePortalSessionFinalizeSubmit,
   );
 
-  app.post("/portal/session/sign-out", {
-    preHandler: rateLimitPreHandlers?.public
-  }, async (request, reply) => {
-    const cookieHeader =
-      typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
+  app.post(
+    "/portal/session/sign-out",
+    {
+      preHandler: rateLimitPreHandlers?.public,
+    },
+    async (request, reply) => {
+      const cookieHeader =
+        typeof request.headers.cookie === "string"
+          ? request.headers.cookie
+          : undefined;
 
-    await revokePortalAccessSession(db, cookieHeader);
-    reply.code(204).header("set-cookie", [
-      clearSignedAccessCookie("PortalAccessSession"),
-      clearSignedAccessCookie("PortalAccessProvider"),
-      clearSignedAccessCookie("PortalLinkIntent")
-    ]);
-    return reply.send();
-  });
+      await revokePortalAccessSession(db, cookieHeader);
+      reply
+        .code(204)
+        .header("set-cookie", [
+          clearSignedAccessCookie("PortalAccessSession", runtimeConfig),
+          clearSignedAccessCookie("PortalAccessProvider", runtimeConfig),
+          clearSignedAccessCookie("PortalLinkIntent", runtimeConfig),
+        ]);
+      return reply.send();
+    },
+  );
 
   app.get(
     "/portal/access-requests/me",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
     async (request) => {
       const identity = request.accessIdentity;
@@ -729,7 +874,9 @@ export function registerPortalRoutes(
       const accessEmail = normalizeOptionalEmail(identity?.email);
 
       if (!identity) {
-        throw new Error("Authenticated Access identity was not attached to the request.");
+        throw new Error(
+          "Authenticated Access identity was not attached to the request.",
+        );
       }
 
       const linkedIdentity =
@@ -739,24 +886,27 @@ export function registerPortalRoutes(
               await db.query.userIdentities.findFirst({
                 where: buildUserIdentityProviderSubjectMatch(
                   identity.provider,
-                  identity.subject
-                )
+                  identity.subject,
+                ),
               }),
               identity.provider,
-              identity.subject
+              identity.subject,
             );
 
       const latestRequest =
         (linkedIdentity
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(accessRequests.requestedByUserId, linkedIdentity.userId)
+              where: eq(
+                accessRequests.requestedByUserId,
+                linkedIdentity.userId,
+              ),
             })
           : null) ??
         (pendingUserId
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(accessRequests.requestedByUserId, pendingUserId)
+              where: eq(accessRequests.requestedByUserId, pendingUserId),
             })
           : null) ??
         (canUsePendingFallback && accessEmail
@@ -764,259 +914,301 @@ export function registerPortalRoutes(
               orderBy: [desc(accessRequests.createdAt)],
               where: and(
                 eq(accessRequests.email, accessEmail),
-                eq(accessRequests.status, "pending")
-              )
+                eq(accessRequests.status, "pending"),
+              ),
             })
           : null) ??
         (accessEmail
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(accessRequests.email, accessEmail)
+              where: eq(accessRequests.email, accessEmail),
             })
           : null);
 
       return {
-        item: latestRequest ? toAccessRequestSummary(latestRequest) : null
+        item: latestRequest ? toAccessRequestSummary(latestRequest) : null,
       };
-    }
+    },
   );
 
   app.get(
     "/portal/profile",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request) => {
       const identity = request.accessIdentity;
 
       if (!identity) {
-        throw new Error("Authenticated Access identity was not attached to the request.");
+        throw new Error(
+          "Authenticated Access identity was not attached to the request.",
+        );
       }
 
       return {
         profile: await loadPortalProfile(db, {
           fallbackEmail: normalizeOptionalEmail(identity.email),
           identityProvider: identity.provider,
-          identitySubject: identity.subject
-        })
+          identitySubject: identity.subject,
+        }),
       };
-    }
+    },
   );
 
   app.get(
     "/portal/benchmarks",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.benchmarksListResponse
+        contract: portalBenchmarkOpsReadModelsContract.benchmarksListResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
-    async () => portalBenchmarkOpsReadModels.getBenchmarksList()
+    async () => portalBenchmarkOpsReadModels.getBenchmarksList(),
   );
 
   app.get(
     "/portal/benchmarks/:packageId/dataset",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.benchmarkDatasetResponse
+        contract: portalBenchmarkOpsReadModelsContract.benchmarkDatasetResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(request.params ?? {});
+      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(
+        request.params ?? {},
+      );
 
       if (!parsedParams.success) {
         reply.code(400).send({
           error: "invalid_portal_benchmark_dataset_params",
-          issues: parsedParams.error.issues
+          issues: parsedParams.error.issues,
         });
         return;
       }
 
       const dataset = await portalBenchmarkOpsReadModels.getBenchmarkDataset(
-        parsedParams.data.packageId
+        parsedParams.data.packageId,
       );
 
       if (!dataset) {
         reply.code(404).send({
-          error: "portal_benchmark_dataset_not_found"
+          error: "portal_benchmark_dataset_not_found",
         });
         return;
       }
 
       return dataset;
-    }
+    },
   );
 
   app.get(
     "/portal/benchmarks/:packageId/export",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(request.params ?? {});
+      const parsedParams = portalBenchmarkDatasetParamsSchema.safeParse(
+        request.params ?? {},
+      );
 
       if (!parsedParams.success) {
         reply.code(400).send({
           error: "invalid_portal_benchmark_export_params",
-          issues: parsedParams.error.issues
+          issues: parsedParams.error.issues,
         });
         return;
       }
 
-      const parsedQuery = portalBenchmarkExportQuerySchema.safeParse(request.query ?? {});
+      const parsedQuery = portalBenchmarkExportQuerySchema.safeParse(
+        request.query ?? {},
+      );
 
       if (!parsedQuery.success) {
         reply.code(400).send({
           error: "invalid_portal_benchmark_export_query",
-          issues: parsedQuery.error.issues
+          issues: parsedQuery.error.issues,
         });
         return;
       }
 
       const dataset = await portalBenchmarkOpsReadModels.getBenchmarkDataset(
-        parsedParams.data.packageId
+        parsedParams.data.packageId,
       );
 
       if (!dataset) {
         reply.code(404).send({
-          error: "portal_benchmark_dataset_not_found"
+          error: "portal_benchmark_dataset_not_found",
         });
         return;
       }
 
-      const filenameRoot = sanitizeExportFilenameSegment(parsedParams.data.packageId);
+      const filenameRoot = sanitizeExportFilenameSegment(
+        parsedParams.data.packageId,
+      );
 
       if (parsedQuery.data.format === "csv") {
         reply
-          .header("content-disposition", `attachment; filename="${filenameRoot}-dataset.csv"`)
+          .header(
+            "content-disposition",
+            `attachment; filename="${filenameRoot}-dataset.csv"`,
+          )
           .type("text/csv; charset=utf-8");
         return reply.send(buildBenchmarkDatasetCsv(dataset));
       }
 
       reply
-        .header("content-disposition", `attachment; filename="${filenameRoot}-dataset.json"`)
+        .header(
+          "content-disposition",
+          `attachment; filename="${filenameRoot}-dataset.json"`,
+        )
         .type("application/json; charset=utf-8");
       return reply.send(dataset);
-    }
+    },
   );
 
   app.get(
     "/portal/runs",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.runsListResponse
+        contract: portalBenchmarkOpsReadModelsContract.runsListResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedQuery = portalRunsListQuerySchema.safeParse(request.query ?? {});
+      const parsedQuery = portalRunsListQuerySchema.safeParse(
+        request.query ?? {},
+      );
 
       if (!parsedQuery.success) {
         reply.code(400).send({
           error: "invalid_portal_runs_query",
-          issues: parsedQuery.error.issues
+          issues: parsedQuery.error.issues,
         });
         return;
       }
 
       return portalBenchmarkOpsReadModels.getRunsList(parsedQuery.data);
-    }
+    },
   );
 
   app.get(
     "/portal/runs/:runId",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.runDetailResponse
+        contract: portalBenchmarkOpsReadModelsContract.runDetailResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedParams = portalRunDetailParamsSchema.safeParse(request.params ?? {});
+      const parsedParams = portalRunDetailParamsSchema.safeParse(
+        request.params ?? {},
+      );
 
       if (!parsedParams.success) {
         reply.code(400).send({
           error: "invalid_portal_run_detail_params",
-          issues: parsedParams.error.issues
+          issues: parsedParams.error.issues,
         });
         return;
       }
 
-      const detail = await portalBenchmarkOpsReadModels.getRunDetail(parsedParams.data.runId);
+      const detail = await portalBenchmarkOpsReadModels.getRunDetail(
+        parsedParams.data.runId,
+      );
 
       if (!detail) {
         reply.code(404).send({
-          error: "portal_run_not_found"
+          error: "portal_run_not_found",
         });
         return;
       }
 
       return detail;
-    }
+    },
   );
 
   app.get(
     "/portal/harnesses",
     {
       config: {
-        contract: portalHarnessRegistryReadContract.catalogResponse
+        contract: portalHarnessRegistryReadContract.catalogResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
-    async () => harnessRegistry.getCatalog()
+    async () => harnessRegistry.getCatalog(),
   );
 
   app.get(
     "/portal/launch",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.launchViewResponse
+        contract: portalBenchmarkOpsReadModelsContract.launchViewResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_collaborator_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_collaborator_or_higher"),
+        ),
+      ],
     },
-    async () => portalBenchmarkOpsReadModels.getLaunchView()
+    async () => portalBenchmarkOpsReadModels.getLaunchView(),
   );
 
   app.get(
     "/portal/workers",
     {
       config: {
-        contract: portalBenchmarkOpsReadModelsContract.workersViewResponse
+        contract: portalBenchmarkOpsReadModelsContract.workersViewResponse,
       },
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_collaborator_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_collaborator_or_higher"),
+        ),
+      ],
     },
-    async () => portalBenchmarkOpsReadModels.getWorkersView()
+    async () => portalBenchmarkOpsReadModels.getWorkersView(),
   );
 
   const handlePortalProfileUpdate = async (
     request: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
-    const parsedBody = portalProfileUpdateInputSchema.safeParse(request.body ?? {});
+    const parsedBody = portalProfileUpdateInputSchema.safeParse(
+      request.body ?? {},
+    );
 
     if (!parsedBody.success) {
       reply.code(400).send({
         error: "invalid_profile_payload",
-        issues: parsedBody.error.issues
+        issues: parsedBody.error.issues,
       });
       return;
     }
@@ -1024,7 +1216,9 @@ export function registerPortalRoutes(
     const identity = request.accessIdentity;
 
     if (!identity) {
-      throw new Error("Authenticated Access identity was not attached to the request.");
+      throw new Error(
+        "Authenticated Access identity was not attached to the request.",
+      );
     }
 
     const linkedIdentity =
@@ -1034,19 +1228,19 @@ export function registerPortalRoutes(
             await db.query.userIdentities.findFirst({
               where: buildUserIdentityProviderSubjectMatch(
                 identity.provider,
-                identity.subject
+                identity.subject,
               ),
               with: {
-                user: true
-              }
+                user: true,
+              },
             }),
             identity.provider,
-            identity.subject
+            identity.subject,
           );
 
     if (!linkedIdentity) {
       reply.code(409).send({
-        error: "profile_not_initialized"
+        error: "profile_not_initialized",
       });
       return;
     }
@@ -1055,7 +1249,7 @@ export function registerPortalRoutes(
       .update(users)
       .set({
         displayName: parsedBody.data.displayName,
-        updatedAt: new Date()
+        updatedAt: new Date(),
       })
       .where(eq(users.id, linkedIdentity.user.id));
 
@@ -1063,8 +1257,8 @@ export function registerPortalRoutes(
       profile: await loadPortalProfile(db, {
         fallbackEmail: normalizeOptionalEmail(identity.email),
         identityProvider: identity.provider,
-        identitySubject: identity.subject
-      })
+        identitySubject: identity.subject,
+      }),
     };
   };
 
@@ -1072,36 +1266,44 @@ export function registerPortalRoutes(
     "/portal/profile",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
-    handlePortalProfileUpdate
+    handlePortalProfileUpdate,
   );
 
   app.post(
     "/portal/profile",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
-    handlePortalProfileUpdate
+    handlePortalProfileUpdate,
   );
 
   app.post(
     "/portal/profile/link-intents",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("approved_helper_or_higher"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_helper_or_higher"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedBody = portalProfileLinkIntentInputSchema.safeParse(request.body ?? {});
+      const parsedBody = portalProfileLinkIntentInputSchema.safeParse(
+        request.body ?? {},
+      );
 
       if (!parsedBody.success) {
         reply.code(400).send({
           error: "invalid_profile_link_intent_payload",
-          issues: parsedBody.error.issues
+          issues: parsedBody.error.issues,
         });
         return;
       }
@@ -1110,7 +1312,9 @@ export function registerPortalRoutes(
       const accessContext = request.accessRbacContext;
 
       if (!identity || accessContext?.status !== "approved") {
-        throw new Error("Approved Access identity was not attached to the request.");
+        throw new Error(
+          "Approved Access identity was not attached to the request.",
+        );
       }
 
       const linkedIdentity =
@@ -1120,35 +1324,40 @@ export function registerPortalRoutes(
               await db.query.userIdentities.findFirst({
                 where: buildUserIdentityProviderSubjectMatch(
                   identity.provider,
-                  identity.subject
+                  identity.subject,
                 ),
                 with: {
                   user: {
                     with: {
-                      identities: true
-                    }
-                  }
-                }
+                      identities: true,
+                    },
+                  },
+                },
               }),
               identity.provider,
-              identity.subject
+              identity.subject,
             );
 
       if (!linkedIdentity) {
         reply.code(409).send({
-          error: "profile_not_initialized"
+          error: "profile_not_initialized",
         });
         return;
       }
 
       const targetProvider = parsedBody.data.provider;
       const redirectPath = sanitizePortalRedirectPath(
-        parsedBody.data.redirectPath ?? "/profile"
+        parsedBody.data.redirectPath ?? "/profile",
+        runtimeConfig.portalPublicOrigin,
       );
 
-      if (linkedIdentity.user.identities.some((candidate) => candidate.provider === targetProvider)) {
+      if (
+        linkedIdentity.user.identities.some(
+          (candidate) => candidate.provider === targetProvider,
+        )
+      ) {
         reply.code(409).send({
-          error: "identity_provider_already_linked"
+          error: "identity_provider_already_linked",
         });
         return;
       }
@@ -1159,14 +1368,14 @@ export function registerPortalRoutes(
         await tx
           .update(identityLinkIntents)
           .set({
-            usedAt: new Date()
+            usedAt: new Date(),
           })
           .where(
             and(
               eq(identityLinkIntents.userId, linkedIdentity.user.id),
               eq(identityLinkIntents.targetProvider, targetProvider),
-              isNull(identityLinkIntents.usedAt)
-            )
+              isNull(identityLinkIntents.usedAt),
+            ),
           );
 
         const [createdIntent] = await tx
@@ -1175,7 +1384,7 @@ export function registerPortalRoutes(
             expiresAt,
             redirectPath,
             targetProvider,
-            userId: linkedIdentity.user.id
+            userId: linkedIdentity.user.id,
           })
           .returning();
 
@@ -1191,11 +1400,11 @@ export function registerPortalRoutes(
             expiresAt: createdIntent.expiresAt.toISOString(),
             intentId: createdIntent.id,
             targetProvider,
-            targetUserId: linkedIdentity.user.id
+            targetUserId: linkedIdentity.user.id,
           },
           severity: "info",
           subjectKind: "user_identity",
-          targetUserId: linkedIdentity.user.id
+          targetUserId: linkedIdentity.user.id,
         });
 
         return createdIntent;
@@ -1205,38 +1414,45 @@ export function registerPortalRoutes(
         expiresAt: intent.expiresAt.toISOString(),
         provider: targetProvider,
         startUrl: buildPortalAuthStartUrl({
+          authPublicOrigin: runtimeConfig.authPublicOrigin,
           provider: targetProvider,
-          redirectPath: intent.redirectPath
-        })
+          redirectPath: intent.redirectPath,
+        }),
       };
 
       reply.header(
         "set-cookie",
         buildSignedAccessCookie("PortalLinkIntent", intent.id, {
-          secret: accessProviderStateSecret
-        })
+          cookieDomain: runtimeConfig.accessCookieDomain,
+          secret: accessProviderStateSecret,
+          secure: runtimeConfig.accessCookieSecure,
+        }),
       );
 
       return {
-        intent: responseBody
+        intent: responseBody,
       };
-    }
+    },
   );
 
   app.post(
     "/portal/access-requests",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedBody = portalAccessRequestInputSchema.safeParse(request.body ?? {});
+      const parsedBody = portalAccessRequestInputSchema.safeParse(
+        request.body ?? {},
+      );
 
       if (!parsedBody.success) {
         reply.code(400).send({
           error: "invalid_access_request_payload",
-          issues: parsedBody.error.issues
+          issues: parsedBody.error.issues,
         });
         return;
       }
@@ -1245,7 +1461,7 @@ export function registerPortalRoutes(
 
       if (!identity?.email) {
         reply.code(400).send({
-          error: "access_email_required"
+          error: "access_email_required",
         });
         return;
       }
@@ -1254,14 +1470,14 @@ export function registerPortalRoutes(
 
       if (!accessEmail) {
         reply.code(400).send({
-          error: "access_email_required"
+          error: "access_email_required",
         });
         return;
       }
 
       if (!identity.provider) {
         reply.code(409).send({
-          error: "identity_provider_required"
+          error: "identity_provider_required",
         });
         return;
       }
@@ -1276,27 +1492,27 @@ export function registerPortalRoutes(
             await tx.query.userIdentities.findFirst({
               where: buildUserIdentityProviderSubjectMatch(
                 accessProvider,
-                identity.subject
-              )
+                identity.subject,
+              ),
             }),
             accessProvider,
-            identity.subject
+            identity.subject,
           );
 
           const linkedUser = existingIdentity
             ? await tx.query.users.findFirst({
                 where: eq(users.id, existingIdentity.userId),
                 with: {
-                  identities: true
-                }
+                  identities: true,
+                },
               })
             : null;
 
           const matchingUser = await tx.query.users.findFirst({
             where: eq(users.email, accessEmail),
             with: {
-              identities: true
-            }
+              identities: true,
+            },
           });
 
           if (
@@ -1304,7 +1520,9 @@ export function registerPortalRoutes(
             matchingUser &&
             existingIdentity.userId !== matchingUser.id
           ) {
-            throw new PortalAccessRequestConflictError("access_identity_already_linked");
+            throw new PortalAccessRequestConflictError(
+              "access_identity_already_linked",
+            );
           }
 
           if (
@@ -1312,7 +1530,9 @@ export function registerPortalRoutes(
             matchingUser &&
             matchingUser.identities.length > 0
           ) {
-            throw new PortalAccessRequestConflictError("identity_link_required");
+            throw new PortalAccessRequestConflictError(
+              "identity_link_required",
+            );
           }
 
           const user =
@@ -1322,16 +1542,18 @@ export function registerPortalRoutes(
               await tx
                 .insert(users)
                 .values({
-                  email: accessEmail
+                  email: accessEmail,
                 })
                 .returning({
                   email: users.email,
-                  id: users.id
+                  id: users.id,
                 })
             )[0];
 
           if (!user) {
-            throw new Error("Failed to persist the access-request user record.");
+            throw new Error(
+              "Failed to persist the access-request user record.",
+            );
           }
 
           if (existingIdentity) {
@@ -1340,7 +1562,7 @@ export function registerPortalRoutes(
                 .update(users)
                 .set({
                   email: accessEmail,
-                  updatedAt: new Date()
+                  updatedAt: new Date(),
                 })
                 .where(eq(users.id, user.id));
             }
@@ -1349,7 +1571,7 @@ export function registerPortalRoutes(
               .update(userIdentities)
               .set({
                 lastSeenAt: new Date(),
-                providerEmail: accessEmail
+                providerEmail: accessEmail,
               })
               .where(eq(userIdentities.id, existingIdentity.id));
           } else {
@@ -1359,16 +1581,18 @@ export function registerPortalRoutes(
               provider: accessProvider,
               providerEmail: accessEmail,
               providerSubject: identity.subject,
-              userId: user.id
+              userId: user.id,
             });
           }
 
           const activeRoleRows = await tx
             .select({
-              role: roleGrants.role
+              role: roleGrants.role,
             })
             .from(roleGrants)
-            .where(and(eq(roleGrants.userId, user.id), isNull(roleGrants.revokedAt)));
+            .where(
+              and(eq(roleGrants.userId, user.id), isNull(roleGrants.revokedAt)),
+            );
 
           if (activeRoleRows.length > 0) {
             throw new PortalAccessRequestConflictError("already_approved");
@@ -1376,7 +1600,7 @@ export function registerPortalRoutes(
 
           const existingRequest = await tx.query.accessRequests.findFirst({
             orderBy: [desc(accessRequests.createdAt)],
-            where: eq(accessRequests.email, accessEmail)
+            where: eq(accessRequests.email, accessEmail),
           });
 
           if (
@@ -1384,7 +1608,9 @@ export function registerPortalRoutes(
             (existingRequest.status === "rejected" ||
               existingRequest.status === "withdrawn")
           ) {
-            throw new PortalAccessRequestConflictError("access_request_reentry_not_allowed");
+            throw new PortalAccessRequestConflictError(
+              "access_request_reentry_not_allowed",
+            );
           }
 
           if (existingRequest?.status === "pending") {
@@ -1401,7 +1627,7 @@ export function registerPortalRoutes(
               .update(accessRequests)
               .set({
                 rationale: parsedBody.data.rationale,
-                requestedRole: parsedBody.data.requestedRole
+                requestedRole: parsedBody.data.requestedRole,
               })
               .where(eq(accessRequests.id, existingRequest.id))
               .returning();
@@ -1415,11 +1641,11 @@ export function registerPortalRoutes(
                 actorUserId: user.id,
                 requestKind: "access_request",
                 requestedRole: parsedBody.data.requestedRole,
-                targetEmail: accessEmail
+                targetEmail: accessEmail,
               }),
               severity: "info",
               subjectKind: "access_request",
-              targetUserId: user.id
+              targetUserId: user.id,
             });
 
             return updatedRequest ?? existingRequest;
@@ -1432,7 +1658,7 @@ export function registerPortalRoutes(
               rationale: parsedBody.data.rationale,
               requestKind: "access_request",
               requestedByUserId: user.id,
-              requestedRole: parsedBody.data.requestedRole
+              requestedRole: parsedBody.data.requestedRole,
             })
             .returning();
 
@@ -1449,11 +1675,11 @@ export function registerPortalRoutes(
               actorUserId: user.id,
               requestKind: "access_request",
               requestedRole: parsedBody.data.requestedRole,
-              targetEmail: accessEmail
+              targetEmail: accessEmail,
             }),
             severity: "info",
             subjectKind: "access_request",
-            targetUserId: user.id
+            targetUserId: user.id,
           });
 
           return createdRequest;
@@ -1464,8 +1690,8 @@ export function registerPortalRoutes(
             orderBy: [desc(accessRequests.createdAt)],
             where: and(
               eq(accessRequests.email, accessEmail),
-              eq(accessRequests.status, "pending")
-            )
+              eq(accessRequests.status, "pending"),
+            ),
           });
 
           if (!latestRequest) {
@@ -1473,7 +1699,7 @@ export function registerPortalRoutes(
           }
         } else if (error instanceof PortalAccessRequestConflictError) {
           reply.code(409).send({
-            error: error.message
+            error: error.message,
           });
           return;
         }
@@ -1482,29 +1708,35 @@ export function registerPortalRoutes(
       }
 
       if (!latestRequest) {
-        throw new Error("The access-request flow completed without returning a request.");
+        throw new Error(
+          "The access-request flow completed without returning a request.",
+        );
       }
 
       return {
-        item: toAccessRequestSummary(latestRequest)
+        item: toAccessRequestSummary(latestRequest),
       };
-    }
+    },
   );
 
   app.post(
     "/portal/access-recovery",
     {
       preHandler: [
-        ...withAuthenticatedRateLimit(requireAccess("authenticated_access_identity"))
-      ]
+        ...withAuthenticatedRateLimit(
+          requireAccess("authenticated_access_identity"),
+        ),
+      ],
     },
     async (request, reply) => {
-      const parsedBody = portalAccessRecoveryInputSchema.safeParse(request.body ?? {});
+      const parsedBody = portalAccessRecoveryInputSchema.safeParse(
+        request.body ?? {},
+      );
 
       if (!parsedBody.success) {
         reply.code(400).send({
           error: "invalid_access_recovery_payload",
-          issues: parsedBody.error.issues
+          issues: parsedBody.error.issues,
         });
         return;
       }
@@ -1513,7 +1745,7 @@ export function registerPortalRoutes(
 
       if (!identity?.email) {
         reply.code(400).send({
-          error: "access_email_required"
+          error: "access_email_required",
         });
         return;
       }
@@ -1522,14 +1754,14 @@ export function registerPortalRoutes(
 
       if (!accessEmail) {
         reply.code(400).send({
-          error: "access_email_required"
+          error: "access_email_required",
         });
         return;
       }
 
       if (!identity.provider) {
         reply.code(409).send({
-          error: "identity_provider_required"
+          error: "identity_provider_required",
         });
         return;
       }
@@ -1544,40 +1776,51 @@ export function registerPortalRoutes(
             await tx.query.userIdentities.findFirst({
               where: buildUserIdentityProviderSubjectMatch(
                 accessProvider,
-                identity.subject
-              )
+                identity.subject,
+              ),
             }),
             accessProvider,
-            identity.subject
+            identity.subject,
           );
 
           if (existingIdentity) {
-            throw new PortalAccessRequestConflictError("identity_already_linked");
+            throw new PortalAccessRequestConflictError(
+              "identity_already_linked",
+            );
           }
 
           const matchingUser = await tx.query.users.findFirst({
-            where: eq(users.email, accessEmail)
+            where: eq(users.email, accessEmail),
           });
 
           if (!matchingUser) {
-            throw new PortalAccessRequestConflictError("identity_recovery_not_available");
+            throw new PortalAccessRequestConflictError(
+              "identity_recovery_not_available",
+            );
           }
 
           const activeRoleRows = await tx
             .select({
-              role: roleGrants.role
+              role: roleGrants.role,
             })
             .from(roleGrants)
-            .where(and(eq(roleGrants.userId, matchingUser.id), isNull(roleGrants.revokedAt)));
+            .where(
+              and(
+                eq(roleGrants.userId, matchingUser.id),
+                isNull(roleGrants.revokedAt),
+              ),
+            );
 
           if (activeRoleRows.length === 0) {
-            throw new PortalAccessRequestConflictError("identity_recovery_not_available");
+            throw new PortalAccessRequestConflictError(
+              "identity_recovery_not_available",
+            );
           }
 
           const recoveryRole = activeRoleRows[0]?.role ?? "helper";
           const existingRequest = await tx.query.accessRequests.findFirst({
             orderBy: [desc(accessRequests.createdAt)],
-            where: eq(accessRequests.email, accessEmail)
+            where: eq(accessRequests.email, accessEmail),
           });
 
           if (
@@ -1586,7 +1829,7 @@ export function registerPortalRoutes(
               existingRequest.status === "withdrawn")
           ) {
             throw new PortalAccessRequestConflictError(
-              "identity_recovery_reentry_not_allowed"
+              "identity_recovery_reentry_not_allowed",
             );
           }
 
@@ -1610,7 +1853,7 @@ export function registerPortalRoutes(
                 requestedIdentityProvider: accessProvider,
                 requestedIdentitySubject: identity.subject,
                 requestedByUserId: matchingUser.id,
-                requestedRole: recoveryRole
+                requestedRole: recoveryRole,
               })
               .where(eq(accessRequests.id, existingRequest.id))
               .returning();
@@ -1624,11 +1867,11 @@ export function registerPortalRoutes(
                 actorUserId: matchingUser.id,
                 requestKind: "identity_recovery",
                 requestedRole: recoveryRole,
-                targetEmail: accessEmail
+                targetEmail: accessEmail,
               }),
               severity: "info",
               subjectKind: "access_request",
-              targetUserId: matchingUser.id
+              targetUserId: matchingUser.id,
             });
 
             return updatedRequest ?? existingRequest;
@@ -1643,7 +1886,7 @@ export function registerPortalRoutes(
               requestedIdentityProvider: accessProvider,
               requestedIdentitySubject: identity.subject,
               requestedByUserId: matchingUser.id,
-              requestedRole: recoveryRole
+              requestedRole: recoveryRole,
             })
             .returning();
 
@@ -1660,11 +1903,11 @@ export function registerPortalRoutes(
               actorUserId: matchingUser.id,
               requestKind: "identity_recovery",
               requestedRole: recoveryRole,
-              targetEmail: accessEmail
+              targetEmail: accessEmail,
             }),
             severity: "info",
             subjectKind: "access_request",
-            targetUserId: matchingUser.id
+            targetUserId: matchingUser.id,
           });
 
           return createdRequest;
@@ -1675,8 +1918,8 @@ export function registerPortalRoutes(
             orderBy: [desc(accessRequests.createdAt)],
             where: and(
               eq(accessRequests.email, accessEmail),
-              eq(accessRequests.status, "pending")
-            )
+              eq(accessRequests.status, "pending"),
+            ),
           });
 
           if (!latestRequest) {
@@ -1684,7 +1927,7 @@ export function registerPortalRoutes(
           }
         } else if (error instanceof PortalAccessRequestConflictError) {
           reply.code(409).send({
-            error: error.message
+            error: error.message,
           });
           return;
         }
@@ -1693,12 +1936,14 @@ export function registerPortalRoutes(
       }
 
       if (!latestRequest) {
-        throw new Error("The access-recovery flow completed without returning a request.");
+        throw new Error(
+          "The access-recovery flow completed without returning a request.",
+        );
       }
 
       return {
-        item: toAccessRequestSummary(latestRequest)
+        item: toAccessRequestSummary(latestRequest),
       };
-    }
+    },
   );
 }

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -5,7 +5,7 @@ import Fastify from "fastify";
 import type { ApiRuntimeEnv } from "../config/runtime.js";
 import {
   createAccessGuard,
-  runtimeEnvToAccessResolverOptions
+  runtimeEnvToAccessResolverOptions,
 } from "../auth/require-access.js";
 import { createDbClient } from "../db/client.js";
 import { registerAdminRoutes } from "../routes/admin.js";
@@ -16,47 +16,43 @@ import { registerOfflineIngestRoutes } from "../routes/offline-ingest.js";
 import { registerPortalRoutes } from "../routes/portal.js";
 import {
   createInMemoryRateLimiter,
-  createRateLimitPreHandlers
+  createRateLimitPreHandlers,
 } from "../middleware/rate-limit.js";
 import {
   createTrustedMutationOriginHook,
   isAllowedLocalBrandedAuthOrigin,
   isAllowedLocalOrigin,
-  normalizeOrigin
+  normalizeOrigin,
 } from "./trusted-mutation-origin.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
-  const brandedAuthOrigins = new Set(readBrandedAuthOrigins());
-  const baselineOrigins = [
-    "https://portal.paretoproof.com"
-  ];
+  const brandedAuthOrigins = new Set(runtimeEnv.brandedAuthOrigins);
+  const baselineOrigins = [runtimeEnv.portalPublicOrigin];
 
   return [
     ...new Set(
       [...baselineOrigins, ...runtimeEnv.corsAllowedOrigins]
         .map(normalizeOrigin)
-        .filter((origin) => !brandedAuthOrigins.has(origin))
-    )
+        .filter((origin) => !brandedAuthOrigins.has(origin)),
+    ),
   ];
 }
 
-function readBrandedAuthOrigins() {
-  return [
-    "https://auth.paretoproof.com",
-    "https://github.auth.paretoproof.com",
-    "https://google.auth.paretoproof.com"
-  ];
-}
-
-function usesBrandedFinalizeSubmitCorsBoundary(method: string, routePath: string) {
+function usesBrandedFinalizeSubmitCorsBoundary(
+  method: string,
+  routePath: string,
+) {
   return (
     routePath === "/portal/session/finalize/submit" &&
     (method === "POST" || method === "OPTIONS")
   );
 }
 
-export function readCorsRoutePath(routePath: string | undefined, rawUrl: string | undefined) {
+export function readCorsRoutePath(
+  routePath: string | undefined,
+  rawUrl: string | undefined,
+) {
   if (routePath && routePath !== "*") {
     return routePath;
   }
@@ -102,7 +98,10 @@ export function isAllowedCorsOrigin(options: {
 
   return (
     options.allowLocalhostCors &&
-    isAllowedLocalBrandedAuthOrigin(normalizedOrigin)
+    isAllowedLocalBrandedAuthOrigin(
+      normalizedOrigin,
+      options.brandedAuthOrigins,
+    )
   );
 }
 
@@ -119,25 +118,30 @@ function createDatabaseReadinessCheck(db: ReturnTypeOfCreateDbClient) {
 
 export async function buildServer(
   runtimeEnv: ApiRuntimeEnv,
-  options?: BuildServerOptions
+  options?: BuildServerOptions,
 ) {
   const app = Fastify({
-    logger: true
+    logger: true,
   });
-  const db = (options?.createDbClient ?? createDbClient)(runtimeEnv.databaseUrl);
+  const db = (options?.createDbClient ?? createDbClient)(
+    runtimeEnv.databaseUrl,
+  );
   const accessResolverOptions = runtimeEnvToAccessResolverOptions(runtimeEnv);
   const requireAccess = createAccessGuard(db, accessResolverOptions);
-  const rateLimitPreHandlers = createRateLimitPreHandlers(createInMemoryRateLimiter());
+  const rateLimitPreHandlers = createRateLimitPreHandlers(
+    createInMemoryRateLimiter(),
+  );
   const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
-  const brandedAuthOrigins = readBrandedAuthOrigins();
+  const brandedAuthOrigins = runtimeEnv.brandedAuthOrigins;
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
-  const checkReadiness = options?.checkReadiness ?? createDatabaseReadinessCheck(db);
+  const checkReadiness =
+    options?.checkReadiness ?? createDatabaseReadinessCheck(db);
 
   await app.register(cors, {
     delegator(request, callback) {
       const routePath = readCorsRoutePath(
         request.routeOptions.url,
-        request.raw.url
+        request.raw.url,
       );
 
       callback(null, {
@@ -150,22 +154,22 @@ export async function buildServer(
 
           if (
             isAllowedCorsOrigin({
-            allowLocalhostCors,
-            allowedOrigins,
-            brandedAuthOrigins,
-            method: request.method,
-            origin,
-            routePath
-          })
+              allowLocalhostCors,
+              allowedOrigins,
+              brandedAuthOrigins,
+              method: request.method,
+              origin,
+              routePath,
+            })
           ) {
             originCallback(null, true);
             return;
           }
 
           originCallback(new Error("origin_not_allowed"), false);
-        }
+        },
       });
-    }
+    },
   });
   await app.register(formbody);
   app.addHook(
@@ -173,24 +177,30 @@ export async function buildServer(
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: allowLocalhostCors,
       allowedOrigins,
-      brandedAuthOrigins
-    })
+      brandedAuthOrigins,
+    }),
   );
 
   registerHealthRoute(app, {
     checkReadiness,
-    rateLimitPreHandlers
+    rateLimitPreHandlers,
   });
   registerPortalRoutes(app, db, requireAccess, {
+    accessCookieDomain: runtimeEnv.accessCookieDomain,
+    accessCookieSecure: runtimeEnv.accessCookieSecure,
     accessProviderStateSecret: runtimeEnv.accessProviderStateSecret,
     accessResolverOptions,
-    rateLimitPreHandlers
+    allowLocalhostOrigins: runtimeEnv.corsAllowLocalhost,
+    authPublicOrigin: runtimeEnv.authPublicOrigin,
+    brandedAuthOrigins,
+    portalPublicOrigin: runtimeEnv.portalPublicOrigin,
+    rateLimitPreHandlers,
   });
   registerAdminRoutes(app, db, requireAccess, {
-    rateLimitPreHandlers
+    rateLimitPreHandlers,
   });
   registerBenchmarkWorkflowRoutes(app, db, requireAccess, {
-    rateLimitPreHandlers
+    rateLimitPreHandlers,
   });
   registerOfflineIngestRoutes(app, db, requireAccess);
   registerInternalWorkerRoutes(app, db, runtimeEnv);

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -26,15 +26,31 @@ import {
 } from "./trusted-mutation-origin.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
+export function readBrandedAuthOrigins(runtimeEnv: ApiRuntimeEnv) {
+  const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
+
+  return [
+    ...new Set(
+      runtimeEnv.brandedAuthOrigins
+        .map(normalizeOrigin)
+        .filter((origin) => origin !== portalPublicOrigin),
+    ),
+  ];
+}
+
 export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
-  const brandedAuthOrigins = new Set(runtimeEnv.brandedAuthOrigins);
-  const baselineOrigins = [runtimeEnv.portalPublicOrigin];
+  const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
+  const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
+  const baselineOrigins = [portalPublicOrigin];
 
   return [
     ...new Set(
       [...baselineOrigins, ...runtimeEnv.corsAllowedOrigins]
         .map(normalizeOrigin)
-        .filter((origin) => !brandedAuthOrigins.has(origin)),
+        .filter(
+          (origin) =>
+            origin === portalPublicOrigin || !brandedAuthOrigins.has(origin),
+        ),
     ),
   ];
 }
@@ -132,7 +148,7 @@ export async function buildServer(
     createInMemoryRateLimiter(),
   );
   const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
-  const brandedAuthOrigins = runtimeEnv.brandedAuthOrigins;
+  const brandedAuthOrigins = readBrandedAuthOrigins(runtimeEnv);
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
   const checkReadiness =
     options?.checkReadiness ?? createDatabaseReadinessCheck(db);
@@ -192,7 +208,7 @@ export async function buildServer(
     accessResolverOptions,
     allowLocalhostOrigins: runtimeEnv.corsAllowLocalhost,
     authPublicOrigin: runtimeEnv.authPublicOrigin,
-    brandedAuthOrigins,
+    brandedAuthOrigins: runtimeEnv.brandedAuthOrigins,
     portalPublicOrigin: runtimeEnv.portalPublicOrigin,
     rateLimitPreHandlers,
   });

--- a/apps/api/src/server/trusted-mutation-origin.ts
+++ b/apps/api/src/server/trusted-mutation-origin.ts
@@ -1,7 +1,7 @@
 import type {
   FastifyReply,
   FastifyRequest,
-  HookHandlerDoneFunction
+  HookHandlerDoneFunction,
 } from "fastify";
 
 export function normalizeOrigin(value: string) {
@@ -12,27 +12,55 @@ export function isAllowedLocalOrigin(origin: string) {
   return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/u.test(origin);
 }
 
-const localBrandedAuthHosts = new Set([
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com"
-]);
+function readConfiguredBrandedAuthHosts(brandedAuthOrigins: string[]) {
+  return new Set(
+    brandedAuthOrigins.map((allowedOrigin) => new URL(allowedOrigin).hostname),
+  );
+}
 
-export function isAllowedLocalBrandedAuthOrigin(origin: string) {
+export function isAllowedLocalBrandedAuthOrigin(
+  origin: string,
+  brandedAuthOrigins: string[],
+) {
   try {
     const parsedOrigin = new URL(origin);
 
     return (
       parsedOrigin.protocol === "http:" &&
       parsedOrigin.port.length > 0 &&
-      localBrandedAuthHosts.has(parsedOrigin.hostname)
+      readConfiguredBrandedAuthHosts(brandedAuthOrigins).has(
+        parsedOrigin.hostname,
+      )
     );
   } catch {
     return false;
   }
 }
 
-export function shouldEnforceTrustedMutationOrigin(method: string, routePath: string) {
+export function isAllowedBrandedAuthOrigin(options: {
+  allowLocalhostOrigins: boolean;
+  brandedAuthOrigins: string[];
+  origin: string;
+}) {
+  const normalizedOrigin = normalizeOrigin(options.origin);
+
+  if (options.brandedAuthOrigins.includes(normalizedOrigin)) {
+    return true;
+  }
+
+  return (
+    options.allowLocalhostOrigins &&
+    isAllowedLocalBrandedAuthOrigin(
+      normalizedOrigin,
+      options.brandedAuthOrigins,
+    )
+  );
+}
+
+export function shouldEnforceTrustedMutationOrigin(
+  method: string,
+  routePath: string,
+) {
   return (
     method !== "GET" &&
     method !== "HEAD" &&
@@ -53,7 +81,7 @@ export function createTrustedMutationOriginHook(options: {
   return (
     request: FastifyRequest,
     reply: FastifyReply,
-    done: HookHandlerDoneFunction
+    done: HookHandlerDoneFunction,
   ) => {
     const routePath = request.routeOptions.url ?? request.raw.url ?? "";
 
@@ -63,38 +91,39 @@ export function createTrustedMutationOriginHook(options: {
     }
 
     const requestOrigin =
-      typeof request.headers.origin === "string" && request.headers.origin.length > 0
+      typeof request.headers.origin === "string" &&
+      request.headers.origin.length > 0
         ? normalizeOrigin(request.headers.origin)
         : null;
 
     if (!requestOrigin) {
       reply.code(403).send({
-        error: "trusted_origin_required"
+        error: "trusted_origin_required",
       });
       return;
     }
 
     const brandedAuthOrigins = options.brandedAuthOrigins ?? [];
-    const brandedAuthOrigin = brandedAuthOrigins.includes(requestOrigin);
+    const brandedAuthOrigin = isAllowedBrandedAuthOrigin({
+      allowLocalhostOrigins: false,
+      brandedAuthOrigins,
+      origin: requestOrigin,
+    });
     const originAllowed =
-      (
-        options.allowedOrigins.includes(requestOrigin) &&
-        !brandedAuthOrigin
-      ) ||
-      (
-        brandedAuthOrigin &&
-        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)
-      ) ||
-      (
-        options.allowLocalhostOrigins &&
-        isAllowedLocalBrandedAuthOrigin(requestOrigin) &&
-        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)
-      ) ||
+      (options.allowedOrigins.includes(requestOrigin) && !brandedAuthOrigin) ||
+      (brandedAuthOrigin &&
+        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)) ||
+      (isAllowedBrandedAuthOrigin({
+        allowLocalhostOrigins: options.allowLocalhostOrigins,
+        brandedAuthOrigins,
+        origin: requestOrigin,
+      }) &&
+        allowsBrandedFinalizeSubmitOrigin(request.method, routePath)) ||
       (options.allowLocalhostOrigins && isAllowedLocalOrigin(requestOrigin));
 
     if (!originAllowed) {
       reply.code(403).send({
-        error: "trusted_origin_not_allowed"
+        error: "trusted_origin_not_allowed",
       });
       return;
     }

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -5,45 +5,55 @@ import {
   buildServer,
   isAllowedCorsOrigin,
   readCorsRoutePath,
-  readAllowedCorsOrigins
+  readAllowedCorsOrigins,
 } from "../src/server/build-server.ts";
 
 test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allowlist", () => {
   const origins = readAllowedCorsOrigins({
+    brandedAuthOrigins: [
+      "https://auth.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+      "https://google.auth.preview.paretoproof.com",
+    ],
     corsAllowedOrigins: [
       "https://portal.preview.paretoproof.com",
-      "https://github.auth.paretoproof.com"
-    ]
+      "https://github.auth.preview.paretoproof.com",
+    ],
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
   } as never);
 
-  assert.deepEqual(origins, [
-    "https://portal.paretoproof.com",
-    "https://portal.preview.paretoproof.com"
-  ]);
-  assert.equal(origins.includes("https://auth.paretoproof.com"), false);
-  assert.equal(origins.includes("https://github.auth.paretoproof.com"), false);
-  assert.equal(origins.includes("https://google.auth.paretoproof.com"), false);
+  assert.deepEqual(origins, ["https://portal.preview.paretoproof.com"]);
+  assert.equal(origins.includes("https://auth.preview.paretoproof.com"), false);
+  assert.equal(
+    origins.includes("https://github.auth.preview.paretoproof.com"),
+    false,
+  );
+  assert.equal(
+    origins.includes("https://google.auth.preview.paretoproof.com"),
+    false,
+  );
 });
 
 test("readCorsRoutePath falls back to the raw request URL for Fastify preflights", () => {
   assert.equal(
-    readCorsRoutePath("*", "/portal/session/finalize/submit?redirect=%2Fprofile"),
-    "/portal/session/finalize/submit"
+    readCorsRoutePath(
+      "*",
+      "/portal/session/finalize/submit?redirect=%2Fprofile",
+    ),
+    "/portal/session/finalize/submit",
   );
   assert.equal(
     readCorsRoutePath("/portal/profile", "/portal/profile?tab=settings"),
-    "/portal/profile"
+    "/portal/profile",
   );
 });
 
 test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-submit POST and OPTIONS only", () => {
-  const allowedOrigins = [
-    "https://portal.paretoproof.com"
-  ];
+  const allowedOrigins = ["https://portal.preview.paretoproof.com"];
   const brandedAuthOrigins = [
-    "https://auth.paretoproof.com",
-    "https://github.auth.paretoproof.com",
-    "https://google.auth.paretoproof.com"
+    "https://auth.preview.paretoproof.com",
+    "https://github.auth.preview.paretoproof.com",
+    "https://google.auth.preview.paretoproof.com",
   ];
 
   assert.equal(
@@ -52,10 +62,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "POST",
-      origin: "https://github.auth.paretoproof.com",
-      routePath: "/portal/session/finalize/submit"
+      origin: "https://github.auth.preview.paretoproof.com",
+      routePath: "/portal/session/finalize/submit",
     }),
-    true
+    true,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -63,13 +73,13 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "OPTIONS",
-      origin: "https://github.auth.paretoproof.com",
+      origin: "https://github.auth.preview.paretoproof.com",
       routePath: readCorsRoutePath(
         "*",
-        "/portal/session/finalize/submit?redirect=%2Fprofile"
-      )
+        "/portal/session/finalize/submit?redirect=%2Fprofile",
+      ),
     }),
-    true
+    true,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -77,10 +87,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "POST",
-      origin: "https://github.auth.paretoproof.com",
-      routePath: "/portal/profile"
+      origin: "https://github.auth.preview.paretoproof.com",
+      routePath: "/portal/profile",
     }),
-    false
+    false,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -88,10 +98,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "OPTIONS",
-      origin: "https://github.auth.paretoproof.com",
-      routePath: "/portal/profile"
+      origin: "https://github.auth.preview.paretoproof.com",
+      routePath: "/portal/profile",
     }),
-    false
+    false,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -99,10 +109,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "POST",
-      origin: "http://github.auth.paretoproof.com:4371",
-      routePath: "/portal/session/finalize/submit"
+      origin: "http://github.auth.preview.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit",
     }),
-    true
+    true,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -110,10 +120,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "OPTIONS",
-      origin: "http://github.auth.paretoproof.com:4371",
-      routePath: "/portal/session/finalize/submit"
+      origin: "http://github.auth.preview.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit",
     }),
-    true
+    true,
   );
   assert.equal(
     isAllowedCorsOrigin({
@@ -121,10 +131,10 @@ test("isAllowedCorsOrigin keeps branded finalize callers scoped to finalize-subm
       allowedOrigins,
       brandedAuthOrigins,
       method: "POST",
-      origin: "http://github.auth.paretoproof.com:4371",
-      routePath: "/portal/session/finalize/submit"
+      origin: "http://github.auth.preview.paretoproof.com:4371",
+      routePath: "/portal/session/finalize/submit",
     }),
-    false
+    false,
   );
 });
 
@@ -133,7 +143,7 @@ test("buildServer keeps the parsed runtime contract authoritative during boot an
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
     CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
-    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
   };
 
   process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-secret";
@@ -145,19 +155,22 @@ test("buildServer keeps the parsed runtime contract authoritative during boot an
   const app = await buildServer(
     parseApiRuntimeEnv({
       ACCESS_PROVIDER_STATE_SECRET: "runtime-secret",
+      AUTH_PUBLIC_ORIGIN: "https://auth.preview.paretoproof.com",
       CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
       CF_ACCESS_PORTAL_AUD: "portal-audience",
       CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
       DATABASE_URL: "postgres://localhost:5432/paretoproof",
-      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+      PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
+      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
     }),
     {
-      createDbClient: () => ({
-        execute: async () => {
-          readinessChecks += 1;
-        }
-      }) as never
-    }
+      createDbClient: () =>
+        ({
+          execute: async () => {
+            readinessChecks += 1;
+          },
+        }) as never,
+    },
   );
 
   t.after(async () => {
@@ -167,13 +180,13 @@ test("buildServer keeps the parsed runtime contract authoritative during boot an
 
   const response = await app.inject({
     method: "GET",
-    url: "/health"
+    url: "/health",
   });
 
   assert.equal(response.statusCode, 200);
   assert.deepEqual(response.json(), {
     ok: true,
-    service: "api"
+    service: "api",
   });
   assert.equal(readinessChecks, 1);
 });
@@ -182,19 +195,22 @@ test("buildServer maps default DB readiness failures to 503 health responses", a
   const app = await buildServer(
     parseApiRuntimeEnv({
       ACCESS_PROVIDER_STATE_SECRET: "runtime-secret",
+      AUTH_PUBLIC_ORIGIN: "https://auth.preview.paretoproof.com",
       CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
       CF_ACCESS_PORTAL_AUD: "portal-audience",
       CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
       DATABASE_URL: "postgres://localhost:5432/paretoproof",
-      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+      PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
+      WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
     }),
     {
-      createDbClient: () => ({
-        execute: async () => {
-          throw new Error("database_unreachable");
-        }
-      }) as never
-    }
+      createDbClient: () =>
+        ({
+          execute: async () => {
+            throw new Error("database_unreachable");
+          },
+        }) as never,
+    },
   );
 
   t.after(async () => {
@@ -203,13 +219,13 @@ test("buildServer maps default DB readiness failures to 503 health responses", a
 
   const response = await app.inject({
     method: "GET",
-    url: "/health"
+    url: "/health",
   });
 
   assert.equal(response.statusCode, 503);
   assert.deepEqual(response.json(), {
     error: "service_unavailable",
     ok: false,
-    service: "api"
+    service: "api",
   });
 });

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -4,6 +4,7 @@ import { parseApiRuntimeEnv } from "../src/config/runtime.ts";
 import {
   buildServer,
   isAllowedCorsOrigin,
+  readBrandedAuthOrigins,
   readCorsRoutePath,
   readAllowedCorsOrigins,
 } from "../src/server/build-server.ts";
@@ -32,6 +33,28 @@ test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allow
     origins.includes("https://google.auth.preview.paretoproof.com"),
     false,
   );
+});
+
+test("readAllowedCorsOrigins keeps the portal origin when auth and portal share one origin", () => {
+  const origins = readAllowedCorsOrigins({
+    brandedAuthOrigins: ["https://portal.preview.paretoproof.com"],
+    corsAllowedOrigins: [],
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
+  } as never);
+
+  assert.deepEqual(origins, ["https://portal.preview.paretoproof.com"]);
+});
+
+test("readBrandedAuthOrigins excludes the portal origin when auth and portal share one origin", () => {
+  const origins = readBrandedAuthOrigins({
+    brandedAuthOrigins: [
+      "https://portal.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+    ],
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
+  } as never);
+
+  assert.deepEqual(origins, ["https://github.auth.preview.paretoproof.com"]);
 });
 
 test("readCorsRoutePath falls back to the raw request URL for Fastify preflights", () => {

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -5,15 +5,15 @@ import {
   readAccessJwtAssertion,
   selectCloudflareAccessVerifier,
   verifyAccessProviderHint,
-  type CloudflareAccessVerifierSet
+  type CloudflareAccessVerifierSet,
 } from "../src/auth/cloudflare-access.ts";
 import { createAccessResolver } from "../src/auth/require-access.ts";
 
 test("readAccessJwtAssertion falls back to CF_Authorization when the Access header is absent", () => {
   const assertion = readAccessJwtAssertion({
     headers: {
-      cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed"
-    }
+      cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed",
+    },
   } as never);
 
   assert.equal(assertion, "session-cookie");
@@ -23,8 +23,8 @@ test("readAccessJwtAssertion prefers the Access header over the cookie fallback"
   const assertion = readAccessJwtAssertion({
     headers: {
       "cf-access-jwt-assertion": "header-assertion",
-      cookie: "CF_Authorization=session-cookie"
-    }
+      cookie: "CF_Authorization=session-cookie",
+    },
   } as never);
 
   assert.equal(assertion, "header-assertion");
@@ -33,8 +33,8 @@ test("readAccessJwtAssertion prefers the Access header over the cookie fallback"
 test("readAccessJwtAssertion returns null when no usable Access assertion is present", () => {
   const assertion = readAccessJwtAssertion({
     headers: {
-      cookie: "PortalAccessProvider=signed"
-    }
+      cookie: "PortalAccessProvider=signed",
+    },
   } as never);
 
   assert.equal(assertion, null);
@@ -49,23 +49,23 @@ test("PortalAccessProvider verification continues to use ACCESS_PROVIDER_STATE_S
   try {
     const providerCookie = buildSignedAccessCookie(
       "PortalAccessProvider",
-      "cloudflare_google|subject-1"
+      "cloudflare_google|subject-1",
     );
 
     assert.equal(
       verifyAccessProviderHint(providerCookie, {
-        expectedSubject: "subject-1"
+        expectedSubject: "subject-1",
       }),
-      "cloudflare_google"
+      "cloudflare_google",
     );
 
     process.env.PORTAL_SESSION_SECRET = "wrong-session-secret";
 
     assert.equal(
       verifyAccessProviderHint(providerCookie, {
-        expectedSubject: "subject-1"
+        expectedSubject: "subject-1",
       }),
-      "cloudflare_google"
+      "cloudflare_google",
     );
   } finally {
     process.env.ACCESS_PROVIDER_STATE_SECRET = originalProviderSecret;
@@ -82,27 +82,44 @@ test("PortalAccessProvider verification can use a runtime-provided secret withou
       "PortalAccessProvider",
       "cloudflare_google|subject-1",
       {
-        secret: "runtime-provider-secret"
-      }
+        secret: "runtime-provider-secret",
+      },
     );
 
     assert.equal(
       verifyAccessProviderHint(providerCookie, {
         expectedSubject: "subject-1",
-        secret: "runtime-provider-secret"
+        secret: "runtime-provider-secret",
       }),
-      "cloudflare_google"
+      "cloudflare_google",
     );
     assert.equal(
       verifyAccessProviderHint(providerCookie, {
         expectedSubject: "subject-1",
-        secret: "wrong-provider-secret"
+        secret: "wrong-provider-secret",
       }),
-      null
+      null,
     );
   } finally {
     process.env.ACCESS_PROVIDER_STATE_SECRET = originalProviderSecret;
   }
+});
+
+test("buildSignedAccessCookie honors configurable cookie domain and secure posture", () => {
+  const cookie = buildSignedAccessCookie(
+    "PortalAccessProvider",
+    "cloudflare_google|subject-1",
+    {
+      cookieDomain: ".preview.paretoproof.com",
+      secret: "runtime-provider-secret",
+      secure: false,
+    },
+  );
+
+  assert.match(cookie, /^PortalAccessProvider=/);
+  assert.match(cookie, /Domain=.preview.paretoproof.com/);
+  assert.match(cookie, /; SameSite=Strict;/);
+  assert.doesNotMatch(cookie, /; Secure;/);
 });
 
 test("createAccessResolver accepts an opaque portal access session when the DB session lookup succeeds", async () => {
@@ -110,7 +127,7 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
     ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
     CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
-    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
   };
 
   process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-env-secret";
@@ -120,79 +137,82 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
 
   try {
     let touchedSession = false;
-    const resolveAccess = createAccessResolver({
-      query: {
-        sessions: {
-          findFirst: async () => ({
-            expiresAt: new Date(Date.now() + 60_000),
-            id: "session-1",
-            identity: {
+    const resolveAccess = createAccessResolver(
+      {
+        query: {
+          sessions: {
+            findFirst: async () => ({
+              expiresAt: new Date(Date.now() + 60_000),
+              id: "session-1",
+              identity: {
+                id: "identity-1",
+                provider: "cloudflare_google",
+                providerEmail: "person@example.com",
+                providerSubject: "subject-1",
+                user: {
+                  email: "person@example.com",
+                  id: "user-1",
+                },
+              },
+              revokedAt: null,
+            }),
+          },
+          userIdentities: {
+            findFirst: async () => ({
               id: "identity-1",
               provider: "cloudflare_google",
               providerEmail: "person@example.com",
               providerSubject: "subject-1",
               user: {
                 email: "person@example.com",
-                id: "user-1"
-              }
-            },
-            revokedAt: null
-          })
+                id: "user-1",
+              },
+            }),
+          },
         },
-        userIdentities: {
-          findFirst: async () => ({
-            id: "identity-1",
-            provider: "cloudflare_google",
-            providerEmail: "person@example.com",
-            providerSubject: "subject-1",
-            user: {
-              email: "person@example.com",
-              id: "user-1"
-            }
-          })
-        }
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => [{ role: "helper" }],
+              };
+            },
+          };
+        },
+        update() {
+          return {
+            set() {
+              return {
+                where: async () => {
+                  touchedSession = true;
+                },
+              };
+            },
+          };
+        },
+      } as never,
+      {
+        accessProviderStateSecret: "runtime-secret",
+        teamDomain: "paretoproof.cloudflareaccess.com",
+        verifiers: {
+          brandedRelay: { audiences: ["branded"] },
+          internal: { audiences: ["internal"] },
+          portal: { audiences: ["portal"] },
+        } as never,
       },
-      select() {
-        return {
-          from() {
-            return {
-              where: async () => [{ role: "helper" }]
-            };
-          }
-        };
-      },
-      update() {
-        return {
-          set() {
-            return {
-              where: async () => {
-                touchedSession = true;
-              }
-            };
-          }
-        };
-      }
-    } as never, {
-      accessProviderStateSecret: "runtime-secret",
-      teamDomain: "paretoproof.cloudflareaccess.com",
-      verifiers: {
-        brandedRelay: { audiences: ["branded"] },
-        internal: { audiences: ["internal"] },
-        portal: { audiences: ["portal"] }
-      } as never
-    });
+    );
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
       headers: {
-        cookie: "PortalAccessSession=opaque-session-token"
+        cookie: "PortalAccessSession=opaque-session-token",
       },
       raw: {
-        url: "/portal/me"
+        url: "/portal/me",
       },
       routeOptions: {
-        url: "/portal/me"
-      }
+        url: "/portal/me",
+      },
     } as never;
 
     const context = await resolveAccess(request);
@@ -203,13 +223,13 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
       roles: ["helper"],
       status: "approved",
       subject: "subject-1",
-      userId: "user-1"
+      userId: "user-1",
     });
     assert.equal(request.accessIdentity?.subject, "subject-1");
     assert.equal(request.accessIdentity?.provider, "cloudflare_google");
     assert.equal(
       request.accessIdentity?.issuer,
-      "https://paretoproof.cloudflareaccess.com"
+      "https://paretoproof.cloudflareaccess.com",
     );
     assert.equal(touchedSession, true);
   } finally {
@@ -224,7 +244,7 @@ test("createAccessResolver gracefully rejects legacy signed portal session cooki
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
     CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
     DATABASE_URL: process.env.DATABASE_URL,
-    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN,
   };
 
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -235,32 +255,35 @@ test("createAccessResolver gracefully rejects legacy signed portal session cooki
   process.env.WORKER_BOOTSTRAP_TOKEN = "worker-bootstrap-token";
 
   try {
-    const resolveAccess = createAccessResolver({
-      query: {
-        sessions: {
-          findFirst: async () => null
-        }
-      }
-    } as never, {
-      teamDomain: "paretoproof.cloudflareaccess.com",
-      verifiers: {
-        brandedRelay: { audiences: ["branded"] },
-        internal: { audiences: ["internal"] },
-        portal: { audiences: ["portal"] }
-      } as never
-    });
+    const resolveAccess = createAccessResolver(
+      {
+        query: {
+          sessions: {
+            findFirst: async () => null,
+          },
+        },
+      } as never,
+      {
+        teamDomain: "paretoproof.cloudflareaccess.com",
+        verifiers: {
+          brandedRelay: { audiences: ["branded"] },
+          internal: { audiences: ["internal"] },
+          portal: { audiences: ["portal"] },
+        } as never,
+      },
+    );
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
       headers: {
-        cookie: "PortalAccessSession=legacy.payload.signature"
+        cookie: "PortalAccessSession=legacy.payload.signature",
       },
       raw: {
-        url: "/portal/me"
+        url: "/portal/me",
       },
       routeOptions: {
-        url: "/portal/me"
-      }
+        url: "/portal/me",
+      },
     } as never;
 
     const context = await resolveAccess(request);
@@ -279,7 +302,7 @@ test("createAccessResolver rejects revoked opaque portal sessions", async () => 
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
     CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
     DATABASE_URL: process.env.DATABASE_URL,
-    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN,
   };
 
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -291,57 +314,60 @@ test("createAccessResolver rejects revoked opaque portal sessions", async () => 
 
   try {
     let touchedSession = false;
-    const resolveAccess = createAccessResolver({
-      query: {
-        sessions: {
-          findFirst: async () => ({
-            expiresAt: new Date(Date.now() + 60_000),
-            id: "session-1",
-            identity: {
-              id: "identity-1",
-              provider: "cloudflare_google",
-              providerEmail: "person@example.com",
-              providerSubject: "subject-1",
-              user: {
-                email: "person@example.com",
-                id: "user-1"
-              }
+    const resolveAccess = createAccessResolver(
+      {
+        query: {
+          sessions: {
+            findFirst: async () => ({
+              expiresAt: new Date(Date.now() + 60_000),
+              id: "session-1",
+              identity: {
+                id: "identity-1",
+                provider: "cloudflare_google",
+                providerEmail: "person@example.com",
+                providerSubject: "subject-1",
+                user: {
+                  email: "person@example.com",
+                  id: "user-1",
+                },
+              },
+              revokedAt: new Date(),
+            }),
+          },
+        },
+        update() {
+          return {
+            set() {
+              return {
+                where: async () => {
+                  touchedSession = true;
+                },
+              };
             },
-            revokedAt: new Date()
-          })
-        }
+          };
+        },
+      } as never,
+      {
+        teamDomain: "paretoproof.cloudflareaccess.com",
+        verifiers: {
+          brandedRelay: { audiences: ["branded"] },
+          internal: { audiences: ["internal"] },
+          portal: { audiences: ["portal"] },
+        } as never,
       },
-      update() {
-        return {
-          set() {
-            return {
-              where: async () => {
-                touchedSession = true;
-              }
-            };
-          }
-        };
-      }
-    } as never, {
-      teamDomain: "paretoproof.cloudflareaccess.com",
-      verifiers: {
-        brandedRelay: { audiences: ["branded"] },
-        internal: { audiences: ["internal"] },
-        portal: { audiences: ["portal"] }
-      } as never
-    });
+    );
     const request = {
       accessIdentity: null,
       accessRbacContext: null,
       headers: {
-        cookie: "PortalAccessSession=opaque-session-token"
+        cookie: "PortalAccessSession=opaque-session-token",
       },
       raw: {
-        url: "/portal/me"
+        url: "/portal/me",
       },
       routeOptions: {
-        url: "/portal/me"
-      }
+        url: "/portal/me",
+      },
     } as never;
 
     const context = await resolveAccess(request);
@@ -357,82 +383,85 @@ test("selectCloudflareAccessVerifier keeps branded relay audiences only on POST 
   const verifiers = {
     brandedRelay: { audiences: ["portal-aud", "github-aud", "google-aud"] },
     internal: { audiences: ["internal-aud"] },
-    portal: { audiences: ["portal-aud"] }
-  } satisfies Record<keyof CloudflareAccessVerifierSet, { audiences: string[] }>;
+    portal: { audiences: ["portal-aud"] },
+  } satisfies Record<
+    keyof CloudflareAccessVerifierSet,
+    { audiences: string[] }
+  >;
 
   assert.equal(
     selectCloudflareAccessVerifier(
       {
         method: "POST",
         raw: {
-          url: "/portal/session/finalize"
+          url: "/portal/session/finalize",
         },
         routeOptions: {
-          url: "/portal/session/finalize"
-        }
+          url: "/portal/session/finalize",
+        },
       } as never,
-      verifiers as never
+      verifiers as never,
     ),
-    verifiers.portal
+    verifiers.portal,
   );
   assert.equal(
     selectCloudflareAccessVerifier(
       {
         method: "POST",
         raw: {
-          url: "/portal/session/finalize/submit"
+          url: "/portal/session/finalize/submit",
         },
         routeOptions: {
-          url: "/portal/session/finalize/submit"
-        }
+          url: "/portal/session/finalize/submit",
+        },
       } as never,
-      verifiers as never
+      verifiers as never,
     ),
-    verifiers.brandedRelay
+    verifiers.brandedRelay,
   );
   assert.equal(
     selectCloudflareAccessVerifier(
       {
         method: "GET",
         raw: {
-          url: "/portal/session/finalize/submit"
+          url: "/portal/session/finalize/submit",
         },
         routeOptions: {
-          url: "/portal/session/finalize/submit"
-        }
+          url: "/portal/session/finalize/submit",
+        },
       } as never,
-      verifiers as never
+      verifiers as never,
     ),
-    verifiers.portal
+    verifiers.portal,
   );
   assert.equal(
     selectCloudflareAccessVerifier(
       {
         method: "GET",
         raw: {
-          url: "/portal/me"
+          url: "/portal/me",
         },
         routeOptions: {
-          url: "/portal/me"
-        }
+          url: "/portal/me",
+        },
       } as never,
-      verifiers as never
+      verifiers as never,
     ),
-    verifiers.portal
+    verifiers.portal,
   );
   assert.equal(
     selectCloudflareAccessVerifier(
       {
         method: "POST",
         raw: {
-          url: "/internal/worker/claims"
+          url: "/internal/worker/claims",
         },
         routeOptions: {
-          url: "/internal/worker/claims"
-        }
+          url: "/internal/worker/claims",
+        },
       } as never,
-      verifiers as never
+      verifiers as never,
     ),
-    verifiers.internal
+    verifiers.internal,
   );
 });

--- a/apps/api/test/portal-access-request-origin.test.ts
+++ b/apps/api/test/portal-access-request-origin.test.ts
@@ -5,24 +5,25 @@ import { registerPortalRoutes } from "../src/routes/portal.ts";
 import { createTrustedMutationOriginHook } from "../src/server/trusted-mutation-origin.ts";
 
 function createAuthenticatedAccessGuard() {
-  return () => (
-    request: {
-      accessIdentity?: {
-        email: string;
-        provider: "cloudflare_google";
-        subject: string;
+  return () =>
+    (
+      request: {
+        accessIdentity?: {
+          email: string;
+          provider: "cloudflare_google";
+          subject: string;
+        };
+      },
+      _reply: unknown,
+      done: () => void,
+    ) => {
+      request.accessIdentity = {
+        email: "person@example.com",
+        provider: "cloudflare_google",
+        subject: "subject-1",
       };
-    },
-    _reply: unknown,
-    done: () => void
-  ) => {
-    request.accessIdentity = {
-      email: "person@example.com",
-      provider: "cloudflare_google",
-      subject: "subject-1"
+      done();
     };
-    done();
-  };
 }
 
 function createMutationTrackingDb(onMutationAttempt: () => void) {
@@ -30,7 +31,7 @@ function createMutationTrackingDb(onMutationAttempt: () => void) {
     transaction: async () => {
       onMutationAttempt();
       throw new Error("expected test database failure");
-    }
+    },
   } as never;
 }
 
@@ -45,8 +46,10 @@ function registerPortalAccessRequestTestApp(options: {
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: options.allowLocalhostOrigins ?? false,
-      allowedOrigins: options.allowedOrigins ?? ["https://portal.paretoproof.com"]
-    })
+      allowedOrigins: options.allowedOrigins ?? [
+        "https://portal.preview.paretoproof.com",
+      ],
+    }),
   );
 
   registerPortalRoutes(
@@ -54,8 +57,8 @@ function registerPortalAccessRequestTestApp(options: {
     createMutationTrackingDb(options.onMutationAttempt),
     createAuthenticatedAccessGuard(),
     {
-      resolvePortalAccess: async () => null
-    }
+      resolvePortalAccess: async () => null,
+    },
   );
 
   return app;
@@ -66,7 +69,7 @@ test("POST /portal/access-requests rejects requests without an Origin header bef
   const app = registerPortalAccessRequestTestApp({
     onMutationAttempt: () => {
       mutationAttempted = true;
-    }
+    },
   });
 
   t.after(async () => {
@@ -77,14 +80,14 @@ test("POST /portal/access-requests rejects requests without an Origin header bef
     method: "POST",
     payload: {
       rationale: "Need contributor access",
-      requestedRole: "helper"
+      requestedRole: "helper",
     },
-    url: "/portal/access-requests"
+    url: "/portal/access-requests",
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_required"
+    error: "trusted_origin_required",
   });
   assert.equal(mutationAttempted, false);
 });
@@ -94,7 +97,7 @@ test("POST /portal/access-requests rejects untrusted origins before mutation wor
   const app = registerPortalAccessRequestTestApp({
     onMutationAttempt: () => {
       mutationAttempted = true;
-    }
+    },
   });
 
   t.after(async () => {
@@ -105,17 +108,17 @@ test("POST /portal/access-requests rejects untrusted origins before mutation wor
     method: "POST",
     payload: {
       rationale: "Need contributor access",
-      requestedRole: "helper"
+      requestedRole: "helper",
     },
     url: "/portal/access-requests",
     headers: {
-      origin: "https://evil.example"
-    }
+      origin: "https://evil.example",
+    },
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
   assert.equal(mutationAttempted, false);
 });
@@ -125,7 +128,7 @@ test("POST /portal/access-requests allows the trusted portal origin to reach mut
   const app = registerPortalAccessRequestTestApp({
     onMutationAttempt: () => {
       mutationAttempted = true;
-    }
+    },
   });
 
   t.after(async () => {
@@ -136,12 +139,12 @@ test("POST /portal/access-requests allows the trusted portal origin to reach mut
     method: "POST",
     payload: {
       rationale: "Need contributor access",
-      requestedRole: "helper"
+      requestedRole: "helper",
     },
     url: "/portal/access-requests",
     headers: {
-      origin: "https://portal.paretoproof.com"
-    }
+      origin: "https://portal.preview.paretoproof.com",
+    },
   });
 
   assert.equal(response.statusCode, 500);

--- a/apps/api/test/portal-link-intent-cookie.test.ts
+++ b/apps/api/test/portal-link-intent-cookie.test.ts
@@ -4,30 +4,31 @@ import Fastify from "fastify";
 import { registerPortalRoutes } from "../src/routes/portal.ts";
 
 function createApprovedAccessGuard() {
-  return () => (
-    request: {
-      accessIdentity?: unknown;
-      accessRbacContext?: unknown;
-    },
-    _reply: unknown,
-    done: () => void
-  ) => {
-    request.accessIdentity = {
-      email: "person@example.com",
-      issuer: "https://paretoproof.cloudflareaccess.com",
-      provider: "cloudflare_google",
-      subject: "subject-1"
+  return () =>
+    (
+      request: {
+        accessIdentity?: unknown;
+        accessRbacContext?: unknown;
+      },
+      _reply: unknown,
+      done: () => void,
+    ) => {
+      request.accessIdentity = {
+        email: "person@example.com",
+        issuer: "https://paretoproof.cloudflareaccess.com",
+        provider: "cloudflare_google",
+        subject: "subject-1",
+      };
+      request.accessRbacContext = {
+        email: "person@example.com",
+        identityId: "identity-1",
+        roles: ["helper"],
+        status: "approved",
+        subject: "subject-1",
+        userId: "user-1",
+      };
+      done();
     };
-    request.accessRbacContext = {
-      email: "person@example.com",
-      identityId: "identity-1",
-      roles: ["helper"],
-      status: "approved",
-      subject: "subject-1",
-      userId: "user-1"
-    };
-    done();
-  };
 }
 
 test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie for profile linking", async (t) => {
@@ -51,18 +52,25 @@ test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie 
             id: "user-1",
             identities: [
               {
-                provider: "cloudflare_google"
-              }
-            ]
-          }
-        })
-      }
+                provider: "cloudflare_google",
+              },
+            ],
+          },
+        }),
+      },
     },
     transaction: async (
       callback: (tx: {
         insert: () => {
           values: (value: unknown) => {
-            returning?: () => Promise<Array<{ expiresAt: Date; id: string; redirectPath: string; targetProvider: "cloudflare_github" }>>;
+            returning?: () => Promise<
+              Array<{
+                expiresAt: Date;
+                id: string;
+                redirectPath: string;
+                targetProvider: "cloudflare_github";
+              }>
+            >;
           };
         };
         update: () => {
@@ -70,7 +78,7 @@ test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie 
             where: () => Promise<void>;
           };
         };
-      }) => Promise<unknown>
+      }) => Promise<unknown>,
     ) =>
       callback({
         insert() {
@@ -85,52 +93,60 @@ test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie 
                       expiresAt: new Date("2026-03-15T11:00:00.000Z"),
                       id: "intent-1",
                       redirectPath: "/profile?tab=identities",
-                      targetProvider: "cloudflare_github"
-                    }
-                  ]
+                      targetProvider: "cloudflare_github",
+                    },
+                  ],
                 };
               }
 
               insertedAuditEvents.push(value as { eventId?: string });
               return {};
-            }
+            },
           };
         },
         update() {
           return {
             set() {
               return {
-                where: async () => undefined
+                where: async () => undefined,
               };
-            }
+            },
           };
-        }
-      } as never)
+        },
+      } as never),
   };
 
   registerPortalRoutes(app, db as never, createApprovedAccessGuard() as never, {
-    resolvePortalAccess: async () => null
+    accessCookieDomain: ".preview.paretoproof.com",
+    accessCookieSecure: false,
+    authPublicOrigin: "https://auth.preview.paretoproof.com",
+    resolvePortalAccess: async () => null,
   });
 
   const response = await app.inject({
     method: "POST",
     payload: {
       provider: "cloudflare_github",
-      redirectPath: "/profile?tab=identities"
+      redirectPath: "/profile?tab=identities",
     },
-    url: "/portal/profile/link-intents"
+    url: "/portal/profile/link-intents",
   });
 
   assert.equal(response.statusCode, 200);
   assert.equal(
     response.json().intent.startUrl,
-    "https://auth.paretoproof.com/api/access/start/github?redirect=%2Fprofile%3Ftab%3Didentities&flow=link"
+    "https://auth.preview.paretoproof.com/api/access/start/github?redirect=%2Fprofile%3Ftab%3Didentities&flow=link",
   );
-  assert.equal(insertedAuditEvents[0]?.eventId, "user_identity.link_intent_created");
+  assert.equal(
+    insertedAuditEvents[0]?.eventId,
+    "user_identity.link_intent_created",
+  );
 
   const setCookie = response.headers["set-cookie"];
   const setCookies = Array.isArray(setCookie) ? setCookie : [setCookie];
   assert.equal(setCookies.length, 1);
   assert.match(String(setCookies[0]), /^PortalLinkIntent=/);
+  assert.match(String(setCookies[0]), /Domain=.preview.paretoproof.com/);
   assert.match(String(setCookies[0]), /; SameSite=Strict;/);
+  assert.doesNotMatch(String(setCookies[0]), /; Secure;/);
 });

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -30,8 +30,10 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
     {
       transaction: async () => {
         mutationAttempted = true;
-        throw new Error("portal finalize GET should not reach the mutation path");
-      }
+        throw new Error(
+          "portal finalize GET should not reach the mutation path",
+        );
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
@@ -43,9 +45,9 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
         roles: ["helper"],
         status: "approved",
         subject: "subject-1",
-        userId: "user-1"
-      })
-    }
+        userId: "user-1",
+      }),
+    },
   );
 
   const response = await app.inject({
@@ -54,14 +56,14 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
     headers: {
       accept: "text/html",
       cookie: buildSignedAccessCookie("PortalLinkIntent", "intent-1"),
-      "cf-access-jwt-assertion": "test-assertion"
-    }
+      "cf-access-jwt-assertion": "test-assertion",
+    },
   });
 
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry",
   );
   assert.equal(mutationAttempted, false);
 });
@@ -79,23 +81,26 @@ test("GET /portal/session/finalize/submit honors a runtime-provided link-intent 
     {
       transaction: async () => {
         mutationAttempted = true;
-        throw new Error("portal finalize GET should not reach the mutation path");
-      }
+        throw new Error(
+          "portal finalize GET should not reach the mutation path",
+        );
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
     },
     {
       accessProviderStateSecret: "runtime-secret",
+      authPublicOrigin: "https://auth.preview.paretoproof.com",
       resolvePortalAccess: async () => ({
         email: "person@example.com",
         identityId: "identity-1",
         roles: ["helper"],
         status: "approved",
         subject: "subject-1",
-        userId: "user-1"
-      })
-    }
+        userId: "user-1",
+      }),
+    },
   );
 
   const response = await app.inject({
@@ -104,18 +109,120 @@ test("GET /portal/session/finalize/submit honors a runtime-provided link-intent 
     headers: {
       accept: "text/html",
       cookie: buildSignedAccessCookie("PortalLinkIntent", "intent-1", {
-        secret: "runtime-secret"
+        secret: "runtime-secret",
       }),
-      "cf-access-jwt-assertion": "test-assertion"
-    }
+      "cf-access-jwt-assertion": "test-assertion",
+    },
   });
 
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+    "https://auth.preview.paretoproof.com/?redirect=%2Fprofile&handoff=retry",
   );
   assert.equal(mutationAttempted, false);
+});
+
+test("GET /portal/session/finalize/submit uses configured portal/auth origins and cookie policy", async (t) => {
+  let mutationAttempted = false;
+  const insertedSessions: Array<typeof sessions.$inferInsert> = [];
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      insert() {
+        return {
+          values: async (value: unknown) => {
+            insertedSessions.push(value as typeof sessions.$inferInsert);
+            return value;
+          },
+        };
+      },
+      query: {
+        userIdentities: {
+          findFirst: async () => ({
+            id: "identity-1",
+            provider: "cloudflare_google",
+            providerSubject: "subject-1",
+            userId: "user-1",
+          }),
+        },
+      },
+      transaction: async () => {
+        mutationAttempted = true;
+        throw new Error(
+          "configured finalize GET should not hit the identity-link mutation path",
+        );
+      },
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      accessCookieDomain: ".preview.paretoproof.com",
+      accessCookieSecure: false,
+      authPublicOrigin: "https://auth.preview.paretoproof.com",
+      portalPublicOrigin: "https://portal.preview.paretoproof.com",
+      resolvePortalAccess: async (request) => {
+        request.accessIdentity = {
+          email: "person@example.com",
+          issuer: "https://paretoproof.cloudflareaccess.com",
+          provider: "cloudflare_google",
+          subject: "subject-1",
+        };
+        request.accessRbacContext = {
+          email: "person@example.com",
+          identityId: "identity-1",
+          roles: ["helper"],
+          status: "approved",
+          subject: "subject-1",
+          userId: "user-1",
+        };
+
+        return request.accessRbacContext;
+      },
+    },
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/session/finalize/submit?redirect=/profile",
+    headers: {
+      accept: "text/html",
+      cookie: buildSignedAccessCookie(
+        "PortalAccessProvider",
+        "cloudflare_google|subject-1",
+        {
+          cookieDomain: ".preview.paretoproof.com",
+          secure: false,
+          secret: "test-secret",
+        },
+      ),
+      "cf-access-jwt-assertion": "test-assertion",
+    },
+  });
+
+  assert.equal(response.statusCode, 302);
+  assert.equal(
+    response.headers.location,
+    "https://portal.preview.paretoproof.com/profile",
+  );
+  assert.equal(mutationAttempted, false);
+  assert.equal(insertedSessions.length, 1);
+
+  const setCookies = response.headers["set-cookie"];
+  assert.ok(Array.isArray(setCookies));
+  assert.match(setCookies[0], /Domain=.preview.paretoproof.com/);
+  assert.doesNotMatch(setCookies[0], /; Secure;/);
+  assert.match(setCookies[1], /Domain=.preview.paretoproof.com/);
+  assert.doesNotMatch(setCookies[1], /; Secure;/);
+  assert.match(setCookies[2], /Domain=.preview.paretoproof.com/);
+  assert.doesNotMatch(setCookies[2], /; Secure;/);
 });
 
 test("GET /portal/session/finalize/submit creates an opaque DB-backed session for approved users", async (t) => {
@@ -138,7 +245,7 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
           values: async (value: unknown) => {
             insertedSessions.push(value as typeof sessions.$inferInsert);
             return value;
-          }
+          },
         };
       },
       query: {
@@ -147,14 +254,16 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
             id: "identity-1",
             provider: "cloudflare_google",
             providerSubject: "subject-1",
-            userId: "user-1"
-          })
-        }
+            userId: "user-1",
+          }),
+        },
       },
       transaction: async () => {
         mutationAttempted = true;
-        throw new Error("plain sign-in finalize GET should not hit the identity-link mutation path");
-      }
+        throw new Error(
+          "plain sign-in finalize GET should not hit the identity-link mutation path",
+        );
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
@@ -165,7 +274,7 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
           email: "person@example.com",
           issuer: "https://paretoproof.cloudflareaccess.com",
           provider: "cloudflare_google",
-          subject: "subject-1"
+          subject: "subject-1",
         };
         request.accessRbacContext = {
           email: "person@example.com",
@@ -173,12 +282,12 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
           roles: ["helper"],
           status: "approved",
           subject: "subject-1",
-          userId: "user-1"
+          userId: "user-1",
         };
 
         return request.accessRbacContext;
-      }
-    }
+      },
+    },
   );
 
   const response = await app.inject({
@@ -188,14 +297,17 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
       accept: "text/html",
       cookie: buildSignedAccessCookie(
         "PortalAccessProvider",
-        "cloudflare_google|subject-1"
+        "cloudflare_google|subject-1",
       ),
-      "cf-access-jwt-assertion": "test-assertion"
-    }
+      "cf-access-jwt-assertion": "test-assertion",
+    },
   });
 
   assert.equal(response.statusCode, 302);
-  assert.equal(response.headers.location, "https://portal.paretoproof.com/profile");
+  assert.equal(
+    response.headers.location,
+    "https://portal.paretoproof.com/profile",
+  );
   assert.equal(mutationAttempted, false);
   assert.equal(insertedSessions.length, 1);
   assert.equal(insertedSessions[0]?.identityId, "identity-1");
@@ -237,7 +349,7 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
           values: async (value: unknown) => {
             insertedSessions.push(value as typeof sessions.$inferInsert);
             return value;
-          }
+          },
         };
       },
       query: {
@@ -246,14 +358,16 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
             id: "identity-1",
             provider: "cloudflare_google",
             providerSubject: "subject-1",
-            userId: "user-1"
-          })
-        }
+            userId: "user-1",
+          }),
+        },
       },
       transaction: async () => {
         mutationAttempted = true;
-        throw new Error("plain sign-in finalize submit should not hit the identity-link mutation path");
-      }
+        throw new Error(
+          "plain sign-in finalize submit should not hit the identity-link mutation path",
+        );
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
@@ -264,7 +378,7 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
           email: "person@example.com",
           issuer: "https://paretoproof.cloudflareaccess.com",
           provider: "cloudflare_google",
-          subject: "subject-1"
+          subject: "subject-1",
         };
         request.accessRbacContext = {
           email: "person@example.com",
@@ -272,25 +386,25 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
           roles: ["helper"],
           status: "approved",
           subject: "subject-1",
-          userId: "user-1"
+          userId: "user-1",
         };
 
         return request.accessRbacContext;
-      }
-    }
+      },
+    },
   );
 
   const response = await app.inject({
     method: "POST",
     url: "/portal/session/finalize/submit?redirect=/profile",
     headers: {
-      accept: "application/json"
-    }
+      accept: "application/json",
+    },
   });
 
   assert.equal(response.statusCode, 200);
   assert.deepEqual(response.json(), {
-    redirectTo: "https://portal.paretoproof.com/profile"
+    redirectTo: "https://portal.paretoproof.com/profile",
   });
   assert.equal(mutationAttempted, false);
   assert.equal(insertedSessions.length, 1);
@@ -310,8 +424,8 @@ test("POST /portal/session/finalize/submit bounces stale direct browser handoffs
       done();
     },
     {
-      resolvePortalAccess: async () => null
-    }
+      resolvePortalAccess: async () => null,
+    },
   );
 
   const response = await app.inject({
@@ -320,14 +434,14 @@ test("POST /portal/session/finalize/submit bounces stale direct browser handoffs
     headers: {
       accept: "text/html",
       origin: "https://google.auth.paretoproof.com",
-      referer: "https://google.auth.paretoproof.com/"
-    }
+      referer: "https://google.auth.paretoproof.com/",
+    },
   });
 
   assert.equal(response.statusCode, 307);
   assert.equal(
     response.headers.location,
-    "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile"
+    "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile",
   );
 });
 
@@ -345,16 +459,16 @@ test("POST /portal/session/finalize/submit still returns JSON auth errors for no
       done();
     },
     {
-      resolvePortalAccess: async () => null
-    }
+      resolvePortalAccess: async () => null,
+    },
   );
 
   const response = await app.inject({
     method: "POST",
     url: "/portal/session/finalize/submit",
     headers: {
-      accept: "application/json"
-    }
+      accept: "application/json",
+    },
   });
 
   assert.equal(response.statusCode, 401);
@@ -375,8 +489,10 @@ test("POST /portal/session/finalize/submit clears PortalAccessSession for pendin
     app,
     {
       transaction: async () => {
-        throw new Error("pending sign-in finalize submit should not hit the identity-link mutation path");
-      }
+        throw new Error(
+          "pending sign-in finalize submit should not hit the identity-link mutation path",
+        );
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
@@ -386,25 +502,25 @@ test("POST /portal/session/finalize/submit clears PortalAccessSession for pendin
         assert.equal(request.headers["cf-access-jwt-assertion"], undefined);
         assert.match(
           String(request.headers.cookie),
-          /CF_Authorization=session-cookie/
+          /CF_Authorization=session-cookie/,
         );
         request.accessIdentity = {
           email: "pending@example.com",
           issuer: "https://paretoproof.cloudflareaccess.com",
           provider: "cloudflare_google",
-          subject: "subject-pending"
+          subject: "subject-pending",
         };
         request.accessRbacContext = {
           email: "pending@example.com",
           requestId: "request-pending",
           status: "pending",
           subject: "subject-pending",
-          userId: "user-pending"
+          userId: "user-pending",
         };
 
         return request.accessRbacContext;
-      }
-    }
+      },
+    },
   );
 
   const response = await app.inject({
@@ -416,18 +532,18 @@ test("POST /portal/session/finalize/submit clears PortalAccessSession for pendin
         "CF_Authorization=session-cookie",
         buildSignedAccessCookie(
           "PortalAccessProvider",
-          "cloudflare_google|subject-pending"
-        )
+          "cloudflare_google|subject-pending",
+        ),
       ].join("; "),
       origin: "https://google.auth.paretoproof.com",
-      referer: "https://google.auth.paretoproof.com/"
-    }
+      referer: "https://google.auth.paretoproof.com/",
+    },
   });
 
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://portal.paretoproof.com/access-request"
+    "https://portal.paretoproof.com/access-request",
   );
 
   const setCookies = response.headers["set-cookie"];
@@ -456,35 +572,37 @@ test("POST /portal/session/sign-out revokes the active opaque session and clears
         assert.equal(table, sessions);
         return {
           set(value: unknown) {
-            assert.ok((value as { revokedAt?: Date }).revokedAt instanceof Date);
+            assert.ok(
+              (value as { revokedAt?: Date }).revokedAt instanceof Date,
+            );
             return {
               where() {
                 return {
                   returning: async () => {
                     revokedSession = true;
                     return [{ id: "session-1" }];
-                  }
+                  },
                 };
-              }
+              },
             };
-          }
+          },
         };
-      }
+      },
     } as never,
     () => (_request, _reply, done) => {
       done();
     },
     {
-      resolvePortalAccess: async () => null
-    }
+      resolvePortalAccess: async () => null,
+    },
   );
 
   const response = await app.inject({
     method: "POST",
     url: "/portal/session/sign-out",
     headers: {
-      cookie: "PortalAccessSession=opaque-session-token"
-    }
+      cookie: "PortalAccessSession=opaque-session-token",
+    },
   });
 
   assert.equal(response.statusCode, 204);
@@ -506,7 +624,7 @@ test("GET /portal/me rejects legacy signed portal session cookies without crashi
     CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
     CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
     DATABASE_URL: process.env.DATABASE_URL,
-    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN
+    WORKER_BOOTSTRAP_TOKEN: process.env.WORKER_BOOTSTRAP_TOKEN,
   };
 
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -526,25 +644,25 @@ test("GET /portal/me rejects legacy signed portal session cookies without crashi
     {
       query: {
         sessions: {
-          findFirst: async () => null
-        }
-      }
+          findFirst: async () => null,
+        },
+      },
     } as never,
     createAccessGuard({
       query: {
         sessions: {
-          findFirst: async () => null
-        }
-      }
-    } as never)
+          findFirst: async () => null,
+        },
+      },
+    } as never),
   );
 
   const response = await app.inject({
     method: "GET",
     url: "/portal/me",
     headers: {
-      cookie: "PortalAccessSession=legacy.payload.signature"
-    }
+      cookie: "PortalAccessSession=legacy.payload.signature",
+    },
   });
 
   assert.equal(response.statusCode, 401);

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -445,6 +445,44 @@ test("POST /portal/session/finalize/submit bounces stale direct browser handoffs
   );
 });
 
+test("POST /portal/session/finalize/submit keeps the shared auth origin relay when auth and portal share one origin", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      authPublicOrigin: "https://portal.preview.paretoproof.com",
+      brandedAuthOrigins: ["https://portal.preview.paretoproof.com"],
+      portalPublicOrigin: "https://portal.preview.paretoproof.com",
+      resolvePortalAccess: async () => null,
+    },
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit?redirect=/profile",
+    headers: {
+      accept: "text/html",
+      origin: "https://portal.preview.paretoproof.com",
+      referer: "https://portal.preview.paretoproof.com/",
+    },
+  });
+
+  assert.equal(response.statusCode, 307);
+  assert.equal(
+    response.headers.location,
+    "https://portal.preview.paretoproof.com/api/access/finalize?redirect=%2Fprofile",
+  );
+});
+
 test("POST /portal/session/finalize/submit still returns JSON auth errors for non-branded callers without access", async (t) => {
   const app = Fastify();
 

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -135,6 +135,36 @@ test("parseApiRuntimeEnv always includes the configured auth origin in branded a
   assert.equal(runtimeEnv.accessCookieSecure, false);
 });
 
+test("parseApiRuntimeEnv avoids deriving cookie domains that are only public suffixes", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "https://auth.co.uk",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.co.uk",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.equal(runtimeEnv.accessCookieDomain, undefined);
+});
+
+test("parseApiRuntimeEnv avoids deriving cookie domains that are private PSL suffixes", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "https://auth.github.io",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.github.io",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.equal(runtimeEnv.accessCookieDomain, undefined);
+});
+
 test("parseApiRuntimeEnv rejects runtimes without a portal access audience", () => {
   assert.throws(
     () =>

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -9,14 +9,19 @@ test("parseApiRuntimeEnv accepts the documented local API runtime contract", () 
     CF_ACCESS_PORTAL_AUD: "portal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
     DATABASE_URL: "postgres://localhost:5432/paretoproof",
-    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
 
   assert.deepEqual(runtimeEnv, {
     accessProviderStateSecret: "state-secret",
-    brandedAccessAudiences: [
-      "github-audience",
-      "google-audience"
+    accessCookieDomain: ".paretoproof.com",
+    accessCookieSecure: true,
+    authPublicOrigin: "https://auth.paretoproof.com",
+    brandedAccessAudiences: ["github-audience", "google-audience"],
+    brandedAuthOrigins: [
+      "https://auth.paretoproof.com",
+      "https://github.auth.paretoproof.com",
+      "https://google.auth.paretoproof.com",
     ],
     corsAllowedOrigins: [],
     corsAllowLocalhost: false,
@@ -26,38 +31,52 @@ test("parseApiRuntimeEnv accepts the documented local API runtime contract", () 
     nodeEnv: undefined,
     port: 3000,
     portalAccessAudience: "portal-audience",
+    portalPublicOrigin: "https://portal.paretoproof.com",
     portalSessionSecret: "state-secret",
     teamDomain: "paretoproof.cloudflareaccess.com",
-    workerBootstrapToken: "worker-bootstrap-token"
+    workerBootstrapToken: "worker-bootstrap-token",
   });
 });
 
 test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides", () => {
   const runtimeEnv = parseApiRuntimeEnv({
     ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    ACCESS_COOKIE_DOMAIN: ".preview.paretoproof.com",
+    ACCESS_COOKIE_SECURE: "false",
+    AUTH_PUBLIC_ORIGIN: "https://auth.preview.paretoproof.com",
+    BRANDED_AUTH_ORIGINS:
+      "https://auth.preview.paretoproof.com, https://github.auth.preview.paretoproof.com, https://google.auth.preview.paretoproof.com ",
     CF_ACCESS_AUD: "legacy-audience",
-    CF_ACCESS_BRANDED_AUDS: "github-audience, google-audience , github-audience",
+    CF_ACCESS_BRANDED_AUDS:
+      "github-audience, google-audience , github-audience",
     CF_ACCESS_INTERNAL_AUD: "internal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
-    CORS_ALLOWED_ORIGINS: "https://staging.paretoproof.com, https://admin.paretoproof.com ",
+    CORS_ALLOWED_ORIGINS:
+      "https://staging.paretoproof.com, https://admin.paretoproof.com ",
     CORS_ALLOW_LOCALHOST: "true",
     DATABASE_URL: "postgres://railway.internal:5432/paretoproof",
     HOST: "127.0.0.1",
     NODE_ENV: "production",
     PORT: "4310",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
     PORTAL_SESSION_SECRET: "session-secret",
-    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
 
   assert.deepEqual(runtimeEnv, {
     accessProviderStateSecret: "state-secret",
-    brandedAccessAudiences: [
-      "github-audience",
-      "google-audience"
+    accessCookieDomain: ".preview.paretoproof.com",
+    accessCookieSecure: false,
+    authPublicOrigin: "https://auth.preview.paretoproof.com",
+    brandedAccessAudiences: ["github-audience", "google-audience"],
+    brandedAuthOrigins: [
+      "https://auth.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+      "https://google.auth.preview.paretoproof.com",
     ],
     corsAllowedOrigins: [
       "https://staging.paretoproof.com",
-      "https://admin.paretoproof.com"
+      "https://admin.paretoproof.com",
     ],
     corsAllowLocalhost: true,
     databaseUrl: "postgres://railway.internal:5432/paretoproof",
@@ -66,10 +85,54 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
     nodeEnv: "production",
     port: 4310,
     portalAccessAudience: "legacy-audience",
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
     portalSessionSecret: "session-secret",
     teamDomain: "paretoproof.cloudflareaccess.com",
-    workerBootstrapToken: "worker-bootstrap-token"
+    workerBootstrapToken: "worker-bootstrap-token",
   });
+});
+
+test("parseApiRuntimeEnv derives host-only insecure cookie mode from explicit local origins", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "http://auth.local.test:8788",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "http://localhost:4173",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.equal(runtimeEnv.accessCookieDomain, undefined);
+  assert.equal(runtimeEnv.accessCookieSecure, false);
+  assert.deepEqual(runtimeEnv.brandedAuthOrigins, [
+    "http://auth.local.test:8788",
+    "http://github.auth.local.test:8788",
+    "http://google.auth.local.test:8788",
+  ]);
+});
+
+test("parseApiRuntimeEnv always includes the configured auth origin in branded auth handling", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "http://auth.local.test:8788",
+    BRANDED_AUTH_ORIGINS:
+      "https://github.auth.preview.paretoproof.com, https://google.auth.preview.paretoproof.com",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.deepEqual(runtimeEnv.brandedAuthOrigins, [
+    "http://auth.local.test:8788",
+    "https://github.auth.preview.paretoproof.com",
+    "https://google.auth.preview.paretoproof.com",
+  ]);
+  assert.equal(runtimeEnv.accessCookieSecure, false);
 });
 
 test("parseApiRuntimeEnv rejects runtimes without a portal access audience", () => {
@@ -80,9 +143,9 @@ test("parseApiRuntimeEnv rejects runtimes without a portal access audience", () 
         CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
         CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
         DATABASE_URL: "postgres://localhost:5432/paretoproof",
-        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
       }),
-    /CF_ACCESS_PORTAL_AUD: CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required/
+    /CF_ACCESS_PORTAL_AUD: CF_ACCESS_PORTAL_AUD or CF_ACCESS_AUD is required/,
   );
 });
 
@@ -92,25 +155,61 @@ test("parseApiRuntimeEnv reports omitted required variables explicitly", () => {
       parseApiRuntimeEnv({
         CF_ACCESS_PORTAL_AUD: "portal-audience",
         CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
-        DATABASE_URL: "postgres://localhost:5432/paretoproof"
+        DATABASE_URL: "postgres://localhost:5432/paretoproof",
       }),
-    /ACCESS_PROVIDER_STATE_SECRET: is required; CF_ACCESS_BRANDED_AUDS: is required; WORKER_BOOTSTRAP_TOKEN: is required|ACCESS_PROVIDER_STATE_SECRET: is required; WORKER_BOOTSTRAP_TOKEN: is required; CF_ACCESS_BRANDED_AUDS: is required|CF_ACCESS_BRANDED_AUDS: is required; ACCESS_PROVIDER_STATE_SECRET: is required; WORKER_BOOTSTRAP_TOKEN: is required|CF_ACCESS_BRANDED_AUDS: is required; WORKER_BOOTSTRAP_TOKEN: is required; ACCESS_PROVIDER_STATE_SECRET: is required|WORKER_BOOTSTRAP_TOKEN: is required; ACCESS_PROVIDER_STATE_SECRET: is required; CF_ACCESS_BRANDED_AUDS: is required|WORKER_BOOTSTRAP_TOKEN: is required; CF_ACCESS_BRANDED_AUDS: is required; ACCESS_PROVIDER_STATE_SECRET: is required/
+    /ACCESS_PROVIDER_STATE_SECRET: is required; CF_ACCESS_BRANDED_AUDS: is required; WORKER_BOOTSTRAP_TOKEN: is required|ACCESS_PROVIDER_STATE_SECRET: is required; WORKER_BOOTSTRAP_TOKEN: is required; CF_ACCESS_BRANDED_AUDS: is required|CF_ACCESS_BRANDED_AUDS: is required; ACCESS_PROVIDER_STATE_SECRET: is required; WORKER_BOOTSTRAP_TOKEN: is required|CF_ACCESS_BRANDED_AUDS: is required; WORKER_BOOTSTRAP_TOKEN: is required; ACCESS_PROVIDER_STATE_SECRET: is required|WORKER_BOOTSTRAP_TOKEN: is required; ACCESS_PROVIDER_STATE_SECRET: is required; CF_ACCESS_BRANDED_AUDS: is required|WORKER_BOOTSTRAP_TOKEN: is required; CF_ACCESS_BRANDED_AUDS: is required; ACCESS_PROVIDER_STATE_SECRET: is required/,
   );
 });
 
 test("parseApiRuntimeEnv rejects missing and malformed values with explicit field names", () => {
-  assert.throws(
-    () =>
-      parseApiRuntimeEnv({
-        ACCESS_PROVIDER_STATE_SECRET: "   ",
-        CF_ACCESS_BRANDED_AUDS: " ",
-        CF_ACCESS_PORTAL_AUD: "portal-audience",
-        CF_ACCESS_TEAM_DOMAIN: "",
-        CORS_ALLOW_LOCALHOST: "maybe",
-        DATABASE_URL: "",
-        PORT: "70000",
-        WORKER_BOOTSTRAP_TOKEN: " "
-      }),
-    /ACCESS_PROVIDER_STATE_SECRET: must not be empty; CF_ACCESS_BRANDED_AUDS: must not be empty; CF_ACCESS_TEAM_DOMAIN: must not be empty; CORS_ALLOW_LOCALHOST: Invalid enum value\..*DATABASE_URL: must not be empty; PORT: must be at most 65535; WORKER_BOOTSTRAP_TOKEN: must not be empty/
+  let thrownError: unknown;
+
+  try {
+    parseApiRuntimeEnv({
+      ACCESS_PROVIDER_STATE_SECRET: "   ",
+      ACCESS_COOKIE_DOMAIN: "localhost",
+      AUTH_PUBLIC_ORIGIN: "ftp://auth.example.com",
+      CF_ACCESS_BRANDED_AUDS: " ",
+      CF_ACCESS_PORTAL_AUD: "portal-audience",
+      CF_ACCESS_TEAM_DOMAIN: "",
+      CORS_ALLOW_LOCALHOST: "maybe",
+      DATABASE_URL: "",
+      PORT: "70000",
+      PORTAL_PUBLIC_ORIGIN: "https://portal.example.com/path",
+      WORKER_BOOTSTRAP_TOKEN: " ",
+    });
+  } catch (error) {
+    thrownError = error;
+  }
+
+  assert.ok(thrownError instanceof Error);
+
+  assert.match(
+    String(thrownError),
+    /ACCESS_PROVIDER_STATE_SECRET: must not be empty/,
+  );
+  assert.match(
+    String(thrownError),
+    /ACCESS_COOKIE_DOMAIN: must be a hostname suffix, not localhost or an IP address/,
+  );
+  assert.match(
+    String(thrownError),
+    /AUTH_PUBLIC_ORIGIN: must use http or https/,
+  );
+  assert.match(
+    String(thrownError),
+    /CF_ACCESS_BRANDED_AUDS: must not be empty/,
+  );
+  assert.match(String(thrownError), /CF_ACCESS_TEAM_DOMAIN: must not be empty/);
+  assert.match(String(thrownError), /CORS_ALLOW_LOCALHOST: Invalid enum value/);
+  assert.match(String(thrownError), /DATABASE_URL: must not be empty/);
+  assert.match(String(thrownError), /PORT: must be at most 65535/);
+  assert.match(
+    String(thrownError),
+    /PORTAL_PUBLIC_ORIGIN: must be an origin without path, search, or hash/,
+  );
+  assert.match(
+    String(thrownError),
+    /WORKER_BOOTSTRAP_TOKEN: must not be empty/,
   );
 });

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -165,6 +165,38 @@ test("parseApiRuntimeEnv avoids deriving cookie domains that are private PSL suf
   assert.equal(runtimeEnv.accessCookieDomain, undefined);
 });
 
+test("parseApiRuntimeEnv rejects explicit cookie domains that are only public suffixes", () => {
+  assert.throws(
+    () =>
+      parseApiRuntimeEnv({
+        ACCESS_COOKIE_DOMAIN: ".co.uk",
+        ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+        CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+        CF_ACCESS_PORTAL_AUD: "portal-audience",
+        CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+        DATABASE_URL: "postgres://localhost:5432/paretoproof",
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+      }),
+    /ACCESS_COOKIE_DOMAIN: must not be a public suffix cookie domain/,
+  );
+});
+
+test("parseApiRuntimeEnv rejects explicit cookie domains that are private PSL suffixes", () => {
+  assert.throws(
+    () =>
+      parseApiRuntimeEnv({
+        ACCESS_COOKIE_DOMAIN: ".github.io",
+        ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+        CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+        CF_ACCESS_PORTAL_AUD: "portal-audience",
+        CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+        DATABASE_URL: "postgres://localhost:5432/paretoproof",
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+      }),
+    /ACCESS_COOKIE_DOMAIN: must not be a public suffix cookie domain/,
+  );
+});
+
 test("parseApiRuntimeEnv rejects runtimes without a portal access audience", () => {
   assert.throws(
     () =>

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -14,9 +14,9 @@ test("trusted mutation origin hook rejects state-changing portal requests withou
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"],
-      brandedAuthOrigins: []
-    })
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
   );
 
   app.post("/portal/access-requests", async () => ({ ok: true }));
@@ -24,14 +24,14 @@ test("trusted mutation origin hook rejects state-changing portal requests withou
   const response = await app.inject({
     method: "POST",
     payload: {
-      rationale: "test"
+      rationale: "test",
     },
-    url: "/portal/access-requests"
+    url: "/portal/access-requests",
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_required"
+    error: "trusted_origin_required",
   });
 });
 
@@ -46,28 +46,30 @@ test("trusted mutation origin hook rejects state-changing portal requests from u
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"],
-      brandedAuthOrigins: []
-    })
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
   );
 
-  app.post("/portal/admin/access-requests/req_123/approve", async () => ({ ok: true }));
+  app.post("/portal/admin/access-requests/req_123/approve", async () => ({
+    ok: true,
+  }));
 
   const response = await app.inject({
     method: "POST",
     payload: {
       approvedRole: "helper",
-      decisionNote: "test"
+      decisionNote: "test",
     },
     url: "/portal/admin/access-requests/req_123/approve",
     headers: {
-      origin: "https://evil.example"
-    }
+      origin: "https://evil.example",
+    },
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
 });
 
@@ -82,27 +84,29 @@ test("trusted mutation origin hook also protects admin role revocation mutations
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"],
-      brandedAuthOrigins: []
-    })
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
   );
 
-  app.post("/portal/admin/users/user_123/revoke-role", async () => ({ ok: true }));
+  app.post("/portal/admin/users/user_123/revoke-role", async () => ({
+    ok: true,
+  }));
 
   const response = await app.inject({
     method: "POST",
     payload: {
-      reason: "test"
+      reason: "test",
     },
     url: "/portal/admin/users/user_123/revoke-role",
     headers: {
-      origin: "https://evil.example"
-    }
+      origin: "https://evil.example",
+    },
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
 });
 
@@ -117,27 +121,29 @@ test("trusted mutation origin hook also protects portal-admin offline ingest mut
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"],
-      brandedAuthOrigins: []
-    })
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
   );
 
-  app.post("/portal/admin/offline-ingest/problem9-run-bundles", async () => ({ ok: true }));
+  app.post("/portal/admin/offline-ingest/problem9-run-bundles", async () => ({
+    ok: true,
+  }));
 
   const response = await app.inject({
     method: "POST",
     payload: {
-      bundle: {}
+      bundle: {},
     },
     url: "/portal/admin/offline-ingest/problem9-run-bundles",
     headers: {
-      origin: "https://evil.example"
-    }
+      origin: "https://evil.example",
+    },
   });
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(response.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
 });
 
@@ -152,9 +158,9 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.paretoproof.com"],
-      brandedAuthOrigins: []
-    })
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
   );
 
   app.post("/portal/profile", async () => ({ ok: true }));
@@ -163,26 +169,26 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
   const trustedPost = await app.inject({
     method: "POST",
     payload: {
-      displayName: "Ada"
+      displayName: "Ada",
     },
     url: "/portal/profile",
     headers: {
-      origin: "https://portal.paretoproof.com"
-    }
+      origin: "https://portal.preview.paretoproof.com",
+    },
   });
 
   const redirectGet = await app.inject({
     method: "GET",
-    url: "/portal/session/finalize/submit"
+    url: "/portal/session/finalize/submit",
   });
 
   assert.equal(trustedPost.statusCode, 200);
   assert.deepEqual(trustedPost.json(), {
-    ok: true
+    ok: true,
   });
   assert.equal(redirectGet.statusCode, 200);
   assert.deepEqual(redirectGet.json(), {
-    ok: true
+    ok: true,
   });
 });
 
@@ -198,17 +204,17 @@ test("trusted mutation origin hook only allows branded auth POSTs on the finaliz
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
       allowedOrigins: [
-        "https://auth.paretoproof.com",
-        "https://github.auth.paretoproof.com",
-        "https://google.auth.paretoproof.com",
-        "https://portal.paretoproof.com"
+        "https://auth.preview.paretoproof.com",
+        "https://github.auth.preview.paretoproof.com",
+        "https://google.auth.preview.paretoproof.com",
+        "https://portal.preview.paretoproof.com",
       ],
       brandedAuthOrigins: [
-        "https://auth.paretoproof.com",
-        "https://github.auth.paretoproof.com",
-        "https://google.auth.paretoproof.com"
-      ]
-    })
+        "https://auth.preview.paretoproof.com",
+        "https://github.auth.preview.paretoproof.com",
+        "https://google.auth.preview.paretoproof.com",
+      ],
+    }),
   );
 
   app.post("/portal/session/finalize", async () => ({ ok: true }));
@@ -218,47 +224,47 @@ test("trusted mutation origin hook only allows branded auth POSTs on the finaliz
   const finalizeResponse = await app.inject({
     method: "POST",
     payload: {
-      redirect: "/profile"
+      redirect: "/profile",
     },
     url: "/portal/session/finalize",
     headers: {
-      origin: "https://github.auth.paretoproof.com"
-    }
+      origin: "https://github.auth.preview.paretoproof.com",
+    },
   });
 
   const submitResponse = await app.inject({
     method: "POST",
     payload: {
-      redirect: "/profile"
+      redirect: "/profile",
     },
     url: "/portal/session/finalize/submit",
     headers: {
-      origin: "https://github.auth.paretoproof.com"
-    }
+      origin: "https://github.auth.preview.paretoproof.com",
+    },
   });
 
   const profileResponse = await app.inject({
     method: "POST",
     payload: {
-      displayName: "Ada"
+      displayName: "Ada",
     },
     url: "/portal/profile",
     headers: {
-      origin: "https://github.auth.paretoproof.com"
-    }
+      origin: "https://github.auth.preview.paretoproof.com",
+    },
   });
 
   assert.equal(finalizeResponse.statusCode, 403);
   assert.deepEqual(finalizeResponse.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
   assert.equal(submitResponse.statusCode, 200);
   assert.deepEqual(submitResponse.json(), {
-    ok: true
+    ok: true,
   });
   assert.equal(profileResponse.statusCode, 403);
   assert.deepEqual(profileResponse.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
 });
 
@@ -273,13 +279,13 @@ test("trusted mutation origin hook only allows loopback-mapped branded auth orig
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: true,
-      allowedOrigins: ["https://portal.paretoproof.com"],
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
       brandedAuthOrigins: [
-        "https://auth.paretoproof.com",
-        "https://github.auth.paretoproof.com",
-        "https://google.auth.paretoproof.com"
-      ]
-    })
+        "https://auth.preview.paretoproof.com",
+        "https://github.auth.preview.paretoproof.com",
+        "https://google.auth.preview.paretoproof.com",
+      ],
+    }),
   );
 
   app.post("/portal/session/finalize/submit", async () => ({ ok: true }));
@@ -288,31 +294,31 @@ test("trusted mutation origin hook only allows loopback-mapped branded auth orig
   const finalizeResponse = await app.inject({
     method: "POST",
     payload: {
-      redirect: "/profile"
+      redirect: "/profile",
     },
     url: "/portal/session/finalize/submit",
     headers: {
-      origin: "http://github.auth.paretoproof.com:4371"
-    }
+      origin: "http://github.auth.preview.paretoproof.com:4371",
+    },
   });
 
   const profileResponse = await app.inject({
     method: "POST",
     payload: {
-      displayName: "Ada"
+      displayName: "Ada",
     },
     url: "/portal/profile",
     headers: {
-      origin: "http://github.auth.paretoproof.com:4371"
-    }
+      origin: "http://github.auth.preview.paretoproof.com:4371",
+    },
   });
 
   assert.equal(finalizeResponse.statusCode, 200);
   assert.deepEqual(finalizeResponse.json(), {
-    ok: true
+    ok: true,
   });
   assert.equal(profileResponse.statusCode, 403);
   assert.deepEqual(profileResponse.json(), {
-    error: "trusted_origin_not_allowed"
+    error: "trusted_origin_not_allowed",
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "fastify": "latest",
         "jose": "^6.2.0",
         "postgres": "latest",
+        "tldts": "^7.0.17",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -516,6 +517,10 @@
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
+
+    "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -67,6 +67,11 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
   - `CF_ACCESS_INTERNAL_AUD`
   - `CORS_ALLOWED_ORIGINS`
   - `CORS_ALLOW_LOCALHOST`
+  - `PORTAL_PUBLIC_ORIGIN`
+  - `AUTH_PUBLIC_ORIGIN`
+  - `BRANDED_AUTH_ORIGINS`
+  - `ACCESS_COOKIE_DOMAIN`
+  - `ACCESS_COOKIE_SECURE`
 - Secret env:
   - `DATABASE_URL`
   - `ACCESS_PROVIDER_STATE_SECRET`
@@ -75,6 +80,11 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
   - `CF_ACCESS_INTERNAL_AUD` falls back to the portal audience when omitted
   - `CF_ACCESS_BRANDED_AUDS` is the comma-separated allowlist of branded provider-host Access audiences accepted only on the finalize-submit handoff boundary
   - set `CORS_ALLOW_LOCALHOST=true` when you need loopback-mapped branded auth hosts such as `http://github.auth.paretoproof.com:<port>` or `http://google.auth.paretoproof.com:<port>` to post directly to the local API finalize-submit boundary during auth-flow previews
+  - `PORTAL_PUBLIC_ORIGIN` defaults to `https://portal.paretoproof.com`
+  - `AUTH_PUBLIC_ORIGIN` defaults to `https://auth.paretoproof.com`
+  - `BRANDED_AUTH_ORIGINS` defaults to the configured auth origin plus the matching GitHub and Google branded auth origins
+  - `ACCESS_COOKIE_DOMAIN` defaults to the shared domain suffix derived from the configured portal and branded auth origins when one exists
+  - `ACCESS_COOKIE_SECURE` defaults to `true` only when every configured portal/branded auth origin is `https`
   - `HOST` defaults to `0.0.0.0`
   - `PORT` defaults to `3000`
 
@@ -97,6 +107,11 @@ Use this mode for the hosted `api.paretoproof.com` control plane.
   - `CF_ACCESS_INTERNAL_AUD`
   - `CORS_ALLOWED_ORIGINS`
   - `CORS_ALLOW_LOCALHOST`
+  - `PORTAL_PUBLIC_ORIGIN`
+  - `AUTH_PUBLIC_ORIGIN`
+  - `BRANDED_AUTH_ORIGINS`
+  - `ACCESS_COOKIE_DOMAIN`
+  - `ACCESS_COOKIE_SECURE`
 - Secret env:
   - `DATABASE_URL`
   - `ACCESS_PROVIDER_STATE_SECRET`
@@ -106,6 +121,7 @@ Use this mode for the hosted `api.paretoproof.com` control plane.
   - keep migration credentials out of the live service runtime
   - `api.paretoproof.com/portal/*` must bypass Cloudflare Access because the portal SPA talks to it with cross-origin `fetch()` and needs JSON `200`/`401` responses, not Access redirects
   - keep `api.paretoproof.com/internal/*` on its own Cloudflare Access app for owner and service-token callers
+  - use the explicit portal/auth origin and cookie overrides when a hosted non-prod environment does not live on the canonical `*.paretoproof.com` pair
 
 ### API migration mode
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -7,6 +7,7 @@ This repo uses a small number of runtime rules.
 - `apps/api/.env.example`, `apps/web/.env.example`, and `apps/worker/.env.example` are the local examples.
 - [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) is the operator-facing per-mode checklist for the supported local, hosted, and owner-only runtime paths.
 - `bun run test:startup-validation` is the executable smoke owner for startup env validation across the currently supported runtime surfaces.
+- API portal/auth origin and shared-cookie deployment assumptions are runtime-configurable; keep non-prod hostnames and cookie policy in the API runtime instead of re-hard-coding them in route helpers.
 - Keep browser env separate from Pages function secrets and worker machine credentials.
 - Do not store short-lived access assertions, human session data, or local auth caches in committed env files.
 - Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -12,6 +12,8 @@ const checks = [
       "# Owner-ops config. Only set these when you are intentionally running owner workflows.",
       "# App runtime config for local Cloudflare Access parity and internal worker auth.",
       "# Optional local runtime overrides. Expand only for deliberate local testing.",
+      "# Optional non-prod portal/auth origin overrides. Leave unset for the canonical",
+      "# Optional portal/auth coordination cookie overrides. When unset, the API",
       "# Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them."
     ],
     variables: [
@@ -35,6 +37,11 @@ const checks = [
       { name: "CLOUDFLARE_ACCOUNT_ID", commented: false },
       { name: "CORS_ALLOWED_ORIGINS", commented: false },
       { name: "CORS_ALLOW_LOCALHOST", commented: false },
+      { name: "PORTAL_PUBLIC_ORIGIN", commented: true },
+      { name: "AUTH_PUBLIC_ORIGIN", commented: true },
+      { name: "BRANDED_AUTH_ORIGINS", commented: true },
+      { name: "ACCESS_COOKIE_DOMAIN", commented: true },
+      { name: "ACCESS_COOKIE_SECURE", commented: true },
       { name: "CF_INTERNAL_API_SERVICE_TOKEN_ID", commented: true },
       { name: "CF_INTERNAL_API_SERVICE_TOKEN_SECRET", commented: true },
       { name: "R2_ACCESS_KEY_ID", commented: true },


### PR DESCRIPTION
## Summary\n- move portal/auth origin handling and shared portal cookie policy onto the API runtime contract\n- thread that runtime config through CORS, trusted-origin checks, auth handoff routes, and cookie issuance/clearing\n- document the new non-prod overrides and add targeted regressions for runtime parsing, finalize redirects, cookie attrs, and trusted origins\n\n## Testing\n- bun run test:api\n- ='1'; bun run test:startup-validation\n- bun run build\n\nCloses #1001