### PR TITLE
[Finding][Worker] Remove the unsafe prompt-package delete boundary

### DIFF
--- a/apps/worker/src/lib/problem9-prompt-package-cli.ts
+++ b/apps/worker/src/lib/problem9-prompt-package-cli.ts
@@ -23,22 +23,58 @@ export async function runProblem9PromptPackageCli(args: string[]): Promise<void>
     commandFamily: "materializer"
   });
 
-  const getRequiredValue = (flag: string): string => {
+  const readFlagValue = (flag: string): { present: boolean; value: string | null } => {
     const index = args.findIndex((argument) => argument === flag);
 
-    if (index === -1 || !args[index + 1]) {
+    if (index === -1) {
+      return {
+        present: false,
+        value: null
+      };
+    }
+
+    const candidateValue = args[index + 1];
+
+    if (!candidateValue || candidateValue.startsWith("--")) {
+      return {
+        present: true,
+        value: null
+      };
+    }
+
+    return {
+      present: true,
+      value: candidateValue
+    };
+  };
+
+  const getRequiredValue = (flag: string): string => {
+    const { value } = readFlagValue(flag);
+
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
-    return args[index + 1];
+    return value;
   };
 
   const getOptionalValue = (flag: string): string | null => {
-    const index = args.findIndex((argument) => argument === flag);
-    return index === -1 || !args[index + 1] ? null : args[index + 1];
+    const { present, value } = readFlagValue(flag);
+
+    if (!present) {
+      return null;
+    }
+
+    if (value === null) {
+      throw new Error(`Missing ${flag} <value> argument.`);
+    }
+
+    return value;
   };
 
   const defaults = getDefaultProblem9PromptPackageOptions();
+  const passKCount = getOptionalValue("--pass-k-count");
+  const passKIndex = getOptionalValue("--pass-k-index");
   const result = await materializeProblem9PromptPackage({
     attemptId: getRequiredValue("--attempt-id"),
     authMode: getRequiredValue("--auth-mode") as Problem9LocalAuthMode,
@@ -48,12 +84,8 @@ export async function runProblem9PromptPackageCli(args: string[]): Promise<void>
     laneId: getRequiredValue("--lane-id"),
     modelConfigId: getRequiredValue("--model-config-id"),
     outputRoot: path.resolve(getRequiredValue("--output")),
-    passKCount: getOptionalValue("--pass-k-count")
-      ? Number(getOptionalValue("--pass-k-count"))
-      : null,
-    passKIndex: getOptionalValue("--pass-k-index")
-      ? Number(getOptionalValue("--pass-k-index"))
-      : null,
+    passKCount: passKCount ? Number(passKCount) : null,
+    passKIndex: passKIndex ? Number(passKIndex) : null,
     promptLayerVersions: defaults.promptLayerVersions,
     promptProtocolVersion: defaults.promptProtocolVersion,
     providerFamily: getRequiredValue("--provider-family") as Problem9ProviderFamily,

--- a/apps/worker/src/lib/problem9-prompt-package.ts
+++ b/apps/worker/src/lib/problem9-prompt-package.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  lstat,
   mkdir,
   readdir,
   readFile,
@@ -14,6 +15,7 @@ import {
   getProblem9ModelConfigIdPrefix,
   problem9LocalAuthModes,
   problem9ProviderFamilies,
+  problem9PromptPackageManifestSchema,
   problem9RunModes,
   problem9ToolProfiles
 } from "@paretoproof/shared";
@@ -141,6 +143,9 @@ const promptTemplateSourceRoot = path.resolve(
 );
 
 const textLayerFilenames = ["system.md", "benchmark.md", "item.md", "run-envelope.json"] as const;
+const promptPackageManifestFilename = "prompt-package.json";
+const managedPromptPackageEntryNames = [...textLayerFilenames, promptPackageManifestFilename] as const;
+const managedPromptPackageEntryNameSet = new Set<string>(managedPromptPackageEntryNames);
 
 const promptDefaults = {
   promptLayerVersions: {
@@ -170,6 +175,7 @@ const requiredBenchmarkPackagePaths = [
 ] as const;
 
 type BenchmarkPackageManifest = z.infer<typeof benchmarkPackageManifestSchema>;
+type PromptPackageManifest = z.output<typeof problem9PromptPackageManifestSchema>;
 
 export type MaterializeProblem9PromptPackageOptions = z.infer<
   typeof problem9PromptPackageOptionsSchema
@@ -199,8 +205,7 @@ export async function materializeProblem9PromptPackage(
   await assertNoPathOverlap(promptTemplateSourceRoot, outputRoot, "prompt template source");
   await assertNoPathOverlap(benchmarkPackageRoot, outputRoot, "benchmark package input");
 
-  await rm(outputRoot, { force: true, recursive: true });
-  await mkdir(outputRoot, { recursive: true });
+  await preparePromptPackageOutputRoot(outputRoot);
 
   const systemTemplate = await loadNormalizedText(
     path.join(promptTemplateSourceRoot, "system.md")
@@ -251,25 +256,23 @@ export async function materializeProblem9PromptPackage(
     Object.entries(layerContents)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([filename, content]) => [filename, sha256Text(content)])
-  );
+  ) as Record<(typeof textLayerFilenames)[number], string>;
 
-  const promptPackageDigest = sha256Text(
-    stableStringify({
-      authMode: options.authMode,
-      benchmarkPackageDigest: benchmarkManifest.packageDigest,
-      benchmarkPackageId: benchmarkManifest.packageId,
-      benchmarkPackageVersion: benchmarkManifest.packageVersion,
-      harnessRevision: options.harnessRevision,
-      laneId: options.laneId,
-      layerDigests,
-      layerVersions: options.promptLayerVersions,
-      modelConfigId: options.modelConfigId,
-      promptProtocolVersion: options.promptProtocolVersion,
-      providerFamily: options.providerFamily,
-      runMode: options.runMode,
-      toolProfile: options.toolProfile
-    })
-  );
+  const promptPackageDigest = computePromptPackageDigest({
+    authMode: options.authMode,
+    benchmarkPackageDigest: benchmarkManifest.packageDigest,
+    benchmarkPackageId: benchmarkManifest.packageId,
+    benchmarkPackageVersion: benchmarkManifest.packageVersion,
+    harnessRevision: options.harnessRevision,
+    laneId: options.laneId,
+    layerDigests,
+    layerVersions: options.promptLayerVersions,
+    modelConfigId: options.modelConfigId,
+    promptProtocolVersion: options.promptProtocolVersion,
+    providerFamily: options.providerFamily,
+    runMode: options.runMode,
+    toolProfile: options.toolProfile
+  });
 
   const promptPackageManifest = {
     promptPackageSchemaVersion: "1",
@@ -297,7 +300,10 @@ export async function materializeProblem9PromptPackage(
     }
   };
 
-  await writeNormalizedText(path.join(outputRoot, "prompt-package.json"), stableStringify(promptPackageManifest));
+  await writeNormalizedText(
+    path.join(outputRoot, promptPackageManifestFilename),
+    stableStringify(promptPackageManifest)
+  );
 
   return {
     outputRoot,
@@ -590,6 +596,116 @@ async function assertNoPathOverlap(
   }
 }
 
+async function preparePromptPackageOutputRoot(outputRoot: string): Promise<void> {
+  const outputRootStats = await lstat(outputRoot).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  });
+
+  if (outputRootStats === null) {
+    await mkdir(outputRoot, { recursive: true });
+    return;
+  }
+
+  if (outputRootStats.isSymbolicLink()) {
+    throw new Error(
+      "Prompt package output may not be a symbolic link. Choose a dedicated output directory."
+    );
+  }
+
+  if (!outputRootStats.isDirectory()) {
+    throw new Error(
+      "Prompt package output must be a directory path. Choose an empty directory or a prior prompt-package output."
+    );
+  }
+
+  const unexpectedEntries = (await readdir(outputRoot, { withFileTypes: true }))
+    .filter((entry) => !entry.isFile() || !managedPromptPackageEntryNameSet.has(entry.name))
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+
+  if (unexpectedEntries.length > 0) {
+    throw new Error(
+      `Prompt package output must be empty or contain only a prior prompt-package materialization. Unexpected entries: ${unexpectedEntries.join(", ")}.`
+    );
+  }
+
+  if ((await readdir(outputRoot)).length > 0) {
+    await assertPriorPromptPackageOutput(outputRoot);
+  }
+
+  await Promise.all(
+    managedPromptPackageEntryNames.map((entryName) => rm(path.join(outputRoot, entryName), { force: true }))
+  );
+}
+
+async function assertPriorPromptPackageOutput(outputRoot: string): Promise<void> {
+  const existingEntryNames = new Set(await readdir(outputRoot));
+  const missingEntries = managedPromptPackageEntryNames.filter(
+    (entryName) => !existingEntryNames.has(entryName)
+  );
+
+  if (missingEntries.length > 0) {
+    throw new Error(
+      `Prompt package output must be empty or contain only a prior prompt-package materialization. Missing managed entries: ${missingEntries.join(", ")}.`
+    );
+  }
+
+  let promptPackageManifest: PromptPackageManifest;
+
+  try {
+    promptPackageManifest = problem9PromptPackageManifestSchema.parse(
+      JSON.parse(await readFile(path.join(outputRoot, promptPackageManifestFilename), "utf8"))
+    );
+  } catch {
+    throw new Error(
+      "Prompt package output must be empty or contain only a prior prompt-package materialization. Existing managed files do not form a valid prompt-package output."
+    );
+  }
+
+  const layerDigests = Object.fromEntries(
+    await Promise.all(
+      textLayerFilenames.map(async (filename) => [
+        filename,
+        sha256Text(await loadNormalizedText(path.join(outputRoot, filename)))
+      ])
+    )
+  ) as Record<(typeof textLayerFilenames)[number], string>;
+
+  for (const filename of textLayerFilenames) {
+    if (layerDigests[filename] !== promptPackageManifest.layerDigests[filename]) {
+      throw new Error(
+        "Prompt package output must be empty or contain only a prior prompt-package materialization. Existing managed files do not match their manifest digests."
+      );
+    }
+  }
+
+  const expectedPromptPackageDigest = computePromptPackageDigest({
+    authMode: promptPackageManifest.authMode,
+    benchmarkPackageDigest: promptPackageManifest.benchmarkPackageDigest,
+    benchmarkPackageId: promptPackageManifest.benchmarkPackageId,
+    benchmarkPackageVersion: promptPackageManifest.benchmarkPackageVersion,
+    harnessRevision: promptPackageManifest.harnessRevision,
+    laneId: promptPackageManifest.laneId,
+    layerDigests: promptPackageManifest.layerDigests,
+    layerVersions: promptPackageManifest.layerVersions,
+    modelConfigId: promptPackageManifest.modelConfigId,
+    promptProtocolVersion: promptPackageManifest.promptProtocolVersion,
+    providerFamily: promptPackageManifest.providerFamily,
+    runMode: promptPackageManifest.runMode,
+    toolProfile: promptPackageManifest.toolProfile
+  });
+
+  if (expectedPromptPackageDigest !== promptPackageManifest.promptPackageDigest) {
+    throw new Error(
+      "Prompt package output must be empty or contain only a prior prompt-package materialization. Existing managed files do not match their manifest digest."
+    );
+  }
+}
+
 function assertOutputRootIsNotFilesystemRoot(outputRoot: string): void {
   const parsedOutputRoot = path.parse(outputRoot).root;
 
@@ -644,6 +760,40 @@ async function sha256NormalizedFile(filePath: string): Promise<string> {
 
 function sha256Text(text: string): string {
   return createHash("sha256").update(Buffer.from(normalizeText(text), "utf8")).digest("hex");
+}
+
+function computePromptPackageDigest(value: {
+  authMode: MaterializeProblem9PromptPackageOptions["authMode"];
+  benchmarkPackageDigest: string;
+  benchmarkPackageId: string;
+  benchmarkPackageVersion: string;
+  harnessRevision: string;
+  laneId: string;
+  layerDigests: Record<(typeof textLayerFilenames)[number], string>;
+  layerVersions: MaterializeProblem9PromptPackageOptions["promptLayerVersions"];
+  modelConfigId: string;
+  promptProtocolVersion: string;
+  providerFamily: MaterializeProblem9PromptPackageOptions["providerFamily"];
+  runMode: MaterializeProblem9PromptPackageOptions["runMode"];
+  toolProfile: MaterializeProblem9PromptPackageOptions["toolProfile"];
+}) {
+  return sha256Text(
+    stableStringify({
+      authMode: value.authMode,
+      benchmarkPackageDigest: value.benchmarkPackageDigest,
+      benchmarkPackageId: value.benchmarkPackageId,
+      benchmarkPackageVersion: value.benchmarkPackageVersion,
+      harnessRevision: value.harnessRevision,
+      laneId: value.laneId,
+      layerDigests: value.layerDigests,
+      layerVersions: value.layerVersions,
+      modelConfigId: value.modelConfigId,
+      promptProtocolVersion: value.promptProtocolVersion,
+      providerFamily: value.providerFamily,
+      runMode: value.runMode,
+      toolProfile: value.toolProfile
+    })
+  );
 }
 
 function stableStringify(value: unknown): string {

--- a/apps/worker/test/problem9-prompt-package.test.ts
+++ b/apps/worker/test/problem9-prompt-package.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { materializeProblem9Package } from "../src/lib/problem9-package.ts";
+import {
+  getDefaultProblem9PromptPackageOptions,
+  materializeProblem9PromptPackage
+} from "../src/lib/problem9-prompt-package.ts";
+
+test("materializeProblem9PromptPackage rejects output roots with unexpected existing entries", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-prompt-package-unsafe-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const outputRoot = path.join(tempRoot, "prompt-package");
+  const sentinelPath = path.join(outputRoot, "keep.txt");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  await mkdir(outputRoot, { recursive: true });
+  await writeFile(sentinelPath, "do not delete\n", "utf8");
+
+  await assert.rejects(
+    () =>
+      materializeProblem9PromptPackage(
+        buildPromptPackageOptions({
+          benchmarkPackageRoot,
+          outputRoot
+        })
+      ),
+    /Prompt package output must be empty or contain only a prior prompt-package materialization\. Unexpected entries: keep\.txt\./u
+  );
+  assert.equal(await readFile(sentinelPath, "utf8"), "do not delete\n");
+});
+
+test("materializeProblem9PromptPackage rejects lookalike managed files that are not a valid prior output", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-prompt-package-lookalike-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const outputRoot = path.join(tempRoot, "prompt-package");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  await mkdir(outputRoot, { recursive: true });
+  await writeFile(path.join(outputRoot, "system.md"), "handwritten system layer\n", "utf8");
+  await writeFile(path.join(outputRoot, "benchmark.md"), "handwritten benchmark layer\n", "utf8");
+  await writeFile(path.join(outputRoot, "item.md"), "handwritten item layer\n", "utf8");
+  await writeFile(path.join(outputRoot, "run-envelope.json"), "{\n  \"runId\": \"manual\"\n}\n", "utf8");
+  await writeFile(path.join(outputRoot, "prompt-package.json"), "{\n  \"promptPackageSchemaVersion\": \"1\"\n}\n", "utf8");
+
+  await assert.rejects(
+    () =>
+      materializeProblem9PromptPackage(
+        buildPromptPackageOptions({
+          benchmarkPackageRoot,
+          outputRoot
+        })
+      ),
+    /Existing managed files do not form a valid prompt-package output\./u
+  );
+  assert.equal(await readFile(path.join(outputRoot, "system.md"), "utf8"), "handwritten system layer\n");
+});
+
+test("materializeProblem9PromptPackage rejects symbolic-link output roots", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-prompt-package-symlink-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const realOutputRoot = path.join(tempRoot, "real-output");
+  const symlinkOutputRoot = path.join(tempRoot, "prompt-package-link");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  await mkdir(realOutputRoot, { recursive: true });
+  await symlink(realOutputRoot, symlinkOutputRoot, "junction");
+
+  await assert.rejects(
+    () =>
+      materializeProblem9PromptPackage(
+        buildPromptPackageOptions({
+          benchmarkPackageRoot,
+          outputRoot: symlinkOutputRoot
+        })
+      ),
+    /Prompt package output may not be a symbolic link\./u
+  );
+});
+
+test("materializeProblem9PromptPackage safely refreshes an existing prompt-package output", async (t) => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-prompt-package-refresh-"));
+  const benchmarkPackageRoot = (
+    await materializeProblem9Package({
+      outputRoot: path.join(tempRoot, "benchmark-package")
+    })
+  ).outputRoot;
+  const outputRoot = path.join(tempRoot, "prompt-package");
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const firstResult = await materializeProblem9PromptPackage(
+    buildPromptPackageOptions({
+      benchmarkPackageRoot,
+      outputRoot
+    })
+  );
+
+  const secondResult = await materializeProblem9PromptPackage(
+    buildPromptPackageOptions({
+      benchmarkPackageRoot,
+      outputRoot
+    })
+  );
+  const promptPackageManifest = JSON.parse(
+    await readFile(path.join(outputRoot, "prompt-package.json"), "utf8")
+  ) as {
+    promptPackageDigest: string;
+  };
+
+  assert.equal(firstResult.outputRoot, outputRoot);
+  assert.equal(secondResult.outputRoot, outputRoot);
+  assert.equal(secondResult.promptPackageDigest, promptPackageManifest.promptPackageDigest);
+  assert.equal(secondResult.promptPackageDigest, firstResult.promptPackageDigest);
+});
+
+function buildPromptPackageOptions(options: {
+  benchmarkPackageRoot: string;
+  outputRoot: string;
+}) {
+  const promptDefaults = getDefaultProblem9PromptPackageOptions();
+
+  return {
+    attemptId: "attempt-prompt-package-001",
+    authMode: "local_stub" as const,
+    benchmarkPackageRoot: options.benchmarkPackageRoot,
+    harnessRevision: "prompt-package-test-rev",
+    jobId: null,
+    laneId: "lean422_exact",
+    modelConfigId: "local_stub/problem9_fixture.v1",
+    outputRoot: options.outputRoot,
+    passKCount: null,
+    passKIndex: null,
+    promptLayerVersions: promptDefaults.promptLayerVersions,
+    promptProtocolVersion: promptDefaults.promptProtocolVersion,
+    providerFamily: "openai" as const,
+    runId: "run-prompt-package-001",
+    runMode: "single_pass_probe" as const,
+    toolProfile: "workspace_edit_limited" as const
+  };
+}

--- a/apps/worker/test/worker-cli-smoke.test.ts
+++ b/apps/worker/test/worker-cli-smoke.test.ts
@@ -104,6 +104,80 @@ test("runProblem9PromptPackageCli materializes a prompt package and prints its d
   assert.equal(payload.promptPackageDigest, promptPackage.promptPackageDigest);
 });
 
+test("runProblem9PromptPackageCli rejects missing required flag values before another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9PromptPackageCli([
+        "--attempt-id",
+        "attempt-cli-invalid-001",
+        "--auth-mode",
+        "local_stub",
+        "--benchmark-package-root",
+        "ignored-benchmark",
+        "--harness-revision",
+        "smoke-harness-rev",
+        "--lane-id",
+        "lean422_exact",
+        "--model-config-id",
+        "local_stub/problem9_fixture.v1",
+        "--output",
+        "--run-id",
+        "run-cli-invalid-001",
+        "--run-mode",
+        "single_pass_probe",
+        "--tool-profile",
+        "workspace_edit_limited",
+        "--provider-family",
+        "openai"
+      ]),
+    /Missing required --output <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
+test("runProblem9PromptPackageCli rejects optional flag names that omit a value", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9PromptPackageCli([
+        "--attempt-id",
+        "attempt-cli-invalid-002",
+        "--auth-mode",
+        "local_stub",
+        "--benchmark-package-root",
+        "ignored-benchmark",
+        "--harness-revision",
+        "smoke-harness-rev",
+        "--lane-id",
+        "lean422_exact",
+        "--model-config-id",
+        "local_stub/problem9_fixture.v1",
+        "--output",
+        "ignored-output",
+        "--pass-k-count",
+        "--pass-k-index",
+        "0",
+        "--provider-family",
+        "openai",
+        "--run-id",
+        "run-cli-invalid-002",
+        "--run-mode",
+        "pass_k_probe",
+        "--tool-profile",
+        "workspace_edit_limited"
+      ]),
+    /Missing --pass-k-count <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
 test("runProblem9RunBundleCli materializes a canonical run bundle and prints digest output", async (t) => {
   const fixture = await createRunBundleFixture();
   const captured = captureConsole(t);


### PR DESCRIPTION
## Summary
- stop prompt-package materialization from recursively deleting arbitrary caller-selected output roots
- only allow an empty directory or a validated prior prompt-package output, and reject symbolic-link output roots
- harden prompt-package CLI flag parsing so missing values cannot be misread as the next flag token
- add focused regressions for unexpected output contents, lookalike managed files, symbolic-link outputs, safe reruns, and missing CLI flag values

## Verification
- `bun test apps/worker/test/problem9-prompt-package.test.ts`
- `bun test apps/worker/test/worker-cli-smoke.test.ts`
- `bun test apps/worker/test/problem9-integrity.test.ts`
- `bun run build`

Closes #1009