### PR TITLE
Make admin approval conflicts rollback side effects

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -61,6 +61,13 @@ type AuditEventWithActor = DbAuditEventRow & {
   actorUser: DbUserRow | null;
 };
 
+class AccessRequestApprovalConflictError extends Error {
+  constructor(readonly requestRow: DbAccessRequestRow | null) {
+    super("Access request approval lost the pending-state race.");
+    this.name = "AccessRequestApprovalConflictError";
+  }
+}
+
 type AdminUserRelations = DbUserRow & {
   accessRequests: AccessRequestWithReviewer[];
   auditEventsAsTarget: AuditEventWithActor[];
@@ -814,222 +821,234 @@ export function registerAdminRoutes(
       const actorUserId = getAdminActorUserId(request);
       const accessRequestId = (request.params as { accessRequestId?: string }).accessRequestId;
 
-      const result = await db.transaction(async (tx) => {
-        const requestRow = await tx.query.accessRequests.findFirst({
-          where: eq(accessRequests.id, accessRequestId ?? "")
-        });
+      const result = await (async () => {
+        try {
+          return await db.transaction(async (tx) => {
+            const requestRow = await tx.query.accessRequests.findFirst({
+              where: eq(accessRequests.id, accessRequestId ?? "")
+            });
 
-        if (!requestRow) {
-          return {
-            kind: "not_found" as const
-          };
-        }
+            if (!requestRow) {
+              return {
+                kind: "not_found" as const
+              };
+            }
 
-        if (requestRow.status !== "pending") {
-          return {
-            kind: "conflict" as const,
-            requestRow
-          };
-        }
+            if (requestRow.status !== "pending") {
+              return {
+                kind: "conflict" as const,
+                requestRow
+              };
+            }
 
-        const targetUser =
-          requestRow.requestedByUserId
-            ? await tx.query.users.findFirst({
-                where: eq(users.id, requestRow.requestedByUserId)
-              })
-            : await tx.query.users.findFirst({
-                where: eq(users.email, requestRow.email)
-              });
+            const targetUser =
+              requestRow.requestedByUserId
+                ? await tx.query.users.findFirst({
+                    where: eq(users.id, requestRow.requestedByUserId)
+                  })
+                : await tx.query.users.findFirst({
+                    where: eq(users.email, requestRow.email)
+                  });
 
-        if (!targetUser) {
-          return {
-            kind: "target_user_missing" as const,
-            requestRow
-          };
-        }
+            if (!targetUser) {
+              return {
+                kind: "target_user_missing" as const,
+                requestRow
+              };
+            }
 
-        const now = new Date();
-        let linkedIdentityAuditEvent: typeof auditEvents.$inferInsert | null = null;
+            const now = new Date();
+            let linkedIdentityAuditEvent: typeof auditEvents.$inferInsert | null = null;
 
-        if (requestRow.requestKind === "identity_recovery") {
-          const requestedIdentitySubject = requestRow.requestedIdentitySubject;
-          const requestedIdentityProvider = requestRow.requestedIdentityProvider;
+            if (requestRow.requestKind === "identity_recovery") {
+              const requestedIdentitySubject = requestRow.requestedIdentitySubject;
+              const requestedIdentityProvider = requestRow.requestedIdentityProvider;
 
-          if (!requestedIdentitySubject || !requestedIdentityProvider) {
-            return {
-              kind: "recovery_identity_missing" as const,
-              requestRow
-            };
-          }
+              if (!requestedIdentitySubject || !requestedIdentityProvider) {
+                return {
+                  kind: "recovery_identity_missing" as const,
+                  requestRow
+                };
+              }
 
-          const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
-            await tx.query.userIdentities.findFirst({
-              where: buildUserIdentityProviderSubjectMatch(
+              const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
+                await tx.query.userIdentities.findFirst({
+                  where: buildUserIdentityProviderSubjectMatch(
+                    requestedIdentityProvider,
+                    requestedIdentitySubject
+                  )
+                }),
                 requestedIdentityProvider,
                 requestedIdentitySubject
-              )
-            }),
-            requestedIdentityProvider,
-            requestedIdentitySubject
-          );
+              );
 
-          if (existingSubjectOwner && existingSubjectOwner.userId !== targetUser.id) {
-            return {
-              conflictUserId: existingSubjectOwner.userId,
-              kind: "recovery_identity_conflict" as const,
-              requestRow
-            };
-          }
-        } else {
-          const linkedIdentity = await tx.query.userIdentities.findFirst({
-            where: eq(userIdentities.userId, targetUser.id)
-          });
+              if (existingSubjectOwner && existingSubjectOwner.userId !== targetUser.id) {
+                return {
+                  conflictUserId: existingSubjectOwner.userId,
+                  kind: "recovery_identity_conflict" as const,
+                  requestRow
+                };
+              }
+            } else {
+              const linkedIdentity = await tx.query.userIdentities.findFirst({
+                where: eq(userIdentities.userId, targetUser.id)
+              });
 
-          if (!linkedIdentity) {
-            return {
-              kind: "identity_link_required" as const,
-              requestRow
-            };
-          }
-        }
+              if (!linkedIdentity) {
+                return {
+                  kind: "identity_link_required" as const,
+                  requestRow
+                };
+              }
+            }
 
-        const activeRoleRows = await tx
-          .select({
-            id: roleGrants.id,
-            role: roleGrants.role
-          })
-          .from(roleGrants)
-          .where(and(eq(roleGrants.userId, targetUser.id), isNull(roleGrants.revokedAt)));
+            const activeRoleRows = await tx
+              .select({
+                id: roleGrants.id,
+                role: roleGrants.role
+              })
+              .from(roleGrants)
+              .where(and(eq(roleGrants.userId, targetUser.id), isNull(roleGrants.revokedAt)));
 
-        if (requestRow.requestKind === "identity_recovery") {
-          const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
-            await tx.query.userIdentities.findFirst({
-              where: buildUserIdentityProviderSubjectMatch(
+            if (requestRow.requestKind === "identity_recovery") {
+              const existingSubjectOwner = filterUserIdentityProviderSubjectMatch(
+                await tx.query.userIdentities.findFirst({
+                  where: buildUserIdentityProviderSubjectMatch(
+                    requestRow.requestedIdentityProvider!,
+                    requestRow.requestedIdentitySubject!
+                  )
+                }),
                 requestRow.requestedIdentityProvider!,
                 requestRow.requestedIdentitySubject!
-              )
-            }),
-            requestRow.requestedIdentityProvider!,
-            requestRow.requestedIdentitySubject!
-          );
+              );
 
-          if (!existingSubjectOwner) {
-            await tx.insert(userIdentities).values({
-              provider: requestRow.requestedIdentityProvider!,
-              providerEmail: requestRow.email,
-              providerSubject: requestRow.requestedIdentitySubject!,
-              userId: targetUser.id
-            });
-            linkedIdentityAuditEvent = {
-              actorKind: "portal_user" as const,
-              actorUserId,
-              eventId: "user_identity.linked",
-              payload: {
-                actorUserId,
-                identityProvider: requestRow.requestedIdentityProvider!,
-                identitySubject: requestRow.requestedIdentitySubject!,
-                targetUserId: targetUser.id
-              },
-              severity: "critical" as const,
-              subjectKind: "user_identity" as const,
-              targetUserId: targetUser.id
-            };
-          } else {
-            await tx
-              .update(userIdentities)
-              .set({
-                lastSeenAt: now,
-                providerEmail: requestRow.email
-              })
-              .where(eq(userIdentities.id, existingSubjectOwner.id));
-          }
-        } else {
-          if (activeRoleRows.length > 0) {
-            return {
-              kind: "already_approved" as const,
-              requestRow
-            };
-          }
-
-          await tx.insert(roleGrants).values({
-            grantedByUserId: actorUserId,
-            role: parsedBody.data.approvedRole,
-            userId: targetUser.id
-          });
-        }
-
-        const [reviewedRequest] = await tx
-          .update(accessRequests)
-          .set({
-            decisionNote: parsedBody.data.decisionNote,
-            reviewedAt: now,
-            reviewedByUserId: actorUserId,
-            status: "approved"
-          })
-          .where(
-            and(
-              eq(accessRequests.id, requestRow.id),
-              eq(accessRequests.status, "pending")
-            )
-          )
-          .returning();
-
-        if (!reviewedRequest) {
-          return {
-            kind: "conflict" as const,
-            requestRow: await tx.query.accessRequests.findFirst({
-              where: eq(accessRequests.id, requestRow.id)
-            })
-          };
-        }
-
-        const auditEventRows: Array<typeof auditEvents.$inferInsert> = [
-          {
-            actorKind: "portal_user" as const,
-            actorUserId,
-            eventId: "access_request.approved",
-            payload: {
-              accessRequestId: reviewedRequest.id,
-              actorUserId,
-              approvedRole:
-                requestRow.requestKind === "identity_recovery"
-                  ? requestRow.requestedRole
-                  : parsedBody.data.approvedRole,
-              requestKind: requestRow.requestKind,
-              targetUserId: targetUser.id
-            },
-            severity: "critical" as const,
-            subjectKind: "access_request" as const,
-            targetUserId: targetUser.id
-          },
-          ...(requestRow.requestKind === "identity_recovery"
-            ? linkedIdentityAuditEvent
-              ? [linkedIdentityAuditEvent]
-              : []
-            : [
-                {
+              if (!existingSubjectOwner) {
+                await tx.insert(userIdentities).values({
+                  provider: requestRow.requestedIdentityProvider!,
+                  providerEmail: requestRow.email,
+                  providerSubject: requestRow.requestedIdentitySubject!,
+                  userId: targetUser.id
+                });
+                linkedIdentityAuditEvent = {
                   actorKind: "portal_user" as const,
                   actorUserId,
-                  eventId: "role_grant.granted",
+                  eventId: "user_identity.linked",
                   payload: {
                     actorUserId,
-                    grantedRole: parsedBody.data.approvedRole,
+                    identityProvider: requestRow.requestedIdentityProvider!,
+                    identitySubject: requestRow.requestedIdentitySubject!,
                     targetUserId: targetUser.id
                   },
                   severity: "critical" as const,
-                  subjectKind: "role_grant" as const,
+                  subjectKind: "user_identity" as const,
                   targetUserId: targetUser.id
-                }
-              ])
-        ];
+                };
+              } else {
+                await tx
+                  .update(userIdentities)
+                  .set({
+                    lastSeenAt: now,
+                    providerEmail: requestRow.email
+                  })
+                  .where(eq(userIdentities.id, existingSubjectOwner.id));
+              }
+            } else {
+              if (activeRoleRows.length > 0) {
+                return {
+                  kind: "already_approved" as const,
+                  requestRow
+                };
+              }
 
-        await tx.insert(auditEvents).values(auditEventRows);
+              await tx.insert(roleGrants).values({
+                grantedByUserId: actorUserId,
+                role: parsedBody.data.approvedRole,
+                userId: targetUser.id
+              });
+            }
 
-        return {
-          item: reviewedRequest,
-          kind: "approved" as const
-        };
-      });
+            const [reviewedRequest] = await tx
+              .update(accessRequests)
+              .set({
+                decisionNote: parsedBody.data.decisionNote,
+                reviewedAt: now,
+                reviewedByUserId: actorUserId,
+                status: "approved"
+              })
+              .where(
+                and(
+                  eq(accessRequests.id, requestRow.id),
+                  eq(accessRequests.status, "pending")
+                )
+              )
+              .returning();
+
+            if (!reviewedRequest) {
+              throw new AccessRequestApprovalConflictError(
+                (await tx.query.accessRequests.findFirst({
+                  where: eq(accessRequests.id, requestRow.id)
+                })) ?? null
+              );
+            }
+
+            const auditEventRows: Array<typeof auditEvents.$inferInsert> = [
+              {
+                actorKind: "portal_user" as const,
+                actorUserId,
+                eventId: "access_request.approved",
+                payload: {
+                  accessRequestId: reviewedRequest.id,
+                  actorUserId,
+                  approvedRole:
+                    requestRow.requestKind === "identity_recovery"
+                      ? requestRow.requestedRole
+                      : parsedBody.data.approvedRole,
+                  requestKind: requestRow.requestKind,
+                  targetUserId: targetUser.id
+                },
+                severity: "critical" as const,
+                subjectKind: "access_request" as const,
+                targetUserId: targetUser.id
+              },
+              ...(requestRow.requestKind === "identity_recovery"
+                ? linkedIdentityAuditEvent
+                  ? [linkedIdentityAuditEvent]
+                  : []
+                : [
+                    {
+                      actorKind: "portal_user" as const,
+                      actorUserId,
+                      eventId: "role_grant.granted",
+                      payload: {
+                        actorUserId,
+                        grantedRole: parsedBody.data.approvedRole,
+                        targetUserId: targetUser.id
+                      },
+                      severity: "critical" as const,
+                      subjectKind: "role_grant" as const,
+                      targetUserId: targetUser.id
+                    }
+                  ])
+            ];
+
+            await tx.insert(auditEvents).values(auditEventRows);
+
+            return {
+              item: reviewedRequest,
+              kind: "approved" as const
+            };
+          });
+        } catch (error) {
+          if (error instanceof AccessRequestApprovalConflictError) {
+            return {
+              kind: "conflict" as const,
+              requestRow: error.requestRow
+            };
+          }
+
+          throw error;
+        }
+      })();
 
       if (result.kind === "not_found") {
         reply.code(404).send({

--- a/apps/api/test/admin-routes.test.ts
+++ b/apps/api/test/admin-routes.test.ts
@@ -974,6 +974,135 @@ test("POST /portal/admin/access-requests/:id/approve returns a stale-request con
   assert.equal(touchedWritePath, false);
 });
 
+test("POST /portal/admin/access-requests/:id/approve rolls back a late standard approval conflict", async (t) => {
+  const requestRow = buildAccessRequest();
+  const reviewedRequest = buildAccessRequest({
+    decisionNote: "Already handled elsewhere",
+    reviewedAt: new Date("2026-03-13T19:22:00.000Z"),
+    reviewedByUserId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    status: "approved"
+  });
+  const targetUser = buildUser();
+  const committedAuditEvents: Array<typeof auditEvents.$inferInsert> = [];
+  const committedRoleGrants: Array<typeof roleGrants.$inferInsert> = [];
+  let accessRequestReads = 0;
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => { values: (value: unknown) => Promise<unknown> };
+        query: {
+          accessRequests: { findFirst: () => Promise<typeof requestRow | typeof reviewedRequest> };
+          userIdentities: { findFirst: () => Promise<typeof userIdentities.$inferSelect> };
+          users: { findFirst: () => Promise<typeof targetUser> };
+        };
+        select: () => {
+          from: () => {
+            where: () => Promise<[]>;
+          };
+        };
+        update: (table: unknown) => {
+          set: (_value: unknown) => {
+            where: () => {
+              returning?: () => Promise<unknown[]>;
+            };
+          };
+        };
+      }) => Promise<unknown>
+    ) => {
+      const pendingAuditEvents: Array<typeof auditEvents.$inferInsert> = [];
+      const pendingRoleGrants: Array<typeof roleGrants.$inferInsert> = [];
+      const tx = {
+        insert(table: unknown) {
+          return {
+            values: async (value: unknown) => {
+              if (table === auditEvents) {
+                pendingAuditEvents.push(...(value as Array<typeof auditEvents.$inferInsert>));
+              }
+
+              if (table === roleGrants) {
+                pendingRoleGrants.push(value as typeof roleGrants.$inferInsert);
+              }
+
+              return value;
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async () => {
+              accessRequestReads += 1;
+              return accessRequestReads === 1 ? requestRow : reviewedRequest;
+            }
+          },
+          userIdentities: {
+            findFirst: async () => buildIdentity()
+          },
+          users: {
+            findFirst: async () => targetUser
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => []
+              };
+            }
+          };
+        },
+        update(table: unknown) {
+          return {
+            set(_value: unknown) {
+              return {
+                where() {
+                  if (table === accessRequests) {
+                    return {
+                      returning: async () => []
+                    };
+                  }
+
+                  return {};
+                }
+              };
+            }
+          };
+        }
+      };
+
+      try {
+        const result = await callback(tx as never);
+        committedAuditEvents.push(...pendingAuditEvents);
+        committedRoleGrants.push(...pendingRoleGrants);
+        return result;
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+  };
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerAdminRoutes(app, db as never, createAdminAccessGuard() as never);
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      approvedRole: "collaborator",
+      decisionNote: "Looks good"
+    } satisfies PortalAdminAccessRequestApproveInput,
+    url: `/portal/admin/access-requests/${requestRow.id}/approve`
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(response.json().error, "access_request_not_pending");
+  assert.equal(response.json().item.status, "approved");
+  assert.equal(committedRoleGrants.length, 0);
+  assert.equal(committedAuditEvents.length, 0);
+});
+
 test("POST /portal/admin/access-requests/:id/approve returns a recovery-specific conflict payload", async (t) => {
   const requestRow = buildAccessRequest({
     email: "recover@paretoproof.com",
@@ -1046,6 +1175,146 @@ test("POST /portal/admin/access-requests/:id/approve returns a recovery-specific
       status: requestRow.status
     }
   });
+});
+
+test("POST /portal/admin/access-requests/:id/approve rolls back a late recovery approval conflict", async (t) => {
+  const requestRow = buildAccessRequest({
+    email: "recover@paretoproof.com",
+    requestKind: "identity_recovery",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "recovery-subject",
+    requestedRole: "helper"
+  });
+  const reviewedRequest = buildAccessRequest({
+    decisionNote: "Recovered elsewhere",
+    email: "recover@paretoproof.com",
+    requestKind: "identity_recovery",
+    requestedIdentityProvider: "cloudflare_google",
+    requestedIdentitySubject: "recovery-subject",
+    requestedRole: "helper",
+    reviewedAt: new Date("2026-03-13T19:22:00.000Z"),
+    reviewedByUserId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    status: "approved"
+  });
+  const targetUser = buildUser();
+  const committedAuditEvents: Array<typeof auditEvents.$inferInsert> = [];
+  const committedUserIdentities: Array<typeof userIdentities.$inferInsert> = [];
+  let accessRequestReads = 0;
+  const db = {
+    transaction: async (
+      callback: (tx: {
+        insert: (table: unknown) => { values: (value: unknown) => Promise<unknown> };
+        query: {
+          accessRequests: { findFirst: () => Promise<typeof requestRow | typeof reviewedRequest> };
+          userIdentities: { findFirst: () => Promise<null> };
+          users: { findFirst: () => Promise<typeof targetUser> };
+        };
+        select: () => {
+          from: () => {
+            where: () => Promise<Array<{ id: string; role: string }>>;
+          };
+        };
+        update: (table: unknown) => {
+          set: (_value: unknown) => {
+            where: () => {
+              returning?: () => Promise<unknown[]>;
+            };
+          };
+        };
+      }) => Promise<unknown>
+    ) => {
+      const pendingAuditEvents: Array<typeof auditEvents.$inferInsert> = [];
+      const pendingUserIdentities: Array<typeof userIdentities.$inferInsert> = [];
+      const tx = {
+        insert(table: unknown) {
+          return {
+            values: async (value: unknown) => {
+              if (table === auditEvents) {
+                pendingAuditEvents.push(...(value as Array<typeof auditEvents.$inferInsert>));
+              }
+
+              if (table === userIdentities) {
+                pendingUserIdentities.push(value as typeof userIdentities.$inferInsert);
+              }
+
+              return value;
+            }
+          };
+        },
+        query: {
+          accessRequests: {
+            findFirst: async () => {
+              accessRequestReads += 1;
+              return accessRequestReads === 1 ? requestRow : reviewedRequest;
+            }
+          },
+          userIdentities: {
+            findFirst: async () => null
+          },
+          users: {
+            findFirst: async () => targetUser
+          }
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => [{ id: "existing-role-grant", role: "helper" }]
+              };
+            }
+          };
+        },
+        update(table: unknown) {
+          return {
+            set(_value: unknown) {
+              return {
+                where() {
+                  if (table === accessRequests) {
+                    return {
+                      returning: async () => []
+                    };
+                  }
+
+                  return {};
+                }
+              };
+            }
+          };
+        }
+      };
+
+      try {
+        const result = await callback(tx as never);
+        committedAuditEvents.push(...pendingAuditEvents);
+        committedUserIdentities.push(...pendingUserIdentities);
+        return result;
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+  };
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerAdminRoutes(app, db as never, createAdminAccessGuard() as never);
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      approvedRole: "helper",
+      decisionNote: "Recovered Google identity"
+    } satisfies PortalAdminAccessRequestApproveInput,
+    url: `/portal/admin/access-requests/${requestRow.id}/approve`
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(response.json().error, "access_request_not_pending");
+  assert.equal(response.json().item.status, "approved");
+  assert.equal(committedUserIdentities.length, 0);
+  assert.equal(committedAuditEvents.length, 0);
 });
 
 test("POST /portal/admin/access-requests/:id/approve does not duplicate a recovery identity that is already linked", async (t) => {


### PR DESCRIPTION
## Summary
- abort the approval transaction when the final pending-to-approved update loses the race
- map that rollback path back to the existing stale conflict response
- add rollback regressions for both the standard role-grant and recovery identity-link approval flows

## Testing
- bun test test/admin-routes.test.ts
- bun run test:api
- bun run build

Closes #998