### PR TITLE
Tighten worker artifact finalization integrity

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -49,7 +49,6 @@ const heartbeatIntervalSeconds = 60;
 const heartbeatTimeoutSeconds = 180;
 const runBundleSchemaVersion = "1";
 const requiredProblem9ArtifactRoles = [
-  "run_manifest",
   "package_reference",
   "prompt_package",
   "candidate_source",

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -28,7 +28,6 @@ import {
 import { registerInternalWorkerRoutes } from "../src/routes/internal-worker.ts";
 
 const supportedArtifactRoles = [
-  "run_manifest",
   "package_reference",
   "prompt_package",
   "candidate_source",

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -1,6 +1,11 @@
-import { mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, realpath, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import {
+  problem9BenchmarkPackageManifestSchema,
+  problem9EnvironmentManifestSchema,
+  problem9PackageRefSchema,
+  problem9PromptPackageManifestSchema,
   assertProblem9HostedCapability,
   problem9HostedAuthModes,
   type WorkerArtifactManifestEntry,
@@ -23,6 +28,7 @@ import {
   workerArtifactManifestResponseSchema,
   workerClaimResponseSchema,
   workerExecutionEventResponseSchema,
+  workerFailureCodeSchema,
   workerHeartbeatResponseSchema,
   workerResultMessageResponseSchema,
   workerTerminalFailureResponseSchema,
@@ -56,28 +62,53 @@ const workerClaimLoopOptionsSchema = z.object({
   workspaceRoot: z.string().min(1)
 });
 
-const artifactManifestFileSchema = z.object({
-  artifacts: z.array(
-    z.object({
-      artifactRole: z.string().min(1),
-      byteSize: z.number().int().nonnegative(),
-      contentEncoding: z.string().min(1).nullable(),
-      mediaType: z.string().min(1).nullable(),
-      relativePath: z.string().min(1),
-      requiredForIngest: z.boolean(),
-      sha256: z.string().regex(/^[a-f0-9]{64}$/i)
-    })
-  )
-});
+const artifactManifestFileSchema = z
+  .object({
+    artifacts: z.array(
+      z.object({
+        artifactRole: z.string().min(1),
+        byteSize: z.number().int().nonnegative(),
+        contentEncoding: z.string().min(1).nullable(),
+        mediaType: z.string().min(1).nullable(),
+        relativePath: z.string().min(1),
+        requiredForIngest: z.boolean(),
+        sha256: z.string().regex(/^[a-f0-9]{64}$/i)
+      })
+    )
+  })
+  .passthrough();
 
-const runBundleFileSchema = z.object({
-  artifactManifestDigest: z.string().regex(/^[a-f0-9]{64}$/i),
-  bundleDigest: z.string().regex(/^[a-f0-9]{64}$/i),
-  candidateDigest: z.string().regex(/^[a-f0-9]{64}$/i),
-  environmentDigest: z.string().regex(/^[a-f0-9]{64}$/i),
-  runId: z.string().min(1),
-  verdictDigest: z.string().regex(/^[a-f0-9]{64}$/i)
-});
+const runBundleFileSchema = z
+  .object({
+    artifactManifestDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    attemptId: z.string().min(1),
+    authMode: z.string().min(1),
+    benchmarkItemId: z.string().min(1),
+    benchmarkPackageDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    benchmarkPackageId: z.string().min(1),
+    benchmarkPackageVersion: z.string().min(1),
+    bundleDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    bundleSchemaVersion: z.string().min(1),
+    candidateDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    environmentDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    harnessRevision: z.string().min(1),
+    jobId: z.string().min(1).nullable(),
+    laneId: z.string().min(1),
+    modelConfigId: z.string().min(1),
+    modelSnapshotId: z.string().min(1),
+    promptPackageDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    promptProtocolVersion: z.string().min(1),
+    providerFamily: z.string().min(1),
+    runConfigDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+    runId: z.string().min(1),
+    runMode: z.string().min(1),
+    status: z.string().min(1),
+    stopReason: z.string().min(1),
+    toolProfile: z.string().min(1),
+    verifierVersion: z.string().min(1),
+    verdictDigest: z.string().regex(/^[a-f0-9]{64}$/i)
+  })
+  .passthrough();
 
 const supportedArtifactRoles = [
   "run_manifest",
@@ -92,6 +123,20 @@ const supportedArtifactRoles = [
   "usage_summary",
   "execution_trace"
 ] satisfies WorkerBundleArtifactRole[];
+
+const optionalArtifactRoles = new Set(["usage_summary", "execution_trace"] as const);
+
+const canonicalArtifactRoleByPath = {
+  "candidate/Candidate.lean": "candidate_source",
+  "environment/environment.json": "environment_snapshot",
+  "package/benchmark-package.json": "package_reference",
+  "package/package-ref.json": "package_reference",
+  "prompt/prompt-package.json": "prompt_package",
+  "verification/compiler-diagnostics.json": "compiler_diagnostics",
+  "verification/compiler-output.txt": "compiler_output",
+  "verification/verdict.json": "verdict_record",
+  "verification/verifier-output.json": "verifier_output"
+} as const satisfies Record<string, WorkerBundleArtifactRole>;
 
 type WorkerClaimLoopOptions = z.input<typeof workerClaimLoopOptionsSchema>;
 type WorkerClaimLoopResolvedOptions = z.output<typeof workerClaimLoopOptionsSchema>;
@@ -150,7 +195,8 @@ type PreparedBundleSubmission = {
   bundleDigest: string;
   candidateDigest: string;
   environmentDigest: string;
-  verifierVerdict: WorkerVerifierVerdict;
+  runBundle: z.output<typeof runBundleFileSchema>;
+  verifierVerdict: WorkerVerifierVerdict & { runId: string };
   verdictDigest: string;
 };
 
@@ -161,6 +207,20 @@ type CancellationTerminalContext = {
   bundleDigest: string;
   candidateDigest: string;
 };
+
+class BundleSubmissionIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BundleSubmissionIntegrityError";
+  }
+}
+
+const bundleVerifierVerdictFileSchema = workerVerifierVerdictSchema
+  .extend({
+    failureCode: workerFailureCodeSchema.optional(),
+    runId: z.string().min(1)
+  })
+  .passthrough();
 
 type LeaseFilesystemRoots = {
   attemptOutputRoot: string;
@@ -549,8 +609,61 @@ async function processClaimedJob(
       return "lease_lost";
     }
 
-    const bundleSubmission = await readBundleSubmission(attemptResult.outputRoot);
-    assertRequiredArtifactRoles(bundleSubmission.artifactManifest, workerJob.requiredArtifactRoles);
+    let bundleSubmission: PreparedBundleSubmission;
+
+    try {
+      bundleSubmission = await readBundleSubmission(attemptResult.outputRoot);
+      assertBundleSubmissionMatchesJobTarget(bundleSubmission, {
+        attemptId: workerJob.attemptId,
+        authMode: workerJob.target.authMode,
+        benchmarkItemId: workerJob.target.benchmarkItemId,
+        benchmarkPackageDigest: workerJob.target.benchmarkPackageDigest,
+        benchmarkPackageId: workerJob.target.benchmarkPackageId,
+        benchmarkPackageVersion: workerJob.target.benchmarkPackageVersion,
+        bundleSchemaVersion: workerJob.runBundleSchemaVersion,
+        harnessRevision: workerJob.target.harnessRevision,
+        jobId: workerJob.jobId,
+        laneId: workerJob.target.laneId,
+        modelConfigId: workerJob.target.modelConfigId,
+        modelSnapshotId: workerJob.target.modelSnapshotId,
+        promptPackageDigest: workerJob.target.promptPackageDigest,
+        promptProtocolVersion: workerJob.target.promptProtocolVersion,
+        providerFamily: workerJob.target.providerFamily,
+        runId: workerJob.runId,
+        runMode: workerJob.target.runMode,
+        status: attemptResult.result === "pass" ? "success" : "failure",
+        stopReason: attemptResult.stopReason,
+        toolProfile: workerJob.target.toolProfile
+      });
+      assertRequiredArtifactRoles(bundleSubmission.artifactManifest, workerJob.requiredArtifactRoles);
+    } catch (error) {
+      if (error instanceof Error) {
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          buildStaticFailure({
+            summary: error.message,
+            failureCode: "harness_crashed",
+            phase: "finalize"
+          })
+        );
+        if (
+          await submitCancellationIfRequested(
+            leaseState,
+            apiBaseUrl,
+            dependencies,
+            "Worker received a control-plane cancellation request while validating the terminal bundle."
+          )
+        ) {
+          return "completed";
+        }
+
+        return leaseState.leaseLost ? "lease_lost" : "completed";
+      }
+
+      throw error;
+    }
 
     const manifestResponse = await submitArtifactManifest(
       leaseState,
@@ -1049,14 +1162,104 @@ function assertExpectedBenchmarkIdentity(
 }
 
 async function readBundleSubmission(bundleRoot: string): Promise<PreparedBundleSubmission> {
-  const manifestFile = artifactManifestFileSchema.parse(
-    JSON.parse(await readFile(path.join(bundleRoot, "artifact-manifest.json"), "utf8"))
+  const bundleRootRealPath = await realpath(bundleRoot);
+  const artifactManifestText = await loadBundleTextFile(bundleRootRealPath, "artifact-manifest.json");
+  const runBundleText = await loadBundleTextFile(bundleRootRealPath, "run-bundle.json");
+  const verdictText = await loadBundleTextFile(bundleRootRealPath, "verification/verdict.json");
+  const candidateText = await loadBundleTextFile(bundleRootRealPath, "candidate/Candidate.lean");
+  const environmentText = await loadBundleTextFile(bundleRootRealPath, "environment/environment.json");
+  const benchmarkPackageText = await loadBundleTextFile(
+    bundleRootRealPath,
+    "package/benchmark-package.json"
   );
-  const runBundle = runBundleFileSchema.parse(
-    JSON.parse(await readFile(path.join(bundleRoot, "run-bundle.json"), "utf8"))
+  const promptPackageText = await loadBundleTextFile(
+    bundleRootRealPath,
+    "prompt/prompt-package.json"
   );
-  const verifierVerdict = workerVerifierVerdictSchema.parse(
-    JSON.parse(await readFile(path.join(bundleRoot, "verification", "verdict.json"), "utf8"))
+  const packageRefText = await loadBundleTextFile(bundleRootRealPath, "package/package-ref.json");
+  const manifestValue = JSON.parse(artifactManifestText);
+  const environmentValue = JSON.parse(environmentText);
+  const verdictValue = JSON.parse(verdictText);
+  const benchmarkPackageValue = JSON.parse(benchmarkPackageText);
+  const promptPackageValue = JSON.parse(promptPackageText);
+  const packageRefValue = JSON.parse(packageRefText);
+  const manifestFile = artifactManifestFileSchema.parse(manifestValue);
+  const runBundle = runBundleFileSchema.parse(JSON.parse(runBundleText));
+  const verifierVerdict = bundleVerifierVerdictFileSchema.parse(verdictValue);
+  const benchmarkPackage = problem9BenchmarkPackageManifestSchema.parse(benchmarkPackageValue);
+  const promptPackage = problem9PromptPackageManifestSchema.parse(promptPackageValue);
+  const packageRef = problem9PackageRefSchema.parse(packageRefValue);
+  const environment = problem9EnvironmentManifestSchema.parse(environmentValue);
+  const artifactManifestDigest = sha256Text(artifactManifestText);
+  const candidateDigest = sha256Text(candidateText);
+  const environmentDigest = sha256Text(stableStringify(environment));
+  const verdictDigest = sha256Text(stableStringify(verdictValue));
+  const bundleDigest = computeBundleDigest(runBundle, manifestFile);
+
+  assertCanonicalDigest(
+    artifactManifestDigest,
+    runBundle.artifactManifestDigest,
+    "run-bundle.json artifactManifestDigest does not match artifact-manifest.json."
+  );
+  assertCanonicalDigest(
+    candidateDigest,
+    runBundle.candidateDigest,
+    "run-bundle.json candidateDigest does not match candidate/Candidate.lean."
+  );
+  assertCanonicalDigest(
+    environmentDigest,
+    runBundle.environmentDigest,
+    "run-bundle.json environmentDigest does not match environment/environment.json."
+  );
+  assertCanonicalDigest(
+    verdictDigest,
+    runBundle.verdictDigest,
+    "run-bundle.json verdictDigest does not match verification/verdict.json."
+  );
+  assertCanonicalDigest(
+    bundleDigest,
+    runBundle.bundleDigest,
+    "run-bundle.json bundleDigest does not match the canonical bundle digest."
+  );
+
+  await assertManifestEntriesMatchFiles(bundleRootRealPath, manifestFile);
+
+  if (normalizeDigest(verifierVerdict.candidateDigest) !== normalizeDigest(candidateDigest)) {
+    throw new BundleSubmissionIntegrityError(
+      "verification/verdict.json candidateDigest does not match candidate/Candidate.lean."
+    );
+  }
+
+  if (
+    (verifierVerdict.result === "pass" && runBundle.status !== "success") ||
+    (verifierVerdict.result === "fail" && runBundle.status !== "failure")
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      "run-bundle.json status does not match verification/verdict.json result."
+    );
+  }
+
+  assertBundleSubmissionFileConsistency({
+    benchmarkPackage,
+    environment,
+    environmentDigest,
+    packageRef,
+    promptPackage,
+    runBundle,
+    verifierVerdict
+  });
+
+  assertVerifierVerdictSemantics(verifierVerdict);
+
+  assertCanonicalDigest(
+    computeRunConfigDigest({
+      benchmarkPackage,
+      environment,
+      environmentDigest,
+      promptPackage
+    }),
+    runBundle.runConfigDigest,
+    "run-bundle.json runConfigDigest does not match the canonical run configuration digest."
   );
 
   return {
@@ -1065,17 +1268,461 @@ async function readBundleSubmission(bundleRoot: string): Promise<PreparedBundleS
       byteSize: artifact.byteSize,
       contentEncoding: artifact.contentEncoding,
       mediaType: artifact.mediaType,
-      relativePath: artifact.relativePath,
+      relativePath: normalizeManifestRelativePath(artifact.relativePath),
       requiredForIngest: artifact.requiredForIngest,
       sha256: artifact.sha256
     })),
-    artifactManifestDigest: runBundle.artifactManifestDigest,
-    bundleDigest: runBundle.bundleDigest,
-    candidateDigest: runBundle.candidateDigest,
-    environmentDigest: runBundle.environmentDigest,
+    artifactManifestDigest,
+    bundleDigest,
+    candidateDigest,
+    environmentDigest,
+    runBundle,
     verifierVerdict,
-    verdictDigest: runBundle.verdictDigest
+    verdictDigest
   };
+}
+
+function assertBundleSubmissionMatchesJobTarget(
+  bundleSubmission: PreparedBundleSubmission,
+  expected: {
+    attemptId: string;
+    authMode: string;
+    benchmarkItemId: string;
+    benchmarkPackageDigest: string;
+    benchmarkPackageId: string;
+    benchmarkPackageVersion: string;
+    bundleSchemaVersion: string;
+    harnessRevision: string;
+    jobId: string;
+    laneId: string;
+    modelConfigId: string;
+    modelSnapshotId: string;
+    promptPackageDigest: string;
+    promptProtocolVersion: string;
+    providerFamily: string;
+    runId: string;
+    runMode: string;
+    status: string;
+    stopReason: string;
+    toolProfile: string;
+  }
+): void {
+  const runBundleChecks: Array<[field: string, actual: string | null, expectedValue: string]> = [
+    ["attemptId", bundleSubmission.runBundle.attemptId, expected.attemptId],
+    ["authMode", bundleSubmission.runBundle.authMode, expected.authMode],
+    ["benchmarkItemId", bundleSubmission.runBundle.benchmarkItemId, expected.benchmarkItemId],
+    ["benchmarkPackageDigest", bundleSubmission.runBundle.benchmarkPackageDigest, expected.benchmarkPackageDigest],
+    ["benchmarkPackageId", bundleSubmission.runBundle.benchmarkPackageId, expected.benchmarkPackageId],
+    ["benchmarkPackageVersion", bundleSubmission.runBundle.benchmarkPackageVersion, expected.benchmarkPackageVersion],
+    ["bundleSchemaVersion", bundleSubmission.runBundle.bundleSchemaVersion, expected.bundleSchemaVersion],
+    ["harnessRevision", bundleSubmission.runBundle.harnessRevision, expected.harnessRevision],
+    ["jobId", bundleSubmission.runBundle.jobId, expected.jobId],
+    ["laneId", bundleSubmission.runBundle.laneId, expected.laneId],
+    ["modelConfigId", bundleSubmission.runBundle.modelConfigId, expected.modelConfigId],
+    ["modelSnapshotId", bundleSubmission.runBundle.modelSnapshotId, expected.modelSnapshotId],
+    ["promptPackageDigest", bundleSubmission.runBundle.promptPackageDigest, expected.promptPackageDigest],
+    ["promptProtocolVersion", bundleSubmission.runBundle.promptProtocolVersion, expected.promptProtocolVersion],
+    ["providerFamily", bundleSubmission.runBundle.providerFamily, expected.providerFamily],
+    ["runId", bundleSubmission.runBundle.runId, expected.runId],
+    ["runMode", bundleSubmission.runBundle.runMode, expected.runMode],
+    ["status", bundleSubmission.runBundle.status, expected.status],
+    ["stopReason", bundleSubmission.runBundle.stopReason, expected.stopReason],
+    ["toolProfile", bundleSubmission.runBundle.toolProfile, expected.toolProfile]
+  ];
+  const mismatchedRunBundleField = runBundleChecks.find(
+    ([field, actual, expectedValue]) => !isBundleFieldMatch(field, actual, expectedValue)
+  );
+
+  if (mismatchedRunBundleField) {
+    throw new BundleSubmissionIntegrityError(
+      `run-bundle.json ${mismatchedRunBundleField[0]} does not match the claimed job target.`
+    );
+  }
+
+  const verdictChecks: Array<[field: string, actual: string, expectedValue: string]> = [
+    ["attemptId", bundleSubmission.verifierVerdict.attemptId, expected.attemptId],
+    ["benchmarkPackageDigest", bundleSubmission.verifierVerdict.benchmarkPackageDigest, expected.benchmarkPackageDigest],
+    ["laneId", bundleSubmission.verifierVerdict.laneId, expected.laneId],
+    ["runId", bundleSubmission.verifierVerdict.runId, expected.runId]
+  ];
+  const mismatchedVerdictField = verdictChecks.find(
+    ([, actual, expectedValue]) => actual !== expectedValue
+  );
+
+  if (mismatchedVerdictField) {
+    throw new BundleSubmissionIntegrityError(
+      `verification/verdict.json ${mismatchedVerdictField[0]} does not match the claimed job target.`
+    );
+  }
+}
+
+async function assertManifestEntriesMatchFiles(
+  bundleRootRealPath: string,
+  artifactManifest: z.output<typeof artifactManifestFileSchema>
+): Promise<void> {
+  const seenRelativePaths = new Set<string>();
+
+  for (const artifact of artifactManifest.artifacts) {
+    const canonicalRelativePath = normalizeManifestRelativePath(artifact.relativePath);
+
+    if (seenRelativePaths.has(canonicalRelativePath)) {
+      throw new BundleSubmissionIntegrityError(
+        `artifact-manifest.json contains a duplicate relativePath: ${canonicalRelativePath}.`
+      );
+    }
+
+    seenRelativePaths.add(canonicalRelativePath);
+
+    const expectedArtifactRole =
+      canonicalArtifactRoleByPath[canonicalRelativePath as keyof typeof canonicalArtifactRoleByPath];
+
+    if (expectedArtifactRole && artifact.artifactRole !== expectedArtifactRole) {
+      throw new BundleSubmissionIntegrityError(
+        `artifact-manifest.json ${canonicalRelativePath} must use artifactRole ${expectedArtifactRole}.`
+      );
+    }
+
+    if (!expectedArtifactRole && !isOptionalArtifactRole(artifact.artifactRole)) {
+      throw new BundleSubmissionIntegrityError(
+        `artifact-manifest.json ${canonicalRelativePath} uses unsupported artifactRole ${artifact.artifactRole}.`
+      );
+    }
+
+    if (artifact.relativePath === "run-bundle.json" || artifact.artifactRole === "run_manifest") {
+      throw new BundleSubmissionIntegrityError(
+        "artifact-manifest.json must not declare run-bundle.json as a manifest artifact."
+      );
+    }
+
+    const filePath = await resolveBundleFilePath(bundleRootRealPath, canonicalRelativePath);
+    const fileStats = await stat(filePath);
+
+    assertCanonicalDigest(
+      await computeArtifactDigest(filePath, artifact),
+      artifact.sha256,
+      `${canonicalRelativePath} sha256 does not match artifact-manifest.json.`
+    );
+
+    if (fileStats.size !== artifact.byteSize) {
+      throw new BundleSubmissionIntegrityError(
+        `${canonicalRelativePath} byteSize does not match artifact-manifest.json.`
+      );
+    }
+
+    if (!expectedArtifactRole) {
+      continue;
+    }
+
+    const expectedManifestMetadata = expectedManifestMetadataForPath(canonicalRelativePath);
+
+    if (artifact.contentEncoding !== expectedManifestMetadata.contentEncoding) {
+      throw new BundleSubmissionIntegrityError(
+        `${canonicalRelativePath} contentEncoding does not match the canonical bundle contract.`
+      );
+    }
+
+    if (artifact.mediaType !== expectedManifestMetadata.mediaType) {
+      throw new BundleSubmissionIntegrityError(
+        `${canonicalRelativePath} mediaType does not match the canonical bundle contract.`
+      );
+    }
+
+    if (artifact.requiredForIngest !== expectedManifestMetadata.requiredForIngest) {
+      throw new BundleSubmissionIntegrityError(
+        `${canonicalRelativePath} requiredForIngest does not match the canonical bundle contract.`
+      );
+    }
+  }
+}
+
+async function resolveBundleFilePath(
+  bundleRootRealPath: string,
+  relativePath: string
+): Promise<string> {
+  const fullPath = path.join(bundleRootRealPath, relativePath);
+  const fileStats = await lstat(fullPath).catch(() => null);
+
+  if (!fileStats?.isFile() || fileStats.isSymbolicLink()) {
+    throw new BundleSubmissionIntegrityError(
+      `artifact-manifest.json references a missing or unsupported bundle file: ${relativePath}.`
+    );
+  }
+
+  const resolvedFilePath = await realpath(fullPath);
+  const relativeResolvedPath = path.relative(bundleRootRealPath, resolvedFilePath);
+
+  if (
+    relativeResolvedPath.startsWith("..") ||
+    path.isAbsolute(relativeResolvedPath) ||
+    relativeResolvedPath.length === 0
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      `artifact-manifest.json path escapes the bundle root: ${relativePath}.`
+    );
+  }
+
+  return resolvedFilePath;
+}
+
+async function loadBundleTextFile(
+  bundleRootRealPath: string,
+  relativePath: string
+): Promise<string> {
+  const filePath = await resolveBundleFilePath(bundleRootRealPath, relativePath);
+  return loadNormalizedText(filePath);
+}
+
+async function computeArtifactDigest(
+  filePath: string,
+  artifact: Pick<WorkerArtifactManifestEntry, "contentEncoding" | "mediaType">
+): Promise<string> {
+  const fileBytes = await readFile(filePath);
+
+  if (shouldHashNormalizedTextArtifact(artifact)) {
+    return sha256Text(fileBytes.toString("utf8"));
+  }
+
+  return sha256Bytes(fileBytes);
+}
+
+function shouldHashNormalizedTextArtifact(
+  artifact: Pick<WorkerArtifactManifestEntry, "contentEncoding" | "mediaType">
+): boolean {
+  if (artifact.contentEncoding !== null) {
+    return false;
+  }
+
+  return artifact.mediaType === "application/json" || artifact.mediaType?.startsWith("text/") === true;
+}
+
+function assertBundleSubmissionFileConsistency(options: {
+  benchmarkPackage: z.output<typeof problem9BenchmarkPackageManifestSchema>;
+  environment: z.output<typeof problem9EnvironmentManifestSchema>;
+  environmentDigest: string;
+  packageRef: z.output<typeof problem9PackageRefSchema>;
+  promptPackage: z.output<typeof problem9PromptPackageManifestSchema>;
+  runBundle: z.output<typeof runBundleFileSchema>;
+  verifierVerdict: z.output<typeof bundleVerifierVerdictFileSchema>;
+}): void {
+  if (normalizeDigest(options.packageRef.benchmarkPackageDigest) !== normalizeDigest(options.benchmarkPackage.packageDigest)) {
+    throw new BundleSubmissionIntegrityError(
+      "package/package-ref.json benchmarkPackageDigest does not match package/benchmark-package.json."
+    );
+  }
+
+  if (options.packageRef.benchmarkPackageVersion !== options.benchmarkPackage.packageVersion) {
+    throw new BundleSubmissionIntegrityError(
+      "package/package-ref.json benchmarkPackageVersion does not match package/benchmark-package.json."
+    );
+  }
+
+  if (options.packageRef.benchmarkItemId !== options.benchmarkPackage.benchmarkItemId) {
+    throw new BundleSubmissionIntegrityError(
+      "package/package-ref.json benchmarkItemId does not match package/benchmark-package.json."
+    );
+  }
+
+  if (
+    normalizeDigest(options.promptPackage.benchmarkPackageDigest) !==
+    normalizeDigest(options.benchmarkPackage.packageDigest)
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      "prompt/prompt-package.json benchmarkPackageDigest does not match package/benchmark-package.json."
+    );
+  }
+
+  if (options.promptPackage.benchmarkPackageVersion !== options.benchmarkPackage.packageVersion) {
+    throw new BundleSubmissionIntegrityError(
+      "prompt/prompt-package.json benchmarkPackageVersion does not match package/benchmark-package.json."
+    );
+  }
+
+  if (options.promptPackage.benchmarkItemId !== options.benchmarkPackage.benchmarkItemId) {
+    throw new BundleSubmissionIntegrityError(
+      "prompt/prompt-package.json benchmarkItemId does not match package/benchmark-package.json."
+    );
+  }
+
+  const runBundlePromptChecks: Array<[field: string, actual: string, expectedValue: string]> = [
+    ["authMode", options.runBundle.authMode, options.promptPackage.authMode],
+    ["benchmarkItemId", options.runBundle.benchmarkItemId, options.promptPackage.benchmarkItemId],
+    ["benchmarkPackageId", options.runBundle.benchmarkPackageId, options.promptPackage.benchmarkPackageId],
+    ["benchmarkPackageVersion", options.runBundle.benchmarkPackageVersion, options.promptPackage.benchmarkPackageVersion],
+    ["harnessRevision", options.runBundle.harnessRevision, options.promptPackage.harnessRevision],
+    ["laneId", options.runBundle.laneId, options.promptPackage.laneId],
+    ["modelConfigId", options.runBundle.modelConfigId, options.promptPackage.modelConfigId],
+    ["promptProtocolVersion", options.runBundle.promptProtocolVersion, options.promptPackage.promptProtocolVersion],
+    ["providerFamily", options.runBundle.providerFamily, options.promptPackage.providerFamily],
+    ["runMode", options.runBundle.runMode, options.promptPackage.runMode],
+    ["toolProfile", options.runBundle.toolProfile, options.promptPackage.toolProfile]
+  ];
+  const mismatchedRunBundlePromptField = runBundlePromptChecks.find(
+    ([, actual, expectedValue]) => actual !== expectedValue
+  );
+
+  if (mismatchedRunBundlePromptField) {
+    throw new BundleSubmissionIntegrityError(
+      `run-bundle.json ${mismatchedRunBundlePromptField[0]} does not match prompt/prompt-package.json.`
+    );
+  }
+
+  if (normalizeDigest(options.runBundle.benchmarkPackageDigest) !== normalizeDigest(options.benchmarkPackage.packageDigest)) {
+    throw new BundleSubmissionIntegrityError(
+      "run-bundle.json benchmarkPackageDigest does not match package/benchmark-package.json."
+    );
+  }
+
+  if (normalizeDigest(options.runBundle.promptPackageDigest) !== normalizeDigest(options.promptPackage.promptPackageDigest)) {
+    throw new BundleSubmissionIntegrityError(
+      "run-bundle.json promptPackageDigest does not match prompt/prompt-package.json."
+    );
+  }
+
+  if (normalizeDigest(options.runBundle.environmentDigest) !== normalizeDigest(options.environmentDigest)) {
+    throw new BundleSubmissionIntegrityError(
+      "run-bundle.json environmentDigest does not match environment/environment.json."
+    );
+  }
+
+  if (options.environment.harnessRevision !== options.runBundle.harnessRevision) {
+    throw new BundleSubmissionIntegrityError(
+      "environment/environment.json harnessRevision does not match run-bundle.json."
+    );
+  }
+
+  const environmentRunBundleChecks: Array<[field: string, actual: string, expectedValue: string]> = [
+    ["authMode", options.environment.authMode, options.runBundle.authMode],
+    ["laneId", options.environment.laneId, options.runBundle.laneId],
+    ["modelConfigId", options.environment.modelConfigId, options.runBundle.modelConfigId],
+    ["promptProtocolVersion", options.environment.promptProtocolVersion, options.runBundle.promptProtocolVersion],
+    ["providerFamily", options.environment.providerFamily, options.runBundle.providerFamily],
+    ["runMode", options.environment.runMode, options.runBundle.runMode],
+    ["toolProfile", options.environment.toolProfile, options.runBundle.toolProfile],
+    ["verifierVersion", options.environment.verifierVersion, options.runBundle.verifierVersion]
+  ];
+  const mismatchedEnvironmentField = environmentRunBundleChecks.find(
+    ([, actual, expectedValue]) => actual !== expectedValue
+  );
+
+  if (mismatchedEnvironmentField) {
+    throw new BundleSubmissionIntegrityError(
+      `environment/environment.json ${mismatchedEnvironmentField[0]} does not match run-bundle.json.`
+    );
+  }
+
+  if (options.environment.modelSnapshotId !== options.runBundle.modelSnapshotId) {
+    throw new BundleSubmissionIntegrityError(
+      "environment/environment.json modelSnapshotId does not match run-bundle.json."
+    );
+  }
+
+  if (options.verifierVerdict.runId !== options.runBundle.runId) {
+    throw new BundleSubmissionIntegrityError(
+      "verification/verdict.json runId does not match run-bundle.json."
+    );
+  }
+
+  if (options.verifierVerdict.attemptId !== options.runBundle.attemptId) {
+    throw new BundleSubmissionIntegrityError(
+      "verification/verdict.json attemptId does not match run-bundle.json."
+    );
+  }
+
+  if (
+    normalizeDigest(options.verifierVerdict.benchmarkPackageDigest) !==
+    normalizeDigest(options.runBundle.benchmarkPackageDigest)
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      "verification/verdict.json benchmarkPackageDigest does not match run-bundle.json."
+    );
+  }
+
+  if (options.verifierVerdict.laneId !== options.runBundle.laneId) {
+    throw new BundleSubmissionIntegrityError(
+      "verification/verdict.json laneId does not match run-bundle.json."
+    );
+  }
+}
+
+function assertVerifierVerdictSemantics(
+  verifierVerdict: z.output<typeof bundleVerifierVerdictFileSchema>
+): void {
+  if (verifierVerdict.result === "pass") {
+    if (verifierVerdict.primaryFailure !== null) {
+      throw new BundleSubmissionIntegrityError(
+        "Passing verifier verdicts may not include a primaryFailure classification."
+      );
+    }
+
+    if (verifierVerdict.semanticEquality !== "matched") {
+      throw new BundleSubmissionIntegrityError(
+        "Passing verifier verdicts require semanticEquality=matched."
+      );
+    }
+
+    if (verifierVerdict.containsAdmit || verifierVerdict.containsSorry) {
+      throw new BundleSubmissionIntegrityError(
+        "Passing verifier verdicts may not contain sorry or admit."
+      );
+    }
+
+    if (verifierVerdict.axiomCheck !== "passed") {
+      throw new BundleSubmissionIntegrityError(
+        "Passing verifier verdicts require axiomCheck=passed."
+      );
+    }
+
+    if (verifierVerdict.diagnosticGate !== "passed") {
+      throw new BundleSubmissionIntegrityError(
+        "Passing verifier verdicts require diagnosticGate=passed."
+      );
+    }
+
+    return;
+  }
+
+  if (verifierVerdict.primaryFailure === null) {
+    throw new BundleSubmissionIntegrityError(
+      "Failing verifier verdicts require a primaryFailure classification."
+    );
+  }
+
+  if (
+    verifierVerdict.failureCode !== undefined &&
+    verifierVerdict.failureCode !== verifierVerdict.primaryFailure.failureCode
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      "Failing verifier verdicts require failureCode to match primaryFailure.failureCode."
+    );
+  }
+}
+
+function computeRunConfigDigest(options: {
+  benchmarkPackage: z.output<typeof problem9BenchmarkPackageManifestSchema>;
+  environment: z.output<typeof problem9EnvironmentManifestSchema>;
+  environmentDigest: string;
+  promptPackage: z.output<typeof problem9PromptPackageManifestSchema>;
+}): string {
+  return sha256Text(
+    stableStringify({
+      authMode: options.promptPackage.authMode,
+      benchmarkItemId: options.benchmarkPackage.benchmarkItemId,
+      benchmarkPackageDigest: options.benchmarkPackage.packageDigest,
+      benchmarkPackageId: options.benchmarkPackage.packageId,
+      benchmarkPackageVersion: options.benchmarkPackage.packageVersion,
+      environmentDigest: options.environmentDigest,
+      harnessRevision: options.promptPackage.harnessRevision,
+      laneId: options.promptPackage.laneId,
+      modelConfigId: options.promptPackage.modelConfigId,
+      modelSnapshotId: options.environment.modelSnapshotId,
+      promptPackageDigest: options.promptPackage.promptPackageDigest,
+      promptProtocolVersion: options.promptPackage.promptProtocolVersion,
+      providerFamily: options.promptPackage.providerFamily,
+      runMode: options.promptPackage.runMode,
+      toolProfile: options.promptPackage.toolProfile,
+      verifierVersion: options.environment.verifierVersion
+    })
+  );
 }
 
 function assertRequiredArtifactRoles(
@@ -1083,13 +1730,52 @@ function assertRequiredArtifactRoles(
   requiredArtifactRoles: WorkerBundleArtifactRole[]
 ): void {
   const presentRoles = new Set(artifacts.map((artifact) => artifact.artifactRole));
-  const missingRoles = requiredArtifactRoles.filter((role) => !presentRoles.has(role));
+  const missingRoles = requiredArtifactRoles.filter(
+    (role) => role !== "run_manifest" && !presentRoles.has(role)
+  );
 
   if (missingRoles.length > 0) {
     throw new Error(
       `Artifact manifest is missing required roles: ${missingRoles.sort().join(", ")}.`
     );
   }
+}
+
+function normalizeManifestRelativePath(value: string): string {
+  const slashNormalized = value.replace(/\\/g, "/");
+  const canonicalPath = path.posix.normalize(slashNormalized);
+
+  if (
+    slashNormalized.length === 0 ||
+    slashNormalized !== canonicalPath ||
+    canonicalPath.startsWith("../") ||
+    canonicalPath === ".." ||
+    canonicalPath.startsWith("/") ||
+    canonicalPath.endsWith("/") ||
+    canonicalPath === "."
+  ) {
+    throw new BundleSubmissionIntegrityError(
+      `artifact-manifest.json relativePath must be canonical and traversal-free: ${value}.`
+    );
+  }
+
+  return canonicalPath;
+}
+
+function expectedManifestMetadataForPath(relativePath: string) {
+  return {
+    contentEncoding: null,
+    mediaType: relativePath.endsWith(".json")
+      ? "application/json"
+      : relativePath.endsWith(".txt") || relativePath.endsWith(".lean")
+        ? "text/plain"
+        : null,
+    requiredForIngest: true
+  };
+}
+
+function isOptionalArtifactRole(role: string): role is "usage_summary" | "execution_trace" {
+  return optionalArtifactRoles.has(role as "usage_summary" | "execution_trace");
 }
 
 function resolveProviderModel(options: {
@@ -1121,6 +1807,84 @@ function sanitizePathSegment(value: string): string {
   }
 
   return sanitized;
+}
+
+function assertCanonicalDigest(actual: string, declared: string, message: string): void {
+  if (normalizeDigest(actual) !== normalizeDigest(declared)) {
+    throw new BundleSubmissionIntegrityError(message);
+  }
+}
+
+function normalizeDigest(digest: string): string {
+  return digest.trim().toLowerCase();
+}
+
+function computeBundleDigest(
+  runBundle: z.output<typeof runBundleFileSchema>,
+  artifactManifest: z.output<typeof artifactManifestFileSchema>
+): string {
+  return sha256Text(
+    stableStringify({
+      artifactInventory: [...artifactManifest.artifacts].sort((left, right) =>
+        left.relativePath.localeCompare(right.relativePath)
+      ),
+      runBundle: omitDigestFields(runBundle)
+    })
+  );
+}
+
+function omitDigestFields<TValue extends Record<string, unknown>>(value: TValue) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => !key.toLowerCase().endsWith("digest"))
+  );
+}
+
+function loadNormalizedText(filePath: string): Promise<string> {
+  return readFile(filePath, "utf8").then(normalizeText);
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function sha256Text(text: string): string {
+  return createHash("sha256").update(Buffer.from(normalizeText(text), "utf8")).digest("hex");
+}
+
+function sha256Bytes(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value), null, 2);
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+function isBundleFieldMatch(field: string, actual: string | null, expectedValue: string): boolean {
+  if (actual === null) {
+    return false;
+  }
+
+  if (field.toLowerCase().endsWith("digest")) {
+    return normalizeDigest(actual) === normalizeDigest(expectedValue);
+  }
+
+  return actual === expectedValue;
 }
 
 function buildLeaseFilesystemRoots(options: {

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -1346,7 +1346,7 @@ function assertBundleSubmissionMatchesJobTarget(
     ["runId", bundleSubmission.verifierVerdict.runId, expected.runId]
   ];
   const mismatchedVerdictField = verdictChecks.find(
-    ([, actual, expectedValue]) => actual !== expectedValue
+    ([field, actual, expectedValue]) => !isBundleFieldMatch(field, actual, expectedValue)
   );
 
   if (mismatchedVerdictField) {

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto";
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 import type {
   WorkerArtifactManifestEntry,
   WorkerClaimRequest,
@@ -30,6 +32,14 @@ type ApiMockResponse = {
   body: unknown;
   path: string;
   status?: number;
+};
+
+type WrittenBundleDigests = {
+  artifactManifestDigest: string;
+  bundleDigest: string;
+  candidateDigest: string;
+  environmentDigest: string;
+  verdictDigest: string;
 };
 
 test("runWorkerClaimLoop submits manifest and terminal result for a claimed single_run", async () => {
@@ -108,6 +118,7 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
       calls
     );
     const attemptCalls: Array<Record<string, unknown>> = [];
+    let writtenBundle: WrittenBundleDigests | null = null;
 
     const result = await runWorkerClaimLoop(
       {
@@ -124,7 +135,7 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
       {
         attemptRunner: async (options) => {
           attemptCalls.push(options);
-          await writeBundleOutputs(options.outputRoot, artifactEntries);
+          writtenBundle = await writeBundleOutputs(options.outputRoot, artifactEntries);
 
           return {
             artifactManifestDigest,
@@ -209,7 +220,12 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
     const resultBody = calls.at(-1)?.body as WorkerResultMessageRequest;
     assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/result`);
     assert.equal(calls.at(-1)?.token, "job-token-2");
-    assert.deepEqual(resultBody.artifactIds, ["artifact-1", "artifact-2"]);
+    assert.deepEqual(resultBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(resultBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(resultBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(resultBody.candidateDigest, writtenBundle?.candidateDigest);
+    assert.equal(resultBody.environmentDigest, writtenBundle?.environmentDigest);
+    assert.equal(resultBody.verdictDigest, writtenBundle?.verdictDigest);
     assert.deepEqual(resultBody.usageSummary, {
       compileRepairCount: 1,
       providerTurnsUsed: 2,
@@ -615,6 +631,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
     const calls: ApiCall[] = [];
     const workerJob = buildWorkerJob();
     const artifactEntries = buildArtifactEntries();
+    let writtenBundle: WrittenBundleDigests | null = null;
     let heartbeatCount = 0;
     let sleepCount = 0;
     let releaseLateCancelHeartbeat: (() => void) | null = null;
@@ -731,7 +748,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
       },
       {
         attemptRunner: async (options) => {
-          await writeBundleOutputs(options.outputRoot, artifactEntries);
+          writtenBundle = await writeBundleOutputs(options.outputRoot, artifactEntries);
 
           return {
             artifactManifestDigest,
@@ -801,10 +818,10 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
       ]
     );
     const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
-    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
-    assert.equal(failureBody.artifactManifestDigest, artifactManifestDigest);
-    assert.equal(failureBody.bundleDigest, bundleDigest);
-    assert.equal(failureBody.candidateDigest, candidateDigest);
+    assert.deepEqual(failureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(failureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(failureBody.candidateDigest, writtenBundle?.candidateDigest);
     assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
     assert.equal(failureBody.terminalState, "cancelled");
     assert.equal(calls.at(-1)?.token, "job-token-4");
@@ -824,6 +841,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
     const calls: ApiCall[] = [];
     const workerJob = buildWorkerJob();
     const artifactEntries = buildArtifactEntries();
+    let writtenBundle: WrittenBundleDigests | null = null;
     let heartbeatCount = 0;
     let sleepCount = 0;
     let releaseLateCancelHeartbeat: (() => void) | null = null;
@@ -940,7 +958,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
       },
       {
         attemptRunner: async (options) => {
-          await writeBundleOutputs(options.outputRoot, artifactEntries);
+          writtenBundle = await writeBundleOutputs(options.outputRoot, artifactEntries);
 
           return {
             artifactManifestDigest,
@@ -1011,10 +1029,10 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
       ]
     );
     const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
-    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
-    assert.equal(failureBody.artifactManifestDigest, artifactManifestDigest);
-    assert.equal(failureBody.bundleDigest, bundleDigest);
-    assert.equal(failureBody.candidateDigest, candidateDigest);
+    assert.deepEqual(failureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(failureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(failureBody.candidateDigest, writtenBundle?.candidateDigest);
     assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
     assert.equal(failureBody.terminalState, "cancelled");
     assert.equal(calls.at(-1)?.token, "job-token-4");
@@ -1621,8 +1639,18 @@ function buildWorkerJob() {
     leaseExpiresAt: fixedNow.toISOString(),
     leaseId: "lease-1",
     offlineBundleCompatible: true as const,
-    requiredArtifactRoles: ["run_manifest", "verdict_record"],
-    runBundleSchemaVersion: "problem9-run-bundle.v1",
+    requiredArtifactRoles: [
+      "run_manifest",
+      "package_reference",
+      "prompt_package",
+      "candidate_source",
+      "verdict_record",
+      "compiler_output",
+      "compiler_diagnostics",
+      "verifier_output",
+      "environment_snapshot"
+    ],
+    runBundleSchemaVersion: "1",
     runId: "run-1",
     target: {
       authMode: "machine_api_key" as const,
@@ -1659,13 +1687,58 @@ function buildHeartbeatResponse(overrides: Partial<Record<string, unknown>> = {}
 function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
   return [
     {
-      artifactRole: "run_manifest",
+      artifactRole: "package_reference",
       byteSize: 128,
       contentEncoding: null,
       mediaType: "application/json",
-      relativePath: "run-bundle.json",
+      relativePath: "package/benchmark-package.json",
       requiredForIngest: true,
       sha256: "3".repeat(64)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "package/package-ref.json",
+      requiredForIngest: true,
+      sha256: "4".repeat(64)
+    },
+    {
+      artifactRole: "prompt_package",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "prompt/prompt-package.json",
+      requiredForIngest: true,
+      sha256: "5".repeat(64)
+    },
+    {
+      artifactRole: "candidate_source",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "candidate/Candidate.lean",
+      requiredForIngest: true,
+      sha256: "6".repeat(64)
+    },
+    {
+      artifactRole: "compiler_diagnostics",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "verification/compiler-diagnostics.json",
+      requiredForIngest: true,
+      sha256: "7".repeat(64)
+    },
+    {
+      artifactRole: "compiler_output",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "verification/compiler-output.txt",
+      requiredForIngest: true,
+      sha256: "8".repeat(64)
     },
     {
       artifactRole: "verdict_record",
@@ -1674,69 +1747,963 @@ function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
       mediaType: "application/json",
       relativePath: "verification/verdict.json",
       requiredForIngest: true,
-      sha256: "4".repeat(64)
+      sha256: "9".repeat(64)
+    },
+    {
+      artifactRole: "verifier_output",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "verification/verifier-output.json",
+      requiredForIngest: true,
+      sha256: "a".repeat(64)
+    },
+    {
+      artifactRole: "environment_snapshot",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "environment/environment.json",
+      requiredForIngest: true,
+      sha256: "b".repeat(64)
+    },
+    {
+      artifactRole: "usage_summary",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "diagnostics/usage-summary.json",
+      requiredForIngest: false,
+      sha256: "c".repeat(64)
+    },
+    {
+      artifactRole: "execution_trace",
+      byteSize: 64,
+      contentEncoding: "gzip",
+      mediaType: "application/x-ndjson",
+      relativePath: "traces/execution-trace.ndjson.gz",
+      requiredForIngest: false,
+      sha256: "d".repeat(64)
     }
   ];
 }
 
 async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArtifactManifestEntry[]) {
-  await writeBundleOutputsWithVerdict(outputRoot, artifactEntries);
+  return writeBundleOutputsWithVerdict(outputRoot, artifactEntries);
 }
 
 async function writeBundleOutputsWithVerdict(
   outputRoot: string,
   artifactEntries: WorkerArtifactManifestEntry[],
   verdictOverrides: Record<string, unknown> = {}
-) {
+) : Promise<WrittenBundleDigests> {
+  await mkdir(path.join(outputRoot, "package"), { recursive: true });
+  await mkdir(path.join(outputRoot, "prompt"), { recursive: true });
+  await mkdir(path.join(outputRoot, "candidate"), { recursive: true });
+  await mkdir(path.join(outputRoot, "diagnostics"), { recursive: true });
+  await mkdir(path.join(outputRoot, "environment"), { recursive: true });
+  await mkdir(path.join(outputRoot, "traces"), { recursive: true });
   await mkdir(path.join(outputRoot, "verification"), { recursive: true });
+  const candidateSource = "theorem Candidate : True := by\n  trivial\n";
+  const benchmarkPackage = {
+    benchmarkFamily: "firstproof",
+    benchmarkItemId: "Problem9",
+    canonicalModules: {
+      gold: "FirstProof/Problem9/Gold.lean",
+      statement: "FirstProof/Problem9/Statement.lean",
+      support: "FirstProof/Problem9/Support.lean"
+    },
+    hashAlgorithm: "sha256",
+    hashes: {
+      "FirstProof/Problem9/Gold.lean": "9".repeat(64),
+      "FirstProof/Problem9/Statement.lean": "8".repeat(64),
+      "FirstProof/Problem9/Support.lean": "7".repeat(64),
+      "README.md": "6".repeat(64)
+    },
+    lanePolicy: {
+      primaryLane: "lean422_exact",
+      supportedLanes: ["lean422_exact"]
+    },
+    manifestSchemaVersion: "1",
+    packageDigest: benchmarkDigest,
+    packageDigestMode: "metadata_plus_file_inventory_v1",
+    packageId: "firstproof/Problem9",
+    packageRoot: "firstproof/Problem9",
+    packageVersion: "2026.03.13",
+    sourceManifestDigest: "5".repeat(64)
+  };
+  const packageRef = {
+    benchmarkItemId: "Problem9",
+    benchmarkPackageDigest: benchmarkDigest,
+    benchmarkPackageId: "firstproof/Problem9",
+    benchmarkPackageVersion: "2026.03.13",
+    canonicalModules: benchmarkPackage.canonicalModules,
+    laneId: "lean422_exact",
+    packageRefSchemaVersion: "1",
+    packageRoot: "firstproof/Problem9"
+  };
+  const promptPackage = {
+    authMode: "machine_api_key",
+    benchmarkItemId: "Problem9",
+    benchmarkPackageDigest: benchmarkDigest,
+    benchmarkPackageId: "firstproof/Problem9",
+    benchmarkPackageVersion: "2026.03.13",
+    harnessRevision: "worker-harness.v1",
+    laneId: "lean422_exact",
+    layerDigests: {
+      "benchmark.md": "2".repeat(64),
+      "item.md": "3".repeat(64),
+      "run-envelope.json": "4".repeat(64),
+      "system.md": "5".repeat(64)
+    },
+    layerVersions: {
+      benchmark: "1",
+      item: "1",
+      runEnvelope: "1",
+      system: "1"
+    },
+    layers: {
+      benchmark: "benchmark.md",
+      item: "item.md",
+      runEnvelope: "run-envelope.json",
+      system: "system.md"
+    },
+    modelConfigId: "openai/gpt-5",
+    promptPackageDigest: promptDigest,
+    promptPackageDigestMode: "metadata_plus_layer_inventory_v1",
+    promptPackageSchemaVersion: "1",
+    promptProtocolVersion: "problem9-prompt-protocol.v1",
+    providerFamily: "openai",
+    runMode: "bounded_agentic_attempt",
+    toolProfile: "workspace_edit_limited"
+  };
+  const compilerDiagnostics = {
+    severity: "info"
+  };
+  const compilerOutput = "Build completed successfully.\n";
+  const verifierOutput = {
+    exitCode: 0
+  };
+  const usageSummary = {
+    completionTokens: 22,
+    promptTokens: 20,
+    totalTokens: 42
+  };
+  const executionTrace = gzipSync(
+    Buffer.from('{"event":"attempt_started","ts":"2026-03-13T00:00:00.000Z"}\n', "utf8")
+  );
+  const environment = {
+    authMode: "machine_api_key",
+    environmentSchemaVersion: "1",
+    executionImageDigest: null,
+    executionTargetKind: "problem9-execution",
+    harnessRevision: "worker-harness.v1",
+    lakeSnapshotId: "leanprover/lean4:v4.22.0",
+    laneId: "lean422_exact",
+    leanVersion: "4.22.0",
+    localDevboxDigest: null,
+    metadata: {},
+    modelConfigId: "openai/gpt-5",
+    modelSnapshotId: "openai/gpt-5.2026-03-13",
+    os: {
+      arch: process.arch,
+      platform: process.platform,
+      release: "test-kernel"
+    },
+    promptProtocolVersion: "problem9-prompt-protocol.v1",
+    providerFamily: "openai",
+    runMode: "bounded_agentic_attempt",
+    runtime: {
+      bunVersion: null,
+      nodeVersion: process.version,
+      tsxVersion: null
+    },
+    toolProfile: "workspace_edit_limited",
+    verifierVersion: "lean4.22.0"
+  };
+  const baseVerdict = {
+    attemptId: "attempt-1",
+    axiomCheck: "passed",
+    benchmarkPackageDigest: benchmarkDigest,
+    candidateDigest: sha256Text(candidateSource),
+    containsAdmit: false,
+    containsSorry: false,
+    diagnosticGate: "passed",
+    laneId: "lean422_exact",
+    primaryFailure: null,
+    result: "pass",
+    runId: "run-1",
+    semanticEquality: "matched",
+    surfaceEquality: "matched",
+    surface_drift: false,
+    verdictSchemaVersion: "problem9-verdict.v1"
+  };
+  const verdict = {
+    ...baseVerdict,
+    ...verdictOverrides
+  };
+  const writtenBenchmarkPackage = `${stableStringify(benchmarkPackage)}\n`;
+  const writtenPackageRef = `${stableStringify(packageRef)}\n`;
+  const writtenPromptPackage = `${stableStringify(promptPackage)}\n`;
+  const writtenEnvironment = `${stableStringify(environment)}\n`;
+  const writtenUsageSummary = `${stableStringify(usageSummary)}\n`;
+  const writtenVerdict = `${stableStringify(verdict)}\n`;
+  const writtenCompilerDiagnostics = `${stableStringify(compilerDiagnostics)}\n`;
+  const writtenVerifierOutput = `${stableStringify(verifierOutput)}\n`;
+  await writeFile(path.join(outputRoot, "candidate", "Candidate.lean"), candidateSource, "utf8");
   await writeFile(
-    path.join(outputRoot, "artifact-manifest.json"),
-    JSON.stringify({ artifacts: artifactEntries }, null, 2),
+    path.join(outputRoot, "package", "benchmark-package.json"),
+    writtenBenchmarkPackage,
+    "utf8"
+  );
+  await writeFile(path.join(outputRoot, "package", "package-ref.json"), writtenPackageRef, "utf8");
+  await writeFile(
+    path.join(outputRoot, "prompt", "prompt-package.json"),
+    writtenPromptPackage,
     "utf8"
   );
   await writeFile(
-    path.join(outputRoot, "run-bundle.json"),
-    JSON.stringify(
-      {
-        artifactManifestDigest,
-        bundleDigest,
-        candidateDigest,
-        environmentDigest,
-        runId: "run-1",
-        verdictDigest
-      },
-      null,
-      2
-    ),
+    path.join(outputRoot, "environment", "environment.json"),
+    writtenEnvironment,
+    "utf8"
+  );
+  await writeFile(
+    path.join(outputRoot, "diagnostics", "usage-summary.json"),
+    writtenUsageSummary,
+    "utf8"
+  );
+  await writeFile(
+    path.join(outputRoot, "verification", "compiler-diagnostics.json"),
+    writtenCompilerDiagnostics,
+    "utf8"
+  );
+  await writeFile(
+    path.join(outputRoot, "verification", "compiler-output.txt"),
+    compilerOutput,
+    "utf8"
+  );
+  await writeFile(
+    path.join(outputRoot, "verification", "verifier-output.json"),
+    writtenVerifierOutput,
     "utf8"
   );
   await writeFile(
     path.join(outputRoot, "verification", "verdict.json"),
-    JSON.stringify(
-      {
-        attemptId: "attempt-1",
-        axiomCheck: "passed",
-        benchmarkPackageDigest: benchmarkDigest,
-        candidateDigest,
-        containsAdmit: false,
-        containsSorry: false,
-        diagnosticGate: "passed",
-        laneId: "lean422_exact",
-        primaryFailure: null,
-        result: "pass",
-        semanticEquality: "matched",
-        surfaceEquality: "matched",
-        verdictSchemaVersion: "problem9-verdict.v1",
-        ...verdictOverrides
-      },
-      null,
-      2
-    ),
+    writtenVerdict,
     "utf8"
   );
+  await writeFile(
+    path.join(outputRoot, "traces", "execution-trace.ndjson.gz"),
+    executionTrace
+  );
+  const writtenCandidate = normalizeText(candidateSource);
+  const canonicalCandidateDigest = sha256Text(writtenCandidate);
+  const canonicalEnvironmentDigest = sha256Text(stableStringify(environment));
+  const canonicalVerdictDigest = sha256Text(stableStringify(verdict));
+  const verdictResult = String(verdict.result ?? "pass");
+  const manifestEntries = await Promise.all(
+    artifactEntries.map((artifact) => materializeArtifactManifestEntry(outputRoot, artifact))
+  );
+  const manifest = {
+    artifactManifestSchemaVersion: "1",
+    artifacts: manifestEntries,
+    hashAlgorithm: "sha256"
+  };
+  const writtenArtifactManifest = `${stableStringify(manifest)}\n`;
+  const canonicalArtifactManifestDigest = sha256Text(writtenArtifactManifest);
+  const runBundle = {
+    artifactManifestDigest: canonicalArtifactManifestDigest,
+    attemptId: "attempt-1",
+    authMode: "machine_api_key",
+    benchmarkItemId: "Problem9",
+    benchmarkPackageDigest: benchmarkDigest,
+    benchmarkPackageId: "firstproof/Problem9",
+    benchmarkPackageVersion: "2026.03.13",
+    bundleSchemaVersion: "1",
+    candidateDigest: canonicalCandidateDigest,
+    environmentDigest: canonicalEnvironmentDigest,
+    harnessRevision: "worker-harness.v1",
+    jobId: "job-1",
+    laneId: "lean422_exact",
+    modelConfigId: "openai/gpt-5",
+    modelSnapshotId: "openai/gpt-5.2026-03-13",
+    promptPackageDigest: promptDigest,
+    promptProtocolVersion: "problem9-prompt-protocol.v1",
+    providerFamily: "openai",
+    runConfigDigest: computeRunConfigDigest({
+      benchmarkPackage,
+      environmentDigest: canonicalEnvironmentDigest,
+      promptPackage
+    }),
+    runId: "run-1",
+    runMode: "bounded_agentic_attempt",
+    status: verdictResult === "pass" ? "success" : "failure",
+    stopReason: verdictResult === "pass" ? "verification_passed" : "verifier_failed",
+    toolProfile: "workspace_edit_limited",
+    verifierVersion: "lean4.22.0",
+    verdictDigest: canonicalVerdictDigest
+  };
+  const canonicalBundleDigest = sha256Text(
+    stableStringify({
+      artifactInventory: [...manifestEntries].sort((left, right) =>
+        left.relativePath.localeCompare(right.relativePath)
+      ),
+      runBundle: omitDigestFields(runBundle)
+    })
+  );
+  await writeFile(
+    path.join(outputRoot, "artifact-manifest.json"),
+    writtenArtifactManifest,
+    "utf8"
+  );
+  await writeFile(
+    path.join(outputRoot, "run-bundle.json"),
+    `${stableStringify({
+      ...runBundle,
+      bundleDigest: canonicalBundleDigest
+    })}\n`,
+    "utf8"
+  );
+
+  return {
+    artifactManifestDigest: canonicalArtifactManifestDigest,
+    bundleDigest: canonicalBundleDigest,
+    candidateDigest: canonicalCandidateDigest,
+    environmentDigest: canonicalEnvironmentDigest,
+    verdictDigest: canonicalVerdictDigest
+  };
 }
 
-test("runWorkerClaimLoop uses selected artifact refs when a failing verdict omits primaryFailure", async () => {
+test("runWorkerClaimLoop rejects bundle digest drift before artifact registration", async (t) => {
+  const mismatchCases = [
+    {
+      expectedSummary: /artifactManifestDigest does not match artifact-manifest\.json/i,
+      name: "artifactManifestDigest",
+      tamper: async (outputRoot: string) => {
+        await rewriteRunBundle(outputRoot, (runBundle) => ({
+          ...runBundle,
+          artifactManifestDigest: "0".repeat(64)
+        }));
+      }
+    },
+    {
+      expectedSummary: /candidateDigest does not match candidate\/Candidate\.lean/i,
+      name: "candidateDigest",
+      tamper: async (outputRoot: string) => {
+        await rewriteRunBundle(outputRoot, (runBundle) => ({
+          ...runBundle,
+          candidateDigest: "0".repeat(64)
+        }));
+      }
+    },
+    {
+      expectedSummary: /environmentDigest does not match environment\/environment\.json/i,
+      name: "environmentDigest",
+      tamper: async (outputRoot: string) => {
+        await rewriteRunBundle(outputRoot, (runBundle) => ({
+          ...runBundle,
+          environmentDigest: "0".repeat(64)
+        }));
+      }
+    },
+    {
+      expectedSummary: /verdictDigest does not match verification\/verdict\.json/i,
+      name: "verdictDigest",
+      tamper: async (outputRoot: string) => {
+        await rewriteRunBundle(outputRoot, (runBundle) => ({
+          ...runBundle,
+          verdictDigest: "0".repeat(64)
+        }));
+      }
+    },
+    {
+      expectedSummary: /bundleDigest does not match the canonical bundle digest/i,
+      name: "bundleDigest",
+      tamper: async (outputRoot: string) => {
+        await rewriteRunBundle(outputRoot, (runBundle) => ({
+          ...runBundle,
+          bundleDigest: "0".repeat(64)
+        }));
+      }
+    },
+    {
+      expectedSummary: /verification\/verdict\.json candidateDigest does not match candidate\/Candidate\.lean/i,
+      name: "verdict candidateDigest drift",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const artifactManifest = await readJsonFile(path.join(outputRoot, "artifact-manifest.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          candidateDigest: "0".repeat(64)
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => {
+          const nextRunBundle = {
+            ...runBundle,
+            verdictDigest: sha256Text(verdictText)
+          };
+
+          return {
+            ...nextRunBundle,
+            bundleDigest: sha256Text(
+              stableStringify({
+                artifactInventory: [
+                  ...((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? [])
+                ].sort((left, right) =>
+                  String(left.relativePath).localeCompare(String(right.relativePath))
+                ),
+                runBundle: omitDigestFields(nextRunBundle)
+              })
+            )
+          };
+        });
+      }
+    },
+    {
+      expectedSummary: /benchmarkPackageDigest does not match the claimed job target/i,
+      name: "benchmarkPackageDigest identity drift",
+      tamper: async (outputRoot: string) => {
+        const benchmarkPackage = await readJsonFile(path.join(outputRoot, "package", "benchmark-package.json"));
+        const packageRef = await readJsonFile(path.join(outputRoot, "package", "package-ref.json"));
+        const promptPackage = await readJsonFile(path.join(outputRoot, "prompt", "prompt-package.json"));
+        const environment = await readJsonFile(path.join(outputRoot, "environment", "environment.json"));
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedBenchmarkPackage = {
+          ...benchmarkPackage,
+          packageDigest: "9".repeat(64)
+        };
+        const tamperedPackageRef = {
+          ...packageRef,
+          benchmarkPackageDigest: "9".repeat(64)
+        };
+        const tamperedPromptPackage = {
+          ...promptPackage,
+          benchmarkPackageDigest: "9".repeat(64)
+        };
+        const tamperedVerdict = {
+          ...verdict,
+          benchmarkPackageDigest: "9".repeat(64)
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(
+          path.join(outputRoot, "package", "benchmark-package.json"),
+          `${stableStringify(tamperedBenchmarkPackage)}\n`,
+          "utf8"
+        );
+        await writeFile(
+          path.join(outputRoot, "prompt", "prompt-package.json"),
+          `${stableStringify(tamperedPromptPackage)}\n`,
+          "utf8"
+        );
+        await writeFile(
+          path.join(outputRoot, "package", "package-ref.json"),
+          `${stableStringify(tamperedPackageRef)}\n`,
+          "utf8"
+        );
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "package_reference",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "package/benchmark-package.json",
+          requiredForIngest: true
+        });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "package_reference",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "package/package-ref.json",
+          requiredForIngest: true
+        });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          benchmarkPackageDigest: "9".repeat(64),
+          runConfigDigest: computeRunConfigDigest({
+            benchmarkPackage: {
+              benchmarkItemId: String(tamperedBenchmarkPackage.benchmarkItemId),
+              packageDigest: String(tamperedBenchmarkPackage.packageDigest),
+              packageId: String(tamperedBenchmarkPackage.packageId),
+              packageVersion: String(tamperedBenchmarkPackage.packageVersion)
+            },
+            environmentDigest: sha256Text(stableStringify(environment)),
+            promptPackage: {
+              authMode: String(tamperedPromptPackage.authMode),
+              harnessRevision: String(tamperedPromptPackage.harnessRevision),
+              laneId: String(tamperedPromptPackage.laneId),
+              modelConfigId: String(tamperedPromptPackage.modelConfigId),
+              promptPackageDigest: String(tamperedPromptPackage.promptPackageDigest),
+              promptProtocolVersion: String(tamperedPromptPackage.promptProtocolVersion),
+              providerFamily: String(tamperedPromptPackage.providerFamily),
+              runMode: String(tamperedPromptPackage.runMode),
+              toolProfile: String(tamperedPromptPackage.toolProfile)
+            }
+          }),
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /modelConfigId does not match the claimed job target/i,
+      name: "coherent prompt and environment retamper",
+      tamper: async (outputRoot: string) => {
+        const promptPackage = await readJsonFile(path.join(outputRoot, "prompt", "prompt-package.json"));
+        const environment = await readJsonFile(path.join(outputRoot, "environment", "environment.json"));
+        const tamperedPromptPackage = { ...promptPackage, modelConfigId: "openai/gpt-5-pro" };
+        const tamperedEnvironment = { ...environment, modelConfigId: "openai/gpt-5-pro" };
+
+        await writeFile(
+          path.join(outputRoot, "prompt", "prompt-package.json"),
+          `${stableStringify(tamperedPromptPackage)}\n`,
+          "utf8"
+        );
+        await writeFile(
+          path.join(outputRoot, "environment", "environment.json"),
+          `${stableStringify(tamperedEnvironment)}\n`,
+          "utf8"
+        );
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "environment_snapshot",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "environment/environment.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          environmentDigest: sha256Text(stableStringify(tamperedEnvironment)),
+          modelConfigId: "openai/gpt-5-pro",
+          runConfigDigest: computeRunConfigDigest({
+            benchmarkPackage: {
+              benchmarkItemId: "Problem9",
+              packageDigest: benchmarkDigest,
+              packageId: "firstproof/Problem9",
+              packageVersion: "2026.03.13"
+            },
+            environmentDigest: sha256Text(stableStringify(tamperedEnvironment)),
+            promptPackage: {
+              authMode: String(tamperedPromptPackage.authMode),
+              harnessRevision: String(tamperedPromptPackage.harnessRevision),
+              laneId: String(tamperedPromptPackage.laneId),
+              modelConfigId: String(tamperedPromptPackage.modelConfigId),
+              promptPackageDigest: String(tamperedPromptPackage.promptPackageDigest),
+              promptProtocolVersion: String(tamperedPromptPackage.promptProtocolVersion),
+              providerFamily: String(tamperedPromptPackage.providerFamily),
+              runMode: String(tamperedPromptPackage.runMode),
+              toolProfile: String(tamperedPromptPackage.toolProfile)
+            }
+          })
+        }));
+      }
+    },
+    {
+      expectedSummary: /bundleSchemaVersion does not match the claimed job target/i,
+      name: "bundleSchemaVersion drift",
+      tamper: async (outputRoot: string) => {
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          bundleSchemaVersion: "2"
+        }));
+      }
+    },
+    {
+      expectedSummary: /environment\/environment\.json must use artifactRole environment_snapshot/i,
+      name: "artifact role path drift",
+      tamper: async (outputRoot: string) => {
+        await rewriteArtifactManifest(outputRoot, (artifactManifest) => ({
+          ...artifactManifest,
+          artifacts: (((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? []))
+            .map((artifact) =>
+              String(artifact.relativePath) === "environment/environment.json"
+                ? {
+                    ...artifact,
+                    artifactRole: "prompt_package"
+                  }
+                : artifact
+            )
+        }));
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary: /Passing verifier verdicts require diagnosticGate=passed/i,
+      name: "passing verdict semantic drift",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          diagnosticGate: "failed"
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /Passing verifier verdicts may not include a primaryFailure classification/i,
+      name: "passing verdict with primaryFailure",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          primaryFailure: {
+            evidenceArtifactRefs: ["verification/verdict.json"],
+            failureCode: "proof_policy_failed",
+            failureFamily: "verification",
+            phase: "verify",
+            retryEligibility: "never",
+            summary: "unexpected failure payload",
+            terminality: "terminal_attempt",
+            userVisibility: "internal_only"
+          }
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /failureCode to match primaryFailure\.failureCode/i,
+      name: "failing verdict failureCode drift",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          diagnosticGate: "failed",
+          failureCode: "proof_policy_failed",
+          primaryFailure: {
+            evidenceArtifactRefs: ["verification/verdict.json"],
+            failureCode: "forbidden_axiom_dependency",
+            failureFamily: "verification",
+            phase: "verify",
+            retryEligibility: "never",
+            summary: "axiom drift",
+            terminality: "terminal_attempt",
+            userVisibility: "internal_only"
+          },
+          result: "fail"
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          status: "failure",
+          stopReason: "verifier_failed",
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /status does not match verification\/verdict\.json result/i,
+      name: "verdict result drift",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          result: "fail"
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /verification\/verdict\.json runId does not match run-bundle\.json/i,
+      name: "verdict runId drift",
+      tamper: async (outputRoot: string) => {
+        const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
+        const tamperedVerdict = {
+          ...verdict,
+          runId: "run-2"
+        };
+        const verdictText = stableStringify(tamperedVerdict);
+
+        await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "verdict_record",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "verification/verdict.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          verdictDigest: sha256Text(verdictText)
+        }));
+      }
+    },
+    {
+      expectedSummary: /prompt\/prompt-package\.json sha256 does not match artifact-manifest\.json/i,
+      name: "artifact manifest entry sha256 drift",
+      tamper: async (outputRoot: string) => {
+        const promptEntry = await buildArtifactManifestEntryForPath(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+
+        await rewriteArtifactManifest(outputRoot, (artifactManifest) => ({
+          ...artifactManifest,
+          artifacts: (((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? []))
+            .map((artifact) =>
+              String(artifact.relativePath) === "prompt/prompt-package.json"
+                ? {
+                    ...promptEntry,
+                    sha256: "0".repeat(64)
+                  }
+                : artifact
+            )
+        }));
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary: /prompt\/prompt-package\.json byteSize does not match artifact-manifest\.json/i,
+      name: "artifact manifest entry byteSize drift",
+      tamper: async (outputRoot: string) => {
+        const promptEntry = await buildArtifactManifestEntryForPath(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+
+        await rewriteArtifactManifest(outputRoot, (artifactManifest) => ({
+          ...artifactManifest,
+          artifacts: (((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? []))
+            .map((artifact) =>
+              String(artifact.relativePath) === "prompt/prompt-package.json"
+                ? {
+                    ...promptEntry,
+                    byteSize: promptEntry.byteSize + 1
+                  }
+                : artifact
+            )
+        }));
+        await refreshBundleDigests(outputRoot);
+      }
+    }
+  ] as const;
+
+  for (const mismatchCase of mismatchCases) {
+    await t.test(mismatchCase.name, async () => {
+      const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), `paretoproof-worker-claim-bundle-mismatch-${sanitizePath(mismatchCase.name)}-`)
+      );
+
+      try {
+        const calls: ApiCall[] = [];
+        const workerJob = buildWorkerJob();
+        const artifactEntries = buildArtifactEntries();
+        const fetchImpl = createFetchMock(
+          [
+            {
+              body: {
+                leaseStatus: "active",
+                pollAfterSeconds: 0,
+                workerJob
+              },
+              path: "/internal/worker/claims"
+            },
+            {
+              body: buildHeartbeatResponse({
+                acknowledgedEventSequence: 0,
+                jobToken: "job-token-2"
+              }),
+              path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+            },
+            {
+              body: {
+                acceptedAt: fixedNow.toISOString(),
+                acknowledgedSequence: 1
+              },
+              path: `/internal/worker/jobs/${workerJob.jobId}/events`
+            },
+            {
+              body: buildHeartbeatResponse({
+                acknowledgedEventSequence: 1
+              }),
+              path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+            },
+            {
+              body: {
+                acceptedAt: fixedNow.toISOString(),
+                attemptState: "failed",
+                jobState: "failed",
+                runState: "failed"
+              },
+              path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+            }
+          ],
+          calls
+        );
+
+        const result = await runWorkerClaimLoop(
+          {
+            authMode: "machine_api_key",
+            maxJobs: 1,
+            once: true,
+            outputRoot: path.join(tempRoot, "output"),
+            workerId: "worker-1",
+            workerPool: "modal-dev",
+            workerRuntime: "modal",
+            workerVersion: "worker.v1",
+            workspaceRoot: path.join(tempRoot, "workspace")
+          },
+          {
+            attemptRunner: async (options) => {
+              await writeBundleOutputs(options.outputRoot, artifactEntries);
+              await mismatchCase.tamper(options.outputRoot);
+
+              return {
+                artifactManifestDigest,
+                attemptId: workerJob.attemptId,
+                authMode: "machine_api_key",
+                bundleDigest,
+                compileRepairCount: 0,
+                outputRoot: options.outputRoot,
+                promptPackageDigest: promptDigest,
+                providerFamily: "openai",
+                providerTurnsUsed: 1,
+                result: "pass",
+                runConfigDigest: "2".repeat(64),
+                runId: workerJob.runId,
+                stopReason: "verification_passed",
+                verifierRepairCount: 0,
+                verdictDigest
+              };
+            },
+            fetchImpl,
+            materializeBenchmarkPackage: async ({ outputRoot }) => ({
+              outputRoot,
+              packageDigest: benchmarkDigest,
+              packageId: "firstproof/Problem9",
+              packageVersion: "2026.03.13"
+            }),
+            materializePromptPackage: async ({ outputRoot }) => ({
+              outputRoot,
+              promptPackageDigest: promptDigest
+            }),
+            now: () => fixedNow,
+            rawEnv: {
+              API_BASE_URL: "https://api.paretoproof.test",
+              CODEX_API_KEY: "worker-api-key",
+              WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+            },
+            sleep: neverSleep
+          }
+        );
+
+        assert.deepEqual(result, {
+          claimedJobs: 1,
+          completedJobs: 1,
+          idlePollCount: 0,
+          stoppedReason: "max_jobs_reached"
+        });
+        assert.deepEqual(
+          calls.map((call) => call.path),
+          [
+            "/internal/worker/claims",
+            `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+            `/internal/worker/jobs/${workerJob.jobId}/events`,
+            `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+            `/internal/worker/jobs/${workerJob.jobId}/failure`
+          ]
+        );
+        const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+        assert.equal(failureBody.failure.failureCode, "harness_crashed");
+        assert.match(failureBody.failure.summary, mismatchCase.expectedSummary);
+        assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+        assert.equal(failureBody.artifactIds, undefined);
+        assert.equal(failureBody.artifactManifestDigest, null);
+        assert.equal(failureBody.bundleDigest, null);
+        assert.equal(failureBody.candidateDigest, null);
+        assert.equal(failureBody.verdictDigest, null);
+        assert.equal(failureBody.verifierVerdict, null);
+        await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+        await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+      } finally {
+        await rm(tempRoot, { force: true, recursive: true });
+      }
+    });
+  }
+});
+
+test("runWorkerClaimLoop rejects a failing verdict that omits primaryFailure before artifact registration", async () => {
   const tempRoot = await mkdtemp(
     path.join(os.tmpdir(), "paretoproof-worker-claim-fail-without-primary-failure-")
   );
@@ -1774,32 +2741,6 @@ test("runWorkerClaimLoop uses selected artifact refs when a failing verdict omit
             acknowledgedEventSequence: 1
           }),
           path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
-        },
-        {
-          body: {
-            acceptedAt: fixedNow.toISOString(),
-            artifactManifestDigest,
-            artifacts: artifactEntries.map((artifact, index) => ({
-              artifactId: `artifact-${index + 1}`,
-              artifactRole: artifact.artifactRole,
-              relativePath: artifact.relativePath
-            }))
-          },
-          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
-        },
-        {
-          body: {
-            acceptedAt: fixedNow.toISOString(),
-            acknowledgedSequence: 2
-          },
-          path: `/internal/worker/jobs/${workerJob.jobId}/events`
-        },
-        {
-          body: {
-            acceptedAt: fixedNow.toISOString(),
-            acknowledgedSequence: 3
-          },
-          path: `/internal/worker/jobs/${workerJob.jobId}/events`
         },
         {
           body: {
@@ -1879,13 +2820,25 @@ test("runWorkerClaimLoop uses selected artifact refs when a failing verdict omit
       stoppedReason: "max_jobs_reached"
     });
 
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
     const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
     assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/failure`);
-    assert.deepEqual(failureBody.artifactIds, ["artifact-1", "artifact-2"]);
-    assert.equal(failureBody.failure.failureCode, "proof_policy_failed");
-    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
-    assert.equal(failureBody.bundleDigest, bundleDigest);
-    assert.notEqual(failureBody.verifierVerdict, null);
+    assert.equal(failureBody.failure.failureCode, "harness_crashed");
+    assert.match(failureBody.failure.summary, /Failing verifier verdicts require a primaryFailure classification/i);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+    assert.equal(failureBody.artifactIds, undefined);
+    assert.equal(failureBody.artifactManifestDigest, null);
+    assert.equal(failureBody.bundleDigest, null);
+    assert.equal(failureBody.verifierVerdict, null);
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {
@@ -1920,6 +2873,220 @@ function createFetchMock(script: ApiMockResponse[], calls: ApiCall[]) {
       status: next.status ?? 200
     });
   };
+}
+
+async function rewriteRunBundle(
+  outputRoot: string,
+  mutator: (runBundle: Record<string, unknown>) => Record<string, unknown>
+) {
+  const runBundlePath = path.join(outputRoot, "run-bundle.json");
+  const currentRunBundle = await readJsonFile(runBundlePath);
+  await writeFile(runBundlePath, `${stableStringify(mutator(currentRunBundle))}\n`, "utf8");
+}
+
+async function rewriteArtifactManifest(
+  outputRoot: string,
+  mutator: (artifactManifest: Record<string, unknown>) => Record<string, unknown>
+) {
+  const artifactManifestPath = path.join(outputRoot, "artifact-manifest.json");
+  const currentArtifactManifest = await readJsonFile(artifactManifestPath);
+  await writeFile(
+    artifactManifestPath,
+    `${stableStringify(mutator(currentArtifactManifest))}\n`,
+    "utf8"
+  );
+}
+
+async function refreshBundleDigests(
+  outputRoot: string,
+  mutator: (runBundle: Record<string, unknown>) => Record<string, unknown> = (runBundle) => runBundle
+) {
+  const artifactManifestPath = path.join(outputRoot, "artifact-manifest.json");
+  const runBundlePath = path.join(outputRoot, "run-bundle.json");
+  const artifactManifestText = normalizeText(await readFile(artifactManifestPath, "utf8"));
+  const artifactManifest = JSON.parse(artifactManifestText) as {
+    artifacts?: Array<Record<string, unknown>>;
+  };
+  const currentRunBundle = await readJsonFile(runBundlePath);
+  const artifactManifestDigest = sha256Text(artifactManifestText);
+  const nextRunBundle = mutator({
+    ...currentRunBundle,
+    artifactManifestDigest
+  });
+  const bundleDigest = sha256Text(
+    stableStringify({
+      artifactInventory: [...(artifactManifest.artifacts ?? [])].sort((left, right) =>
+        String(left.relativePath).localeCompare(String(right.relativePath))
+      ),
+      runBundle: omitDigestFields(nextRunBundle)
+    })
+  );
+
+  await writeFile(
+    runBundlePath,
+    `${stableStringify({
+      ...nextRunBundle,
+      artifactManifestDigest,
+      bundleDigest
+    })}\n`,
+    "utf8"
+  );
+}
+
+async function upsertArtifactManifestEntry(
+  outputRoot: string,
+  artifact: Pick<
+    WorkerArtifactManifestEntry,
+    "artifactRole" | "contentEncoding" | "mediaType" | "relativePath" | "requiredForIngest"
+  >
+) {
+  const materializedArtifact = await buildArtifactManifestEntryForPath(outputRoot, artifact);
+
+  await rewriteArtifactManifest(outputRoot, (artifactManifest) => {
+    const currentArtifacts = ((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? [])
+      .filter((entry) => String(entry.relativePath) !== artifact.relativePath);
+
+    return {
+      ...artifactManifest,
+      artifacts: [...currentArtifacts, materializedArtifact].sort((left, right) =>
+        String(left.relativePath).localeCompare(String(right.relativePath))
+      )
+    };
+  });
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(normalizeText(await readFile(filePath, "utf8"))) as Record<
+    string,
+    unknown
+  >;
+}
+
+function sanitizePath(value: string): string {
+  return value.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase();
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function sha256Text(text: string): string {
+  return createHash("sha256").update(Buffer.from(normalizeText(text), "utf8")).digest("hex");
+}
+
+function sha256Bytes(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function computeRunConfigDigest(options: {
+  benchmarkPackage: {
+    benchmarkItemId: string;
+    packageDigest: string;
+    packageId: string;
+    packageVersion: string;
+  };
+  environmentDigest: string;
+  promptPackage: {
+    authMode: string;
+    harnessRevision: string;
+    laneId: string;
+    modelConfigId: string;
+    promptPackageDigest: string;
+    promptProtocolVersion: string;
+    providerFamily: string;
+    runMode: string;
+    toolProfile: string;
+  };
+}) {
+  return sha256Text(
+    stableStringify({
+      authMode: options.promptPackage.authMode,
+      benchmarkItemId: options.benchmarkPackage.benchmarkItemId,
+      benchmarkPackageDigest: options.benchmarkPackage.packageDigest,
+      benchmarkPackageId: options.benchmarkPackage.packageId,
+      benchmarkPackageVersion: options.benchmarkPackage.packageVersion,
+      environmentDigest: options.environmentDigest,
+      harnessRevision: options.promptPackage.harnessRevision,
+      laneId: options.promptPackage.laneId,
+      modelConfigId: options.promptPackage.modelConfigId,
+      modelSnapshotId: "openai/gpt-5.2026-03-13",
+      promptPackageDigest: options.promptPackage.promptPackageDigest,
+      promptProtocolVersion: options.promptPackage.promptProtocolVersion,
+      providerFamily: options.promptPackage.providerFamily,
+      runMode: options.promptPackage.runMode,
+      toolProfile: options.promptPackage.toolProfile,
+      verifierVersion: "lean4.22.0"
+    })
+  );
+}
+
+function expectedArtifactIds(artifactEntries: WorkerArtifactManifestEntry[]) {
+  return artifactEntries.map((_, index) => `artifact-${index + 1}`);
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value), null, 2);
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+function omitDigestFields<TValue extends Record<string, unknown>>(value: TValue) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => !key.toLowerCase().endsWith("digest"))
+  );
+}
+
+async function materializeArtifactManifestEntry(
+  outputRoot: string,
+  artifact: WorkerArtifactManifestEntry
+): Promise<WorkerArtifactManifestEntry> {
+  if (artifact.artifactRole === "run_manifest" || artifact.relativePath === "run-bundle.json") {
+    return artifact;
+  }
+
+  return buildArtifactManifestEntryForPath(outputRoot, artifact);
+}
+
+async function buildArtifactManifestEntryForPath(
+  outputRoot: string,
+  artifact: Pick<
+    WorkerArtifactManifestEntry,
+    "artifactRole" | "contentEncoding" | "mediaType" | "relativePath" | "requiredForIngest"
+  >
+): Promise<WorkerArtifactManifestEntry> {
+  const fileBytes = await readFile(path.join(outputRoot, artifact.relativePath));
+
+  return {
+    ...artifact,
+    byteSize: fileBytes.byteLength,
+    sha256: shouldHashNormalizedTextArtifact(artifact)
+      ? sha256Text(fileBytes.toString("utf8"))
+      : sha256Bytes(fileBytes)
+  };
+}
+
+function shouldHashNormalizedTextArtifact(
+  artifact: Pick<WorkerArtifactManifestEntry, "contentEncoding" | "mediaType">
+) {
+  if (artifact.contentEncoding !== null) {
+    return false;
+  }
+
+  return artifact.mediaType === "application/json" || artifact.mediaType?.startsWith("text/") === true;
 }
 
 function neverSleep(): Promise<void> {

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -239,6 +239,153 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
   }
 });
 
+test("runWorkerClaimLoop accepts uppercase verdict benchmarkPackageDigest hex", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-uppercase-verdict-digest-"));
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "succeeded",
+            jobState: "completed",
+            runState: "succeeded"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/result`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputsWithVerdict(options.outputRoot, artifactEntries, {
+            benchmarkPackageDigest: benchmarkDigest.toUpperCase()
+          });
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/result`);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("runWorkerClaimLoop terminalizes cancellation after the first cancel-requested heartbeat", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-cancel-"));
 


### PR DESCRIPTION
## Summary
- validate run bundles against the claimed job target and canonical core bundle invariants before artifact registration
- fence path aliasing, symlink escapes, and digest drift while still allowing optional usage/trace artifacts
- keep the API and worker tests aligned with the run_manifest compatibility boundary and the stricter finalization checks

## Verification
- node --import tsx --test test/worker-claim-loop.test.ts
- bun run test:api
- bun run build

Closes #1005