### PR TITLE
fix: make worker claim recovery concurrency-safe

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -522,10 +522,17 @@ async function reconcileWorkerInstanceLifecycles(
   }
 }
 
-async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
+async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
   const staleLeases = await tx
     .select({
-      leaseRowId: workerJobLeases.id
+      attemptRowId: attempts.id,
+      attemptState: attempts.state,
+      jobRowId: jobs.id,
+      jobState: jobs.state,
+      leaseRowId: workerJobLeases.id,
+      runRowId: runs.id,
+      runState: runs.state,
+      workerInstanceId: workerJobLeases.workerInstanceId
     })
     .from(workerJobLeases)
     .innerJoin(jobs, eq(workerJobLeases.jobId, jobs.id))
@@ -533,9 +540,18 @@ async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
     .innerJoin(attempts, eq(workerJobLeases.attemptId, attempts.id))
     .where(
       and(
-        eq(jobs.state, "claimed"),
-        eq(attempts.state, "prepared"),
-        or(eq(runs.state, "queued"), eq(runs.state, "running")),
+        or(
+          and(
+            eq(jobs.state, "claimed"),
+            eq(attempts.state, "prepared"),
+            or(eq(runs.state, "queued"), eq(runs.state, "running"))
+          ),
+          and(
+            eq(jobs.state, "running"),
+            eq(attempts.state, "active"),
+            eq(runs.state, "running")
+          )
+        ),
         lte(workerJobLeases.leaseExpiresAt, now),
         isNull(workerJobLeases.revokedAt)
       )
@@ -546,6 +562,7 @@ async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
   }
 
   const leaseRowIds = staleLeases.map((lease) => lease.leaseRowId);
