### PR TITLE
Fix bounded worker cancellation finalization

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -1706,7 +1706,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           } satisfies WorkerHeartbeatResponse;
         }
 
-        if (lease.jobState === "cancel_requested") {
+        if (lease.jobState === "cancel_requested" || lease.runState === "cancel_requested") {
           const nextLeaseExpiresAt = resolveCancelRequestedLeaseExpiry(lease);
           const nextJobTokenExpiresAt = nextLeaseExpiresAt;
           const nextJobToken = issueJobToken();

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -1047,6 +1047,7 @@ function assertFailureEvidenceArtifactRefs(
   const allowedSyntheticPreBundleFailureCodes: ReadonlySet<
     WorkerTerminalFailureRequest["failure"]["failureCode"]
   > = new Set([
+    "manual_cancelled",
     "benchmark_input_digest_mismatch",
     "benchmark_input_missing",
     "prompt_package_missing",
@@ -1642,24 +1643,51 @@ export function createInternalWorkerControlService(db: DbClient) {
         }
 
         if (lease.jobState === "cancel_requested") {
-          await tx
+          const nextLeaseExpiresAt = addSeconds(now, lease.heartbeatTimeoutSeconds);
+          const nextJobTokenExpiresAt = createJobTokenExpiry(now);
+          const nextJobToken = issueJobToken();
+          const continuedLeases = await tx
             .update(workerJobLeases)
             .set({
+              jobTokenExpiresAt: nextJobTokenExpiresAt,
+              jobTokenHash: nextJobToken.tokenHash,
               lastEventSequence: acknowledgedEventSequence,
               lastHeartbeatAt: now,
-              revokedAt: now,
+              leaseExpiresAt: nextLeaseExpiresAt,
               updatedAt: now
             })
-            .where(eq(workerJobLeases.id, authContext.leaseRowId));
+            .where(
+              and(
+                eq(workerJobLeases.id, authContext.leaseRowId),
+                isNull(workerJobLeases.revokedAt),
+                gt(workerJobLeases.leaseExpiresAt, now)
+              )
+            )
+            .returning({
+              id: workerJobLeases.id
+            });
 
-          await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+          if (continuedLeases.length === 0) {
+            await reconcileWorkerInstanceLifecycle(tx, lease.workerInstanceId, now);
+
+            return {
+              acknowledgedEventSequence,
+              cancelRequested: false,
+              jobToken: null,
+              jobTokenExpiresAt: null,
+              leaseExpiresAt: null,
+              leaseStatus: "expired"
+            } satisfies WorkerHeartbeatResponse;
+          }
+
+          await touchWorkerInstanceHeartbeat(tx, lease.workerInstanceId, now);
 
           return {
             acknowledgedEventSequence,
             cancelRequested: true,
-            jobToken: null,
-            jobTokenExpiresAt: null,
-            leaseExpiresAt: null,
+            jobToken: nextJobToken.token,
+            jobTokenExpiresAt: nextJobTokenExpiresAt.toISOString(),
+            leaseExpiresAt: nextLeaseExpiresAt.toISOString(),
             leaseStatus: "cancel_requested"
           } satisfies WorkerHeartbeatResponse;
         }

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -573,6 +573,12 @@ async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
             eq(jobs.state, "running"),
             eq(attempts.state, "active"),
             eq(runs.state, "running")
+          ),
+          and(
+            or(eq(jobs.state, "cancel_requested"), eq(runs.state, "cancel_requested")),
+            inArray(attempts.state, ["prepared", "active"]),
+            inArray(jobs.state, ["claimed", "running", "cancel_requested"]),
+            inArray(runs.state, ["queued", "running", "cancel_requested"])
           )
         ),
         lte(workerJobLeases.leaseExpiresAt, now),
@@ -608,22 +614,30 @@ async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
     return;
   }
 
-  const startedLeaseRows = revokedLeases
+  const terminalizedLeaseRows = revokedLeases
     .map((lease) => staleLeasesById.get(lease.leaseRowId))
     .filter(
       (lease): lease is NonNullable<typeof lease> =>
         !!lease &&
-        lease.jobState === "running" &&
-        lease.attemptState === "active" &&
-        lease.runState === "running"
+        ((lease.jobState === "running" &&
+          lease.attemptState === "active" &&
+          lease.runState === "running") ||
+          ((lease.jobState === "cancel_requested" || lease.runState === "cancel_requested") &&
+            (lease.attemptState === "prepared" || lease.attemptState === "active") &&
+            (lease.jobState === "claimed" ||
+              lease.jobState === "running" ||
+              lease.jobState === "cancel_requested") &&
+            (lease.runState === "queued" ||
+              lease.runState === "running" ||
+              lease.runState === "cancel_requested")))
     );
 
-  if (startedLeaseRows.length > 0) {
+  if (terminalizedLeaseRows.length > 0) {
     const completedAt = now;
     const failure = buildLeaseLostFailureClassification();
-    const attemptRowIds = [...new Set(startedLeaseRows.map((lease) => lease.attemptRowId))];
-    const jobRowIds = [...new Set(startedLeaseRows.map((lease) => lease.jobRowId))];
-    const runRowIds = [...new Set(startedLeaseRows.map((lease) => lease.runRowId))];
+    const attemptRowIds = [...new Set(terminalizedLeaseRows.map((lease) => lease.attemptRowId))];
+    const jobRowIds = [...new Set(terminalizedLeaseRows.map((lease) => lease.jobRowId))];
+    const runRowIds = [...new Set(terminalizedLeaseRows.map((lease) => lease.runRowId))];
 
     await tx
       .update(attempts)
@@ -639,7 +653,9 @@ async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
         verifierResult: "invalid_result",
         verdictClass: "invalid_result"
       })
-      .where(and(inArray(attempts.id, attemptRowIds), eq(attempts.state, "active")));
+      .where(
+        and(inArray(attempts.id, attemptRowIds), inArray(attempts.state, ["prepared", "active"]))
+      );
 
     await tx
       .update(jobs)
@@ -653,7 +669,9 @@ async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
         updatedAt: now,
         verdictClass: "invalid_result"
       })
