### PR TITLE
Fix singular portal role contract

### DIFF
--- a/apps/api/src/auth/require-access.ts
+++ b/apps/api/src/auth/require-access.ts
@@ -60,7 +60,17 @@ declare module "fastify" {
 }
 
 function hasRole(context: AccessRbacContext, role: "admin" | "collaborator" | "helper") {
-  return context.status === "approved" && context.roles.includes(role);
+  if (context.status !== "approved") {
+    return false;
+  }
+
+  const roleRank = {
+    admin: 3,
+    collaborator: 2,
+    helper: 1
+  } as const;
+
+  return roleRank[context.role] >= roleRank[role];
 }
 
 function isAllowed(context: AccessRbacContext, requirement: RouteAccessRequirement) {
@@ -73,15 +83,11 @@ function isAllowed(context: AccessRbacContext, requirement: RouteAccessRequireme
   }
 
   if (requirement === "approved_helper_or_higher") {
-    return (
-      hasRole(context, "helper") ||
-      hasRole(context, "collaborator") ||
-      hasRole(context, "admin")
-    );
+    return hasRole(context, "helper");
   }
 
   if (requirement === "approved_collaborator_or_higher") {
-    return hasRole(context, "collaborator") || hasRole(context, "admin");
+    return hasRole(context, "collaborator");
   }
 
   return hasRole(context, "admin");

--- a/apps/api/src/auth/resolve-access-rbac-context.ts
+++ b/apps/api/src/auth/resolve-access-rbac-context.ts
@@ -39,13 +39,13 @@ export type AccessRbacContext =
   | {
       email: string;
       identityId: string;
-      roles: AccessRole[];
+      role: AccessRole;
       status: "approved";
       subject: string;
       userId: string;
     };
 
-async function getActiveRoles(db: DbClient, userId: string) {
+async function getActiveRole(db: DbClient, userId: string) {
   const grants = await db
     .select({
       role: roleGrants.role
@@ -53,7 +53,7 @@ async function getActiveRoles(db: DbClient, userId: string) {
     .from(roleGrants)
     .where(and(eq(roleGrants.userId, userId), isNull(roleGrants.revokedAt)));
 
-  return grants.map(({ role }) => role);
+  return grants[0]?.role ?? null;
 }
 
 async function getLatestStandardAccessRequestByEmail(db: DbClient, email: string) {
@@ -121,13 +121,13 @@ export async function resolveAccessRbacContext(
     : null;
 
   if (linkedIdentity) {
-    const roles = await getActiveRoles(db, linkedIdentity.user.id);
+    const role = await getActiveRole(db, linkedIdentity.user.id);
 
-    if (roles.length > 0) {
+    if (role) {
       return {
         email: linkedIdentity.user.email,
         identityId: linkedIdentity.id,
-        roles,
+        role,
         status: "approved",
         subject: identity.subject,
         userId: linkedIdentity.user.id
@@ -181,15 +181,15 @@ export async function resolveAccessRbacContext(
   const matchingUser = await db.query.users.findFirst({
     where: eq(users.email, normalizedIdentityEmail)
   });
-  const activeMatchingUserRoles = matchingUser
-    ? await getActiveRoles(db, matchingUser.id)
-    : [];
+  const activeMatchingUserRole = matchingUser
+    ? await getActiveRole(db, matchingUser.id)
+    : null;
   const latestRequest = await getLatestStandardAccessRequestByEmail(
     db,
     normalizedIdentityEmail
   );
 
-  if (matchingUser && activeMatchingUserRoles.length > 0) {
+  if (matchingUser && activeMatchingUserRole) {
     const pendingRecoveryRequest = identity.provider
       ? await getPendingRecoveryRequestForSubject(
           db,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -88,7 +88,7 @@ const adminAuditEchoEventIds = new Set([
 function getAdminActorUserId(request: FastifyRequest) {
   const context = request.accessRbacContext;
 
-  if (context?.status !== "approved" || !context.roles.includes("admin")) {
+  if (context?.status !== "approved" || context.role !== "admin") {
     throw new Error("Admin access context was not attached to the request.");
   }
 

--- a/apps/api/src/routes/benchmark-workflow.ts
+++ b/apps/api/src/routes/benchmark-workflow.ts
@@ -80,7 +80,7 @@ function isDatabaseUniqueConstraintError(error: unknown, constraintNames: string
 function getAdminActorUserId(request: FastifyRequest) {
   const context = request.accessRbacContext;
 
-  if (context?.status !== "approved" || !context.roles.includes("admin")) {
+  if (context?.status !== "approved" || context.role !== "admin") {
     throw new Error("Admin access context was not attached to the benchmark workflow request.");
   }
 

--- a/apps/api/src/routes/offline-ingest.ts
+++ b/apps/api/src/routes/offline-ingest.ts
@@ -6,7 +6,7 @@ import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 function getAdminActorUserId(request: FastifyRequest) {
   const context = request.accessRbacContext;
 
-  if (context?.status !== "approved" || !context.roles.includes("admin")) {
+  if (context?.status !== "approved" || context.role !== "admin") {
     throw new Error("Admin access context was not attached to the request.");
   }
 

--- a/apps/api/test/admin-routes.test.ts
+++ b/apps/api/test/admin-routes.test.ts
@@ -22,7 +22,7 @@ function createAdminAccessGuard() {
     request.accessRbacContext = {
       email: "admin@paretoproof.com",
       identityId: "11111111-1111-4111-8111-111111111111",
-      roles: ["admin"],
+      role: "admin",
       status: "approved",
       subject: "admin-subject",
       userId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
@@ -37,7 +37,7 @@ function createDeniedAccessGuard() {
       access: {
         email: "helper@paretoproof.com",
         identityId: "99999999-9999-4999-8999-999999999999",
-        roles: ["helper"],
+        role: "helper",
         status: "approved",
         subject: "helper-subject",
         userId: "99999999-9999-4999-8999-999999999999"

--- a/apps/api/test/benchmark-workflow-routes.test.ts
+++ b/apps/api/test/benchmark-workflow-routes.test.ts
@@ -20,7 +20,7 @@ function createAdminAccessGuard() {
     request.accessRbacContext = {
       email: "admin@paretoproof.com",
       identityId: "11111111-1111-4111-8111-111111111111",
-      roles: ["admin"],
+      role: "admin",
       status: "approved",
       subject: "admin-subject",
       userId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -7,7 +7,8 @@ import {
   verifyAccessProviderHint,
   type CloudflareAccessVerifierSet,
 } from "../src/auth/cloudflare-access.ts";
-import { createAccessResolver } from "../src/auth/require-access.ts";
+import Fastify from "fastify";
+import { createAccessGuard, createAccessResolver } from "../src/auth/require-access.ts";
 
 test("readAccessJwtAssertion falls back to CF_Authorization when the Access header is absent", () => {
   const assertion = readAccessJwtAssertion({
@@ -220,7 +221,7 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
     assert.deepEqual(context, {
       email: "person@example.com",
       identityId: "identity-1",
-      roles: ["helper"],
+      role: "helper",
       status: "approved",
       subject: "subject-1",
       userId: "user-1",
@@ -235,6 +236,127 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
   } finally {
     Object.assign(process.env, originalEnv);
   }
+});
+
+test("createAccessGuard ranks singular approved roles across helper, collaborator, and admin requirements", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const accessGuard = createAccessGuard(
+    {
+      query: {
+        userIdentities: {
+          findFirst: async () => ({
+            id: "identity-1",
+            provider: "cloudflare_google",
+            providerEmail: "person@example.com",
+            providerSubject: "subject-1",
+            user: {
+              email: "person@example.com",
+              id: "user-1",
+            },
+          }),
+        },
+      },
+      select() {
+        return {
+          from() {
+            return {
+              where: async () => [{ role: "collaborator" }],
+            };
+          },
+        };
+      },
+    } as never,
+    {
+      teamDomain: "paretoproof.cloudflareaccess.com",
+      verifiers: {
+        brandedRelay: {
+          verifyAssertion: async () => ({
+            email: "person@example.com",
+            issuer: "https://paretoproof.cloudflareaccess.com",
+            provider: "cloudflare_google",
+            subject: "subject-1",
+          }),
+        },
+        internal: {
+          verifyAssertion: async () => {
+            throw new Error("internal verifier should not run");
+          },
+        },
+        portal: {
+          verifyAssertion: async () => ({
+            email: "person@example.com",
+            issuer: "https://paretoproof.cloudflareaccess.com",
+            provider: "cloudflare_google",
+            subject: "subject-1",
+          }),
+        },
+      } as never,
+    },
+  );
+
+  app.get(
+    "/helper",
+    {
+      preHandler: accessGuard("approved_helper_or_higher"),
+    },
+    async () => ({ ok: true }),
+  );
+  app.get(
+    "/collaborator",
+    {
+      preHandler: accessGuard("approved_collaborator_or_higher"),
+    },
+    async () => ({ ok: true }),
+  );
+  app.get(
+    "/admin",
+    {
+      preHandler: accessGuard("admin_only"),
+    },
+    async () => ({ ok: true }),
+  );
+
+  const helperResponse = await app.inject({
+    headers: {
+      "cf-access-jwt-assertion": "test-assertion",
+    },
+    method: "GET",
+    url: "/helper",
+  });
+  const collaboratorResponse = await app.inject({
+    headers: {
+      "cf-access-jwt-assertion": "test-assertion",
+    },
+    method: "GET",
+    url: "/collaborator",
+  });
+  const adminResponse = await app.inject({
+    headers: {
+      "cf-access-jwt-assertion": "test-assertion",
+    },
+    method: "GET",
+    url: "/admin",
+  });
+
+  assert.equal(helperResponse.statusCode, 200);
+  assert.equal(collaboratorResponse.statusCode, 200);
+  assert.equal(adminResponse.statusCode, 403);
+  assert.deepEqual(adminResponse.json(), {
+    access: {
+      email: "person@example.com",
+      identityId: "identity-1",
+      role: "collaborator",
+      status: "approved",
+      subject: "subject-1",
+      userId: "user-1",
+    },
+    error: "insufficient_role",
+  });
 });
 
 test("createAccessResolver gracefully rejects legacy signed portal session cookies when no DB session exists", async () => {

--- a/apps/api/test/harness-registry.test.ts
+++ b/apps/api/test/harness-registry.test.ts
@@ -26,7 +26,7 @@ function createRequireAccessStub(roles: Array<"admin" | "collaborator" | "helper
       request.accessRbacContext = {
         email: "person@example.com",
         identityId: "identity-1",
-        roles,
+        role: roles[0] ?? null,
         status: "approved",
         subject: "subject-1",
         userId: "user-1"

--- a/apps/api/test/identity-binding.test.ts
+++ b/apps/api/test/identity-binding.test.ts
@@ -269,7 +269,7 @@ test("createPortalAccessSession rejects approved contexts when the stored identi
       {
         email: "person@example.com",
         identityId: "identity-1",
-        roles: ["helper"],
+        role: "helper",
         status: "approved",
         subject: "shared-subject",
         userId: "user-1"

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -43,7 +43,7 @@ function createRequireAccessStub(roles: Array<"admin" | "collaborator" | "helper
       request.accessRbacContext = {
         email: "person@example.com",
         identityId: "identity-1",
-        roles,
+        role: roles[0] ?? null,
         status: "approved",
         subject: "subject-1",
         userId: "user-1"
@@ -699,7 +699,7 @@ function createResolvePortalAccessStub(
     request.accessRbacContext = {
       email: "person@example.com",
       identityId: "identity-1",
-      roles,
+      role: roles[0] ?? null,
       status: "approved",
       subject: "subject-1",
       userId: "user-1"

--- a/apps/api/test/portal-link-intent-cookie.test.ts
+++ b/apps/api/test/portal-link-intent-cookie.test.ts
@@ -22,7 +22,7 @@ function createApprovedAccessGuard() {
       request.accessRbacContext = {
         email: "person@example.com",
         identityId: "identity-1",
-        roles: ["helper"],
+        role: "helper",
         status: "approved",
         subject: "subject-1",
         userId: "user-1",

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -42,7 +42,7 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
       resolvePortalAccess: async () => ({
         email: "person@example.com",
         identityId: "identity-1",
-        roles: ["helper"],
+        role: "helper",
         status: "approved",
         subject: "subject-1",
         userId: "user-1",
@@ -95,7 +95,7 @@ test("GET /portal/session/finalize/submit honors a runtime-provided link-intent 
       resolvePortalAccess: async () => ({
         email: "person@example.com",
         identityId: "identity-1",
-        roles: ["helper"],
+        role: "helper",
         status: "approved",
         subject: "subject-1",
         userId: "user-1",
@@ -178,7 +178,7 @@ test("GET /portal/session/finalize/submit uses configured portal/auth origins an
         request.accessRbacContext = {
           email: "person@example.com",
           identityId: "identity-1",
-          roles: ["helper"],
+          role: "helper",
           status: "approved",
           subject: "subject-1",
           userId: "user-1",
@@ -279,7 +279,7 @@ test("GET /portal/session/finalize/submit creates an opaque DB-backed session fo
         request.accessRbacContext = {
           email: "person@example.com",
           identityId: "identity-1",
-          roles: ["helper"],
+          role: "helper",
           status: "approved",
           subject: "subject-1",
           userId: "user-1",
@@ -383,7 +383,7 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
         request.accessRbacContext = {
           email: "person@example.com",
           identityId: "identity-1",
-          roles: ["helper"],
+          role: "helper",
           status: "approved",
           subject: "subject-1",
           userId: "user-1",

--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -343,7 +343,7 @@ test("POST /portal/admin/offline-ingest/problem9-run-bundles returns created res
       request.accessRbacContext = {
         email: "admin@paretoproof.com",
         identityId: "identity-1",
-        roles: ["admin"],
+        role: "admin",
         status: "approved",
         subject: "subject-1",
         userId: "user-1"
@@ -425,7 +425,7 @@ test("POST /portal/admin/offline-ingest/problem9-run-bundles maps duplicate run 
       request.accessRbacContext = {
         email: "admin@paretoproof.com",
         identityId: "identity-1",
-        roles: ["admin"],
+        role: "admin",
         status: "approved",
         subject: "subject-1",
         userId: "user-1"

--- a/apps/api/test/rate-limit.test.ts
+++ b/apps/api/test/rate-limit.test.ts
@@ -27,7 +27,7 @@ function createApprovedAccessGuard() {
     request.accessRbacContext = {
       email: "person@example.com",
       identityId: "identity-1",
-      roles: ["admin"],
+      role: "admin",
       status: "approved",
       subject: "subject-1",
       userId: "user-1"
@@ -122,7 +122,7 @@ test("authenticated portal and admin routes share the authenticated per-user bud
       request.accessRbacContext = {
         email: "person@example.com",
         identityId: "identity-1",
-        roles: ["admin"],
+        role: "admin",
         status: "approved",
         subject: "subject-1",
         userId: "user-1"
@@ -150,6 +150,14 @@ test("authenticated portal and admin routes share the authenticated per-user bud
   assert.equal(portalResponse.statusCode, 200);
   assert.equal(portalResponse.headers["x-ratelimit-limit"], "2");
   assert.equal(portalResponse.headers["x-ratelimit-remaining"], "1");
+  assert.deepEqual(portalResponse.json().access, {
+    email: "person@example.com",
+    identityId: "identity-1",
+    role: "admin",
+    status: "approved",
+    subject: "subject-1",
+    userId: "user-1"
+  });
 
   const adminResponse = await app.inject({
     method: "GET",

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -28,7 +28,7 @@ afterEach(() => {
 describe("buildPortalUrl", () => {
   it("drops stale denial reasons when building approved portal routes", () => {
     setWindowUrl(
-      "http://localhost/denied?surface=portal&access=approved&roles=helper&reason=insufficient_role&email=lin@paretoproof.local"
+      "http://localhost/denied?surface=portal&access=approved&role=helper&reason=insufficient_role&email=lin@paretoproof.local"
     );
 
     const portalUrl = new URL(buildPortalUrl("/"));
@@ -37,7 +37,7 @@ describe("buildPortalUrl", () => {
     expect(portalUrl.searchParams.get("surface")).toBe("portal");
     expect(portalUrl.searchParams.get("access")).toBe("approved");
     expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
-    expect(portalUrl.searchParams.get("roles")).toBe("helper");
+    expect(portalUrl.searchParams.get("role")).toBe("helper");
     expect(portalUrl.searchParams.has("reason")).toBe(false);
   });
 
@@ -58,7 +58,7 @@ describe("buildPortalUrl", () => {
 
   it("drops stale approved roles when the current preview access is pending", () => {
     setWindowUrl(
-      "http://localhost/pending?surface=portal&access=pending&roles=admin&email=ada@paretoproof.local"
+      "http://localhost/pending?surface=portal&access=pending&role=admin&email=ada@paretoproof.local"
     );
 
     const portalUrl = new URL(buildPortalUrl("/"));
@@ -67,6 +67,17 @@ describe("buildPortalUrl", () => {
     expect(portalUrl.searchParams.get("surface")).toBe("portal");
     expect(portalUrl.searchParams.get("access")).toBe("pending");
     expect(portalUrl.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(portalUrl.searchParams.has("role")).toBe(false);
+  });
+
+  it("preserves the singular approved role preview on local portal redirects", () => {
+    setWindowUrl(
+      "http://localhost/?surface=portal&access=approved&role=collaborator&email=ada@paretoproof.local"
+    );
+
+    const portalUrl = new URL(buildPortalUrl("/launch"));
+
+    expect(portalUrl.searchParams.get("role")).toBe("collaborator");
     expect(portalUrl.searchParams.has("roles")).toBe(false);
   });
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -155,6 +155,17 @@ export function copyLocalPortalState(targetUrl: URL, currentLocation = window.lo
   }
 
   if (
+    !targetUrl.searchParams.has("role") &&
+    shouldPreserveLocalPortalRoles(currentParams)
+  ) {
+    const role = currentParams.get("role");
+
+    if (role) {
+      targetUrl.searchParams.set("role", role);
+    }
+  }
+
+  if (
     !targetUrl.searchParams.has("roles") &&
     shouldPreserveLocalPortalRoles(currentParams)
   ) {
@@ -230,10 +241,18 @@ export function buildAccessStartUrl(
   if (isLocalOrigin(hostname)) {
     const localUrl = new URL(buildPortalUrl(normalizedTargetPath, hostname));
     const currentParams = new URLSearchParams(window.location.search);
+    const approvedRole =
+      currentParams.get("role") ??
+      (currentParams.get("roles") ?? "")
+        .split(",")
+        .map((role) => role.trim())
+        .find(Boolean) ??
+      "admin";
 
     localUrl.searchParams.set("access", "approved");
     localUrl.searchParams.set("email", currentParams.get("email") ?? "local@example.com");
-    localUrl.searchParams.set("roles", currentParams.get("roles") ?? "admin");
+    localUrl.searchParams.set("role", approvedRole);
+    localUrl.searchParams.delete("roles");
     localUrl.searchParams.delete("reason");
     return localUrl.toString();
   }
@@ -291,6 +310,7 @@ export function getCurrentRelativeUrl(location = window.location) {
   params.delete("surface");
   params.delete("access");
   params.delete("email");
+  params.delete("role");
   params.delete("roles");
   params.delete("reason");
 

--- a/apps/web/src/routes/portal-bootstrap-state.ts
+++ b/apps/web/src/routes/portal-bootstrap-state.ts
@@ -1,7 +1,7 @@
 export type PortalAccessState =
   | { status: "loading" }
   | { status: "unauthenticated" }
-  | { status: "approved"; email: string | null; roles: string[] }
+  | { status: "approved"; email: string | null; role: string | null }
   | { status: "pending"; email: string | null }
   | {
       email: string | null;
@@ -21,6 +21,7 @@ export function buildLocalPendingPortalUrl(currentSearch = window.location.searc
   nextParams.set("surface", "portal");
   nextParams.set("access", "pending");
   nextParams.delete("reason");
+  nextParams.delete("role");
   nextParams.delete("roles");
 
   const email = currentParams.get("email");

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -4,6 +4,8 @@ import {
   reducePortalStateAfterAuthExpiry
 } from "./portal-bootstrap-state.ts";
 import {
+  fetchPortalBootstrapState,
+  derivePortalRoles,
   mapPortalMutationErrorMessage,
   shouldRestartPortalAuthForMissingProvider
 } from "./portal-bootstrap.tsx";
@@ -23,11 +25,19 @@ describe("buildLocalPendingPortalUrl", () => {
     ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
   });
 
+  it("clears stale singular approved role previews when returning to pending", () => {
+    expect(
+      buildLocalPendingPortalUrl(
+        "?surface=portal&access=denied&email=ada@paretoproof.local&role=admin"
+      )
+    ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
+  });
+
   it("collapses stale approved state back to unauthenticated after auth expiry", () => {
     expect(
       reducePortalStateAfterAuthExpiry({
         email: "tomthegreatest04@gmail.com",
-        roles: ["admin"],
+        role: "admin",
         status: "approved"
       })
     ).toEqual({
@@ -47,6 +57,37 @@ describe("buildLocalPendingPortalUrl", () => {
 });
 
 describe("mapPortalMutationErrorMessage", () => {
+  it("parses the approved /portal/me payload from the singular role field", async () => {
+    const state = await fetchPortalBootstrapState("https://api.paretoproof.test", {
+      fetcher: async () => ({
+        json: async () => ({
+          access: {
+            email: "collab@paretoproof.local",
+            role: "collaborator",
+            status: "approved"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }),
+        ok: true,
+        status: 200,
+        type: "basic"
+      })
+    });
+
+    expect(state).toEqual({
+      email: "collab@paretoproof.local",
+      role: "collaborator",
+      status: "approved"
+    });
+  });
+
+  it("derives the local singleton role list from the approved portal role", () => {
+    expect(derivePortalRoles("collaborator")).toEqual(["collaborator"]);
+    expect(derivePortalRoles(null)).toEqual([]);
+  });
+
   it("surfaces a restart message when the API cannot prove the sign-in provider", () => {
     expect(
       mapPortalMutationErrorMessage("access_request", 409, "identity_provider_required")

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -1,6 +1,7 @@
 import type {
   PortalAccessRecoveryInput,
-  PortalAccessRequestInput
+  PortalAccessRequestInput,
+  PortalRole
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon } from "../components/app-icon";
@@ -25,7 +26,7 @@ import { PortalShell } from "./portal-shell";
 type PortalMeResponse = {
   access: {
     email: string | null;
-    roles?: string[];
+    role?: PortalRole | null;
     reason?:
       | "access_request_required"
       | "identity_recovery_required"
@@ -43,6 +44,69 @@ type PortalMutationAction = "access_request" | "identity_recovery";
 type PortalMutationErrorPayload = {
   error?: string;
 };
+
+type PortalBootstrapFetchResponse = Pick<Response, "json" | "ok" | "status" | "type">;
+type PortalBootstrapFetcher = (
+  input: string,
+  init: RequestInit
+) => Promise<PortalBootstrapFetchResponse>;
+
+export function derivePortalRoles(role: string | null | undefined) {
+  return role ? [role] : [];
+}
+
+export async function fetchPortalBootstrapState(
+  apiBaseUrl: string,
+  options?: {
+    fetcher?: PortalBootstrapFetcher;
+    signal?: AbortSignal;
+  }
+): Promise<PortalAccessState> {
+  const fetcher = options?.fetcher ?? fetchApi;
+  const response = await fetcher(`${apiBaseUrl}/portal/me`, {
+    credentials: "include",
+    headers: {
+      Accept: "application/json"
+    },
+    redirect: "manual",
+    signal: options?.signal
+  });
+
+  if (response.type === "opaqueredirect" || response.status === 401) {
+    return { status: "unauthenticated" };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Portal bootstrap failed with ${response.status}.`);
+  }
+
+  const payload = (await response.json()) as PortalMeResponse;
+
+  if (shouldRestartPortalAuthForMissingProvider(payload)) {
+    return { status: "unauthenticated" };
+  }
+
+  if (payload.access.status === "approved") {
+    return {
+      email: payload.access.email,
+      role: payload.access.role ?? null,
+      status: "approved"
+    };
+  }
+
+  if (payload.access.status === "pending") {
+    return {
+      email: payload.access.email,
+      status: "pending"
+    };
+  }
+
+  return {
+    email: payload.access.email,
+    reason: payload.access.reason ?? "unknown_identity",
+    status: "denied"
+  };
+}
 
 function parseDeniedReason(
   reason: string | null
@@ -93,12 +157,17 @@ function readLocalAccessOverride(): PortalAccessState | null {
   }
 
   if (accessState === "approved") {
-    return {
-      email: params.get("email"),
-      roles: (params.get("roles") ?? "")
+    const approvedRole =
+      params.get("role") ??
+      (params.get("roles") ?? "")
         .split(",")
         .map((role) => role.trim())
-        .filter(Boolean),
+        .find(Boolean) ??
+      null;
+
+    return {
+      email: params.get("email"),
+      role: approvedRole,
       status: "approved"
     };
   }
@@ -171,16 +240,16 @@ export function PortalBootstrap() {
       return null;
     }
 
-    return resolvePortalRouteRedirect({
-      pathname: window.location.pathname,
-      reason:
-        state.status === "denied"
-          ? state.reason
-          : routeDeniedReason ?? undefined,
-      roles: state.status === "approved" ? state.roles : [],
-      search: window.location.search,
-      status: state.status
-    });
+      return resolvePortalRouteRedirect({
+        pathname: window.location.pathname,
+        reason:
+          state.status === "denied"
+            ? state.reason
+            : routeDeniedReason ?? undefined,
+        roles: state.status === "approved" ? derivePortalRoles(state.role) : [],
+        search: window.location.search,
+        status: state.status
+      });
   }, [routeDeniedReason, state]);
 
   useEffect(() => {
@@ -196,58 +265,11 @@ export function PortalBootstrap() {
 
     async function loadAccessState() {
       try {
-        const response = await fetchApi(`${apiBaseUrl}/portal/me`, {
-          credentials: "include",
-          headers: {
-            Accept: "application/json"
-          },
-          redirect: "manual",
-          signal: controller.signal
-        });
-
-        if (response.type === "opaqueredirect") {
-          setState({ status: "unauthenticated" });
-          return;
-        }
-
-        if (response.status === 401) {
-          setState({ status: "unauthenticated" });
-          return;
-        }
-
-        if (!response.ok) {
-          throw new Error(`Portal bootstrap failed with ${response.status}.`);
-        }
-
-        const payload = (await response.json()) as PortalMeResponse;
-
-        if (shouldRestartPortalAuthForMissingProvider(payload)) {
-          setState({ status: "unauthenticated" });
-          return;
-        }
-
-        if (payload.access.status === "approved") {
-          setState({
-            email: payload.access.email,
-            roles: payload.access.roles ?? [],
-            status: "approved"
-          });
-          return;
-        }
-
-        if (payload.access.status === "pending") {
-          setState({
-            email: payload.access.email,
-            status: "pending"
-          });
-          return;
-        }
-
-        setState({
-          email: payload.access.email,
-          reason: payload.access.reason ?? "unknown_identity",
-          status: "denied"
-        });
+        setState(
+          await fetchPortalBootstrapState(apiBaseUrl, {
+            signal: controller.signal
+          })
+        );
       } catch (error) {
         if (controller.signal.aborted) {
           return;
@@ -458,7 +480,10 @@ export function PortalBootstrap() {
   }
 
   return (
-    <PortalShell email={state.email} roles={state.roles} />
+    <PortalShell
+      email={state.email}
+      roles={derivePortalRoles(state.role)}
+    />
   );
 }
 

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -53,6 +53,19 @@ afterEach(() => {
 });
 
 describe("PortalShell overview ordering", () => {
+  it("preserves a singular local approved role across in-app portal navigation state", async () => {
+    const { mergeLocalPortalSearchParams } = await loadPortalShellModule();
+    const mergedSearch = mergeLocalPortalSearchParams(
+      "?surface=portal&access=approved&role=collaborator&email=ada@paretoproof.local",
+      "?tab=history"
+    );
+    const mergedUrl = new URL(`http://127.0.0.1/${mergedSearch}`);
+
+    expect(mergedUrl.searchParams.get("role")).toBe("collaborator");
+    expect(mergedUrl.searchParams.get("tab")).toBe("history");
+    expect(mergedUrl.searchParams.has("roles")).toBe(false);
+  });
+
   it("puts compact admin recent-run evidence before the action rail", async () => {
     const html = await renderPortalShell({
       email: "ada@paretoproof.local",

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -46,7 +46,28 @@ const portalRoutePathById = new Map<PortalRouteId, string>(
     .filter((entry) => entry.surface === "portal")
     .map((entry) => [entry.id, entry.path] as [PortalRouteId, string])
 );
-const localPortalStateParamKeys = ["surface", "access", "email", "roles", "reason"] as const;
+const localPortalStateParamKeys = ["surface", "access", "email", "role", "roles", "reason"] as const;
+
+export function mergeLocalPortalSearchParams(currentSearch: string, nextSearch: string) {
+  const preservedParams = new URLSearchParams();
+  const currentParams = new URLSearchParams(currentSearch);
+  const nextParams = new URLSearchParams(nextSearch);
+
+  for (const key of localPortalStateParamKeys) {
+    const value = currentParams.get(key);
+
+    if (value && !nextParams.has(key)) {
+      preservedParams.set(key, value);
+    }
+  }
+
+  for (const [key, value] of nextParams.entries()) {
+    preservedParams.set(key, value);
+  }
+
+  const mergedSearch = preservedParams.toString();
+  return mergedSearch ? `?${mergedSearch}` : "";
+}
 
 const portalRoleOrder: PortalRole[] = ["admin", "collaborator", "helper"];
 const portalSectionIconById: Record<PortalSectionDefinition["id"], AppIconName> = {
@@ -300,32 +321,19 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   }, []);
 
   function replacePortalLocation(nextPathname: string, nextSearch: string) {
-    const preservedParams = new URLSearchParams();
-    const currentParams = new URLSearchParams(window.location.search);
-    const nextParams = new URLSearchParams(nextSearch);
-
-    for (const key of localPortalStateParamKeys) {
-      const value = currentParams.get(key);
-
-      if (value && !nextParams.has(key)) {
-        preservedParams.set(key, value);
-      }
-    }
-
-    for (const [key, value] of nextParams.entries()) {
-      preservedParams.set(key, value);
-    }
-
-    const mergedSearch = preservedParams.toString();
+    const mergedSearch = mergeLocalPortalSearchParams(
+      window.location.search,
+      nextSearch
+    );
 
     window.history.replaceState(
       {},
       "",
-      `${nextPathname}${mergedSearch ? `?${mergedSearch}` : ""}`
+      `${nextPathname}${mergedSearch}`
     );
     setLocationState({
       pathname: nextPathname,
-      search: mergedSearch ? `?${mergedSearch}` : ""
+      search: mergedSearch
     });
   }
 


### PR DESCRIPTION
## Summary
- make the approved portal access contract singular at the API boundary
- keep helper/collaborator/admin gating correct with direct guard coverage
- preserve the singular local role preview across bootstrap, redirects, and in-app portal navigation

## Testing
- bun run test:api
- bun test apps/web/src/routes/portal-bootstrap.test.js apps/web/src/lib/surface.test.js apps/web/src/routes/portal-shell.test.js
- bun run build

Closes #1000