+  const staleLeasesById = new Map(staleLeases.map((lease) => [lease.leaseRowId, lease]));
   const revokedLeases = await tx
     .update(workerJobLeases)
     .set({
@@ -560,11 +577,74 @@ async function revokeExpiredUnstartedLeases(tx: ReadWriteExecutor, now: Date) {
       )
     )
     .returning({
+      leaseRowId: workerJobLeases.id,
       workerInstanceId: workerJobLeases.workerInstanceId
     });
 
   if (revokedLeases.length === 0) {
     return;
+  }
+
+  const startedLeaseRows = revokedLeases
+    .map((lease) => staleLeasesById.get(lease.leaseRowId))
+    .filter(
+      (lease): lease is NonNullable<typeof lease> =>
+        !!lease &&
+        lease.jobState === "running" &&
+        lease.attemptState === "active" &&
+        lease.runState === "running"
+    );
+
+  if (startedLeaseRows.length > 0) {
+    const completedAt = now;
+    const failure = buildLeaseLostFailureClassification();
+    const attemptRowIds = [...new Set(startedLeaseRows.map((lease) => lease.attemptRowId))];
+    const jobRowIds = [...new Set(startedLeaseRows.map((lease) => lease.jobRowId))];
+    const runRowIds = [...new Set(startedLeaseRows.map((lease) => lease.runRowId))];
+
+    await tx
+      .update(attempts)
+      .set({
+        completedAt,
+        failureClassification: failure,
+        primaryFailureCode: failure.failureCode,
+        primaryFailureFamily: failure.failureFamily,
+        primaryFailureSummary: failure.summary,
+        state: "failed",
+        stopReason: failure.failureCode,
+        updatedAt: now,
+        verifierResult: "invalid_result",
+        verdictClass: "invalid_result"
+      })
+      .where(and(inArray(attempts.id, attemptRowIds), eq(attempts.state, "active")));
+
+    await tx
+      .update(jobs)
+      .set({
+        completedAt,
+        primaryFailureCode: failure.failureCode,
+        primaryFailureFamily: failure.failureFamily,
+        primaryFailureSummary: failure.summary,
+        state: "failed",
+        stopReason: failure.failureCode,
+        updatedAt: now,
+        verdictClass: "invalid_result"
+      })
+      .where(and(inArray(jobs.id, jobRowIds), eq(jobs.state, "running")));
+
+    await tx
+      .update(runs)
+      .set({
+        completedAt,
+        primaryFailureCode: failure.failureCode,
+        primaryFailureFamily: failure.failureFamily,
+        primaryFailureSummary: failure.summary,
+        state: "failed",
+        stopReason: failure.failureCode,
+        updatedAt: now,
+        verdictClass: "invalid_result"
+      })
+      .where(and(inArray(runs.id, runRowIds), eq(runs.state, "running")));
   }
 
   await reconcileWorkerInstanceLifecycles(
@@ -1227,6 +1307,19 @@ function selectFailureVerdictClass(request: WorkerTerminalFailureRequest) {
     : ("invalid_result" as const);
 }
 
+function buildLeaseLostFailureClassification() {
+  return {
+    evidenceArtifactRefs: ["worker-control/lease-expired-recovery"],
+    failureCode: "worker_lease_lost" as const,
+    failureFamily: "harness" as const,
+    phase: "execute" as const,
+    retryEligibility: "manual_retry_only" as const,
+    summary: "The active worker lease expired before the attempt finished.",
+    terminality: "terminal_attempt" as const,
+    userVisibility: "user_visible" as const
+  };
+}
+
 function isWorkerAttemptEventDuplicateError(error: unknown) {
   if (!error || typeof error !== "object") {
     return false;
@@ -1243,6 +1336,26 @@ function isWorkerAttemptEventDuplicateError(error: unknown) {
   return (
     databaseCode === "23505" &&
     constraintName === "worker_attempt_events_attempt_sequence_unique"
+  );
+}
+
+function isWorkerLeaseClaimConflictError(error: unknown) {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const databaseCode = "code" in error ? String(error.code) : null;
+  const constraintName =
+    "constraint_name" in error
+      ? String(error.constraint_name)
+      : "constraint" in error
+        ? String(error.constraint)
+        : null;
+
+  return (
+    databaseCode === "23505" &&
+    (constraintName === "worker_job_leases_active_job_unique" ||
+      constraintName === "worker_job_leases_active_attempt_unique")
   );
 }
 
@@ -1325,118 +1438,134 @@ export function createInternalWorkerControlService(db: DbClient) {
         return buildIdleClaimResponse();
       }
 
-      return db.transaction(async (tx) => {
-        await revokeExpiredUnstartedLeases(tx, new Date());
-        const candidate = await selectNextClaimCandidate(tx);
-        const now = new Date();
-        const workerPoolDefinitionId = await upsertWorkerPoolDefinition(tx, request, now);
-        const workerInstanceId = await upsertWorkerInstance(tx, {
-          currentLifecycleState:
-            candidate || request.activeJobCount > 0 ? "running" : "ready",
-          lastClaimAt: candidate ? now : undefined,
-          lastLeaseActivityAt: candidate ? now : undefined,
-          now,
-          workerId: request.workerId,
-          workerPoolDefinitionId,
-          workerRuntime: request.workerRuntime,
-          workerVersion: request.workerVersion
-        });
+      let provisionalWorkerInstanceId: string | null = null;
 
-        if (!candidate) {
-          return buildIdleClaimResponse();
-        }
-
-        const leaseExpiresAt = addSeconds(now, heartbeatTimeoutSeconds);
-        const jobTokenExpiresAt = createJobTokenExpiry(now);
-        const { token, tokenHash } = issueJobToken();
-
-        const [lease] = await tx
-          .insert(workerJobLeases)
-          .values({
-            attemptId: candidate.attemptRowId,
-            heartbeatIntervalSeconds,
-            heartbeatTimeoutSeconds,
-            jobId: candidate.jobRowId,
-            jobTokenExpiresAt,
-            jobTokenHash: tokenHash,
-            jobTokenScopes: [...issuedJobTokenScopes],
-            leaseExpiresAt,
-            runId: candidate.runRowId,
-            workerInstanceId,
+      try {
+        return await db.transaction(async (tx) => {
+          await recoverExpiredClaimLeases(tx, new Date());
+          const candidate = await selectNextClaimCandidate(tx);
+          const now = new Date();
+          const workerPoolDefinitionId = await upsertWorkerPoolDefinition(tx, request, now);
+          provisionalWorkerInstanceId = await upsertWorkerInstance(tx, {
+            currentLifecycleState:
+              candidate || request.activeJobCount > 0 ? "running" : "ready",
+            lastClaimAt: candidate ? now : undefined,
+            lastLeaseActivityAt: candidate ? now : undefined,
+            now,
             workerId: request.workerId,
-            workerPool: request.workerPool,
+            workerPoolDefinitionId,
             workerRuntime: request.workerRuntime,
             workerVersion: request.workerVersion
-          })
-          .returning({
-            id: workerJobLeases.id
           });
 
-        if (!lease) {
-          throw new Error("Failed to persist the worker job lease.");
-        }
+          if (!candidate) {
+            return buildIdleClaimResponse();
+          }
 
-        await tx
-          .update(jobs)
-          .set({
-            state: "claimed",
-            updatedAt: now
-          })
-          .where(eq(jobs.id, candidate.jobRowId));
+          const leaseExpiresAt = addSeconds(now, heartbeatTimeoutSeconds);
+          const jobTokenExpiresAt = createJobTokenExpiry(now);
+          const { token, tokenHash } = issueJobToken();
 
-        if (candidate.runState === "queued") {
+          const [lease] = await tx
+            .insert(workerJobLeases)
+            .values({
+              attemptId: candidate.attemptRowId,
+              heartbeatIntervalSeconds,
+              heartbeatTimeoutSeconds,
+              jobId: candidate.jobRowId,
+              jobTokenExpiresAt,
+              jobTokenHash: tokenHash,
+              jobTokenScopes: [...issuedJobTokenScopes],
+              leaseExpiresAt,
+              runId: candidate.runRowId,
+              workerInstanceId: provisionalWorkerInstanceId,
+              workerId: request.workerId,
+              workerPool: request.workerPool,
+              workerRuntime: request.workerRuntime,
+              workerVersion: request.workerVersion
+            })
+            .returning({
+              id: workerJobLeases.id
+            });
+
+          if (!lease) {
+            throw new Error("Failed to persist the worker job lease.");
+          }
+
           await tx
-            .update(runs)
+            .update(jobs)
             .set({
-              state: "running",
+              state: "claimed",
               updatedAt: now
             })
-            .where(eq(runs.id, candidate.runRowId));
+            .where(eq(jobs.id, candidate.jobRowId));
+
+          if (candidate.runState === "queued") {
+            await tx
+              .update(runs)
+              .set({
+                state: "running",
+                updatedAt: now
+              })
+              .where(eq(runs.id, candidate.runRowId));
+          }
+
+          return {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob: {
+              attemptId: candidate.attemptId,
+              heartbeatIntervalSeconds,
+              heartbeatTimeoutSeconds,
+              jobId: candidate.jobId,
+              jobToken: token,
+              jobTokenExpiresAt: jobTokenExpiresAt.toISOString(),
+              jobTokenScopes: [...issuedJobTokenScopes],
+              leaseExpiresAt: leaseExpiresAt.toISOString(),
+              leaseId: lease.id,
+              offlineBundleCompatible: true,
+              requiredArtifactRoles: [...requiredProblem9ArtifactRoles],
+              runBundleSchemaVersion,
+              runId: candidate.runId,
+              target: {
+                authMode: candidate.authMode,
+                benchmarkItemId: candidate.benchmarkItemId,
+                benchmarkPackageDigest: candidate.benchmarkPackageDigest,
+                benchmarkPackageId: candidate.benchmarkPackageId,
+                benchmarkPackageVersion: candidate.benchmarkPackageVersion,
+                harnessRevision: candidate.harnessRevision,
+                laneId: candidate.laneId,
+                modelConfigId: candidate.modelConfigId,
+                modelSnapshotId: candidate.modelSnapshotId,
+                promptPackageDigest: candidate.promptPackageDigest,
+                promptProtocolVersion: candidate.promptProtocolVersion,
+                providerFamily: candidate.providerFamily,
+                runKind: "single_run",
+                runMode: candidate.runMode as
+                  | "single_pass_probe"
+                  | "pass_k_probe"
+                  | "bounded_agentic_attempt",
+                toolProfile: candidate.toolProfile as
+                  | "no_tools"
+                  | "lean_mcp_readonly"
+                  | "workspace_edit_limited"
+              }
+            }
+          } satisfies WorkerClaimResponse;
+        });
+      } catch (error) {
+        if (!isWorkerLeaseClaimConflictError(error)) {
+          throw error;
         }
 
-        return {
-          leaseStatus: "active",
-          pollAfterSeconds: 0,
-          workerJob: {
-            attemptId: candidate.attemptId,
-            heartbeatIntervalSeconds,
-            heartbeatTimeoutSeconds,
-            jobId: candidate.jobId,
-            jobToken: token,
-            jobTokenExpiresAt: jobTokenExpiresAt.toISOString(),
-            jobTokenScopes: [...issuedJobTokenScopes],
-            leaseExpiresAt: leaseExpiresAt.toISOString(),
-            leaseId: lease.id,
-            offlineBundleCompatible: true,
-            requiredArtifactRoles: [...requiredProblem9ArtifactRoles],
-            runBundleSchemaVersion,
-            runId: candidate.runId,
-            target: {
-              authMode: candidate.authMode,
-              benchmarkItemId: candidate.benchmarkItemId,
-              benchmarkPackageDigest: candidate.benchmarkPackageDigest,
-              benchmarkPackageId: candidate.benchmarkPackageId,
-              benchmarkPackageVersion: candidate.benchmarkPackageVersion,
-              harnessRevision: candidate.harnessRevision,
-              laneId: candidate.laneId,
-              modelConfigId: candidate.modelConfigId,
-              modelSnapshotId: candidate.modelSnapshotId,
-              promptPackageDigest: candidate.promptPackageDigest,
-              promptProtocolVersion: candidate.promptProtocolVersion,
-              providerFamily: candidate.providerFamily,
-              runKind: "single_run",
-              runMode: candidate.runMode as
-                | "single_pass_probe"
-                | "pass_k_probe"
-                | "bounded_agentic_attempt",
-              toolProfile: candidate.toolProfile as
-                | "no_tools"
-                | "lean_mcp_readonly"
-                | "workspace_edit_limited"
-            }
-          }
-        } satisfies WorkerClaimResponse;
-      });
+        if (provisionalWorkerInstanceId) {
+          await db.transaction(async (tx) => {
+            await reconcileWorkerInstanceLifecycle(tx, provisionalWorkerInstanceId, new Date());
+          });
+        }
+
+        return buildIdleClaimResponse();
+      }
     },
 
     async heartbeat(

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -1312,7 +1312,7 @@ function buildLeaseLostFailureClassification() {
     evidenceArtifactRefs: ["worker-control/lease-expired-recovery"],
     failureCode: "worker_lease_lost" as const,
     failureFamily: "harness" as const,
-    phase: "execute" as const,
+    phase: "generate" as const,
     retryEligibility: "manual_retry_only" as const,
     summary: "The active worker lease expired before the attempt finished.",
     terminality: "terminal_attempt" as const,

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -270,6 +270,168 @@ function buildStoredArtifactRow(overrides: Partial<Record<string, unknown>> = {}
   };
 }
 
+function createLostClaimRaceDb() {
+  const updateCalls: Array<{
+    target: unknown;
+    values: Record<string, unknown>;
+  }> = [];
+  const insertCalls: Array<{
+    target: unknown;
+    values: Record<string, unknown>;
+  }> = [];
+  let selectCount = 0;
+  const leaseConflict = {
+    code: "23505",
+    constraint_name: "worker_job_leases_active_job_unique"
+  };
+
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  leftJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  orderBy() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      {
+                        authMode: "machine_api_key",
+                        attemptId: "attempt-1",
+                        attemptRowId: "attempt-row-1",
+                        benchmarkItemId: "Problem9",
+                        benchmarkPackageDigest: "a".repeat(64),
+                        benchmarkPackageId: "firstproof/Problem9",
+                        benchmarkPackageVersion: "2026.03.13",
+                        harnessRevision: "worker-harness.v1",
+                        jobId: "job-1",
+                        jobRowId: "job-row-1",
+                        laneId: "problem9-default",
+                        modelConfigId: "openai/gpt-5",
+                        modelSnapshotId: "openai/gpt-5.2026-03-13",
+                        promptPackageDigest: "b".repeat(64),
+                        promptProtocolVersion: "problem9-prompt-protocol.v1",
+                        providerFamily: "openai",
+                        runId: "run-1",
+                        runKind: "single_run",
+                        runMode: "bounded_agentic_attempt",
+                        runRowId: "run-row-1",
+                        runState: "queued",
+                        toolProfile: "workspace_edit_limited"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                }
+              };
+            }
+          };
+        },
+        insert(target: unknown) {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push({ target, values });
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              if (insertCalls.length === 2) {
+                return {
+                  onConflictDoUpdate() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "worker-instance-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                returning() {
+                  throw leaseConflict;
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+
+  return {
+    fakeDb,
+    getSelectCount: () => selectCount,
+    insertCalls,
+    updateCalls
+  };
+}
+
 function createScopeError(scope: WorkerJobTokenScope) {
   return new InternalWorkerControlError({
     code: "worker_job_token_scope_missing",
@@ -345,6 +507,33 @@ test("POST /internal/worker/claims returns an active lease when work is availabl
   assert.equal(response.statusCode, 200);
   assert.equal(receivedRequest?.workerId, "worker-1");
   assert.equal(response.json().workerJob?.jobId, "job-1");
+});
+
+test("POST /internal/worker/claims returns idle when another claimer wins the lease insert race", async (t) => {
+  const app = Fastify();
+  const { fakeDb } = createLostClaimRaceDb();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerInternalWorkerRoutes(app, fakeDb as never, buildRuntimeEnv());
+
+  const response = await app.inject({
+    method: "POST",
+    headers: {
+      authorization: "Bearer worker-bootstrap-token"
+    },
+    payload: buildClaimRequest(),
+    url: "/internal/worker/claims"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
 });
 
 test("POST /internal/worker/claims reclaims stale unstarted work without queued rewinds", async (t) => {
@@ -1861,6 +2050,172 @@ test("stale-lease recovery does not rewind durable job or run state", async () =
   assert.equal(updateCalls.some((call) => call.state === "queued"), false);
 });
 
+test("claim terminal-fails expired started work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "active",
+                        jobRowId: "job-row-1",
+                        jobState: "running",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "running",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].verdictClass, "invalid_result");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[1].primaryFailureFamily, "harness");
+  assert.equal(updateCalls[1].primaryFailureSummary, "The active worker lease expired before the attempt finished.");
+  assert.equal(
+    (updateCalls[1].failureClassification as Record<string, unknown>).failureCode,
+    "worker_lease_lost"
+  );
+  assert.deepEqual(
+    (updateCalls[1].failureClassification as Record<string, unknown>).evidenceArtifactRefs,
+    ["worker-control/lease-expired-recovery"]
+  );
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(Object.hasOwn(updateCalls[4], "lastSeenAt"), false);
+  assert.equal(updateCalls.some((call) => call.state === "queued"), false);
+  assert.equal(updateCalls.some((call) => call.state === "claimed"), false);
+});
+
 test("claim keeps any still-unrevoked lease row blocking candidate selection", async () => {
   let capturedLeaseJoin: SQL | null = null;
   const insertCalls: Array<Record<string, unknown>> = [];
@@ -1962,6 +2317,28 @@ test("claim keeps any still-unrevoked lease row blocking candidate selection", a
   assert.match(query.sql, /"worker_job_leases"\."revoked_at" is null/i);
   assert.doesNotMatch(query.sql, /"worker_job_leases"\."lease_expires_at"/i);
   assert.equal(query.params.length, 0);
+});
+
+test("claim returns idle when another claimer wins the active lease uniqueness race", async () => {
+  const { fakeDb, getSelectCount, insertCalls, updateCalls } = createLostClaimRaceDb();
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(getSelectCount(), 3);
+  assert.equal(insertCalls.length, 3);
+  assert.equal(insertCalls[1]?.values.currentLifecycleState, "running");
+  assert.equal(insertCalls[2]?.values.workerInstanceId, "worker-instance-1");
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0]?.values.currentLifecycleState, "ready");
+  assert.equal(updateCalls[0]?.values.lastSeenAt instanceof Date, true);
+  assert.equal(updateCalls[0]?.values.updatedAt instanceof Date, true);
+  assert.equal("state" in updateCalls[0]!.values, false);
 });
 
 test("claim reuses existing worker pool definitions without hot-row updates", async () => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -2206,6 +2206,10 @@ test("claim terminal-fails expired started work before polling for new candidate
     (updateCalls[1].failureClassification as Record<string, unknown>).evidenceArtifactRefs,
     ["worker-control/lease-expired-recovery"]
   );
+  assert.equal(
+    (updateCalls[1].failureClassification as Record<string, unknown>).phase,
+    "generate"
+  );
   assert.equal(updateCalls[2].state, "failed");
   assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
   assert.equal(updateCalls[3].state, "failed");


### PR DESCRIPTION
## Summary\n- recover expired started worker leases during claim-time cleanup by fencing them and terminal-failing the affected run/job/attempt without lifecycle rewinds\n- return idle when another claimer wins the active-lease uniqueness race by handling the loser path outside the aborted transaction\n- add focused claim-path regressions for stale started-work recovery and uniqueness-race idle fallback\n\n## Testing\n- bun test apps/api/test/internal-worker.test.ts\n- bun run test:api\n- bun run test:startup-validation\n- bun run build\n\nCloses #1003