-      .where(and(inArray(jobs.id, jobRowIds), eq(jobs.state, "running")));
+      .where(
+        and(inArray(jobs.id, jobRowIds), inArray(jobs.state, ["claimed", "running", "cancel_requested"]))
+      );
 
     await tx
       .update(runs)
@@ -667,7 +685,9 @@ async function recoverExpiredClaimLeases(tx: ReadWriteExecutor, now: Date) {
         updatedAt: now,
         verdictClass: "invalid_result"
       })
-      .where(and(inArray(runs.id, runRowIds), eq(runs.state, "running")));
+      .where(
+        and(inArray(runs.id, runRowIds), inArray(runs.state, ["queued", "running", "cancel_requested"]))
+      );
   }
 
   await reconcileWorkerInstanceLifecycles(

--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -106,10 +106,12 @@ type LeaseStateRow = {
   candidateDigest: string;
   heartbeatTimeoutSeconds: number;
   jobState: typeof jobs.$inferSelect.state;
+  jobUpdatedAt: Date;
   lastEventSequence: number;
   leaseExpiresAt: Date;
   revokedAt: Date | null;
   runState: typeof runs.$inferSelect.state;
+  runUpdatedAt: Date;
   verifierVerdict: Record<string, unknown>;
   workerInstanceId: string | null;
   verdictDigest: string;
@@ -305,6 +307,27 @@ async function selectNextClaimCandidate(tx: SelectExecutor): Promise<CandidateCl
 
 function createJobTokenExpiry(now: Date) {
   return addSeconds(now, heartbeatTimeoutSeconds);
+}
+
+function resolveCancelRequestedLeaseExpiry(lease: LeaseStateRow) {
+  const cancelRequestedAtCandidates = [];
+
+  if (lease.jobState === "cancel_requested") {
+    cancelRequestedAtCandidates.push(lease.jobUpdatedAt);
+  }
+
+  if (lease.runState === "cancel_requested") {
+    cancelRequestedAtCandidates.push(lease.runUpdatedAt);
+  }
+
+  const cancelRequestedAt =
+    cancelRequestedAtCandidates.sort((left, right) => left.getTime() - right.getTime())[0] ??
+    lease.leaseExpiresAt;
+  const cancelWindowExpiresAt = addSeconds(cancelRequestedAt, lease.heartbeatTimeoutSeconds);
+
+  return cancelWindowExpiresAt.getTime() > lease.leaseExpiresAt.getTime()
+    ? cancelWindowExpiresAt
+    : lease.leaseExpiresAt;
 }
 
 async function upsertWorkerPoolDefinition(
@@ -789,10 +812,12 @@ async function loadLeaseState(
       candidateDigest: attempts.candidateDigest,
       heartbeatTimeoutSeconds: workerJobLeases.heartbeatTimeoutSeconds,
       jobState: jobs.state,
+      jobUpdatedAt: jobs.updatedAt,
       lastEventSequence: workerJobLeases.lastEventSequence,
       leaseExpiresAt: workerJobLeases.leaseExpiresAt,
       revokedAt: workerJobLeases.revokedAt,
       runState: runs.state,
+      runUpdatedAt: runs.updatedAt,
       verifierVerdict: attempts.verifierVerdict,
       workerInstanceId: workerJobLeases.workerInstanceId,
       verdictDigest: attempts.verdictDigest
@@ -882,6 +907,25 @@ function ensureSubmissionState(
       "attemptState"
     );
   }
+}
+
+function ensureManualCancellationWasRequested(
+  request: WorkerTerminalFailureRequest,
+  leaseState: LeaseStateRow
+) {
+  if (request.failure.failureCode !== "manual_cancelled") {
+    return;
+  }
+
+  if (leaseState.jobState === "cancel_requested" || leaseState.runState === "cancel_requested") {
+    return;
+  }
+
+  throw createConflictError(
+    "worker_cancel_not_requested",
+    "manual_cancelled terminal submissions require a control-plane cancellation request first.",
+    "failure.failureCode"
+  );
 }
 
 async function promoteExecutionToRunning(
@@ -1643,8 +1687,8 @@ export function createInternalWorkerControlService(db: DbClient) {
         }
 
         if (lease.jobState === "cancel_requested") {
-          const nextLeaseExpiresAt = addSeconds(now, lease.heartbeatTimeoutSeconds);
-          const nextJobTokenExpiresAt = createJobTokenExpiry(now);
+          const nextLeaseExpiresAt = resolveCancelRequestedLeaseExpiry(lease);
+          const nextJobTokenExpiresAt = nextLeaseExpiresAt;
           const nextJobToken = issueJobToken();
           const continuedLeases = await tx
             .update(workerJobLeases)
@@ -2124,6 +2168,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           allowCancelRequested: true,
           path: "failure submission"
         });
+        ensureManualCancellationWasRequested(request, lease);
 
         const artifactIds = request.artifactIds ?? [];
         const artifactRows = await loadArtifactsByIds(tx, authContext.attemptRowId, artifactIds);

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -1569,6 +1569,120 @@ test("submitFailure accepts bounded manual cancellation after cancel was request
   assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
 });
 
+test("submitFailure accepts bounded manual cancellation after artifact registration", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      buildLeaseStateRow({
+                        attemptState: "active",
+                        jobState: "cancel_requested",
+                        runState: "cancel_requested"
+                      })
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      id: "artifact-1",
+                      lifecycleState: "registered",
+                      relativePath: "run-bundle.json"
+                    }),
+                    buildStoredArtifactRow({
+                      artifactClassId: "verdict_record",
+                      id: "artifact-2",
+                      lifecycleState: "registered",
+                      objectKey: "runs/run-1/artifacts/attempt-1/verification/verdict.json",
+                      relativePath: "verification/verdict.json"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: ["artifact-1", "artifact-2"],
+    failure: {
+      evidenceArtifactRefs: ["verification/verdict.json"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request after artifact registration.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request after artifact registration.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "cancelled",
+    jobState: "cancelled",
+    runState: "cancelled"
+  });
+  assert.equal(selectCount, 2);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "cancelled");
+  assert.equal(updateCalls[0]!.values.stopReason, "manual_cancelled");
+  assert.equal(updateCalls[1]!.values.state, "cancelled");
+  assert.equal(updateCalls[2]!.values.state, "cancelled");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+});
+
 test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure codes", async () => {
   const control = createInternalWorkerControlService({
     transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -4410,6 +4410,179 @@ test("heartbeat preserves the active lease when cancellation is requested", asyn
   assert.equal(updateCalls[1].lastHeartbeatAt instanceof Date, true);
 });
 
+test("heartbeat returns cancel_requested when only the run state has caught the cancellation", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const beforeHeartbeatAt = Date.now();
+  const runCancelRequestedAt = new Date(beforeHeartbeatAt - 120_000);
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
+      const tx = {
+        select() {
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    {
+                      artifactManifestDigest: "a".repeat(64),
+                      attemptState: "active",
+                      bundleDigest: "b".repeat(64),
+                      candidateDigest: "c".repeat(64),
+                      heartbeatTimeoutSeconds: 180,
+                      jobState: "running",
+                      jobUpdatedAt: new Date(beforeHeartbeatAt - 30_000),
+                      lastEventSequence: 2,
+                      leaseExpiresAt: new Date(beforeHeartbeatAt + 10_000),
+                      revokedAt: null,
+                      runState: "cancel_requested",
+                      runUpdatedAt: runCancelRequestedAt,
+                      verifierVerdict: {},
+                      workerInstanceId: "worker-instance-1",
+                      verdictDigest: "d".repeat(64)
+                    }
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.heartbeat(buildHeartbeatRequest(), buildJobAuthContext());
+
+  assert.equal(response.cancelRequested, true);
+  assert.ok(typeof response.jobToken === "string" && response.jobToken.length > 0);
+  assert.ok(response.jobTokenExpiresAt);
+  assert.equal(response.leaseStatus, "cancel_requested");
+  assert.equal(updateCalls.length, 2);
+  assert.equal(
+    updateCalls[0].leaseExpiresAt.getTime(),
+    runCancelRequestedAt.getTime() + 180_000,
+    "run-side cancel_requested heartbeat should stay anchored to the cancel window"
+  );
+  assert.equal(
+    new Date(response.leaseExpiresAt!).getTime(),
+    runCancelRequestedAt.getTime() + 180_000,
+    "run-side cancel_requested response should stay anchored to the cancel window"
+  );
+  assert.equal(
+    new Date(response.jobTokenExpiresAt!).getTime(),
+    runCancelRequestedAt.getTime() + 180_000,
+    "run-side cancel_requested token expiry should stay bounded to the cancel window"
+  );
+  assert.equal(updateCalls[1].currentLifecycleState, "running");
+});
+
+test("heartbeat returns cancel_requested before start when only the run state has caught the cancellation", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const beforeHeartbeatAt = Date.now();
+  const runCancelRequestedAt = new Date(beforeHeartbeatAt - 120_000);
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
+      const tx = {
+        select() {
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    {
+                      artifactManifestDigest: "a".repeat(64),
+                      attemptState: "prepared",
+                      bundleDigest: "b".repeat(64),
+                      candidateDigest: "c".repeat(64),
+                      heartbeatTimeoutSeconds: 180,
+                      jobState: "claimed",
+                      jobUpdatedAt: new Date(beforeHeartbeatAt - 30_000),
+                      lastEventSequence: 2,
+                      leaseExpiresAt: new Date(beforeHeartbeatAt + 10_000),
+                      revokedAt: null,
+                      runState: "cancel_requested",
+                      runUpdatedAt: runCancelRequestedAt,
+                      verifierVerdict: {},
+                      workerInstanceId: "worker-instance-1",
+                      verdictDigest: "d".repeat(64)
+                    }
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.heartbeat(buildHeartbeatRequest(), buildJobAuthContext());
+
+  assert.equal(response.cancelRequested, true);
+  assert.equal(response.leaseStatus, "cancel_requested");
+  assert.equal(updateCalls.length, 2);
+  assert.equal(
+    updateCalls[0].leaseExpiresAt.getTime(),
+    runCancelRequestedAt.getTime() + 180_000,
+    "pre-start run-side cancel_requested heartbeat should stay anchored to the cancel window"
+  );
+  assert.equal(
+    new Date(response.leaseExpiresAt!).getTime(),
+    runCancelRequestedAt.getTime() + 180_000,
+    "pre-start run-side cancel_requested response should stay anchored to the cancel window"
+  );
+  assert.equal(updateCalls[1].currentLifecycleState, "running");
+});
+
 test("heartbeat returns expired when lease renewal loses the race with recovery revocation", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
   let selectCount = 0;

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -1837,6 +1837,207 @@ test("submitFailure accepts manual cancellation when the job is cancel_requested
   assert.equal(updateCalls.length, 4);
 });
 
+test("submitFailure accepts manual cancellation when only the run is cancel_requested before job state catches up", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    buildLeaseStateRow({
+                      attemptState: "active",
+                      jobState: "running",
+                      runState: "cancel_requested"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: [],
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "cancelled",
+    jobState: "cancelled",
+    runState: "cancelled"
+  });
+  assert.equal(selectCount, 1);
+  assert.equal(updateCalls.length, 4);
+});
+
+test("submitFailure accepts bounded manual cancellation after artifact registration when only the run is cancel_requested", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      buildLeaseStateRow({
+                        attemptState: "active",
+                        jobState: "running",
+                        runState: "cancel_requested"
+                      })
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                where() {
+                  return Promise.resolve([
+                    buildStoredArtifactRow({
+                      id: "artifact-1",
+                      lifecycleState: "registered",
+                      relativePath: "run-bundle.json"
+                    }),
+                    buildStoredArtifactRow({
+                      artifactClassId: "verdict_record",
+                      id: "artifact-2",
+                      lifecycleState: "registered",
+                      objectKey: "runs/run-1/artifacts/attempt-1/verification/verdict.json",
+                      relativePath: "verification/verdict.json"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: ["artifact-1", "artifact-2"],
+    failure: {
+      evidenceArtifactRefs: ["verification/verdict.json"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request after artifact registration.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request after artifact registration.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "cancelled",
+    jobState: "cancelled",
+    runState: "cancelled"
+  });
+  assert.equal(selectCount, 2);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "cancelled");
+  assert.equal(updateCalls[0]!.values.stopReason, "manual_cancelled");
+  assert.equal(updateCalls[1]!.values.state, "cancelled");
+  assert.equal(updateCalls[2]!.values.state, "cancelled");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+});
+
 test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure codes", async () => {
   const control = createInternalWorkerControlService({
     transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -239,10 +239,12 @@ function buildLeaseStateRow(overrides: Partial<Record<string, unknown>> = {}) {
     candidateDigest: null,
     heartbeatTimeoutSeconds: 180,
     jobState: "running",
+    jobUpdatedAt: new Date("2099-03-13T15:00:00.000Z"),
     lastEventSequence: 3,
     leaseExpiresAt: new Date("2099-03-13T15:03:00.000Z"),
     revokedAt: null,
     runState: "running",
+    runUpdatedAt: new Date("2099-03-13T15:00:00.000Z"),
     verifierVerdict: null,
     workerInstanceId: null,
     verdictDigest: null,
@@ -1681,6 +1683,158 @@ test("submitFailure accepts bounded manual cancellation after artifact registrat
   assert.equal(updateCalls[1]!.values.state, "cancelled");
   assert.equal(updateCalls[2]!.values.state, "cancelled");
   assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+});
+
+test("submitFailure rejects manual cancellation when cancel was not requested", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([buildLeaseStateRow()]);
+                  }
+                };
+              }
+            };
+          }
+
+          throw new Error("manual cancellation without cancel_requested should reject early");
+        },
+        update() {
+          throw new Error("manual cancellation without cancel_requested should reject early");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: [],
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  await assert.rejects(
+    () => control.submitFailure(request, buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError && error.code === "worker_cancel_not_requested"
+  );
+});
+
+test("submitFailure accepts manual cancellation when the job is cancel_requested before run state catches up", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    buildLeaseStateRow({
+                      attemptState: "active",
+                      jobState: "cancel_requested",
+                      runState: "running"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: [],
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "cancelled",
+    jobState: "cancelled",
+    runState: "cancelled"
+  });
+  assert.equal(selectCount, 1);
+  assert.equal(updateCalls.length, 4);
 });
 
 test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure codes", async () => {
@@ -3232,6 +3386,9 @@ test("heartbeat rotates the job token while extending the lease", async () => {
 
 test("heartbeat preserves the active lease when cancellation is requested", async () => {
   const updateCalls: Array<Record<string, unknown>> = [];
+  const beforeHeartbeatAt = Date.now();
+  const jobCancelRequestedAt = new Date(beforeHeartbeatAt - 120_000);
+  const runCancelRequestedAt = new Date(beforeHeartbeatAt - 30_000);
   const fakeDb = {
     transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
       const tx = {
@@ -3254,10 +3411,12 @@ test("heartbeat preserves the active lease when cancellation is requested", asyn
                       candidateDigest: "c".repeat(64),
                       heartbeatTimeoutSeconds: 180,
                       jobState: "cancel_requested",
+                      jobUpdatedAt: jobCancelRequestedAt,
                       lastEventSequence: 2,
-                      leaseExpiresAt: new Date(Date.now() + 60_000),
+                      leaseExpiresAt: new Date(beforeHeartbeatAt + 10_000),
                       revokedAt: null,
                       runState: "cancel_requested",
+                      runUpdatedAt: runCancelRequestedAt,
                       verifierVerdict: {},
                       workerInstanceId: "worker-instance-1",
                       verdictDigest: "d".repeat(64)
@@ -3304,6 +3463,24 @@ test("heartbeat preserves the active lease when cancellation is requested", asyn
   assert.equal(updateCalls[0].lastEventSequence, 3);
   assert.equal(updateCalls[0].lastHeartbeatAt instanceof Date, true);
   assert.equal(updateCalls[0].leaseExpiresAt instanceof Date, true);
+  assert.equal(
+    updateCalls[0].leaseExpiresAt.getTime(),
+    jobCancelRequestedAt.getTime() + 180_000,
+    "cancel_requested heartbeat should stay anchored to the original cancellation request"
+  );
+  assert.ok(
+    updateCalls[0].leaseExpiresAt.getTime() < beforeHeartbeatAt + 90_000,
+    "cancel_requested heartbeat should keep a bounded finalization deadline"
+  );
+  assert.equal(
+    new Date(response.leaseExpiresAt!).getTime(),
+    jobCancelRequestedAt.getTime() + 180_000,
+    "returned lease expiry should stay anchored to the original cancellation request"
+  );
+  assert.ok(
+    new Date(response.leaseExpiresAt!).getTime() < beforeHeartbeatAt + 90_000,
+    "returned lease expiry should stay bounded to the cancellation window"
+  );
   assert.equal("revokedAt" in updateCalls[0], false);
   assert.equal(updateCalls[1].currentLifecycleState, "running");
   assert.equal(updateCalls[1].lastHeartbeatAt instanceof Date, true);

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -1477,6 +1477,98 @@ test("submitFailure accepts pre-bundle harness failures with omitted artifactIds
   );
 });
 
+test("submitFailure accepts bounded manual cancellation after cancel was requested", async () => {
+  const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    buildLeaseStateRow({
+                      attemptState: "active",
+                      jobState: "cancel_requested",
+                      runState: "cancel_requested"
+                    })
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update(target: unknown) {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push({ target, values });
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+  const request: WorkerTerminalFailureRequest = {
+    ...buildFailureRequest(),
+    artifactIds: [],
+    artifactManifestDigest: null,
+    bundleDigest: null,
+    candidateDigest: null,
+    failure: {
+      evidenceArtifactRefs: ["worker-control/pre-bundle-failure"],
+      failureCode: "manual_cancelled",
+      failureFamily: "harness",
+      phase: "cancel",
+      retryEligibility: "manual_retry_only",
+      summary: "Worker received a control-plane cancellation request.",
+      terminality: "cancelled",
+      userVisibility: "user_visible"
+    },
+    summary: "Worker received a control-plane cancellation request.",
+    terminalState: "cancelled",
+    verifierVerdict: null,
+    verdictDigest: null
+  };
+
+  const response = await control.submitFailure(request, buildJobAuthContext());
+
+  assert.deepEqual(response, {
+    acceptedAt: updateCalls[0]!.values.updatedAt.toISOString(),
+    attemptState: "cancelled",
+    jobState: "cancelled",
+    runState: "cancelled"
+  });
+  assert.equal(selectCount, 1);
+  assert.equal(updateCalls.length, 4);
+  assert.equal(updateCalls[0]!.values.state, "cancelled");
+  assert.equal(updateCalls[0]!.values.stopReason, "manual_cancelled");
+  assert.equal(updateCalls[1]!.values.state, "cancelled");
+  assert.equal(updateCalls[2]!.values.state, "cancelled");
+  assert.equal(updateCalls[3]!.values.revokedAt instanceof Date, true);
+});
+
 test("submitFailure rejects synthetic pre-bundle refs for non-pre-bundle failure codes", async () => {
   const control = createInternalWorkerControlService({
     transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
@@ -3022,6 +3114,85 @@ test("heartbeat rotates the job token while extending the lease", async () => {
   assert.equal(updateCalls[2].state, "running");
   assert.equal(updateCalls[3].state, "active");
   assert.equal(updateCalls[4].state, "running");
+});
+
+test("heartbeat preserves the active lease when cancellation is requested", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerHeartbeatResponse>) => {
+      const tx = {
+        select() {
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([
+                    {
+                      artifactManifestDigest: "a".repeat(64),
+                      attemptState: "active",
+                      bundleDigest: "b".repeat(64),
+                      candidateDigest: "c".repeat(64),
+                      heartbeatTimeoutSeconds: 180,
+                      jobState: "cancel_requested",
+                      lastEventSequence: 2,
+                      leaseExpiresAt: new Date(Date.now() + 60_000),
+                      revokedAt: null,
+                      runState: "cancel_requested",
+                      verifierVerdict: {},
+                      workerInstanceId: "worker-instance-1",
+                      verdictDigest: "d".repeat(64)
+                    }
+                  ]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  return Promise.resolve([{ id: "lease-row-1" }]);
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.heartbeat(buildHeartbeatRequest(), buildJobAuthContext());
+
+  assert.equal(response.cancelRequested, true);
+  assert.ok(typeof response.jobToken === "string" && response.jobToken.length > 0);
+  assert.notEqual(response.jobToken, "job-token-1");
+  assert.ok(response.jobTokenExpiresAt);
+  assert.equal(response.leaseStatus, "cancel_requested");
+  assert.ok(typeof response.leaseExpiresAt === "string");
+  assert.equal(updateCalls.length, 2);
+  assert.equal(typeof updateCalls[0].jobTokenHash, "string");
+  assert.equal(updateCalls[0].lastEventSequence, 3);
+  assert.equal(updateCalls[0].lastHeartbeatAt instanceof Date, true);
+  assert.equal(updateCalls[0].leaseExpiresAt instanceof Date, true);
+  assert.equal("revokedAt" in updateCalls[0], false);
+  assert.equal(updateCalls[1].currentLifecycleState, "running");
+  assert.equal(updateCalls[1].lastHeartbeatAt instanceof Date, true);
 });
 
 test("heartbeat returns expired when lease renewal loses the race with recovery revocation", async () => {

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -2580,6 +2580,930 @@ test("claim terminal-fails expired started work before polling for new candidate
   assert.equal(updateCalls.some((call) => call.state === "claimed"), false);
 });
 
+test("claim terminal-fails expired cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "active",
+                        jobRowId: "job-row-1",
+                        jobState: "cancel_requested",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "cancel_requested",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+});
+
+test("claim terminal-fails expired active job-side cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "active",
+                        jobRowId: "job-row-1",
+                        jobState: "cancel_requested",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "running",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+});
+
+test("claim terminal-fails expired run-only cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "active",
+                        jobRowId: "job-row-1",
+                        jobState: "running",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "cancel_requested",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+});
+
+test("claim terminal-fails expired pre-start run-only cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "prepared",
+                        jobRowId: "job-row-1",
+                        jobState: "claimed",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "cancel_requested",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+  assert.equal(updateCalls.some((call) => call.state === "queued"), false);
+  assert.equal(updateCalls.some((call) => call.state === "claimed"), false);
+});
+
+test("claim terminal-fails expired pre-start fully cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "prepared",
+                        jobRowId: "job-row-1",
+                        jobState: "cancel_requested",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "cancel_requested",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+  assert.equal(updateCalls.some((call) => call.state === "queued"), false);
+  assert.equal(updateCalls.some((call) => call.state === "claimed"), false);
+});
+
+test("claim terminal-fails expired pre-start cancel_requested work before polling for new candidates", async () => {
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const insertCalls: Array<Record<string, unknown>> = [];
+  let selectCount = 0;
+  const fakeDb = {
+    transaction: async (callback: (tx: unknown) => Promise<WorkerClaimResponse>) => {
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return Promise.resolve([
+                      {
+                        attemptRowId: "attempt-row-1",
+                        attemptState: "prepared",
+                        jobRowId: "job-row-1",
+                        jobState: "cancel_requested",
+                        leaseRowId: "lease-row-1",
+                        runRowId: "run-row-1",
+                        runState: "running",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          if (selectCount === 2) {
+            return {
+              from() {
+                return {
+                  where() {
+                    return Promise.resolve([]);
+                  }
+                };
+              }
+            };
+          }
+
+          return {
+            from() {
+              return {
+                innerJoin() {
+                  return this;
+                },
+                leftJoin() {
+                  return this;
+                },
+                where() {
+                  return this;
+                },
+                orderBy() {
+                  return this;
+                },
+                limit() {
+                  return Promise.resolve([]);
+                }
+              };
+            }
+          };
+        },
+        update() {
+          return {
+            set(values: Record<string, unknown>) {
+              updateCalls.push(values);
+
+              return {
+                where() {
+                  return this;
+                },
+                returning() {
+                  if (updateCalls.length === 1) {
+                    return Promise.resolve([
+                      {
+                        leaseRowId: "lease-row-1",
+                        workerInstanceId: "stale-worker-instance-3"
+                      }
+                    ]);
+                  }
+
+                  return Promise.resolve([{ id: "updated-row-1" }]);
+                }
+              };
+            }
+          };
+        },
+        insert() {
+          return {
+            values(values: Record<string, unknown>) {
+              insertCalls.push(values);
+
+              if (insertCalls.length === 1) {
+                return {
+                  onConflictDoNothing() {
+                    return {
+                      returning() {
+                        return Promise.resolve([{ id: "pool-def-1" }]);
+                      }
+                    };
+                  }
+                };
+              }
+
+              return {
+                onConflictDoUpdate() {
+                  return {
+                    returning() {
+                      return Promise.resolve([{ id: "worker-instance-1" }]);
+                    }
+                  };
+                }
+              };
+            }
+          };
+        }
+      };
+
+      return callback(tx);
+    }
+  };
+  const control = createInternalWorkerControlService(fakeDb as never);
+
+  const response = await control.claim(buildClaimRequest());
+
+  assert.deepEqual(response, {
+    leaseStatus: "idle",
+    pollAfterSeconds: 30,
+    workerJob: null
+  });
+  assert.equal(selectCount, 3);
+  assert.equal(insertCalls.length, 2);
+  assert.equal(insertCalls[1]?.currentLifecycleState, "ready");
+  assert.equal(updateCalls.length, 5);
+  assert.equal(updateCalls[0].revokedAt instanceof Date, true);
+  assert.equal(updateCalls[1].state, "failed");
+  assert.equal(updateCalls[1].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[2].state, "failed");
+  assert.equal(updateCalls[2].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[3].state, "failed");
+  assert.equal(updateCalls[3].primaryFailureCode, "worker_lease_lost");
+  assert.equal(updateCalls[4].currentLifecycleState, "ready");
+  assert.equal(updateCalls.some((call) => call.state === "cancelled"), false);
+  assert.equal(updateCalls.some((call) => call.state === "queued"), false);
+  assert.equal(updateCalls.some((call) => call.state === "claimed"), false);
+});
+
 test("claim keeps any still-unrevoked lease row blocking candidate selection", async () => {
   let capturedLeaseJoin: SQL | null = null;
   const insertCalls: Array<Record<string, unknown>> = [];

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -320,8 +320,15 @@ async function processClaimedJob(
 
     await refreshLease(leaseState, apiBaseUrl, dependencies);
 
-    if (leaseState.cancelRequested) {
-      return "cancelled";
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request before execution started."
+      )
+    ) {
+      return "completed";
     }
 
     if (leaseState.leaseLost) {
@@ -436,8 +443,15 @@ async function processClaimedJob(
       }
     );
 
-    if (leaseState.cancelRequested) {
-      return "cancelled";
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request before the attempt entered execution."
+      )
+    ) {
+      return "completed";
     }
 
     if (leaseState.leaseLost) {
@@ -468,8 +482,15 @@ async function processClaimedJob(
         workspaceRoot: leaseRoots.attemptWorkspaceRoot
       });
     } catch (error) {
-      if (leaseState.cancelRequested) {
-        return "cancelled";
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker stopped after a control-plane cancellation request during attempt execution."
+        )
+      ) {
+        return "completed";
       }
 
       if (leaseState.leaseLost) {
@@ -488,8 +509,15 @@ async function processClaimedJob(
     leaseState.currentPhase = "finalize";
     leaseState.progressMessage = "Preparing terminal worker submission.";
 
-    if (leaseState.cancelRequested) {
-      return "cancelled";
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request before terminal submission."
+      )
+    ) {
+      return "completed";
     }
 
     if (leaseState.leaseLost) {
@@ -498,8 +526,15 @@ async function processClaimedJob(
 
     await refreshLease(leaseState, apiBaseUrl, dependencies);
 
-    if (leaseState.cancelRequested) {
-      return "cancelled";
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request while preparing terminal submission."
+      )
+    ) {
+      return "completed";
     }
 
     if (leaseState.leaseLost) {
@@ -536,6 +571,21 @@ async function processClaimedJob(
       }
     );
 
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request after artifact registration."
+      )
+    ) {
+      return "completed";
+    }
+
+    if (leaseState.leaseLost) {
+      return "lease_lost";
+    }
+
     await appendWorkerEvent(
       leaseState,
       apiBaseUrl,
@@ -548,6 +598,21 @@ async function processClaimedJob(
         verdictDigest: bundleSubmission.verdictDigest
       }
     );
+
+    if (
+      await submitCancellationIfRequested(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "Worker received a control-plane cancellation request after bundle finalization."
+      )
+    ) {
+      return "completed";
+    }
+
+    if (leaseState.leaseLost) {
+      return "lease_lost";
+    }
 
     if (bundleSubmission.verifierVerdict.result === "pass") {
       const resultResponse = await submitWorkerResult(
@@ -849,9 +914,12 @@ async function submitHarnessFailure(
   leaseState: ActiveLeaseState,
   apiBaseUrl: string,
   dependencies: WorkerClaimLoopResolvedDependencies,
-  failure: WorkerFailureClassification
+  failure: WorkerFailureClassification,
+  options: {
+    allowCancelRequested?: boolean;
+  } = {}
 ): Promise<void> {
-  if (leaseState.cancelRequested || leaseState.leaseLost) {
+  if (leaseState.leaseLost || (leaseState.cancelRequested && !options.allowCancelRequested)) {
     return;
   }
 
@@ -873,6 +941,53 @@ async function submitHarnessFailure(
     verifierVerdict: null,
     verdictDigest: null
   });
+}
+
+async function submitCancellationIfRequested(
+  leaseState: ActiveLeaseState,
+  apiBaseUrl: string,
+  dependencies: WorkerClaimLoopResolvedDependencies,
+  summary = "Worker received a control-plane cancellation request."
+): Promise<boolean> {
+  if (!leaseState.cancelRequested || leaseState.leaseLost) {
+    return false;
+  }
+
+  try {
+    await submitHarnessFailure(
+      leaseState,
+      apiBaseUrl,
+      dependencies,
+      buildStaticFailure({
+        summary,
+        failureCode: "manual_cancelled",
+        phase: "cancel"
+      }),
+      {
+        allowCancelRequested: true
+      }
+    );
+  } catch (error) {
+    if (isLeaseLossControlError(error)) {
+      leaseState.heartbeatErrorMessage = error instanceof Error ? error.message : String(error);
+      leaseState.leaseLost = true;
+      return false;
+    }
+
+    throw error;
+  }
+
+  return true;
+}
+
+function isLeaseLossControlError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /invalid_worker_job_token|worker_lease_not_active|worker_lease_not_found/u.test(
+    error.message
+  );
 }
 
 function assertExpectedBenchmarkIdentity(

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -154,6 +154,14 @@ type PreparedBundleSubmission = {
   verdictDigest: string;
 };
 
+type CancellationTerminalContext = {
+  artifactIds: string[];
+  artifactManifestDigest: string;
+  artifacts: Pick<WorkerArtifactManifestResponse["artifacts"][number], "artifactRole" | "relativePath">[];
+  bundleDigest: string;
+  candidateDigest: string;
+};
+
 type LeaseFilesystemRoots = {
   attemptOutputRoot: string;
   attemptWorkspaceRoot: string;
@@ -557,6 +565,13 @@ async function processClaimedJob(
         recordedAt: dependencies.now().toISOString()
       }
     );
+    const cancellationTerminalContext: CancellationTerminalContext = {
+      artifactIds: manifestResponse.artifacts.map((artifact) => artifact.artifactId),
+      artifactManifestDigest: bundleSubmission.artifactManifestDigest,
+      artifacts: manifestResponse.artifacts,
+      bundleDigest: bundleSubmission.bundleDigest,
+      candidateDigest: bundleSubmission.candidateDigest
+    };
 
     await appendWorkerEvent(
       leaseState,
@@ -576,7 +591,8 @@ async function processClaimedJob(
         leaseState,
         apiBaseUrl,
         dependencies,
-        "Worker received a control-plane cancellation request after artifact registration."
+        "Worker received a control-plane cancellation request after artifact registration.",
+        cancellationTerminalContext
       )
     ) {
       return "completed";
@@ -604,7 +620,8 @@ async function processClaimedJob(
         leaseState,
         apiBaseUrl,
         dependencies,
-        "Worker received a control-plane cancellation request after bundle finalization."
+        "Worker received a control-plane cancellation request after bundle finalization.",
+        cancellationTerminalContext
       )
     ) {
       return "completed";
@@ -947,24 +964,47 @@ async function submitCancellationIfRequested(
   leaseState: ActiveLeaseState,
   apiBaseUrl: string,
   dependencies: WorkerClaimLoopResolvedDependencies,
-  summary = "Worker received a control-plane cancellation request."
+  summary = "Worker received a control-plane cancellation request.",
+  terminalContext: CancellationTerminalContext | null = null
 ): Promise<boolean> {
   if (!leaseState.cancelRequested || leaseState.leaseLost) {
     return false;
   }
 
-  try {
-    await submitHarnessFailure(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      buildStaticFailure({
+  leaseState.currentPhase = "cancel";
+  leaseState.progressMessage = summary;
+  const failure = terminalContext
+    ? buildSelectedArtifactFallbackFailure(terminalContext.artifacts, {
         summary,
         failureCode: "manual_cancelled",
         phase: "cancel"
-      }),
+      })
+    : buildStaticFailure({
+        summary,
+        failureCode: "manual_cancelled",
+        phase: "cancel"
+      });
+
+  try {
+    await submitWorkerFailure(
+      leaseState,
+      apiBaseUrl,
+      dependencies,
       {
-        allowCancelRequested: true
+        artifactIds: terminalContext?.artifactIds ?? [],
+        artifactManifestDigest: terminalContext?.artifactManifestDigest ?? null,
+        attemptId: leaseState.job.attemptId,
+        bundleDigest: terminalContext?.bundleDigest ?? null,
+        candidateDigest: terminalContext?.candidateDigest ?? null,
+        failedAt: dependencies.now().toISOString(),
+        failure,
+        jobId: leaseState.job.jobId,
+        leaseId: leaseState.job.leaseId,
+        runId: leaseState.job.runId,
+        summary,
+        terminalState: "cancelled",
+        verifierVerdict: null,
+        verdictDigest: null
       }
     );
   } catch (error) {

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -800,6 +800,13 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
         `/internal/worker/jobs/${workerJob.jobId}/failure`
       ]
     );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
+    assert.equal(failureBody.artifactManifestDigest, artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, bundleDigest);
+    assert.equal(failureBody.candidateDigest, candidateDigest);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.equal(failureBody.terminalState, "cancelled");
     assert.equal(calls.at(-1)?.token, "job-token-4");
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
@@ -1003,6 +1010,13 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
         `/internal/worker/jobs/${workerJob.jobId}/failure`
       ]
     );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
+    assert.equal(failureBody.artifactManifestDigest, artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, bundleDigest);
+    assert.equal(failureBody.candidateDigest, candidateDigest);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.equal(failureBody.terminalState, "cancelled");
     assert.equal(calls.at(-1)?.token, "job-token-4");
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -223,7 +223,7 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
   }
 });
 
-test("runWorkerClaimLoop exits explicitly when the first heartbeat requests cancellation", async () => {
+test("runWorkerClaimLoop terminalizes cancellation after the first cancel-requested heartbeat", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-cancel-"));
 
   try {
@@ -244,12 +244,21 @@ test("runWorkerClaimLoop exits explicitly when the first heartbeat requests canc
           body: {
             acknowledgedEventSequence: 0,
             cancelRequested: true,
-            jobToken: null,
+            jobToken: "job-token-2",
             jobTokenExpiresAt: fixedNow.toISOString(),
             leaseExpiresAt: fixedNow.toISOString(),
             leaseStatus: "cancel_requested"
           },
           path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "cancelled",
+            jobState: "cancelled",
+            runState: "cancelled"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
         }
       ],
       calls
@@ -296,14 +305,705 @@ test("runWorkerClaimLoop exits explicitly when the first heartbeat requests canc
     assert.equal(attemptRunnerCalled, false);
     assert.deepEqual(result, {
       claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(failureBody.failure.phase, "cancel");
+    assert.equal(failureBody.terminalState, "cancelled");
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, [
+      "worker-control/pre-bundle-failure"
+    ]);
+    assert.equal(calls.at(-1)?.token, "job-token-2");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop terminalizes cancellation after control-plane cancel during finalization", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-finalize-cancel-"));
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1,
+            cancelRequested: true,
+            jobToken: "job-token-3",
+            leaseStatus: "cancel_requested"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "cancelled",
+            jobState: "cancelled",
+            runState: "cancelled"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+    let attemptRunnerCalled = false;
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          attemptRunnerCalled = true;
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.equal(attemptRunnerCalled, true);
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(failureBody.failure.phase, "cancel");
+    assert.equal(failureBody.terminalState, "cancelled");
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop treats bounded cancel-finalization window loss as lease loss instead of crashing", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-finalize-cancel-expired-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1,
+            cancelRequested: true,
+            jobToken: "job-token-3",
+            leaseStatus: "cancel_requested"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            error: "worker_lease_not_active"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`,
+          status: 409
+        }
+      ],
+      calls
+    );
+    let attemptRunnerCalled = false;
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          attemptRunnerCalled = true;
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.equal(attemptRunnerCalled, true);
+    assert.deepEqual(result, {
+      claimedJobs: 1,
       completedJobs: 0,
       idlePollCount: 0,
       stoppedReason: "max_jobs_reached"
     });
     assert.deepEqual(
       calls.map((call) => call.path),
-      ["/internal/worker/claims", `/internal/worker/jobs/${workerJob.jobId}/heartbeat`]
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
     );
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss after artifact registration", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-late-finalize-cancel-expired-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    let heartbeatCount = 0;
+    let sleepCount = 0;
+    let releaseLateCancelHeartbeat: (() => void) | null = null;
+    let resolveLateCancelHeartbeatSeen: (() => void) | null = null;
+    const lateCancelHeartbeatReleased = new Promise<void>((resolve) => {
+      releaseLateCancelHeartbeat = resolve;
+    });
+    const lateCancelHeartbeatSeen = new Promise<void>((resolve) => {
+      resolveLateCancelHeartbeatSeen = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+      const body = bodyText.length > 0 ? JSON.parse(bodyText) : null;
+
+      calls.push({
+        body,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 1,
+              jobToken: "job-token-3"
+            })
+          );
+        }
+
+        if (heartbeatCount === 3) {
+          resolveLateCancelHeartbeatSeen?.();
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 1,
+              cancelRequested: true,
+              jobToken: "job-token-4",
+              leaseStatus: "cancel_requested"
+            })
+          );
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        if (body.sequence === 2) {
+          releaseLateCancelHeartbeat?.();
+          await lateCancelHeartbeatSeen;
+        }
+
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: body.sequence
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/artifacts`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          artifactManifestDigest,
+          artifacts: artifactEntries.map((artifact, index) => ({
+            artifactId: `artifact-${index + 1}`,
+            artifactRole: artifact.artifactRole,
+            relativePath: artifact.relativePath
+          }))
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        return new Response(JSON.stringify({ error: "worker_lease_not_active" }), {
+          headers: {
+            "content-type": "application/json"
+          },
+          status: 409
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {
+          sleepCount += 1;
+
+          if (sleepCount === 1) {
+            await lateCancelHeartbeatReleased;
+            return;
+          }
+
+          return neverSleep();
+        }
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 0,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    assert.equal(calls.at(-1)?.token, "job-token-4");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss after bundle finalization", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-post-bundle-cancel-expired-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    let heartbeatCount = 0;
+    let sleepCount = 0;
+    let releaseLateCancelHeartbeat: (() => void) | null = null;
+    let resolveLateCancelHeartbeatSeen: (() => void) | null = null;
+    const lateCancelHeartbeatReleased = new Promise<void>((resolve) => {
+      releaseLateCancelHeartbeat = resolve;
+    });
+    const lateCancelHeartbeatSeen = new Promise<void>((resolve) => {
+      resolveLateCancelHeartbeatSeen = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+      const body = bodyText.length > 0 ? JSON.parse(bodyText) : null;
+
+      calls.push({
+        body,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 1,
+              jobToken: "job-token-3"
+            })
+          );
+        }
+
+        if (heartbeatCount === 3) {
+          resolveLateCancelHeartbeatSeen?.();
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 2,
+              cancelRequested: true,
+              jobToken: "job-token-4",
+              leaseStatus: "cancel_requested"
+            })
+          );
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        if (body.sequence === 3) {
+          releaseLateCancelHeartbeat?.();
+          await lateCancelHeartbeatSeen;
+        }
+
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: body.sequence
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/artifacts`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          artifactManifestDigest,
+          artifacts: artifactEntries.map((artifact, index) => ({
+            artifactId: `artifact-${index + 1}`,
+            artifactRole: artifact.artifactRole,
+            relativePath: artifact.relativePath
+          }))
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        return new Response(JSON.stringify({ error: "worker_lease_not_active" }), {
+          headers: {
+            "content-type": "application/json"
+          },
+          status: 409
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {
+          sleepCount += 1;
+
+          if (sleepCount === 1) {
+            await lateCancelHeartbeatReleased;
+            return;
+          }
+
+          return neverSleep();
+        }
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 0,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    assert.equal(calls.at(-1)?.token, "job-token-4");
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {


### PR DESCRIPTION
## Summary
- renew the worker lease and job token when heartbeat observes cancel_requested
- terminalize control-plane cancellation with bounded manual_cancelled failures and degrade to lease_lost if the bounded window is missed
- add API and worker regressions for first-heartbeat cancel, mid-finalize cancel, and both late-finalize lease-loss checkpoints

## Verification
- 
ode --import tsx --test test/internal-worker.test.ts in pps/api
- 
ode --import tsx --test test/worker-claim-loop.test.ts in pps/worker
- un run test:api
- un run build

## Notes
- un --cwd apps/worker test still has the same 6 unrelated CLI exit-code failures already present on current main.

Closes #1004