### PR TITLE
Fix mixed pending access request and recovery state

### DIFF
--- a/apps/api/drizzle/0015_uneven_argent.sql
+++ b/apps/api/drizzle/0015_uneven_argent.sql
@@ -1,0 +1,2 @@
+DROP INDEX "access_requests_active_pending_email_unique";--> statement-breakpoint
+CREATE UNIQUE INDEX "access_requests_active_pending_email_kind_unique" ON "access_requests" USING btree ("email","request_kind") WHERE "access_requests"."status" = 'pending';

--- a/apps/api/drizzle/meta/0015_snapshot.json
+++ b/apps/api/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,3920 @@
+{
+  "id": "66c55096-3f0a-4f1a-b9c6-941e68a1a3c4",
+  "prevId": "a3baabff-beb6-4ec1-ae40-b5d440699801",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_requests": {
+      "name": "access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_kind": {
+          "name": "request_kind",
+          "type": "access_request_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'access_request'"
+        },
+        "requested_role": {
+          "name": "requested_role",
+          "type": "access_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "access_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_identity_provider": {
+          "name": "requested_identity_provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_identity_subject": {
+          "name": "requested_identity_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "access_requests_email_idx": {
+          "name": "access_requests_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_requested_identity_subject_idx": {
+          "name": "access_requests_requested_identity_subject_idx",
+          "columns": [
+            {
+              "expression": "requested_identity_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_identity_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_status_idx": {
+          "name": "access_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "access_requests_active_pending_email_kind_unique": {
+          "name": "access_requests_active_pending_email_kind_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"access_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_requests_requested_by_user_id_users_id_fk": {
+          "name": "access_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "access_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "access_requests_reviewed_by_user_id_users_id_fk": {
+          "name": "access_requests_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "access_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "artifact_class_id": {
+          "name": "artifact_class_id",
+          "type": "artifact_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_scope": {
+          "name": "owner_scope",
+          "type": "artifact_owner_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relative_path": {
+          "name": "relative_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_for_ingest": {
+          "name": "required_for_ingest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "artifact_storage_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_name": {
+          "name": "bucket_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix_family": {
+          "name": "prefix_family",
+          "type": "artifact_prefix_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_encoding": {
+          "name": "content_encoding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_etag": {
+          "name": "provider_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "artifact_lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_detected_at": {
+          "name": "missing_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artifacts_storage_locator_unique": {
+          "name": "artifacts_storage_locator_unique",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_attempt_relative_path_unique": {
+          "name": "artifacts_attempt_relative_path_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relative_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"artifacts\".\"attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_run_id_idx": {
+          "name": "artifacts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_attempt_id_lifecycle_state_idx": {
+          "name": "artifacts_attempt_id_lifecycle_state_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_run_id_artifact_class_idx": {
+          "name": "artifacts_run_id_artifact_class_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_manifest_digest_idx": {
+          "name": "artifacts_manifest_digest_idx",
+          "columns": [
+            {
+              "expression": "artifact_manifest_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artifacts_sha256_idx": {
+          "name": "artifacts_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artifacts_run_id_runs_id_fk": {
+          "name": "artifacts_run_id_runs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_job_id_jobs_id_fk": {
+          "name": "artifacts_job_id_jobs_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artifacts_attempt_id_attempts_id_fk": {
+          "name": "artifacts_attempt_id_attempts_id_fk",
+          "tableFrom": "artifacts",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempts": {
+      "name": "attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_attempt_id": {
+          "name": "source_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "attempt_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_result": {
+          "name": "verifier_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_digest": {
+          "name": "benchmark_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_package_digest": {
+          "name": "prompt_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_protocol_version": {
+          "name": "prompt_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_family": {
+          "name": "provider_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_snapshot_id": {
+          "name": "model_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_profile": {
+          "name": "tool_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_revision": {
+          "name": "harness_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_version": {
+          "name": "verifier_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_digest": {
+          "name": "candidate_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_digest": {
+          "name": "verdict_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_digest": {
+          "name": "environment_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_classification": {
+          "name": "failure_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verifier_verdict": {
+          "name": "verifier_verdict",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_summary": {
+          "name": "usage_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attempts_run_id_idx": {
+          "name": "attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_job_id_idx": {
+          "name": "attempts_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_state_idx": {
+          "name": "attempts_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_source_attempt_id_unique": {
+          "name": "attempts_source_attempt_id_unique",
+          "columns": [
+            {
+              "expression": "source_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attempts_bundle_digest_unique": {
+          "name": "attempts_bundle_digest_unique",
+          "columns": [
+            {
+              "expression": "bundle_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attempts_run_id_runs_id_fk": {
+          "name": "attempts_run_id_runs_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempts_job_id_jobs_id_fk": {
+          "name": "attempts_job_id_jobs_id_fk",
+          "tableFrom": "attempts",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "audit_actor_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_kind": {
+          "name": "subject_kind",
+          "type": "audit_subject_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "audit_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_created_at_idx": {
+          "name": "audit_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_event_id_idx": {
+          "name": "audit_events_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_target_user_id_idx": {
+          "name": "audit_events_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_events_target_user_id_users_id_fk": {
+          "name": "audit_events_target_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_releases": {
+      "name": "benchmark_releases",
+      "schema": "",
+      "columns": {
+        "benchmark_release_id": {
+          "name": "benchmark_release_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_label": {
+          "name": "release_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "benchmark_release_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "benchmark_release_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_only'"
+        },
+        "methodology_artifact_refs": {
+          "name": "methodology_artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_artifact_refs": {
+          "name": "summary_artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_payload": {
+          "name": "summary_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "benchmark_releases_benchmark_version_id_idx": {
+          "name": "benchmark_releases_benchmark_version_id_idx",
+          "columns": [
+            {
+              "expression": "benchmark_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_public_version_unique": {
+          "name": "benchmark_releases_public_version_unique",
+          "columns": [
+            {
+              "expression": "benchmark_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"benchmark_releases\".\"status\" = 'published' and \"benchmark_releases\".\"visibility\" = 'public'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_status_idx": {
+          "name": "benchmark_releases_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_releases_status_visibility_published_at_idx": {
+          "name": "benchmark_releases_status_visibility_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "benchmark_releases_benchmark_version_id_benchmark_versions_benchmark_version_id_fk": {
+          "name": "benchmark_releases_benchmark_version_id_benchmark_versions_benchmark_version_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "benchmark_versions",
+          "columnsFrom": [
+            "benchmark_version_id"
+          ],
+          "columnsTo": [
+            "benchmark_version_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "benchmark_releases_approved_by_user_id_users_id_fk": {
+          "name": "benchmark_releases_approved_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "benchmark_releases_created_by_user_id_users_id_fk": {
+          "name": "benchmark_releases_created_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_releases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_versions": {
+      "name": "benchmark_versions",
+      "schema": "",
+      "columns": {
+        "benchmark_version_id": {
+          "name": "benchmark_version_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_freeze_id": {
+          "name": "package_freeze_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_version": {
+          "name": "package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_digest": {
+          "name": "package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_family": {
+          "name": "benchmark_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_label": {
+          "name": "scope_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_set_definition": {
+          "name": "item_set_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launchability": {
+          "name": "launchability",
+          "type": "benchmark_version_launchability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal_only'"
+        },
+        "display_label": {
+          "name": "display_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "benchmark_versions_launchability_idx": {
+          "name": "benchmark_versions_launchability_idx",
+          "columns": [
+            {
+              "expression": "launchability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_versions_package_digest_idx": {
+          "name": "benchmark_versions_package_digest_idx",
+          "columns": [
+            {
+              "expression": "package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "benchmark_versions_package_freeze_id_package_freezes_id_fk": {
+          "name": "benchmark_versions_package_freeze_id_package_freezes_id_fk",
+          "tableFrom": "benchmark_versions",
+          "tableTo": "package_freezes",
+          "columnsFrom": [
+            "package_freeze_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "benchmark_versions_created_by_user_id_users_id_fk": {
+          "name": "benchmark_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "benchmark_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_link_intents": {
+      "name": "identity_link_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_provider": {
+          "name": "target_provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_path": {
+          "name": "redirect_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_link_intents_active_user_provider_unique": {
+          "name": "identity_link_intents_active_user_provider_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"identity_link_intents\".\"used_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_link_intents_expires_at_idx": {
+          "name": "identity_link_intents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_link_intents_user_id_idx": {
+          "name": "identity_link_intents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_link_intents_user_id_users_id_fk": {
+          "name": "identity_link_intents_user_id_users_id_fk",
+          "tableFrom": "identity_link_intents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "job_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_run_id_idx": {
+          "name": "jobs_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_state_idx": {
+          "name": "jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_source_job_id_idx": {
+          "name": "jobs_source_job_id_idx",
+          "columns": [
+            {
+              "expression": "source_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_run_id_runs_id_fk": {
+          "name": "jobs_run_id_runs_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_freezes": {
+      "name": "package_freezes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repo_sync_record_id": {
+          "name": "repo_sync_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "math_package_candidate_id": {
+          "name": "math_package_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_version": {
+          "name": "package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_digest": {
+          "name": "package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_family": {
+          "name": "benchmark_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_commit_sha": {
+          "name": "repo_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_tree_path": {
+          "name": "repo_tree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "package_freeze_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_freezes_repo_sync_record_id_unique": {
+          "name": "package_freezes_repo_sync_record_id_unique",
+          "columns": [
+            {
+              "expression": "repo_sync_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "package_freezes_package_digest_unique": {
+          "name": "package_freezes_package_digest_unique",
+          "columns": [
+            {
+              "expression": "package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "package_freezes_math_package_candidate_id_idx": {
+          "name": "package_freezes_math_package_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "math_package_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_freezes_repo_sync_record_id_repo_sync_records_id_fk": {
+          "name": "package_freezes_repo_sync_record_id_repo_sync_records_id_fk",
+          "tableFrom": "package_freezes",
+          "tableTo": "repo_sync_records",
+          "columnsFrom": [
+            "repo_sync_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "package_freezes_created_by_user_id_users_id_fk": {
+          "name": "package_freezes_created_by_user_id_users_id_fk",
+          "tableFrom": "package_freezes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_sync_records": {
+      "name": "repo_sync_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "math_package_candidate_id": {
+          "name": "math_package_candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_repo_path": {
+          "name": "target_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_sha": {
+          "name": "merge_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "repo_sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_by_user_id": {
+          "name": "last_updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repo_sync_records_status_idx": {
+          "name": "repo_sync_records_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_sync_records_math_package_candidate_id_idx": {
+          "name": "repo_sync_records_math_package_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "math_package_candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repo_sync_records_repo_pr_unique": {
+          "name": "repo_sync_records_repo_pr_unique",
+          "columns": [
+            {
+              "expression": "repo_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"repo_sync_records\".\"pull_request_number\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repo_sync_records_recorded_by_user_id_users_id_fk": {
+          "name": "repo_sync_records_recorded_by_user_id_users_id_fk",
+          "tableFrom": "repo_sync_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repo_sync_records_last_updated_by_user_id_users_id_fk": {
+          "name": "repo_sync_records_last_updated_by_user_id_users_id_fk",
+          "tableFrom": "repo_sync_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "last_updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_grants": {
+      "name": "role_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "access_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_user_id": {
+          "name": "granted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_grants_active_user_unique": {
+          "name": "role_grants_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"role_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_grants_user_id_idx": {
+          "name": "role_grants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_grants_role_idx": {
+          "name": "role_grants_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_grants_user_id_users_id_fk": {
+          "name": "role_grants_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_grants_granted_by_user_id_users_id_fk": {
+          "name": "role_grants_granted_by_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "role_grants_revoked_by_user_id_users_id_fk": {
+          "name": "role_grants_revoked_by_user_id_users_id_fk",
+          "tableFrom": "role_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "revoked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single_run'"
+        },
+        "state": {
+          "name": "state",
+          "type": "run_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict_class": {
+          "name": "verdict_class",
+          "type": "evaluation_verdict_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_id": {
+          "name": "benchmark_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_version": {
+          "name": "benchmark_package_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_package_digest": {
+          "name": "benchmark_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmark_item_id": {
+          "name": "benchmark_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lane_id": {
+          "name": "lane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_protocol_version": {
+          "name": "prompt_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_package_digest": {
+          "name": "prompt_package_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_mode": {
+          "name": "run_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_profile": {
+          "name": "tool_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "harness_revision": {
+          "name": "harness_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_version": {
+          "name": "verifier_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_family": {
+          "name": "provider_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_snapshot_id": {
+          "name": "model_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_digest": {
+          "name": "environment_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_config_digest": {
+          "name": "run_config_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stop_reason": {
+          "name": "stop_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_failure_family": {
+          "name": "primary_failure_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_code": {
+          "name": "primary_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_failure_summary": {
+          "name": "primary_failure_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_source_run_id_unique": {
+          "name": "runs_source_run_id_unique",
+          "columns": [
+            {
+              "expression": "source_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_bundle_digest_unique": {
+          "name": "runs_bundle_digest_unique",
+          "columns": [
+            {
+              "expression": "bundle_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_state_idx": {
+          "name": "runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_verdict_class_idx": {
+          "name": "runs_verdict_class_idx",
+          "columns": [
+            {
+              "expression": "verdict_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_benchmark_digest_idx": {
+          "name": "runs_benchmark_digest_idx",
+          "columns": [
+            {
+              "expression": "benchmark_package_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_run_config_digest_idx": {
+          "name": "runs_run_config_digest_idx",
+          "columns": [
+            {
+              "expression": "run_config_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_identity_id_idx": {
+          "name": "sessions_identity_id_idx",
+          "columns": [
+            {
+              "expression": "identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_identity_owner_fk": {
+          "name": "sessions_identity_owner_fk",
+          "tableFrom": "sessions",
+          "tableTo": "user_identities",
+          "columnsFrom": [
+            "identity_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_identities": {
+      "name": "user_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_subject": {
+          "name": "provider_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_email": {
+          "name": "provider_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_identities_provider_subject_unique": {
+          "name": "user_identities_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_id_user_id_unique": {
+          "name": "user_identities_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_user_id_idx": {
+          "name": "user_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_users_id_fk": {
+          "name": "user_identities_user_id_users_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_attempt_events": {
+      "name": "worker_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "worker_execution_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_kind": {
+          "name": "event_kind",
+          "type": "worker_execution_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_attempt_events_attempt_sequence_unique": {
+          "name": "worker_attempt_events_attempt_sequence_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_attempt_events_attempt_recorded_at_idx": {
+          "name": "worker_attempt_events_attempt_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_attempt_events_lease_id_idx": {
+          "name": "worker_attempt_events_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_attempt_events_run_id_runs_id_fk": {
+          "name": "worker_attempt_events_run_id_runs_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_job_id_jobs_id_fk": {
+          "name": "worker_attempt_events_job_id_jobs_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_attempt_id_attempts_id_fk": {
+          "name": "worker_attempt_events_attempt_id_attempts_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_attempt_events_lease_id_worker_job_leases_id_fk": {
+          "name": "worker_attempt_events_lease_id_worker_job_leases_id_fk",
+          "tableFrom": "worker_attempt_events",
+          "tableTo": "worker_job_leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_instances": {
+      "name": "worker_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_pool_definition_id": {
+          "name": "worker_pool_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_lifecycle_state": {
+          "name": "current_lifecycle_state",
+          "type": "worker_instance_lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_claim_at": {
+          "name": "last_claim_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_lease_activity_at": {
+          "name": "last_lease_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_instances_worker_id_unique": {
+          "name": "worker_instances_worker_id_unique",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_instances_pool_state_idx": {
+          "name": "worker_instances_pool_state_idx",
+          "columns": [
+            {
+              "expression": "worker_pool_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_lifecycle_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_instances_last_heartbeat_at_idx": {
+          "name": "worker_instances_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_instances_worker_pool_definition_id_worker_pool_definitions_id_fk": {
+          "name": "worker_instances_worker_pool_definition_id_worker_pool_definitions_id_fk",
+          "tableFrom": "worker_instances",
+          "tableTo": "worker_pool_definitions",
+          "columnsFrom": [
+            "worker_pool_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_job_leases": {
+      "name": "worker_job_leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_pool": {
+          "name": "worker_pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_interval_seconds": {
+          "name": "heartbeat_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_timeout_seconds": {
+          "name": "heartbeat_timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_hash": {
+          "name": "job_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_expires_at": {
+          "name": "job_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_token_scopes": {
+          "name": "job_token_scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_job_leases_active_job_unique": {
+          "name": "worker_job_leases_active_job_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"worker_job_leases\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_active_attempt_unique": {
+          "name": "worker_job_leases_active_attempt_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"worker_job_leases\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_job_token_hash_unique": {
+          "name": "worker_job_leases_job_token_hash_unique",
+          "columns": [
+            {
+              "expression": "job_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_run_id_idx": {
+          "name": "worker_job_leases_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_job_id_idx": {
+          "name": "worker_job_leases_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_attempt_id_idx": {
+          "name": "worker_job_leases_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_worker_instance_id_idx": {
+          "name": "worker_job_leases_worker_instance_id_idx",
+          "columns": [
+            {
+              "expression": "worker_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_job_leases_lease_expires_at_idx": {
+          "name": "worker_job_leases_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "worker_job_leases_run_id_runs_id_fk": {
+          "name": "worker_job_leases_run_id_runs_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_job_id_jobs_id_fk": {
+          "name": "worker_job_leases_job_id_jobs_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_attempt_id_attempts_id_fk": {
+          "name": "worker_job_leases_attempt_id_attempts_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_job_leases_worker_instance_id_worker_instances_id_fk": {
+          "name": "worker_job_leases_worker_instance_id_worker_instances_id_fk",
+          "tableFrom": "worker_job_leases",
+          "tableTo": "worker_instances",
+          "columnsFrom": [
+            "worker_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_pool_definitions": {
+      "name": "worker_pool_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_pool": {
+          "name": "worker_pool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_runtime": {
+          "name": "worker_runtime",
+          "type": "worker_runtime",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_rollout_class": {
+          "name": "default_rollout_class",
+          "type": "worker_pool_rollout_class",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "ownership_summary": {
+          "name": "ownership_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "worker_pool_definitions_worker_pool_unique": {
+          "name": "worker_pool_definitions_worker_pool_unique",
+          "columns": [
+            {
+              "expression": "worker_pool",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "worker_pool_definitions_worker_runtime_idx": {
+          "name": "worker_pool_definitions_worker_runtime_idx",
+          "columns": [
+            {
+              "expression": "worker_runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_request_kind": {
+      "name": "access_request_kind",
+      "schema": "public",
+      "values": [
+        "access_request",
+        "identity_recovery"
+      ]
+    },
+    "public.access_request_status": {
+      "name": "access_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "withdrawn"
+      ]
+    },
+    "public.access_role": {
+      "name": "access_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "collaborator",
+        "helper"
+      ]
+    },
+    "public.artifact_class": {
+      "name": "artifact_class",
+      "schema": "public",
+      "values": [
+        "run_manifest",
+        "package_reference",
+        "prompt_package",
+        "candidate_source",
+        "verdict_record",
+        "compiler_output",
+        "compiler_diagnostics",
+        "verifier_output",
+        "environment_snapshot",
+        "usage_summary",
+        "execution_trace"
+      ]
+    },
+    "public.artifact_lifecycle_state": {
+      "name": "artifact_lifecycle_state",
+      "schema": "public",
+      "values": [
+        "registered",
+        "available",
+        "missing",
+        "quarantined",
+        "deleted"
+      ]
+    },
+    "public.artifact_owner_scope": {
+      "name": "artifact_owner_scope",
+      "schema": "public",
+      "values": [
+        "run_attempt",
+        "benchmark_version",
+        "run_export"
+      ]
+    },
+    "public.artifact_prefix_family": {
+      "name": "artifact_prefix_family",
+      "schema": "public",
+      "values": [
+        "run_artifacts",
+        "run_logs",
+        "run_traces",
+        "run_bundles",
+        "benchmark_source",
+        "benchmark_reports"
+      ]
+    },
+    "public.artifact_storage_provider": {
+      "name": "artifact_storage_provider",
+      "schema": "public",
+      "values": [
+        "cloudflare_r2"
+      ]
+    },
+    "public.attempt_state": {
+      "name": "attempt_state",
+      "schema": "public",
+      "values": [
+        "prepared",
+        "active",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.audit_actor_kind": {
+      "name": "audit_actor_kind",
+      "schema": "public",
+      "values": [
+        "portal_user",
+        "internal_service",
+        "system_bootstrap"
+      ]
+    },
+    "public.audit_severity": {
+      "name": "audit_severity",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "critical"
+      ]
+    },
+    "public.audit_subject_kind": {
+      "name": "audit_subject_kind",
+      "schema": "public",
+      "values": [
+        "access_request",
+        "benchmark_release",
+        "benchmark_version",
+        "benchmark_workflow",
+        "role_grant",
+        "run",
+        "user_identity",
+        "worker_pool",
+        "worker_instance",
+        "worker_incident",
+        "worker_rollout"
+      ]
+    },
+    "public.benchmark_release_status": {
+      "name": "benchmark_release_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "published"
+      ]
+    },
+    "public.benchmark_release_visibility": {
+      "name": "benchmark_release_visibility",
+      "schema": "public",
+      "values": [
+        "internal_only",
+        "held_out",
+        "public"
+      ]
+    },
+    "public.benchmark_version_launchability": {
+      "name": "benchmark_version_launchability",
+      "schema": "public",
+      "values": [
+        "internal_only",
+        "launchable"
+      ]
+    },
+    "public.evaluation_verdict_class": {
+      "name": "evaluation_verdict_class",
+      "schema": "public",
+      "values": [
+        "pass",
+        "fail",
+        "invalid_result"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "cloudflare_one_time_pin",
+        "cloudflare_github",
+        "cloudflare_google"
+      ]
+    },
+    "public.job_state": {
+      "name": "job_state",
+      "schema": "public",
+      "values": [
+        "queued",
+        "claimed",
+        "running",
+        "cancel_requested",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.package_freeze_status": {
+      "name": "package_freeze_status",
+      "schema": "public",
+      "values": [
+        "active"
+      ]
+    },
+    "public.repo_sync_status": {
+      "name": "repo_sync_status",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "pr_open",
+        "merged",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.run_kind": {
+      "name": "run_kind",
+      "schema": "public",
+      "values": [
+        "full_benchmark",
+        "benchmark_slice",
+        "single_run",
+        "repeated_n"
+      ]
+    },
+    "public.run_state": {
+      "name": "run_state",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "running",
+        "cancel_requested",
+        "succeeded",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.worker_execution_event_kind": {
+      "name": "worker_execution_event_kind",
+      "schema": "public",
+      "values": [
+        "attempt_started",
+        "compile_started",
+        "compile_succeeded",
+        "compile_failed",
+        "compile_repair_requested",
+        "compile_repair_applied",
+        "verifier_started",
+        "verifier_passed",
+        "verifier_failed",
+        "verifier_repair_requested",
+        "verifier_repair_applied",
+        "budget_exhausted",
+        "artifact_manifest_written",
+        "bundle_finalized"
+      ]
+    },
+    "public.worker_execution_phase": {
+      "name": "worker_execution_phase",
+      "schema": "public",
+      "values": [
+        "prepare",
+        "generate",
+        "tool",
+        "compile",
+        "verify",
+        "finalize",
+        "cancel"
+      ]
+    },
+    "public.worker_instance_lifecycle_state": {
+      "name": "worker_instance_lifecycle_state",
+      "schema": "public",
+      "values": [
+        "registering",
+        "ready",
+        "claiming",
+        "running",
+        "draining",
+        "unhealthy",
+        "recovering",
+        "terminated"
+      ]
+    },
+    "public.worker_pool_rollout_class": {
+      "name": "worker_pool_rollout_class",
+      "schema": "public",
+      "values": [
+        "stable",
+        "canary",
+        "quarantine"
+      ]
+    },
+    "public.worker_runtime": {
+      "name": "worker_runtime",
+      "schema": "public",
+      "values": [
+        "local_docker",
+        "modal"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775814000000,
       "tag": "0014_even_miracleman",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1776008430940,
+      "tag": "0015_uneven_argent",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/auth/resolve-access-rbac-context.ts
+++ b/apps/api/src/auth/resolve-access-rbac-context.ts
@@ -56,10 +56,13 @@ async function getActiveRoles(db: DbClient, userId: string) {
   return grants.map(({ role }) => role);
 }
 
-async function getLatestAccessRequestByEmail(db: DbClient, email: string) {
+async function getLatestStandardAccessRequestByEmail(db: DbClient, email: string) {
   return db.query.accessRequests.findFirst({
     orderBy: [desc(accessRequests.createdAt)],
-    where: eq(accessRequests.email, email)
+    where: and(
+      eq(accessRequests.email, email),
+      eq(accessRequests.requestKind, "access_request")
+    )
   });
 }
 
@@ -131,7 +134,7 @@ export async function resolveAccessRbacContext(
       };
     }
 
-    const latestRequest = await getLatestAccessRequestByEmail(
+    const latestRequest = await getLatestStandardAccessRequestByEmail(
       db,
       linkedIdentity.user.email
     );
@@ -181,7 +184,10 @@ export async function resolveAccessRbacContext(
   const activeMatchingUserRoles = matchingUser
     ? await getActiveRoles(db, matchingUser.id)
     : [];
-  const latestRequest = await getLatestAccessRequestByEmail(db, normalizedIdentityEmail);
+  const latestRequest = await getLatestStandardAccessRequestByEmail(
+    db,
+    normalizedIdentityEmail
+  );
 
   if (matchingUser && activeMatchingUserRoles.length > 0) {
     const pendingRecoveryRequest = identity.provider

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -314,8 +314,10 @@ export const accessRequests = pgTable(
       table.requestedIdentitySubject
     ),
     statusIndex: index("access_requests_status_idx").on(table.status),
-    activePendingEmailUnique: uniqueIndex("access_requests_active_pending_email_unique")
-      .on(table.email)
+    activePendingEmailKindUnique: uniqueIndex(
+      "access_requests_active_pending_email_kind_unique"
+    )
+      .on(table.email, table.requestKind)
       .where(sql`${table.status} = 'pending'`)
   })
 );

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -91,7 +91,7 @@ function isPendingAccessRequestConflict(error: unknown) {
 
   return (
     databaseCode === "23505" &&
-    constraintName === "access_requests_active_pending_email_unique"
+    constraintName === "access_requests_active_pending_email_kind_unique"
   );
 }
 
@@ -868,6 +868,8 @@ export function registerPortalRoutes(
     async (request) => {
       const identity = request.accessIdentity;
       const accessContext = request.accessRbacContext;
+      const pendingRequestId =
+        accessContext?.status === "pending" ? accessContext.requestId : null;
       const pendingUserId =
         accessContext?.status === "pending" ? accessContext.userId : null;
       const canUsePendingFallback = accessContext?.status === "pending";
@@ -892,21 +894,33 @@ export function registerPortalRoutes(
               identity.provider,
               identity.subject,
             );
+      const currentPendingRequest =
+        pendingRequestId
+          ? await db.query.accessRequests.findFirst({
+              where: eq(accessRequests.id, pendingRequestId),
+            })
+          : null;
 
       const latestRequest =
+        (currentPendingRequest?.requestKind === "access_request"
+          ? currentPendingRequest
+          : null) ??
         (linkedIdentity
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(
-                accessRequests.requestedByUserId,
-                linkedIdentity.userId,
+              where: and(
+                eq(accessRequests.requestedByUserId, linkedIdentity.userId),
+                eq(accessRequests.requestKind, "access_request"),
               ),
             })
           : null) ??
         (pendingUserId
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(accessRequests.requestedByUserId, pendingUserId),
+              where: and(
+                eq(accessRequests.requestedByUserId, pendingUserId),
+                eq(accessRequests.requestKind, "access_request"),
+              ),
             })
           : null) ??
         (canUsePendingFallback && accessEmail
@@ -914,6 +928,7 @@ export function registerPortalRoutes(
               orderBy: [desc(accessRequests.createdAt)],
               where: and(
                 eq(accessRequests.email, accessEmail),
+                eq(accessRequests.requestKind, "access_request"),
                 eq(accessRequests.status, "pending"),
               ),
             })
@@ -921,7 +936,10 @@ export function registerPortalRoutes(
         (accessEmail
           ? await db.query.accessRequests.findFirst({
               orderBy: [desc(accessRequests.createdAt)],
-              where: eq(accessRequests.email, accessEmail),
+              where: and(
+                eq(accessRequests.email, accessEmail),
+                eq(accessRequests.requestKind, "access_request"),
+              ),
             })
           : null);
 
@@ -1600,7 +1618,10 @@ export function registerPortalRoutes(
 
           const existingRequest = await tx.query.accessRequests.findFirst({
             orderBy: [desc(accessRequests.createdAt)],
-            where: eq(accessRequests.email, accessEmail),
+            where: and(
+              eq(accessRequests.email, accessEmail),
+              eq(accessRequests.requestKind, "access_request"),
+            ),
           });
 
           if (
@@ -1690,6 +1711,7 @@ export function registerPortalRoutes(
             orderBy: [desc(accessRequests.createdAt)],
             where: and(
               eq(accessRequests.email, accessEmail),
+              eq(accessRequests.requestKind, "access_request"),
               eq(accessRequests.status, "pending"),
             ),
           });
@@ -1820,7 +1842,10 @@ export function registerPortalRoutes(
           const recoveryRole = activeRoleRows[0]?.role ?? "helper";
           const existingRequest = await tx.query.accessRequests.findFirst({
             orderBy: [desc(accessRequests.createdAt)],
-            where: eq(accessRequests.email, accessEmail),
+            where: and(
+              eq(accessRequests.email, accessEmail),
+              eq(accessRequests.requestKind, "identity_recovery"),
+            ),
           });
 
           if (
@@ -1918,6 +1943,7 @@ export function registerPortalRoutes(
             orderBy: [desc(accessRequests.createdAt)],
             where: and(
               eq(accessRequests.email, accessEmail),
+              eq(accessRequests.requestKind, "identity_recovery"),
               eq(accessRequests.status, "pending"),
             ),
           });

--- a/apps/api/test/identity-binding.test.ts
+++ b/apps/api/test/identity-binding.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PgDialect } from "drizzle-orm/pg-core";
 import {
   createPortalAccessSession
 } from "../src/auth/portal-access-session.ts";
@@ -7,6 +8,8 @@ import { resolveAccessIdentityProvider } from "../src/auth/require-access.ts";
 import {
   resolveAccessRbacContext
 } from "../src/auth/resolve-access-rbac-context.ts";
+
+const pgDialect = new PgDialect();
 
 test("resolveAccessIdentityProvider keeps the provider unset when no provider hint is present", () => {
   assert.equal(
@@ -158,6 +161,70 @@ test("resolveAccessRbacContext denies providerless assertions without probing su
   assert.deepEqual(context, {
     email: "person@example.com",
     reason: "identity_recovery_required",
+    status: "denied",
+    subject: "shared-subject"
+  });
+});
+
+test("resolveAccessRbacContext ignores recovery rows when resolving standard access-request posture", async () => {
+  const recoveryRequest = {
+    createdAt: new Date("2026-04-12T15:30:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "request-1",
+    rationale: "Need to relink my provider",
+    requestKind: "identity_recovery" as const,
+    requestedByUserId: "user-1",
+    requestedIdentityProvider: "cloudflare_google" as const,
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper" as const,
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending" as const
+  };
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async (options: { where: unknown }) => {
+          const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+          return renderedWhere.sql.includes("\"request_kind\"") &&
+            renderedWhere.params.includes("access_request")
+            ? null
+            : recoveryRequest;
+        }
+      },
+      userIdentities: {
+        findFirst: async () => null
+      },
+      users: {
+        findFirst: async () => ({
+          email: "person@example.com",
+          id: "user-1"
+        })
+      }
+    },
+    select() {
+      return {
+        from() {
+          return {
+            where: async () => []
+          };
+        }
+      };
+    }
+  };
+
+  const context = await resolveAccessRbacContext(db as never, {
+    email: "person@example.com",
+    issuer: "https://paretoproof.cloudflareaccess.com",
+    provider: "cloudflare_google",
+    subject: "shared-subject"
+  });
+
+  assert.deepEqual(context, {
+    email: "person@example.com",
+    reason: "access_request_required",
     status: "denied",
     subject: "shared-subject"
   });

--- a/apps/api/test/portal-access-identity-binding.test.ts
+++ b/apps/api/test/portal-access-identity-binding.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
+import { PgDialect } from "drizzle-orm/pg-core";
 import {
   accessRequests,
   auditEvents,
@@ -10,16 +11,20 @@ import {
 } from "../src/db/schema.ts";
 import { registerPortalRoutes } from "../src/routes/portal.ts";
 
+const pgDialect = new PgDialect();
+
 function createAuthenticatedAccessGuard(
   identityOverrides: Partial<{
     email: string;
     issuer: string;
     provider: "cloudflare_google" | null;
     subject: string;
-  }> = {}
+  }> = {},
+  accessRbacContext: Record<string, unknown> | null = null
 ) {
   return () => (
     request: {
+      accessRbacContext?: Record<string, unknown>;
       accessIdentity?: {
         email: string;
         issuer: string;
@@ -37,6 +42,11 @@ function createAuthenticatedAccessGuard(
       subject: "shared-subject",
       ...identityOverrides
     };
+
+    if (accessRbacContext) {
+      request.accessRbacContext = accessRbacContext;
+    }
+
     done();
   };
 }
@@ -356,4 +366,503 @@ test("POST /portal/access-recovery rejects requests whose verified provider is s
     error: "identity_provider_required"
   });
   assert.equal(transactionCalled, false);
+});
+
+test("POST /portal/access-requests does not rewrite a pending recovery row for the same email", async (t) => {
+  const existingRecoveryRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:05:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "88888888-8888-4888-8888-888888888888",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const createdRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:10:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "99999999-9999-4999-8999-999999999999",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const insertedRequestRows: Array<typeof accessRequests.$inferInsert> = [];
+  const app = Fastify();
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => {
+          values: (value: unknown) => {
+            returning?: () => Promise<unknown[]>;
+          };
+        };
+        query: {
+          accessRequests: { findFirst: (options: { where: unknown }) => Promise<typeof accessRequests.$inferSelect | null> };
+          userIdentities: { findFirst: () => Promise<null> };
+          users: { findFirst: () => Promise<{ email: string; id: string; identities: unknown[] }> };
+        };
+        select: () => {
+          from: (_table: unknown) => {
+            where: (_where: unknown) => Promise<Array<{ role: typeof roleGrants.$inferSelect.role }>>;
+          };
+        };
+        update: (table: unknown) => unknown;
+      }) => Promise<unknown>
+    ) =>
+      callback({
+        insert(table: unknown) {
+          return {
+            values(value: unknown) {
+              if (table === userIdentities || table === auditEvents) {
+                return Promise.resolve(value);
+              }
+
+              if (table === accessRequests) {
+                insertedRequestRows.push(value as typeof accessRequests.$inferInsert);
+                return {
+                  returning: async () => [createdRequest]
+                };
+              }
+
+              throw new Error("unexpected insert");
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async (options: { where: unknown }) => {
+              const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+              return renderedWhere.params.includes("access_request")
+                ? null
+                : existingRecoveryRequest;
+            }
+          },
+          userIdentities: {
+            findFirst: async () => null
+          },
+          users: {
+            findFirst: async () => ({
+              email: "person@example.com",
+              id: "22222222-2222-4222-8222-222222222222",
+              identities: []
+            })
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => []
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("access requests should not rewrite pending recovery rows");
+        }
+      } as never)
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, db as never, createAuthenticatedAccessGuard(), {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need helper access",
+      requestedRole: "helper"
+    },
+    url: "/portal/access-requests"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.id, createdRequest.id);
+  assert.equal(response.json().item.requestKind, "access_request");
+  assert.equal(insertedRequestRows.length, 1);
+  assert.equal(insertedRequestRows[0]?.requestKind, "access_request");
+});
+
+test("POST /portal/access-recovery does not rewrite a pending standard access request for the same email", async (t) => {
+  const existingAccessRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:05:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const createdRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:10:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const insertedRequestRows: Array<typeof accessRequests.$inferInsert> = [];
+  const app = Fastify();
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => {
+          values: (value: unknown) => {
+            returning?: () => Promise<unknown[]>;
+          };
+        };
+        query: {
+          accessRequests: { findFirst: (options: { where: unknown }) => Promise<typeof accessRequests.$inferSelect | null> };
+          userIdentities: { findFirst: () => Promise<null> };
+          users: { findFirst: () => Promise<{ email: string; id: string }> };
+        };
+        select: () => {
+          from: (_table: unknown) => {
+            where: (_where: unknown) => Promise<Array<{ role: typeof roleGrants.$inferSelect.role }>>;
+          };
+        };
+        update: (table: unknown) => unknown;
+      }) => Promise<unknown>
+    ) =>
+      callback({
+        insert(table: unknown) {
+          return {
+            values(value: unknown) {
+              if (table === auditEvents) {
+                return Promise.resolve(value);
+              }
+
+              if (table === accessRequests) {
+                insertedRequestRows.push(value as typeof accessRequests.$inferInsert);
+                return {
+                  returning: async () => [createdRequest]
+                };
+              }
+
+              throw new Error("unexpected insert");
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async (options: { where: unknown }) => {
+              const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+              return renderedWhere.params.includes("identity_recovery")
+                ? null
+                : existingAccessRequest;
+            }
+          },
+          userIdentities: {
+            findFirst: async () => null
+          },
+          users: {
+            findFirst: async () => ({
+              email: "person@example.com",
+              id: "22222222-2222-4222-8222-222222222222"
+            })
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => [{ role: "helper" }]
+              };
+            }
+          };
+        },
+        update() {
+          throw new Error("access recovery should not rewrite pending access-request rows");
+        }
+      } as never)
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, db as never, createAuthenticatedAccessGuard(), {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      rationale: "Need to recover my Google login"
+    },
+    url: "/portal/access-recovery"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.id, createdRequest.id);
+  assert.equal(response.json().item.requestKind, "identity_recovery");
+  assert.equal(insertedRequestRows.length, 1);
+  assert.equal(insertedRequestRows[0]?.requestKind, "identity_recovery");
+});
+
+test("GET /portal/access-requests/me returns the pending request referenced by access context", async (t) => {
+  const pendingAccessRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const newerRecoveryRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:10:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const app = Fastify();
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async (options: { where: unknown }) => {
+          const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+          if (renderedWhere.params.includes(pendingAccessRequest.id)) {
+            return pendingAccessRequest;
+          }
+
+          return newerRecoveryRequest;
+        }
+      },
+      userIdentities: {
+        findFirst: async () => null
+      }
+    }
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    db as never,
+    createAuthenticatedAccessGuard(
+      {},
+      {
+        email: "person@example.com",
+        requestId: pendingAccessRequest.id,
+        status: "pending",
+        subject: "shared-subject",
+        userId: "22222222-2222-4222-8222-222222222222"
+      }
+    ),
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/access-requests/me"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.id, pendingAccessRequest.id);
+  assert.equal(response.json().item.requestKind, "access_request");
+});
+
+test("GET /portal/access-requests/me ignores pending recovery rows referenced by access context", async (t) => {
+  const latestStandardAccessRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "abababab-abab-4bab-8bab-abababababab",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const pendingRecoveryRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:10:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const app = Fastify();
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async (options: { where: unknown }) => {
+          const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+          if (renderedWhere.params.includes(pendingRecoveryRequest.id)) {
+            return pendingRecoveryRequest;
+          }
+
+          return renderedWhere.params.includes("access_request")
+            ? latestStandardAccessRequest
+            : pendingRecoveryRequest;
+        }
+      },
+      userIdentities: {
+        findFirst: async () => null
+      }
+    }
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    db as never,
+    createAuthenticatedAccessGuard(
+      {},
+      {
+        email: "person@example.com",
+        requestId: pendingRecoveryRequest.id,
+        status: "pending",
+        subject: "shared-subject",
+        userId: "22222222-2222-4222-8222-222222222222"
+      }
+    ),
+    {
+      resolvePortalAccess: async () => null
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/access-requests/me"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.id, latestStandardAccessRequest.id);
+  assert.equal(response.json().item.requestKind, "access_request");
+});
+
+test("GET /portal/access-requests/me ignores recovery rows when resolving standard access-request history by email", async (t) => {
+  const latestStandardAccessRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    rationale: "Need helper access",
+    requestKind: "access_request",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: null,
+    requestedIdentitySubject: null,
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const newerRecoveryRequest: typeof accessRequests.$inferSelect = {
+    createdAt: new Date("2026-04-10T15:10:00.000Z"),
+    decisionNote: null,
+    email: "person@example.com",
+    id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    rationale: "Need to recover my Google login",
+    requestKind: "identity_recovery",
+    requestedByUserId: "22222222-2222-4222-8222-222222222222",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "shared-subject",
+    requestedRole: "helper",
+    reviewedAt: null,
+    reviewedByUserId: null,
+    status: "pending"
+  };
+  const app = Fastify();
+  const db = {
+    query: {
+      accessRequests: {
+        findFirst: async (options: { where: unknown }) => {
+          const renderedWhere = pgDialect.sqlToQuery(options.where as never);
+
+          return renderedWhere.params.includes("access_request")
+            ? latestStandardAccessRequest
+            : newerRecoveryRequest;
+        }
+      },
+      userIdentities: {
+        findFirst: async () => null
+      }
+    }
+  };
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(app, db as never, createAuthenticatedAccessGuard(), {
+    resolvePortalAccess: async () => null
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/access-requests/me"
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().item.id, latestStandardAccessRequest.id);
+  assert.equal(response.json().item.requestKind, "access_request");
 });


### PR DESCRIPTION
## Summary
- separate pending access request uniqueness from identity recovery by `(email, request_kind)`
- scope portal write and read paths to the correct request kind so recovery rows do not drive standard access state
- add API regressions for the split write paths and `/portal/access-requests/me` recovery edge cases

## Testing
- bun test test/portal-access-identity-binding.test.ts
- bun test test/identity-binding.test.ts
- bun run test:api
- bun run build

Closes #997