### PR TITLE
[Finding][Worker] Make run bundles self-contained for provenance and audit

### DIFF
--- a/apps/api/src/lib/problem9-offline-ingest.ts
+++ b/apps/api/src/lib/problem9-offline-ingest.ts
@@ -91,6 +91,20 @@ const bundleManifestArtifactRoles = {
   "verification/verdict.json": "verdict_record",
   "verification/verifier-output.json": "verifier_output"
 } as const satisfies Record<string, Problem9OfflineArtifactManifestEntry["artifactRole"]>;
+const optionalBundleManifestMetadataByPath = {
+  "execution/usage.json": {
+    artifactRole: "usage_summary",
+    contentEncoding: null,
+    mediaType: "application/json",
+    requiredForIngest: false
+  }
+} as const satisfies Record<
+  string,
+  Pick<
+    Problem9OfflineArtifactManifestEntry,
+    "artifactRole" | "contentEncoding" | "mediaType" | "requiredForIngest"
+  >
+>;
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
 const promptRunEnvelopeSchema = z.object({
   attemptId: z.string().min(1),
@@ -712,6 +726,15 @@ function validateProvidedManifestEntry(
 }
 
 function expectedManifestMetadataForPath(relativePath: string) {
+  const optionalMetadata =
+    optionalBundleManifestMetadataByPath[
+      relativePath as keyof typeof optionalBundleManifestMetadataByPath
+    ];
+
+  if (optionalMetadata) {
+    return optionalMetadata;
+  }
+
   return {
     artifactRole:
       bundleManifestArtifactRoles[relativePath as keyof typeof bundleManifestArtifactRoles],

--- a/apps/api/src/lib/problem9-offline-ingest.ts
+++ b/apps/api/src/lib/problem9-offline-ingest.ts
@@ -13,6 +13,8 @@ import {
   type Problem9VerifierVerdict
 } from "@paretoproof/shared";
 import { eq } from "drizzle-orm";
+import path from "node:path";
+import { z } from "zod";
 import {
   artifacts,
   attempts,
@@ -28,8 +30,21 @@ import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 const requiredManifestPathsBase = [
   "package/benchmark-package.json",
+  "package/FirstProof/Problem9/Gold.lean",
+  "package/FirstProof/Problem9/Statement.lean",
+  "package/FirstProof/Problem9/Support.lean",
+  "package/LICENSE",
+  "package/README.md",
+  "package/lake-manifest.json",
+  "package/lakefile.toml",
+  "package/lean-toolchain",
+  "package/statements/problem.md",
   "package/package-ref.json",
+  "prompt/benchmark.md",
+  "prompt/item.md",
   "prompt/prompt-package.json",
+  "prompt/run-envelope.json",
+  "prompt/system.md",
   "candidate/Candidate.lean",
   "verification/compiler-diagnostics.json",
   "verification/compiler-output.txt",
@@ -50,6 +65,51 @@ const benchmarkExpectedHashPaths = [
   "lean-toolchain",
   "statements/problem.md"
 ] as const;
+const promptLayerPaths = ["benchmark.md", "item.md", "run-envelope.json", "system.md"] as const;
+const bundleManifestArtifactRoles = {
+  "candidate/Candidate.lean": "candidate_source",
+  "environment/environment.json": "environment_snapshot",
+  "package/benchmark-package.json": "package_reference",
+  "package/FirstProof/Problem9/Gold.lean": "package_reference",
+  "package/FirstProof/Problem9/Statement.lean": "package_reference",
+  "package/FirstProof/Problem9/Support.lean": "package_reference",
+  "package/LICENSE": "package_reference",
+  "package/README.md": "package_reference",
+  "package/lake-manifest.json": "package_reference",
+  "package/lakefile.toml": "package_reference",
+  "package/lean-toolchain": "package_reference",
+  "package/package-ref.json": "package_reference",
+  "package/statements/problem.md": "package_reference",
+  "prompt/benchmark.md": "prompt_package",
+  "prompt/item.md": "prompt_package",
+  "prompt/prompt-package.json": "prompt_package",
+  "prompt/run-envelope.json": "prompt_package",
+  "prompt/system.md": "prompt_package",
+  "verification/compiler-diagnostics.json": "compiler_diagnostics",
+  "verification/compiler-output.txt": "compiler_output",
+  "verification/failure-classification.json": "failure_classification",
+  "verification/verdict.json": "verdict_record",
+  "verification/verifier-output.json": "verifier_output"
+} as const satisfies Record<string, Problem9OfflineArtifactManifestEntry["artifactRole"]>;
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
+const promptRunEnvelopeSchema = z.object({
+  attemptId: z.string().min(1),
+  authMode: z.string().min(1),
+  benchmarkItemId: z.literal("Problem9"),
+  benchmarkPackageDigest: sha256Schema,
+  benchmarkPackageId: z.literal("firstproof/Problem9"),
+  benchmarkPackageVersion: z.string().min(1),
+  harnessRevision: z.string().min(1),
+  jobId: z.string().min(1).nullable(),
+  laneId: z.string().min(1),
+  modelConfigId: z.string().min(1),
+  promptProtocolVersion: z.string().min(1),
+  providerFamily: z.string().min(1),
+  runEnvelopeSchemaVersion: z.literal("1"),
+  runId: z.string().min(1),
+  runMode: z.string().min(1),
+  toolProfile: z.string().min(1)
+});
 
 const offlineIngestDuplicateConstraints = new Set([
   "runs_source_run_id_unique",
@@ -336,6 +396,35 @@ export function buildProblem9OfflineIngestPlan(rawRequest: unknown): Problem9Off
     "prompt/prompt-package.json",
     toWrittenText(stableStringify(bundle.promptPackage))
   );
+  for (const relativePath of benchmarkExpectedHashPaths) {
+    const contents = bundle.benchmarkSources[relativePath];
+    validateProvidedManifestEntry(
+      manifestEntriesByPath,
+      `package/${relativePath}`,
+      toWrittenText(contents)
+    );
+    assertDigest(
+      sha256Text(toWrittenText(contents)),
+      bundle.benchmarkPackage.hashes[relativePath],
+      `package/benchmark-package.json hashes.${relativePath}`,
+      "bundle_digest_mismatch"
+    );
+  }
+  for (const relativePath of promptLayerPaths) {
+    const contents = bundle.promptLayers[relativePath];
+    validateProvidedManifestEntry(
+      manifestEntriesByPath,
+      `prompt/${relativePath}`,
+      toWrittenText(contents)
+    );
+    assertDigest(
+      sha256Text(toWrittenText(contents)),
+      bundle.promptPackage.layerDigests[relativePath],
+      `prompt/prompt-package.json layerDigests.${relativePath}`,
+      "bundle_digest_mismatch"
+    );
+  }
+  assertPromptRunEnvelopeConsistency(parsePromptRunEnvelope(bundle.promptLayers["run-envelope.json"]), bundle);
   validateProvidedManifestEntry(
     manifestEntriesByPath,
     "candidate/Candidate.lean",
@@ -585,6 +674,148 @@ function validateProvidedManifestEntry(
       `${relativePath} byteSize does not match artifact-manifest.json.`,
       relativePath
     );
+  }
+
+  const expectedMetadata = expectedManifestMetadataForPath(relativePath);
+
+  if (entry.artifactRole !== expectedMetadata.artifactRole) {
+    throw validationError(
+      "unexpected_artifact_manifest_entry",
+      `${relativePath} artifactRole does not match the canonical bundle contract.`,
+      relativePath
+    );
+  }
+
+  if (entry.contentEncoding !== expectedMetadata.contentEncoding) {
+    throw validationError(
+      "unexpected_artifact_manifest_entry",
+      `${relativePath} contentEncoding does not match the canonical bundle contract.`,
+      relativePath
+    );
+  }
+
+  if (entry.mediaType !== expectedMetadata.mediaType) {
+    throw validationError(
+      "unexpected_artifact_manifest_entry",
+      `${relativePath} mediaType does not match the canonical bundle contract.`,
+      relativePath
+    );
+  }
+
+  if (entry.requiredForIngest !== expectedMetadata.requiredForIngest) {
+    throw validationError(
+      "unexpected_artifact_manifest_entry",
+      `${relativePath} requiredForIngest does not match the canonical bundle contract.`,
+      relativePath
+    );
+  }
+}
+
+function expectedManifestMetadataForPath(relativePath: string) {
+  return {
+    artifactRole:
+      bundleManifestArtifactRoles[relativePath as keyof typeof bundleManifestArtifactRoles],
+    contentEncoding: null,
+    mediaType: relativePath.endsWith(".json")
+      ? "application/json"
+      : isNormalizedTextBundlePath(relativePath)
+        ? "text/plain"
+        : null,
+    requiredForIngest: true
+  };
+}
+
+function isNormalizedTextBundlePath(relativePath: string): boolean {
+  const baseName = path.posix.basename(relativePath);
+
+  return (
+    relativePath.endsWith(".txt") ||
+    relativePath.endsWith(".lean") ||
+    relativePath.endsWith(".md") ||
+    relativePath.endsWith(".toml") ||
+    baseName === "LICENSE" ||
+    baseName === "lean-toolchain"
+  );
+}
+
+function parsePromptRunEnvelope(contents: string) {
+  try {
+    return promptRunEnvelopeSchema.parse(JSON.parse(normalizeText(contents)));
+  } catch {
+    throw validationError(
+      "invalid_problem9_offline_ingest_payload",
+      "prompt/run-envelope.json is not a valid prompt run envelope.",
+      "prompt/run-envelope.json"
+    );
+  }
+}
+
+function assertPromptRunEnvelopeConsistency(
+  runEnvelope: z.infer<typeof promptRunEnvelopeSchema>,
+  bundle: Problem9OfflineIngestBundle
+) {
+  const checks: Array<[actual: string | null, expected: string | null, label: string]> = [
+    [runEnvelope.attemptId, bundle.runBundle.attemptId, "prompt/run-envelope.json attemptId"],
+    [runEnvelope.authMode, bundle.promptPackage.authMode, "prompt/run-envelope.json authMode"],
+    [
+      runEnvelope.benchmarkItemId,
+      bundle.benchmarkPackage.benchmarkItemId,
+      "prompt/run-envelope.json benchmarkItemId"
+    ],
+    [
+      runEnvelope.benchmarkPackageDigest,
+      bundle.benchmarkPackage.packageDigest,
+      "prompt/run-envelope.json benchmarkPackageDigest"
+    ],
+    [
+      runEnvelope.benchmarkPackageId,
+      bundle.benchmarkPackage.packageId,
+      "prompt/run-envelope.json benchmarkPackageId"
+    ],
+    [
+      runEnvelope.benchmarkPackageVersion,
+      bundle.benchmarkPackage.packageVersion,
+      "prompt/run-envelope.json benchmarkPackageVersion"
+    ],
+    [
+      runEnvelope.harnessRevision,
+      bundle.promptPackage.harnessRevision,
+      "prompt/run-envelope.json harnessRevision"
+    ],
+    [runEnvelope.jobId, bundle.runBundle.jobId, "prompt/run-envelope.json jobId"],
+    [runEnvelope.laneId, bundle.promptPackage.laneId, "prompt/run-envelope.json laneId"],
+    [
+      runEnvelope.modelConfigId,
+      bundle.promptPackage.modelConfigId,
+      "prompt/run-envelope.json modelConfigId"
+    ],
+    [
+      runEnvelope.promptProtocolVersion,
+      bundle.promptPackage.promptProtocolVersion,
+      "prompt/run-envelope.json promptProtocolVersion"
+    ],
+    [
+      runEnvelope.providerFamily,
+      bundle.promptPackage.providerFamily,
+      "prompt/run-envelope.json providerFamily"
+    ],
+    [runEnvelope.runId, bundle.runBundle.runId, "prompt/run-envelope.json runId"],
+    [runEnvelope.runMode, bundle.promptPackage.runMode, "prompt/run-envelope.json runMode"],
+    [
+      runEnvelope.toolProfile,
+      bundle.promptPackage.toolProfile,
+      "prompt/run-envelope.json toolProfile"
+    ]
+  ];
+
+  for (const [actual, expected, label] of checks) {
+    if (actual !== expected) {
+      throw validationError(
+        "identity_inconsistent",
+        `${label} does not match the canonical bundle contract.`,
+        "prompt/run-envelope.json"
+      );
+    }
   }
 }
 

--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -37,6 +37,10 @@ async function readOptionalJsonFile<TValue>(filePath: string): Promise<TValue | 
   }
 }
 
+async function readTextFile(filePath: string): Promise<string> {
+  return await readFile(filePath, "utf8");
+}
+
 async function buildOfflineIngestRequest(options: {
   failureClassificationOverride?: Partial<{
     evidenceArtifactRefs: string[];
@@ -236,6 +240,27 @@ async function buildOfflineIngestRequest(options: {
       benchmarkPackage: await readJsonFile(
         path.join(bundleRoot, "package", "benchmark-package.json")
       ),
+      benchmarkSources: {
+        "FirstProof/Problem9/Gold.lean": await readTextFile(
+          path.join(bundleRoot, "package", "FirstProof", "Problem9", "Gold.lean")
+        ),
+        "FirstProof/Problem9/Statement.lean": await readTextFile(
+          path.join(bundleRoot, "package", "FirstProof", "Problem9", "Statement.lean")
+        ),
+        "FirstProof/Problem9/Support.lean": await readTextFile(
+          path.join(bundleRoot, "package", "FirstProof", "Problem9", "Support.lean")
+        ),
+        LICENSE: await readTextFile(path.join(bundleRoot, "package", "LICENSE")),
+        "README.md": await readTextFile(path.join(bundleRoot, "package", "README.md")),
+        "lake-manifest.json": await readTextFile(
+          path.join(bundleRoot, "package", "lake-manifest.json")
+        ),
+        "lakefile.toml": await readTextFile(path.join(bundleRoot, "package", "lakefile.toml")),
+        "lean-toolchain": await readTextFile(path.join(bundleRoot, "package", "lean-toolchain")),
+        "statements/problem.md": await readTextFile(
+          path.join(bundleRoot, "package", "statements", "problem.md")
+        )
+      },
       candidateSource: await readFile(
         path.join(bundleRoot, "candidate", "Candidate.lean"),
         "utf8"
@@ -257,6 +282,14 @@ async function buildOfflineIngestRequest(options: {
       promptPackage: await readJsonFile(
         path.join(bundleRoot, "prompt", "prompt-package.json")
       ),
+      promptLayers: {
+        "benchmark.md": await readTextFile(path.join(bundleRoot, "prompt", "benchmark.md")),
+        "item.md": await readTextFile(path.join(bundleRoot, "prompt", "item.md")),
+        "run-envelope.json": await readTextFile(
+          path.join(bundleRoot, "prompt", "run-envelope.json")
+        ),
+        "system.md": await readTextFile(path.join(bundleRoot, "prompt", "system.md"))
+      },
       runBundle: await readJsonFile<Record<string, unknown>>(path.join(bundleRoot, "run-bundle.json")),
       usage: null,
       verifierOutput: await readJsonFile(
@@ -300,7 +333,7 @@ test("buildProblem9OfflineIngestPlan maps canonical passing bundles to terminal 
   assert.equal(plan.run.stopReason, "verifier_passed");
   assert.equal(plan.job.stopReason, "verifier_passed");
   assert.equal(plan.attempt.stopReason, "verifier_passed");
-  assert.equal(plan.artifacts.length, 11);
+  assert.equal(plan.artifacts.length, 24);
   const rootArtifacts = plan.artifacts.filter(
     (artifact) =>
       artifact.relativePath === "artifact-manifest.json" || artifact.relativePath === "run-bundle.json"
@@ -560,6 +593,95 @@ test("buildProblem9OfflineIngestPlan rejects digest mismatches", async (t) => {
   );
 });
 
+test("buildProblem9OfflineIngestPlan rejects canonical provenance metadata drift", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const readmeEntry = request.bundle.artifactManifest.artifacts.find(
+    (artifact) => artifact.relativePath === "package/README.md"
+  );
+  assert.ok(readmeEntry);
+  readmeEntry.artifactRole = "candidate_source";
+  readmeEntry.requiredForIngest = false;
+  request.bundle.runBundle.artifactManifestDigest = sha256Text(
+    `${stableStringify(request.bundle.artifactManifest)}\n`
+  );
+  request.bundle.runBundle.bundleDigest = computeRunBundleDigest(
+    request.bundle.artifactManifest.artifacts,
+    request.bundle.runBundle
+  );
+
+  assert.throws(
+    () => buildProblem9OfflineIngestPlan(request),
+    (error: unknown) =>
+      error instanceof Problem9OfflineIngestValidationError &&
+      error.code === "unexpected_artifact_manifest_entry"
+  );
+});
+
+test("buildProblem9OfflineIngestPlan rejects run-envelope semantic drift", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const runEnvelope = JSON.parse(request.bundle.promptLayers["run-envelope.json"]) as Record<
+    string,
+    unknown
+  >;
+  runEnvelope.runId = "run-tampered";
+  request.bundle.promptLayers["run-envelope.json"] = `${stableStringify(runEnvelope)}\n`;
+  request.bundle.promptPackage.layerDigests["run-envelope.json"] = sha256Text(
+    request.bundle.promptLayers["run-envelope.json"]
+  );
+  request.bundle.promptPackage.promptPackageDigest = computePromptPackageDigest(
+    request.bundle.promptPackage
+  );
+  request.bundle.runBundle.promptPackageDigest = request.bundle.promptPackage.promptPackageDigest;
+  request.bundle.runBundle.runConfigDigest = computeOfflineIngestRunConfigDigest(request.bundle);
+
+  const promptPackageEntry = request.bundle.artifactManifest.artifacts.find(
+    (artifact) => artifact.relativePath === "prompt/prompt-package.json"
+  );
+  assert.ok(promptPackageEntry);
+  const promptPackageText = `${stableStringify(request.bundle.promptPackage)}\n`;
+  promptPackageEntry.sha256 = sha256Text(promptPackageText);
+  promptPackageEntry.byteSize = Buffer.byteLength(promptPackageText, "utf8");
+
+  const runEnvelopeEntry = request.bundle.artifactManifest.artifacts.find(
+    (artifact) => artifact.relativePath === "prompt/run-envelope.json"
+  );
+  assert.ok(runEnvelopeEntry);
+  runEnvelopeEntry.sha256 = sha256Text(request.bundle.promptLayers["run-envelope.json"]);
+  runEnvelopeEntry.byteSize = Buffer.byteLength(
+    request.bundle.promptLayers["run-envelope.json"],
+    "utf8"
+  );
+
+  request.bundle.runBundle.artifactManifestDigest = sha256Text(
+    `${stableStringify(request.bundle.artifactManifest)}\n`
+  );
+  request.bundle.runBundle.bundleDigest = computeRunBundleDigest(
+    request.bundle.artifactManifest.artifacts,
+    request.bundle.runBundle
+  );
+
+  assert.throws(
+    () => buildProblem9OfflineIngestPlan(request),
+    (error: unknown) =>
+      error instanceof Problem9OfflineIngestValidationError &&
+      error.code === "identity_inconsistent"
+  );
+});
+
 test("buildProblem9OfflineIngestPlan rejects path traversal in identifiers", async (t) => {
   const { request, tempRoot } = await buildOfflineIngestRequest({
     result: "pass"
@@ -701,7 +823,7 @@ test("createProblem9OfflineIngestService persists audit provenance and live-equi
   const response = await service(request, "user-1");
 
   assert.deepEqual(response, {
-    artifactCount: 11,
+    artifactCount: 24,
     attempt: {
       id: "attempt-row-1",
       sourceAttemptId: "attempt-pass-1",
@@ -726,7 +848,7 @@ test("createProblem9OfflineIngestService persists audit provenance and live-equi
     insertedAttempt?.artifactManifestDigest,
     request.bundle.runBundle.artifactManifestDigest
   );
-  assert.equal(insertedArtifacts.length, 11);
+  assert.equal(insertedArtifacts.length, 24);
   const insertedRootArtifacts = insertedArtifacts.filter(
     (artifact) =>
       artifact.relativePath === "artifact-manifest.json" || artifact.relativePath === "run-bundle.json"
@@ -752,7 +874,7 @@ test("createProblem9OfflineIngestService persists audit provenance and live-equi
   assert.equal(insertedAuditEvents[0]?.severity, "critical");
   assert.deepEqual(insertedAuditEvents[0]?.payload, {
     actorUserId: "user-1",
-    artifactCount: 11,
+    artifactCount: 24,
     attemptId: "attempt-row-1",
     jobId: "job-row-1",
     runId: "run-row-1",
@@ -1000,7 +1122,7 @@ test("createProblem9OfflineIngestService preserves source failure stop reasons w
   const response = await service(request, "user-1");
 
   assert.deepEqual(response, {
-    artifactCount: 12,
+    artifactCount: 25,
     attempt: {
       id: "attempt-row-1",
       sourceAttemptId: "attempt-fail-1",
@@ -1021,10 +1143,10 @@ test("createProblem9OfflineIngestService preserves source failure stop reasons w
   assert.equal(insertedRun?.stopReason, "provider_timeout");
   assert.equal(insertedJob?.stopReason, "provider_timeout");
   assert.equal(insertedAttempt?.stopReason, "provider_timeout");
-  assert.equal(insertedArtifacts.length, 12);
+  assert.equal(insertedArtifacts.length, 25);
   assert.deepEqual(insertedAuditEvents[0]?.payload, {
     actorUserId: "user-1",
-    artifactCount: 12,
+    artifactCount: 25,
     attemptId: "attempt-row-1",
     jobId: "job-row-1",
     runId: "run-row-1",
@@ -1066,7 +1188,7 @@ test("POST /portal/admin/offline-ingest/problem9-run-bundles returns created res
         receivedPayload = rawRequest;
 
         return {
-          artifactCount: 11,
+          artifactCount: 24,
           attempt: {
             id: "attempt-row-1",
             sourceAttemptId: "attempt-pass-1",
@@ -1099,7 +1221,7 @@ test("POST /portal/admin/offline-ingest/problem9-run-bundles returns created res
 
   assert.equal(response.statusCode, 201);
   assert.deepEqual(response.json(), {
-    artifactCount: 11,
+    artifactCount: 24,
     attempt: {
       id: "attempt-row-1",
       sourceAttemptId: "attempt-pass-1",
@@ -1197,6 +1319,88 @@ function computeLegacyBenchmarkPackageDigest(manifest: Record<string, unknown>):
       null,
       2
     )
+  );
+}
+
+function computePromptPackageDigest(promptPackage: {
+  authMode: string;
+  benchmarkPackageDigest: string;
+  benchmarkPackageId: string;
+  benchmarkPackageVersion: string;
+  harnessRevision: string;
+  laneId: string;
+  layerDigests: Record<string, string>;
+  layerVersions: Record<string, string>;
+  modelConfigId: string;
+  promptProtocolVersion: string;
+  providerFamily: string;
+  runMode: string;
+  toolProfile: string;
+}) {
+  return sha256Text(
+    stableStringify({
+      authMode: promptPackage.authMode,
+      benchmarkPackageDigest: promptPackage.benchmarkPackageDigest,
+      benchmarkPackageId: promptPackage.benchmarkPackageId,
+      benchmarkPackageVersion: promptPackage.benchmarkPackageVersion,
+      harnessRevision: promptPackage.harnessRevision,
+      laneId: promptPackage.laneId,
+      layerDigests: promptPackage.layerDigests,
+      layerVersions: promptPackage.layerVersions,
+      modelConfigId: promptPackage.modelConfigId,
+      promptProtocolVersion: promptPackage.promptProtocolVersion,
+      providerFamily: promptPackage.providerFamily,
+      runMode: promptPackage.runMode,
+      toolProfile: promptPackage.toolProfile
+    })
+  );
+}
+
+function computeOfflineIngestRunConfigDigest(bundle: {
+  benchmarkPackage: {
+    benchmarkItemId: string;
+    packageDigest: string;
+    packageId: string;
+    packageVersion: string;
+  };
+  environment: {
+    modelSnapshotId: string;
+    verifierVersion: string;
+  };
+  promptPackage: {
+    authMode: string;
+    harnessRevision: string;
+    laneId: string;
+    modelConfigId: string;
+    promptPackageDigest: string;
+    promptProtocolVersion: string;
+    providerFamily: string;
+    runMode: string;
+    toolProfile: string;
+  };
+  runBundle: {
+    environmentDigest: string;
+  };
+}) {
+  return sha256Text(
+    stableStringify({
+      authMode: bundle.promptPackage.authMode,
+      benchmarkItemId: bundle.benchmarkPackage.benchmarkItemId,
+      benchmarkPackageDigest: bundle.benchmarkPackage.packageDigest,
+      benchmarkPackageId: bundle.benchmarkPackage.packageId,
+      benchmarkPackageVersion: bundle.benchmarkPackage.packageVersion,
+      environmentDigest: bundle.runBundle.environmentDigest,
+      harnessRevision: bundle.promptPackage.harnessRevision,
+      laneId: bundle.promptPackage.laneId,
+      modelConfigId: bundle.promptPackage.modelConfigId,
+      modelSnapshotId: bundle.environment.modelSnapshotId,
+      promptPackageDigest: bundle.promptPackage.promptPackageDigest,
+      promptProtocolVersion: bundle.promptPackage.promptProtocolVersion,
+      providerFamily: bundle.promptPackage.providerFamily,
+      runMode: bundle.promptPackage.runMode,
+      toolProfile: bundle.promptPackage.toolProfile,
+      verifierVersion: bundle.environment.verifierVersion
+    })
   );
 }
 

--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -59,6 +59,7 @@ async function buildOfflineIngestRequest(options: {
     terminality: "terminal_attempt" | "retryable_outer" | "cancelled";
     userVisibility: "user_visible" | "user_visible_sanitized" | "internal_only";
   }>;
+  includeUsage?: boolean;
   legacyBenchmarkManifest?: boolean;
   result: "pass" | "fail";
   stopReason?: string;
@@ -308,10 +309,46 @@ async function buildOfflineIngestRequest(options: {
     );
   }
 
+  if (options.includeUsage) {
+    addUsageSummaryArtifact(request, {
+      completionTokens: 5,
+      promptTokens: 8,
+      totalTokens: 13
+    });
+  }
+
   return {
     request,
     tempRoot
   };
+}
+
+function addUsageSummaryArtifact(
+  request: Problem9OfflineIngestRequest,
+  usage: Record<string, unknown>
+) {
+  const usageText = `${stableStringify(usage)}\n`;
+
+  request.bundle.usage = usage;
+  request.bundle.artifactManifest.artifacts = [
+    ...request.bundle.artifactManifest.artifacts,
+    {
+      artifactRole: "usage_summary",
+      byteSize: Buffer.byteLength(usageText, "utf8"),
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "execution/usage.json",
+      requiredForIngest: false,
+      sha256: sha256Text(usageText)
+    }
+  ].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  request.bundle.runBundle.artifactManifestDigest = sha256Text(
+    `${stableStringify(request.bundle.artifactManifest)}\n`
+  );
+  request.bundle.runBundle.bundleDigest = computeRunBundleDigest(
+    request.bundle.artifactManifest.artifacts,
+    request.bundle.runBundle
+  );
 }
 
 test("buildProblem9OfflineIngestPlan maps canonical passing bundles to terminal imported states", async (t) => {
@@ -360,6 +397,44 @@ test("buildProblem9OfflineIngestPlan maps canonical passing bundles to terminal 
     plan.artifacts.find((artifact) => artifact.relativePath === "candidate/Candidate.lean")?.bucketName,
     "paretoproof-dev-artifacts"
   );
+});
+
+test("buildProblem9OfflineIngestPlan accepts optional usage summary artifacts", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    includeUsage: true,
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const plan = buildProblem9OfflineIngestPlan(request);
+  const usageArtifact = plan.artifacts.find((artifact) => artifact.relativePath === "execution/usage.json");
+  const usageText = `${stableStringify(request.bundle.usage)}\n`;
+
+  assert.equal(plan.artifacts.length, 25);
+  assert.deepEqual(plan.attempt.usageSummary, request.bundle.usage);
+  assert.ok(usageArtifact);
+  assert.equal(usageArtifact.artifactClassId, "usage_summary");
+  assert.equal(
+    usageArtifact.artifactManifestDigest,
+    request.bundle.runBundle.artifactManifestDigest
+  );
+  assert.equal(usageArtifact.bucketName, "paretoproof-dev-artifacts");
+  assert.equal(usageArtifact.byteSize, Buffer.byteLength(usageText, "utf8"));
+  assert.equal(usageArtifact.contentEncoding, null);
+  assert.equal(usageArtifact.lifecycleState, "registered");
+  assert.equal(usageArtifact.mediaType, "application/json");
+  assert.equal(
+    usageArtifact.objectKey,
+    "runs/run-pass-1/artifacts/attempt-pass-1/execution/usage.json"
+  );
+  assert.equal(usageArtifact.prefixFamily, "run_artifacts");
+  assert.equal(usageArtifact.providerEtag, null);
+  assert.equal(usageArtifact.requiredForIngest, false);
+  assert.equal(usageArtifact.sha256, sha256Text(usageText));
+  assert.equal(usageArtifact.storageProvider, "cloudflare_r2");
 });
 
 test("buildProblem9OfflineIngestPlan preserves failure metadata for canonical failing bundles", async (t) => {

--- a/apps/worker/src/lib/problem9-offline-ingest.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest.ts
@@ -44,8 +44,21 @@ const requiredBundleFiles = [
   "artifact-manifest.json",
   "run-bundle.json",
   "package/benchmark-package.json",
+  "package/FirstProof/Problem9/Gold.lean",
+  "package/FirstProof/Problem9/Statement.lean",
+  "package/FirstProof/Problem9/Support.lean",
+  "package/LICENSE",
+  "package/README.md",
+  "package/lake-manifest.json",
+  "package/lakefile.toml",
+  "package/lean-toolchain",
+  "package/statements/problem.md",
   "package/package-ref.json",
+  "prompt/benchmark.md",
+  "prompt/item.md",
   "prompt/prompt-package.json",
+  "prompt/run-envelope.json",
+  "prompt/system.md",
   "candidate/Candidate.lean",
   "verification/compiler-diagnostics.json",
   "verification/compiler-output.txt",
@@ -195,10 +208,27 @@ async function loadProblem9OfflineIngestRequest(
     bundleRootRealPath,
     "package/package-ref.json"
   );
+  const benchmarkSources = await loadNamedTextFiles(bundleRootRealPath, [
+    "package/FirstProof/Problem9/Gold.lean",
+    "package/FirstProof/Problem9/Statement.lean",
+    "package/FirstProof/Problem9/Support.lean",
+    "package/LICENSE",
+    "package/README.md",
+    "package/lake-manifest.json",
+    "package/lakefile.toml",
+    "package/lean-toolchain",
+    "package/statements/problem.md"
+  ] as const);
   const promptPackage = await loadJsonFile<Problem9PromptPackageManifest>(
     bundleRootRealPath,
     "prompt/prompt-package.json"
   );
+  const promptLayers = await loadNamedTextFiles(bundleRootRealPath, [
+    "prompt/benchmark.md",
+    "prompt/item.md",
+    "prompt/run-envelope.json",
+    "prompt/system.md"
+  ] as const);
   const runBundle = await loadJsonFile<Problem9RunBundleManifest>(
     bundleRootRealPath,
     "run-bundle.json"
@@ -221,6 +251,19 @@ async function loadProblem9OfflineIngestRequest(
     bundle: {
       artifactManifest,
       benchmarkPackage,
+      benchmarkSources: {
+        "FirstProof/Problem9/Gold.lean": benchmarkSources["package/FirstProof/Problem9/Gold.lean"],
+        "FirstProof/Problem9/Statement.lean":
+          benchmarkSources["package/FirstProof/Problem9/Statement.lean"],
+        "FirstProof/Problem9/Support.lean":
+          benchmarkSources["package/FirstProof/Problem9/Support.lean"],
+        LICENSE: benchmarkSources["package/LICENSE"],
+        "README.md": benchmarkSources["package/README.md"],
+        "lake-manifest.json": benchmarkSources["package/lake-manifest.json"],
+        "lakefile.toml": benchmarkSources["package/lakefile.toml"],
+        "lean-toolchain": benchmarkSources["package/lean-toolchain"],
+        "statements/problem.md": benchmarkSources["package/statements/problem.md"]
+      },
       candidateSource,
       compilerDiagnostics,
       compilerOutput,
@@ -228,6 +271,12 @@ async function loadProblem9OfflineIngestRequest(
       failureClassification,
       packageRef,
       promptPackage,
+      promptLayers: {
+        "benchmark.md": promptLayers["prompt/benchmark.md"],
+        "item.md": promptLayers["prompt/item.md"],
+        "run-envelope.json": promptLayers["prompt/run-envelope.json"],
+        "system.md": promptLayers["prompt/system.md"]
+      },
       runBundle,
       usage,
       verifierOutput,
@@ -316,6 +365,17 @@ async function loadOptionalJsonFile<TValue>(
   await resolveBundleFilePath(bundleRootRealPath, relativePath);
 
   return loadJsonFile<TValue>(bundleRootRealPath, relativePath);
+}
+
+async function loadNamedTextFiles<const TRelativePaths extends readonly string[]>(
+  bundleRootRealPath: string,
+  relativePaths: TRelativePaths
+): Promise<Record<TRelativePaths[number], string>> {
+  const entries = await Promise.all(
+    relativePaths.map(async (relativePath) => [relativePath, await loadTextFile(bundleRootRealPath, relativePath)] as const)
+  );
+
+  return Object.fromEntries(entries) as Record<TRelativePaths[number], string>;
 }
 
 async function resolveBundleFilePath(

--- a/apps/worker/src/lib/problem9-run-bundle.test.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.test.ts
@@ -260,23 +260,37 @@ test("materialize-problem9-run-bundle bundles failure classification artifacts f
       status: string;
       stopReason: string;
     };
+    const expectedArtifactPaths = [
+      "candidate/Candidate.lean",
+      "environment/environment.json",
+      "package/benchmark-package.json",
+      "package/FirstProof/Problem9/Gold.lean",
+      "package/FirstProof/Problem9/Statement.lean",
+      "package/FirstProof/Problem9/Support.lean",
+      "package/LICENSE",
+      "package/README.md",
+      "package/lake-manifest.json",
+      "package/lakefile.toml",
+      "package/lean-toolchain",
+      "package/package-ref.json",
+      "package/statements/problem.md",
+      "prompt/benchmark.md",
+      "prompt/item.md",
+      "prompt/prompt-package.json",
+      "prompt/run-envelope.json",
+      "prompt/system.md",
+      "verification/compiler-diagnostics.json",
+      "verification/compiler-output.txt",
+      "verification/failure-classification.json",
+      "verification/verdict.json",
+      "verification/verifier-output.json"
+    ].sort((left, right) => left.localeCompare(right));
 
     assert.equal(runBundle.status, "failure");
     assert.equal(runBundle.stopReason, "compile_failed");
     assert.deepEqual(
       artifactManifest.artifacts.map((artifact) => artifact.relativePath),
-      [
-        "candidate/Candidate.lean",
-        "environment/environment.json",
-        "package/benchmark-package.json",
-        "package/package-ref.json",
-        "prompt/prompt-package.json",
-        "verification/compiler-diagnostics.json",
-        "verification/compiler-output.txt",
-        "verification/failure-classification.json",
-        "verification/verdict.json",
-        "verification/verifier-output.json"
-      ]
+      expectedArtifactPaths
     );
     assert.equal(
       await readNormalizedText(

--- a/apps/worker/src/lib/problem9-run-bundle.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.ts
@@ -291,13 +291,21 @@ const requiredBenchmarkPackagePaths = [
 const promptLayerFilenames = ["benchmark.md", "item.md", "run-envelope.json", "system.md"] as const;
 const promptPackageManifestFilename = "prompt-package.json";
 const requiredPromptPackagePaths = [promptPackageManifestFilename, ...promptLayerFilenames] as const;
+const benchmarkBundleRelativePaths = expectedBenchmarkHashPaths.map(
+  (relativePath) => `package/${relativePath}`
+);
+const promptLayerBundleRelativePaths = promptLayerFilenames.map(
+  (filename) => `prompt/${filename}`
+);
 
 const requiredBundleBaseFiles = [
   "candidate/Candidate.lean",
   "environment/environment.json",
   "package/benchmark-package.json",
+  ...benchmarkBundleRelativePaths,
   "package/package-ref.json",
   "prompt/prompt-package.json",
+  ...promptLayerBundleRelativePaths,
   "verification/compiler-diagnostics.json",
   "verification/compiler-output.txt",
   "verification/verdict.json",
@@ -471,9 +479,25 @@ export async function materializeProblem9RunBundle(
     path.join(benchmarkPackageRoot, benchmarkPackageManifestRelativePath),
     path.join(bundleRoot, "package", "benchmark-package.json")
   );
+  await Promise.all(
+    expectedBenchmarkHashPaths.map((relativePath) =>
+      copyNormalizedTextFile(
+        path.join(benchmarkPackageRoot, relativePath),
+        path.join(bundleRoot, "package", relativePath)
+      )
+    )
+  );
   await copyNormalizedTextFile(
     path.join(promptPackageRoot, promptPackageManifestFilename),
     path.join(bundleRoot, "prompt", "prompt-package.json")
+  );
+  await Promise.all(
+    promptLayerFilenames.map((filename) =>
+      copyNormalizedTextFile(
+        path.join(promptPackageRoot, filename),
+        path.join(bundleRoot, "prompt", filename)
+      )
+    )
   );
   await writeNormalizedText(path.join(bundleRoot, "candidate", "Candidate.lean"), candidateContents);
   await writeJsonFile(
@@ -1016,12 +1040,15 @@ async function collectArtifactManifestEntries(
 }
 
 function artifactRoleForPath(relativePath: string): string {
+  if (relativePath.startsWith("package/")) {
+    return "package_reference";
+  }
+
+  if (relativePath.startsWith("prompt/")) {
+    return "prompt_package";
+  }
+
   switch (relativePath) {
-    case "package/package-ref.json":
-    case "package/benchmark-package.json":
-      return "package_reference";
-    case "prompt/prompt-package.json":
-      return "prompt_package";
     case "candidate/Candidate.lean":
       return "candidate_source";
     case "verification/verdict.json":
@@ -1046,14 +1073,28 @@ function mediaTypeForPath(relativePath: string): string | null {
     return "application/json";
   }
 
-  if (relativePath.endsWith(".txt") || relativePath.endsWith(".lean")) {
+  if (isNormalizedTextBundlePath(relativePath)) {
     return "text/plain";
   }
 
   return null;
 }
 
+function isNormalizedTextBundlePath(relativePath: string): boolean {
+  const baseName = path.posix.basename(relativePath);
+
+  return (
+    relativePath.endsWith(".txt") ||
+    relativePath.endsWith(".lean") ||
+    relativePath.endsWith(".md") ||
+    relativePath.endsWith(".toml") ||
+    baseName === "LICENSE" ||
+    baseName === "lean-toolchain"
+  );
+}
+
 async function copyNormalizedTextFile(sourcePath: string, destinationPath: string): Promise<void> {
+  await mkdir(path.dirname(destinationPath), { recursive: true });
   await writeNormalizedText(destinationPath, await loadNormalizedText(sourcePath));
 }
 

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -109,6 +109,24 @@ const runBundleFileSchema = z
     verdictDigest: z.string().regex(/^[a-f0-9]{64}$/i)
   })
   .passthrough();
+const promptRunEnvelopeSchema = z.object({
+  attemptId: z.string().min(1),
+  authMode: z.string().min(1),
+  benchmarkItemId: z.literal("Problem9"),
+  benchmarkPackageDigest: z.string().regex(/^[a-f0-9]{64}$/i),
+  benchmarkPackageId: z.literal("firstproof/Problem9"),
+  benchmarkPackageVersion: z.string().min(1),
+  harnessRevision: z.string().min(1),
+  jobId: z.string().min(1).nullable(),
+  laneId: z.string().min(1),
+  modelConfigId: z.string().min(1),
+  promptProtocolVersion: z.string().min(1),
+  providerFamily: z.string().min(1),
+  runEnvelopeSchemaVersion: z.literal("1"),
+  runId: z.string().min(1),
+  runMode: z.string().min(1),
+  toolProfile: z.string().min(1)
+});
 
 const supportedArtifactRoles = [
   "run_manifest",
@@ -119,24 +137,54 @@ const supportedArtifactRoles = [
   "compiler_output",
   "compiler_diagnostics",
   "verifier_output",
+  "failure_classification",
   "environment_snapshot",
   "usage_summary",
   "execution_trace"
 ] satisfies WorkerBundleArtifactRole[];
 
 const optionalArtifactRoles = new Set(["usage_summary", "execution_trace"] as const);
+const benchmarkSourcePaths = [
+  "FirstProof/Problem9/Gold.lean",
+  "FirstProof/Problem9/Statement.lean",
+  "FirstProof/Problem9/Support.lean",
+  "LICENSE",
+  "README.md",
+  "lake-manifest.json",
+  "lakefile.toml",
+  "lean-toolchain",
+  "statements/problem.md"
+] as const;
+const promptLayerPaths = ["benchmark.md", "item.md", "run-envelope.json", "system.md"] as const;
 
 const canonicalArtifactRoleByPath = {
   "candidate/Candidate.lean": "candidate_source",
   "environment/environment.json": "environment_snapshot",
   "package/benchmark-package.json": "package_reference",
+  "package/FirstProof/Problem9/Gold.lean": "package_reference",
+  "package/FirstProof/Problem9/Statement.lean": "package_reference",
+  "package/FirstProof/Problem9/Support.lean": "package_reference",
+  "package/LICENSE": "package_reference",
+  "package/README.md": "package_reference",
+  "package/lake-manifest.json": "package_reference",
+  "package/lakefile.toml": "package_reference",
+  "package/lean-toolchain": "package_reference",
   "package/package-ref.json": "package_reference",
+  "package/statements/problem.md": "package_reference",
+  "prompt/benchmark.md": "prompt_package",
+  "prompt/item.md": "prompt_package",
   "prompt/prompt-package.json": "prompt_package",
+  "prompt/run-envelope.json": "prompt_package",
+  "prompt/system.md": "prompt_package",
   "verification/compiler-diagnostics.json": "compiler_diagnostics",
   "verification/compiler-output.txt": "compiler_output",
+  "verification/failure-classification.json": "failure_classification",
   "verification/verdict.json": "verdict_record",
   "verification/verifier-output.json": "verifier_output"
 } as const satisfies Record<string, WorkerBundleArtifactRole>;
+const alwaysRequiredCanonicalArtifactPaths = Object.keys(canonicalArtifactRoleByPath).filter(
+  (relativePath) => relativePath !== "verification/failure-classification.json"
+);
 
 type WorkerClaimLoopOptions = z.input<typeof workerClaimLoopOptionsSchema>;
 type WorkerClaimLoopResolvedOptions = z.output<typeof workerClaimLoopOptionsSchema>;
@@ -1248,6 +1296,11 @@ async function readBundleSubmission(bundleRoot: string): Promise<PreparedBundleS
     runBundle,
     verifierVerdict
   });
+  await assertBundleProvenanceDigests(bundleRootRealPath, {
+    benchmarkPackage,
+    promptPackage,
+    runBundle
+  });
 
   assertVerifierVerdictSemantics(verifierVerdict);
 
@@ -1430,6 +1483,14 @@ async function assertManifestEntriesMatchFiles(
     if (artifact.requiredForIngest !== expectedManifestMetadata.requiredForIngest) {
       throw new BundleSubmissionIntegrityError(
         `${canonicalRelativePath} requiredForIngest does not match the canonical bundle contract.`
+      );
+    }
+  }
+
+  for (const requiredRelativePath of alwaysRequiredCanonicalArtifactPaths) {
+    if (!seenRelativePaths.has(requiredRelativePath)) {
+      throw new BundleSubmissionIntegrityError(
+        `artifact-manifest.json is missing required bundle file: ${requiredRelativePath}.`
       );
     }
   }
@@ -1644,6 +1705,93 @@ function assertBundleSubmissionFileConsistency(options: {
   }
 }
 
+async function assertBundleProvenanceDigests(
+  bundleRootRealPath: string,
+  options: {
+    benchmarkPackage: z.output<typeof problem9BenchmarkPackageManifestSchema>;
+    promptPackage: z.output<typeof problem9PromptPackageManifestSchema>;
+    runBundle: z.output<typeof runBundleFileSchema>;
+  }
+): Promise<void> {
+  for (const relativePath of benchmarkSourcePaths) {
+    assertCanonicalDigest(
+      sha256Text(await loadBundleTextFile(bundleRootRealPath, `package/${relativePath}`)),
+      options.benchmarkPackage.hashes[relativePath],
+      `package/${relativePath} does not match package/benchmark-package.json hashes.`
+    );
+  }
+
+  for (const relativePath of promptLayerPaths) {
+    assertCanonicalDigest(
+      sha256Text(await loadBundleTextFile(bundleRootRealPath, `prompt/${relativePath}`)),
+      options.promptPackage.layerDigests[relativePath],
+      `prompt/${relativePath} does not match prompt/prompt-package.json layerDigests.`
+    );
+  }
+
+  assertPromptRunEnvelopeConsistency(
+    parsePromptRunEnvelope(await loadBundleTextFile(bundleRootRealPath, "prompt/run-envelope.json")),
+    options
+  );
+}
+
+function parsePromptRunEnvelope(contents: string) {
+  try {
+    return promptRunEnvelopeSchema.parse(JSON.parse(contents));
+  } catch {
+    throw new BundleSubmissionIntegrityError(
+      "prompt/run-envelope.json is not a valid prompt run envelope."
+    );
+  }
+}
+
+function assertPromptRunEnvelopeConsistency(
+  runEnvelope: z.infer<typeof promptRunEnvelopeSchema>,
+  options: {
+    benchmarkPackage: z.output<typeof problem9BenchmarkPackageManifestSchema>;
+    promptPackage: z.output<typeof problem9PromptPackageManifestSchema>;
+    runBundle: z.output<typeof runBundleFileSchema>;
+  }
+): void {
+  const checks: Array<[actual: string | null, expected: string | null, label: string]> = [
+    [runEnvelope.attemptId, options.runBundle.attemptId, "attemptId"],
+    [runEnvelope.authMode, options.promptPackage.authMode, "authMode"],
+    [runEnvelope.benchmarkItemId, options.runBundle.benchmarkItemId, "benchmarkItemId"],
+    [
+      runEnvelope.benchmarkPackageDigest,
+      options.benchmarkPackage.packageDigest,
+      "benchmarkPackageDigest"
+    ],
+    [runEnvelope.benchmarkPackageId, options.benchmarkPackage.packageId, "benchmarkPackageId"],
+    [
+      runEnvelope.benchmarkPackageVersion,
+      options.benchmarkPackage.packageVersion,
+      "benchmarkPackageVersion"
+    ],
+    [runEnvelope.harnessRevision, options.promptPackage.harnessRevision, "harnessRevision"],
+    [runEnvelope.jobId, options.runBundle.jobId, "jobId"],
+    [runEnvelope.laneId, options.promptPackage.laneId, "laneId"],
+    [runEnvelope.modelConfigId, options.promptPackage.modelConfigId, "modelConfigId"],
+    [
+      runEnvelope.promptProtocolVersion,
+      options.promptPackage.promptProtocolVersion,
+      "promptProtocolVersion"
+    ],
+    [runEnvelope.providerFamily, options.promptPackage.providerFamily, "providerFamily"],
+    [runEnvelope.runId, options.runBundle.runId, "runId"],
+    [runEnvelope.runMode, options.promptPackage.runMode, "runMode"],
+    [runEnvelope.toolProfile, options.promptPackage.toolProfile, "toolProfile"]
+  ];
+
+  for (const [actual, expected, label] of checks) {
+    if (actual !== expected) {
+      throw new BundleSubmissionIntegrityError(
+        `prompt/run-envelope.json ${label} does not match the canonical bundle contract.`
+      );
+    }
+  }
+}
+
 function assertVerifierVerdictSemantics(
   verifierVerdict: z.output<typeof bundleVerifierVerdictFileSchema>
 ): void {
@@ -1767,11 +1915,24 @@ function expectedManifestMetadataForPath(relativePath: string) {
     contentEncoding: null,
     mediaType: relativePath.endsWith(".json")
       ? "application/json"
-      : relativePath.endsWith(".txt") || relativePath.endsWith(".lean")
+      : isNormalizedTextBundlePath(relativePath)
         ? "text/plain"
         : null,
     requiredForIngest: true
   };
+}
+
+function isNormalizedTextBundlePath(relativePath: string): boolean {
+  const baseName = path.posix.basename(relativePath);
+
+  return (
+    relativePath.endsWith(".txt") ||
+    relativePath.endsWith(".lean") ||
+    relativePath.endsWith(".md") ||
+    relativePath.endsWith(".toml") ||
+    baseName === "LICENSE" ||
+    baseName === "lean-toolchain"
+  );
 }
 
 function isOptionalArtifactRole(role: string): role is "usage_summary" | "execution_trace" {

--- a/apps/worker/test/problem9-integrity.test.ts
+++ b/apps/worker/test/problem9-integrity.test.ts
@@ -15,7 +15,7 @@ import { materializeProblem9RunBundle } from "../src/lib/problem9-run-bundle.ts"
 const expectedIntegrityDigests = {
   benchmarkPackage: "2a613fe5717c5df32fc3c95b0cf4cbbc9a99312c0cac44948b0cd641acac8dcb",
   promptPackage: "f0fe26f4c426b6b51d524a6bcf23331556a590d0b621f5ccc74fe416c1f7f329",
-  runBundle: "5222dbac0acdcdbe3dbfbdb4bfcc2f483101cf8f3847a9fb21c6dc259a4a21cc"
+  runBundle: "2dd7fae8adf2d9e9559dc0e1148dc3095f5668f15a4e6aa80394ec82c6139059"
 } as const;
 
 const expectedBenchmarkSourceMetadata = {

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -215,7 +215,7 @@ test("runProblem9OfflineIngest posts canonical bundle requests with Access auth"
 
         return new Response(
           JSON.stringify({
-            artifactCount: 11,
+            artifactCount: 24,
             attempt: {
               id: "attempt-row-1",
               sourceAttemptId: "attempt-pass-1",
@@ -255,8 +255,16 @@ test("runProblem9OfflineIngest posts canonical bundle requests with Access auth"
       "ingestRequestSchemaVersion" in receivedRequestBody,
     true
   );
+  const parsedRequest = receivedRequestBody as {
+    bundle: {
+      benchmarkSources: Record<string, string>;
+      promptLayers: Record<string, string>;
+    };
+  };
+  assert.match(parsedRequest.bundle.benchmarkSources["README.md"] ?? "", /.+/u);
+  assert.match(parsedRequest.bundle.promptLayers["system.md"] ?? "", /.+/u);
   assert.deepEqual(result, {
-    artifactCount: 11,
+    artifactCount: 24,
     attempt: {
       id: "attempt-row-1",
       sourceAttemptId: "attempt-pass-1",

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -205,6 +205,7 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
         "compiler_output",
         "compiler_diagnostics",
         "verifier_output",
+        "failure_classification",
         "environment_snapshot",
         "usage_summary",
         "execution_trace"
@@ -379,6 +380,181 @@ test("runWorkerClaimLoop accepts uppercase verdict benchmarkPackageDigest hex", 
       stoppedReason: "max_jobs_reached"
     });
     assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/result`);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop registers failure-classification artifacts for failing verifier results", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-failing-verdict-"));
+
+  try {
+    const calls: ApiCall[] = [];
+    const baseWorkerJob = buildWorkerJob();
+    const workerJob = {
+      ...baseWorkerJob,
+      requiredArtifactRoles: [...baseWorkerJob.requiredArtifactRoles, "failure_classification" as const]
+    };
+    const artifactEntries = buildArtifactEntries({ includeFailureClassification: true });
+    let writtenBundle: WrittenBundleDigests | null = null;
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          writtenBundle = await writeBundleOutputsWithVerdict(options.outputRoot, artifactEntries, {
+            diagnosticGate: "failed",
+            failureCode: "proof_policy_failed",
+            primaryFailure: {
+              evidenceArtifactRefs: ["verification/failure-classification.json"],
+              failureCode: "proof_policy_failed",
+              failureFamily: "verification",
+              phase: "verify",
+              retryEligibility: "never",
+              summary: "Canonical verifier failure payload.",
+              terminality: "terminal_attempt",
+              userVisibility: "internal_only"
+            },
+            result: "fail"
+          });
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "fail",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verifier_failed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.equal(calls.at(-1)?.path, `/internal/worker/jobs/${workerJob.jobId}/failure`);
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.deepEqual(failureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(failureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(failureBody.candidateDigest, writtenBundle?.candidateDigest);
+    assert.equal(failureBody.verdictDigest, writtenBundle?.verdictDigest);
+    assert.equal(failureBody.failure.failureCode, "proof_policy_failed");
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, [
+      "verification/failure-classification.json"
+    ]);
+    assert.equal(failureBody.terminalState, "failed");
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {
@@ -1768,7 +1944,7 @@ test("runWorkerClaimLoop reports invalid hosted modelConfigId prefixes before at
   }
 });
 
-function buildWorkerJob() {
+function buildWorkerJob(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     attemptId: "attempt-1",
     heartbeatIntervalSeconds: 30,
@@ -1815,7 +1991,8 @@ function buildWorkerJob() {
       runKind: "single_run" as const,
       runMode: "bounded_agentic_attempt" as const,
       toolProfile: "workspace_edit_limited" as const
-    }
+    },
+    ...overrides
   };
 }
 
@@ -1831,8 +2008,8 @@ function buildHeartbeatResponse(overrides: Partial<Record<string, unknown>> = {}
   };
 }
 
-function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
-  return [
+function buildArtifactEntries(options: { includeFailureClassification?: boolean } = {}): WorkerArtifactManifestEntry[] {
+  const entries: WorkerArtifactManifestEntry[] = [
     {
       artifactRole: "package_reference",
       byteSize: 128,
@@ -1846,10 +2023,91 @@ function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
       artifactRole: "package_reference",
       byteSize: 64,
       contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/FirstProof/Problem9/Gold.lean",
+      requiredForIngest: true,
+      sha256: "31".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/FirstProof/Problem9/Statement.lean",
+      requiredForIngest: true,
+      sha256: "32".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/FirstProof/Problem9/Support.lean",
+      requiredForIngest: true,
+      sha256: "33".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/LICENSE",
+      requiredForIngest: true,
+      sha256: "34".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/README.md",
+      requiredForIngest: true,
+      sha256: "35".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "package/lake-manifest.json",
+      requiredForIngest: true,
+      sha256: "36".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/lakefile.toml",
+      requiredForIngest: true,
+      sha256: "37".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/lean-toolchain",
+      requiredForIngest: true,
+      sha256: "38".repeat(32)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
       mediaType: "application/json",
       relativePath: "package/package-ref.json",
       requiredForIngest: true,
       sha256: "4".repeat(64)
+    },
+    {
+      artifactRole: "package_reference",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "package/statements/problem.md",
+      requiredForIngest: true,
+      sha256: "39".repeat(32)
     },
     {
       artifactRole: "prompt_package",
@@ -1859,6 +2117,42 @@ function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
       relativePath: "prompt/prompt-package.json",
       requiredForIngest: true,
       sha256: "5".repeat(64)
+    },
+    {
+      artifactRole: "prompt_package",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "prompt/benchmark.md",
+      requiredForIngest: true,
+      sha256: "41".repeat(32)
+    },
+    {
+      artifactRole: "prompt_package",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "prompt/item.md",
+      requiredForIngest: true,
+      sha256: "42".repeat(32)
+    },
+    {
+      artifactRole: "prompt_package",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "prompt/run-envelope.json",
+      requiredForIngest: true,
+      sha256: "43".repeat(32)
+    },
+    {
+      artifactRole: "prompt_package",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "text/plain",
+      relativePath: "prompt/system.md",
+      requiredForIngest: true,
+      sha256: "44".repeat(32)
     },
     {
       artifactRole: "candidate_source",
@@ -1933,6 +2227,20 @@ function buildArtifactEntries(): WorkerArtifactManifestEntry[] {
       sha256: "d".repeat(64)
     }
   ];
+
+  if (options.includeFailureClassification) {
+    entries.splice(entries.findIndex((entry) => entry.relativePath === "verification/verdict.json"), 0, {
+      artifactRole: "failure_classification",
+      byteSize: 64,
+      contentEncoding: null,
+      mediaType: "application/json",
+      relativePath: "verification/failure-classification.json",
+      requiredForIngest: true,
+      sha256: "45".repeat(32)
+    });
+  }
+
+  return entries;
 }
 
 async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArtifactManifestEntry[]) {
@@ -1945,6 +2253,8 @@ async function writeBundleOutputsWithVerdict(
   verdictOverrides: Record<string, unknown> = {}
 ) : Promise<WrittenBundleDigests> {
   await mkdir(path.join(outputRoot, "package"), { recursive: true });
+  await mkdir(path.join(outputRoot, "package", "FirstProof", "Problem9"), { recursive: true });
+  await mkdir(path.join(outputRoot, "package", "statements"), { recursive: true });
   await mkdir(path.join(outputRoot, "prompt"), { recursive: true });
   await mkdir(path.join(outputRoot, "candidate"), { recursive: true });
   await mkdir(path.join(outputRoot, "diagnostics"), { recursive: true });
@@ -1952,6 +2262,40 @@ async function writeBundleOutputsWithVerdict(
   await mkdir(path.join(outputRoot, "traces"), { recursive: true });
   await mkdir(path.join(outputRoot, "verification"), { recursive: true });
   const candidateSource = "theorem Candidate : True := by\n  trivial\n";
+  const benchmarkSources = {
+    "FirstProof/Problem9/Gold.lean": "theorem problem9_gold : True := by\n  trivial\n",
+    "FirstProof/Problem9/Statement.lean": "theorem problem9_statement : True := by\n  trivial\n",
+    "FirstProof/Problem9/Support.lean": "theorem problem9_support : True := by\n  trivial\n",
+    "LICENSE": "Apache License\nVersion 2.0, January 2004\n",
+    "README.md": "# Problem9\n\nCanonical benchmark package fixture.\n",
+    "lake-manifest.json": `${stableStringify({ packagesDir: ".lake/packages" })}\n`,
+    "lakefile.toml": 'name = "FirstProof"\n',
+    "lean-toolchain": "leanprover/lean4:v4.22.0\n",
+    "statements/problem.md": "# Problem 9\n\nShow `True`.\n"
+  } as const;
+  const promptLayers = {
+    "benchmark.md": "Benchmark instructions.\n",
+    "item.md": "Item-specific guidance.\n",
+    "run-envelope.json": `${stableStringify({
+      attemptId: "attempt-1",
+      authMode: "machine_api_key",
+      benchmarkItemId: "Problem9",
+      benchmarkPackageDigest: benchmarkDigest,
+      benchmarkPackageId: "firstproof/Problem9",
+      benchmarkPackageVersion: "2026.03.13",
+      harnessRevision: "worker-harness.v1",
+      jobId: "job-1",
+      laneId: "lean422_exact",
+      modelConfigId: "openai/gpt-5",
+      promptProtocolVersion: "problem9-prompt-protocol.v1",
+      providerFamily: "openai",
+      runEnvelopeSchemaVersion: "1",
+      runId: "run-1",
+      runMode: "bounded_agentic_attempt",
+      toolProfile: "workspace_edit_limited"
+    })}\n`,
+    "system.md": "System prompt guidance.\n"
+  } as const;
   const benchmarkPackage = {
     benchmarkFamily: "firstproof",
     benchmarkItemId: "Problem9",
@@ -1961,12 +2305,12 @@ async function writeBundleOutputsWithVerdict(
       support: "FirstProof/Problem9/Support.lean"
     },
     hashAlgorithm: "sha256",
-    hashes: {
-      "FirstProof/Problem9/Gold.lean": "9".repeat(64),
-      "FirstProof/Problem9/Statement.lean": "8".repeat(64),
-      "FirstProof/Problem9/Support.lean": "7".repeat(64),
-      "README.md": "6".repeat(64)
-    },
+    hashes: Object.fromEntries(
+      Object.entries(benchmarkSources).map(([relativePath, contents]) => [
+        relativePath,
+        sha256Text(contents)
+      ])
+    ),
     lanePolicy: {
       primaryLane: "lean422_exact",
       supportedLanes: ["lean422_exact"]
@@ -1997,12 +2341,12 @@ async function writeBundleOutputsWithVerdict(
     benchmarkPackageVersion: "2026.03.13",
     harnessRevision: "worker-harness.v1",
     laneId: "lean422_exact",
-    layerDigests: {
-      "benchmark.md": "2".repeat(64),
-      "item.md": "3".repeat(64),
-      "run-envelope.json": "4".repeat(64),
-      "system.md": "5".repeat(64)
-    },
+    layerDigests: Object.fromEntries(
+      Object.entries(promptLayers).map(([relativePath, contents]) => [
+        relativePath,
+        sha256Text(contents)
+      ])
+    ),
     layerVersions: {
       benchmark: "1",
       item: "1",
@@ -2039,6 +2383,16 @@ async function writeBundleOutputsWithVerdict(
   const executionTrace = gzipSync(
     Buffer.from('{"event":"attempt_started","ts":"2026-03-13T00:00:00.000Z"}\n', "utf8")
   );
+  const failureClassification = {
+    evidenceArtifactRefs: ["verification/failure-classification.json"],
+    failureCode: "proof_policy_failed",
+    failureFamily: "verification",
+    phase: "verify",
+    retryEligibility: "never",
+    summary: "Canonical verifier failure payload.",
+    terminality: "terminal_attempt",
+    userVisibility: "internal_only"
+  };
   const environment = {
     authMode: "machine_api_key",
     environmentSchemaVersion: "1",
@@ -2103,12 +2457,18 @@ async function writeBundleOutputsWithVerdict(
     writtenBenchmarkPackage,
     "utf8"
   );
+  for (const [relativePath, contents] of Object.entries(benchmarkSources)) {
+    await writeFile(path.join(outputRoot, "package", relativePath), contents, "utf8");
+  }
   await writeFile(path.join(outputRoot, "package", "package-ref.json"), writtenPackageRef, "utf8");
   await writeFile(
     path.join(outputRoot, "prompt", "prompt-package.json"),
     writtenPromptPackage,
     "utf8"
   );
+  for (const [relativePath, contents] of Object.entries(promptLayers)) {
+    await writeFile(path.join(outputRoot, "prompt", relativePath), contents, "utf8");
+  }
   await writeFile(
     path.join(outputRoot, "environment", "environment.json"),
     writtenEnvironment,
@@ -2134,6 +2494,17 @@ async function writeBundleOutputsWithVerdict(
     writtenVerifierOutput,
     "utf8"
   );
+  if (
+    artifactEntries.some(
+      (artifact) => artifact.relativePath === "verification/failure-classification.json"
+    )
+  ) {
+    await writeFile(
+      path.join(outputRoot, "verification", "failure-classification.json"),
+      `${stableStringify(failureClassification)}\n`,
+      "utf8"
+    );
+  }
   await writeFile(
     path.join(outputRoot, "verification", "verdict.json"),
     writtenVerdict,
@@ -2221,7 +2592,7 @@ async function writeBundleOutputsWithVerdict(
   };
 }
 
-test("runWorkerClaimLoop rejects bundle digest drift before artifact registration", async (t) => {
+test("runWorkerClaimLoop rejects bundle digest drift before artifact registration", async () => {
   const mismatchCases = [
     {
       expectedSummary: /artifactManifestDigest does not match artifact-manifest\.json/i,
@@ -2322,6 +2693,7 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
         const benchmarkPackage = await readJsonFile(path.join(outputRoot, "package", "benchmark-package.json"));
         const packageRef = await readJsonFile(path.join(outputRoot, "package", "package-ref.json"));
         const promptPackage = await readJsonFile(path.join(outputRoot, "prompt", "prompt-package.json"));
+        const runEnvelope = await readJsonFile(path.join(outputRoot, "prompt", "run-envelope.json"));
         const environment = await readJsonFile(path.join(outputRoot, "environment", "environment.json"));
         const verdict = await readJsonFile(path.join(outputRoot, "verification", "verdict.json"));
         const tamperedBenchmarkPackage = {
@@ -2336,9 +2708,21 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
           ...promptPackage,
           benchmarkPackageDigest: "9".repeat(64)
         };
+        const tamperedRunEnvelope = {
+          ...runEnvelope,
+          benchmarkPackageDigest: "9".repeat(64)
+        };
         const tamperedVerdict = {
           ...verdict,
           benchmarkPackageDigest: "9".repeat(64)
+        };
+        const runEnvelopeText = `${stableStringify(tamperedRunEnvelope)}\n`;
+        const tamperedPromptPackageWithRunEnvelope = {
+          ...tamperedPromptPackage,
+          layerDigests: {
+            ...(tamperedPromptPackage.layerDigests as Record<string, unknown>),
+            "run-envelope.json": sha256Text(runEnvelopeText)
+          }
         };
         const verdictText = stableStringify(tamperedVerdict);
 
@@ -2349,9 +2733,10 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
         );
         await writeFile(
           path.join(outputRoot, "prompt", "prompt-package.json"),
-          `${stableStringify(tamperedPromptPackage)}\n`,
+          `${stableStringify(tamperedPromptPackageWithRunEnvelope)}\n`,
           "utf8"
         );
+        await writeFile(path.join(outputRoot, "prompt", "run-envelope.json"), runEnvelopeText, "utf8");
         await writeFile(
           path.join(outputRoot, "package", "package-ref.json"),
           `${stableStringify(tamperedPackageRef)}\n`,
@@ -2378,6 +2763,13 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
           relativePath: "prompt/prompt-package.json",
           requiredForIngest: true
         });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/run-envelope.json",
+          requiredForIngest: true
+        });
         await writeFile(path.join(outputRoot, "verification", "verdict.json"), verdictText, "utf8");
         await upsertArtifactManifestEntry(outputRoot, {
           artifactRole: "verdict_record",
@@ -2398,15 +2790,15 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
             },
             environmentDigest: sha256Text(stableStringify(environment)),
             promptPackage: {
-              authMode: String(tamperedPromptPackage.authMode),
-              harnessRevision: String(tamperedPromptPackage.harnessRevision),
-              laneId: String(tamperedPromptPackage.laneId),
-              modelConfigId: String(tamperedPromptPackage.modelConfigId),
-              promptPackageDigest: String(tamperedPromptPackage.promptPackageDigest),
-              promptProtocolVersion: String(tamperedPromptPackage.promptProtocolVersion),
-              providerFamily: String(tamperedPromptPackage.providerFamily),
-              runMode: String(tamperedPromptPackage.runMode),
-              toolProfile: String(tamperedPromptPackage.toolProfile)
+              authMode: String(tamperedPromptPackageWithRunEnvelope.authMode),
+              harnessRevision: String(tamperedPromptPackageWithRunEnvelope.harnessRevision),
+              laneId: String(tamperedPromptPackageWithRunEnvelope.laneId),
+              modelConfigId: String(tamperedPromptPackageWithRunEnvelope.modelConfigId),
+              promptPackageDigest: String(tamperedPromptPackageWithRunEnvelope.promptPackageDigest),
+              promptProtocolVersion: String(tamperedPromptPackageWithRunEnvelope.promptProtocolVersion),
+              providerFamily: String(tamperedPromptPackageWithRunEnvelope.providerFamily),
+              runMode: String(tamperedPromptPackageWithRunEnvelope.runMode),
+              toolProfile: String(tamperedPromptPackageWithRunEnvelope.toolProfile)
             }
           }),
           verdictDigest: sha256Text(verdictText)
@@ -2418,15 +2810,26 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
       name: "coherent prompt and environment retamper",
       tamper: async (outputRoot: string) => {
         const promptPackage = await readJsonFile(path.join(outputRoot, "prompt", "prompt-package.json"));
+        const runEnvelope = await readJsonFile(path.join(outputRoot, "prompt", "run-envelope.json"));
         const environment = await readJsonFile(path.join(outputRoot, "environment", "environment.json"));
         const tamperedPromptPackage = { ...promptPackage, modelConfigId: "openai/gpt-5-pro" };
+        const tamperedRunEnvelope = { ...runEnvelope, modelConfigId: "openai/gpt-5-pro" };
         const tamperedEnvironment = { ...environment, modelConfigId: "openai/gpt-5-pro" };
+        const runEnvelopeText = `${stableStringify(tamperedRunEnvelope)}\n`;
+        const tamperedPromptPackageWithRunEnvelope = {
+          ...tamperedPromptPackage,
+          layerDigests: {
+            ...(tamperedPromptPackage.layerDigests as Record<string, unknown>),
+            "run-envelope.json": sha256Text(runEnvelopeText)
+          }
+        };
 
         await writeFile(
           path.join(outputRoot, "prompt", "prompt-package.json"),
-          `${stableStringify(tamperedPromptPackage)}\n`,
+          `${stableStringify(tamperedPromptPackageWithRunEnvelope)}\n`,
           "utf8"
         );
+        await writeFile(path.join(outputRoot, "prompt", "run-envelope.json"), runEnvelopeText, "utf8");
         await writeFile(
           path.join(outputRoot, "environment", "environment.json"),
           `${stableStringify(tamperedEnvironment)}\n`,
@@ -2437,6 +2840,13 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
           contentEncoding: null,
           mediaType: "application/json",
           relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/run-envelope.json",
           requiredForIngest: true
         });
         await upsertArtifactManifestEntry(outputRoot, {
@@ -2459,15 +2869,15 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
             },
             environmentDigest: sha256Text(stableStringify(tamperedEnvironment)),
             promptPackage: {
-              authMode: String(tamperedPromptPackage.authMode),
-              harnessRevision: String(tamperedPromptPackage.harnessRevision),
-              laneId: String(tamperedPromptPackage.laneId),
-              modelConfigId: String(tamperedPromptPackage.modelConfigId),
-              promptPackageDigest: String(tamperedPromptPackage.promptPackageDigest),
-              promptProtocolVersion: String(tamperedPromptPackage.promptProtocolVersion),
-              providerFamily: String(tamperedPromptPackage.providerFamily),
-              runMode: String(tamperedPromptPackage.runMode),
-              toolProfile: String(tamperedPromptPackage.toolProfile)
+              authMode: String(tamperedPromptPackageWithRunEnvelope.authMode),
+              harnessRevision: String(tamperedPromptPackageWithRunEnvelope.harnessRevision),
+              laneId: String(tamperedPromptPackageWithRunEnvelope.laneId),
+              modelConfigId: String(tamperedPromptPackageWithRunEnvelope.modelConfigId),
+              promptPackageDigest: String(tamperedPromptPackageWithRunEnvelope.promptPackageDigest),
+              promptProtocolVersion: String(tamperedPromptPackageWithRunEnvelope.promptProtocolVersion),
+              providerFamily: String(tamperedPromptPackageWithRunEnvelope.providerFamily),
+              runMode: String(tamperedPromptPackageWithRunEnvelope.runMode),
+              toolProfile: String(tamperedPromptPackageWithRunEnvelope.toolProfile)
             }
           })
         }));
@@ -2498,6 +2908,40 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
                   }
                 : artifact
             )
+        }));
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary:
+        /artifact-manifest\.json is missing required bundle file: package\/README\.md\./i,
+      name: "missing benchmark provenance manifest entry",
+      tamper: async (outputRoot: string) => {
+        await rewriteArtifactManifest(outputRoot, (artifactManifest) => ({
+          ...artifactManifest,
+          artifacts: (((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? [])).filter(
+            (artifact) => String(artifact.relativePath) !== "package/README.md"
+          )
+        }));
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary:
+        /package\/README\.md mediaType does not match the canonical bundle contract\./i,
+      name: "benchmark provenance metadata drift",
+      tamper: async (outputRoot: string) => {
+        await rewriteArtifactManifest(outputRoot, (artifactManifest) => ({
+          ...artifactManifest,
+          artifacts: (((artifactManifest.artifacts as Array<Record<string, unknown>>) ?? [])).map(
+            (artifact) =>
+              String(artifact.relativePath) === "package/README.md"
+                ? {
+                    ...artifact,
+                    mediaType: null
+                  }
+                : artifact
+          )
         }));
         await refreshBundleDigests(outputRoot);
       }
@@ -2703,11 +3147,88 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
         }));
         await refreshBundleDigests(outputRoot);
       }
+    },
+    {
+      expectedSummary:
+        /package\/README\.md does not match package\/benchmark-package\.json hashes\./i,
+      name: "benchmark source digest drift",
+      tamper: async (outputRoot: string) => {
+        await writeFile(path.join(outputRoot, "package", "README.md"), "# Tampered benchmark fixture\n", "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "package_reference",
+          contentEncoding: null,
+          mediaType: "text/plain",
+          relativePath: "package/README.md",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary:
+        /prompt\/system\.md does not match prompt\/prompt-package\.json layerDigests\./i,
+      name: "prompt layer digest drift",
+      tamper: async (outputRoot: string) => {
+        await writeFile(
+          path.join(outputRoot, "prompt", "system.md"),
+          "Tampered system prompt\n",
+          "utf8"
+        );
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "text/plain",
+          relativePath: "prompt/system.md",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot);
+      }
+    },
+    {
+      expectedSummary:
+        /prompt\/run-envelope\.json runId does not match the canonical bundle contract\./i,
+      name: "run-envelope semantic drift",
+      tamper: async (outputRoot: string) => {
+        const runEnvelopePath = path.join(outputRoot, "prompt", "run-envelope.json");
+        const promptPackagePath = path.join(outputRoot, "prompt", "prompt-package.json");
+        const runEnvelope = await readJsonFile(runEnvelopePath);
+        const promptPackage = await readJsonFile(promptPackagePath);
+        const tamperedRunEnvelope = {
+          ...runEnvelope,
+          runId: "run-tampered"
+        };
+        const tamperedRunEnvelopeText = `${stableStringify(tamperedRunEnvelope)}\n`;
+        const tamperedPromptPackage = {
+          ...promptPackage,
+          layerDigests: {
+            ...(promptPackage.layerDigests as Record<string, unknown>),
+            "run-envelope.json": sha256Text(tamperedRunEnvelopeText)
+          }
+        };
+
+        await writeFile(runEnvelopePath, tamperedRunEnvelopeText, "utf8");
+        await writeFile(promptPackagePath, `${stableStringify(tamperedPromptPackage)}\n`, "utf8");
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/run-envelope.json",
+          requiredForIngest: true
+        });
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "prompt_package",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "prompt/prompt-package.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot);
+      }
     }
   ] as const;
 
   for (const mismatchCase of mismatchCases) {
-    await t.test(mismatchCase.name, async () => {
+    {
       const tempRoot = await mkdtemp(
         path.join(os.tmpdir(), `paretoproof-worker-claim-bundle-mismatch-${sanitizePath(mismatchCase.name)}-`)
       );
@@ -2846,7 +3367,7 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
       } finally {
         await rm(tempRoot, { force: true, recursive: true });
       }
-    });
+    }
   }
 });
 

--- a/packages/shared/src/schemas/problem9-offline-ingest.ts
+++ b/packages/shared/src/schemas/problem9-offline-ingest.ts
@@ -233,15 +233,36 @@ export const problem9OfflineArtifactManifestSchema = z.object({
   hashAlgorithm: z.literal("sha256")
 });
 
+export const problem9BenchmarkSourceFilesSchema = z.object({
+  "FirstProof/Problem9/Gold.lean": z.string().min(1),
+  "FirstProof/Problem9/Statement.lean": z.string().min(1),
+  "FirstProof/Problem9/Support.lean": z.string().min(1),
+  LICENSE: z.string().min(1),
+  "README.md": z.string().min(1),
+  "lake-manifest.json": z.string().min(1),
+  "lakefile.toml": z.string().min(1),
+  "lean-toolchain": z.string().min(1),
+  "statements/problem.md": z.string().min(1)
+});
+
+export const problem9PromptLayerContentsSchema = z.object({
+  "benchmark.md": z.string().min(1),
+  "item.md": z.string().min(1),
+  "run-envelope.json": z.string().min(1),
+  "system.md": z.string().min(1)
+});
+
 const problem9OfflineIngestBundleBaseSchema = z.object({
   artifactManifest: problem9OfflineArtifactManifestSchema,
   benchmarkPackage: problem9BenchmarkPackageManifestSchema,
+  benchmarkSources: problem9BenchmarkSourceFilesSchema,
   candidateSource: z.string().min(1),
   compilerDiagnostics: recordValueSchema,
   compilerOutput: z.string(),
   environment: problem9EnvironmentManifestSchema,
   packageRef: problem9PackageRefSchema,
   promptPackage: problem9PromptPackageManifestSchema,
+  promptLayers: problem9PromptLayerContentsSchema,
   runBundle: problem9RunBundleManifestSchema,
   usage: recordValueSchema.nullable(),
   verifierOutput: recordValueSchema

--- a/packages/shared/src/types/problem9-offline-ingest.ts
+++ b/packages/shared/src/types/problem9-offline-ingest.ts
@@ -15,15 +15,36 @@ export type Problem9OfflineIngestRequest = {
   bundle: Problem9OfflineIngestBundle;
 };
 
+export type Problem9BenchmarkSourceFiles = {
+  "FirstProof/Problem9/Gold.lean": string;
+  "FirstProof/Problem9/Statement.lean": string;
+  "FirstProof/Problem9/Support.lean": string;
+  LICENSE: string;
+  "README.md": string;
+  "lake-manifest.json": string;
+  "lakefile.toml": string;
+  "lean-toolchain": string;
+  "statements/problem.md": string;
+};
+
+export type Problem9PromptLayerContents = {
+  "benchmark.md": string;
+  "item.md": string;
+  "run-envelope.json": string;
+  "system.md": string;
+};
+
 type Problem9OfflineIngestBundleBase = {
   artifactManifest: Problem9OfflineArtifactManifest;
   benchmarkPackage: Problem9BenchmarkPackageManifest;
+  benchmarkSources: Problem9BenchmarkSourceFiles;
   candidateSource: string;
   compilerDiagnostics: unknown;
   compilerOutput: string;
   environment: Problem9EnvironmentManifest;
   packageRef: Problem9PackageRef;
   promptPackage: Problem9PromptPackageManifest;
+  promptLayers: Problem9PromptLayerContents;
   runBundle: Problem9RunBundleManifest;
   usage: unknown | null;
   verifierOutput: unknown;


### PR DESCRIPTION
## Summary
- make Problem 9 run bundles self-contained by carrying benchmark source files and prompt layers through the shared offline-ingest contract
- align live worker finalization and API offline-ingest validation on canonical artifact metadata, normalized-text hashing, and prompt run-envelope semantics
- add regressions for provenance digest drift, metadata drift, run-envelope semantic drift, failure-classification coverage, and the updated deterministic run-bundle snapshot

## Verification
- node --import tsx --test src/lib/problem9-run-bundle.test.ts
- node --import tsx --test test/problem9-offline-ingest.test.ts
- node --import tsx --test test/problem9-integrity.test.ts
- node --import tsx --test test/worker-claim-loop.test.ts
- bun test apps/api/test/problem9-offline-ingest.test.ts
- bun run test:shared
- bun run build

Closes #1008