### PR TITLE
[Finding][Worker] Unify worker CLI valued-flag parsing

### DIFF
--- a/apps/worker/src/lib/cli-contract.ts
+++ b/apps/worker/src/lib/cli-contract.ts
@@ -5,6 +5,11 @@ export const workerCliExitCodes = {
   runtime: 3
 } as const;
 
+type WorkerCliFlagValue = {
+  present: boolean;
+  value: string | null;
+};
+
 type WorkerCliExitCode =
   (typeof workerCliExitCodes)[keyof typeof workerCliExitCodes];
 
@@ -25,6 +30,7 @@ export class WorkerCliError extends Error {
 const validationMessagePatterns = [
   /^Invalid worker runtime environment:/u,
   /^Missing required /u,
+  /^Missing --/u,
   /^Unknown worker command:/u,
   /^Unsupported /u,
   /^Trusted-local Codex auth preflight failed\./u,
@@ -115,4 +121,29 @@ export function rejectedOfflineIngestExitCode(stage: string) {
   return stage === "remote_rejection"
     ? workerCliExitCodes.runtime
     : workerCliExitCodes.validation;
+}
+
+export function readWorkerCliFlagValue(args: string[], flag: string): WorkerCliFlagValue {
+  const index = args.findIndex((argument) => argument === flag);
+
+  if (index === -1) {
+    return {
+      present: false,
+      value: null
+    };
+  }
+
+  const candidateValue = args[index + 1];
+
+  if (!candidateValue || candidateValue.startsWith("--")) {
+    return {
+      present: true,
+      value: null
+    };
+  }
+
+  return {
+    present: true,
+    value: candidateValue
+  };
 }

--- a/apps/worker/src/lib/problem9-attempt-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-cli.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Problem9ProviderFamily } from "@paretoproof/shared";
+import { readWorkerCliFlagValue } from "./cli-contract.js";
 import { runProblem9Attempt } from "./problem9-attempt.js";
 import { parseProblem9AuthMode } from "./problem9-auth.js";
 
@@ -12,18 +13,27 @@ export async function runProblem9AttemptCli(args: string[]): Promise<void> {
   }
 
   const getRequiredValue = (flag: string): string => {
-    const index = args.findIndex((argument) => argument === flag);
+    const { value } = readWorkerCliFlagValue(args, flag);
 
-    if (index === -1 || !args[index + 1]) {
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
-    return args[index + 1];
+    return value;
   };
 
   const getOptionalValue = (flag: string): string | undefined => {
-    const index = args.findIndex((argument) => argument === flag);
-    return index === -1 || !args[index + 1] ? undefined : args[index + 1];
+    const { present, value } = readWorkerCliFlagValue(args, flag);
+
+    if (!present) {
+      return undefined;
+    }
+
+    if (value === null) {
+      throw new Error(`Missing ${flag} <value> argument.`);
+    }
+
+    return value;
   };
 
   const result = await runProblem9Attempt({

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -1,6 +1,7 @@
 import { access, constants, mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { readWorkerCliFlagValue } from "./cli-contract.js";
 import {
   parseWorkerRuntimeEnv
 } from "./runtime.js";
@@ -243,17 +244,26 @@ export function buildTrustedLocalDevboxDockerArgs(
 
 function parseDevboxWrapperOptions(args: string[]): DevboxWrapperOptions {
   const getRequiredValue = (flag: string): string => {
-    const value = getOptionalValue(flag);
+    const { value } = readWorkerCliFlagValue(args, flag);
 
-    if (!value) {
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
     return value;
   };
   const getOptionalValue = (flag: string): string | undefined => {
-    const index = args.findIndex((argument) => argument === flag);
-    return index === -1 || !args[index + 1] ? undefined : args[index + 1];
+    const { present, value } = readWorkerCliFlagValue(args, flag);
+
+    if (!present) {
+      return undefined;
+    }
+
+    if (value === null) {
+      throw new Error(`Missing ${flag} <value> argument.`);
+    }
+
+    return value;
   };
   const hasFlag = (flag: string): boolean => args.includes(flag);
   const preflightOnly = hasFlag("--preflight-only");

--- a/apps/worker/src/lib/problem9-offline-ingest-cli.ts
+++ b/apps/worker/src/lib/problem9-offline-ingest-cli.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { rejectedOfflineIngestExitCode } from "./cli-contract.js";
+import { readWorkerCliFlagValue, rejectedOfflineIngestExitCode } from "./cli-contract.js";
 import { runProblem9OfflineIngest } from "./problem9-offline-ingest.js";
 
 export async function runProblem9OfflineIngestCli(args: string[]): Promise<void> {
@@ -11,13 +11,13 @@ export async function runProblem9OfflineIngestCli(args: string[]): Promise<void>
   }
 
   const getRequiredValue = (flag: "--access-jwt" | "--bundle-root"): string => {
-    const index = args.findIndex((argument) => argument === flag);
+    const { value } = readWorkerCliFlagValue(args, flag);
 
-    if (index === -1 || !args[index + 1]) {
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
-    return args[index + 1];
+    return value;
   };
 
   const parsedOptions = (() => {

--- a/apps/worker/src/lib/problem9-package-cli.ts
+++ b/apps/worker/src/lib/problem9-package-cli.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { readWorkerCliFlagValue } from "./cli-contract.js";
 import { materializeProblem9Package } from "./problem9-package.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
@@ -12,15 +13,15 @@ export async function runProblem9PackageCli(args: string[]): Promise<void> {
     commandFamily: "materializer"
   });
 
-  const outputArgumentIndex = args.findIndex((argument) => argument === "--output");
+  const { value: outputValue } = readWorkerCliFlagValue(args, "--output");
 
-  if (outputArgumentIndex === -1 || !args[outputArgumentIndex + 1]) {
+  if (outputValue === null) {
     throw new Error(
       "Missing required --output <directory> argument for materialize-problem9-package."
     );
   }
 
-  const outputRoot = path.resolve(args[outputArgumentIndex + 1]);
+  const outputRoot = path.resolve(outputValue);
   const result = await materializeProblem9Package({ outputRoot });
 
   console.log(

--- a/apps/worker/src/lib/problem9-run-bundle-cli.ts
+++ b/apps/worker/src/lib/problem9-run-bundle-cli.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { WorkerCliError } from "./cli-contract.js";
+import { readWorkerCliFlagValue, WorkerCliError } from "./cli-contract.js";
 import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
@@ -36,18 +36,27 @@ export async function runProblem9RunBundleCli(args: string[]): Promise<void> {
   }
 
   const getRequiredValue = (flag: string): string => {
-    const index = args.findIndex((argument) => argument === flag);
+    const { value } = readWorkerCliFlagValue(args, flag);
 
-    if (index === -1 || !args[index + 1]) {
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
-    return args[index + 1];
+    return value;
   };
 
   const getOptionalValue = (flag: string): string | null => {
-    const index = args.findIndex((argument) => argument === flag);
-    return index === -1 || !args[index + 1] ? null : args[index + 1];
+    const { present, value } = readWorkerCliFlagValue(args, flag);
+
+    if (!present) {
+      return null;
+    }
+
+    if (value === null) {
+      throw new Error(`Missing ${flag} <value> argument.`);
+    }
+
+    return value;
   };
 
   const failureClassificationPath = getOptionalValue("--failure-classification");

--- a/apps/worker/src/lib/worker-claim-loop-cli.ts
+++ b/apps/worker/src/lib/worker-claim-loop-cli.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { type Problem9HostedAuthMode } from "@paretoproof/shared";
+import { readWorkerCliFlagValue } from "./cli-contract.js";
 import { runWorkerClaimLoop } from "./worker-claim-loop.js";
 
 export async function runWorkerClaimLoopCli(args: string[]): Promise<void> {
@@ -14,18 +15,27 @@ export async function runWorkerClaimLoopCli(args: string[]): Promise<void> {
   }
 
   const getRequiredValue = (flag: string): string => {
-    const index = args.findIndex((argument) => argument === flag);
+    const { value } = readWorkerCliFlagValue(args, flag);
 
-    if (index === -1 || !args[index + 1]) {
+    if (value === null) {
       throw new Error(`Missing required ${flag} <value> argument.`);
     }
 
-    return args[index + 1];
+    return value;
   };
 
   const getOptionalValue = (flag: string): string | undefined => {
-    const index = args.findIndex((argument) => argument === flag);
-    return index === -1 || !args[index + 1] ? undefined : args[index + 1];
+    const { present, value } = readWorkerCliFlagValue(args, flag);
+
+    if (!present) {
+      return undefined;
+    }
+
+    if (value === null) {
+      throw new Error(`Missing ${flag} <value> argument.`);
+    }
+
+    return value;
   };
 
   const maxJobs = getOptionalValue("--max-jobs");

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -506,6 +506,50 @@ test("runProblem9OfflineIngestCli emits JSON setup failures for missing flags", 
   });
 });
 
+test("runProblem9OfflineIngestCli keeps JSON setup failures when a required flag value is another flag", async (t) => {
+  const originalExitCode = process.exitCode;
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const stderrLines: string[] = [];
+  const stdoutLines: string[] = [];
+
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map(String).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map(String).join(" "));
+  };
+
+  t.after(() => {
+    process.exitCode = originalExitCode;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+
+  await runProblem9OfflineIngestCli([
+    "--access-jwt",
+    "--bundle-root",
+    path.join(os.tmpdir(), "bundle-root")
+  ]);
+
+  assert.equal(stdoutLines.length, 0);
+  assert.equal(process.exitCode, 2);
+  assert.deepEqual(JSON.parse(stderrLines.join("\n")), {
+    bundleRoot: null,
+    endpoint: null,
+    error: "offline_ingest_setup_failure",
+    issues: [
+      {
+        message: "Missing required --access-jwt <value> argument.",
+        path: "--access-jwt"
+      }
+    ],
+    stage: "setup_failure",
+    status: "rejected"
+  });
+});
+
 test("runProblem9OfflineIngestCli uses runtime exit code for remote rejections", async (t) => {
   const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
     result: "pass"

--- a/apps/worker/test/worker-cli-contract.test.ts
+++ b/apps/worker/test/worker-cli-contract.test.ts
@@ -147,6 +147,34 @@ test("worker entrypoint exits 2 for unsupported hosted auth-mode input", () => {
   assert.equal(result.stdout, "");
 });
 
+test("worker entrypoint exits 2 for optional valued flags that omit a value", () => {
+  const result = spawnWorkerCli(
+    [
+      "run-worker-claim-loop",
+      "--worker-id",
+      "worker-contract-test",
+      "--worker-pool",
+      "modal-dev",
+      "--worker-version",
+      "worker-smoke-1",
+      "--workspace-root",
+      path.join(os.tmpdir(), "worker-workspace"),
+      "--output-root",
+      path.join(os.tmpdir(), "worker-output"),
+      "--max-jobs",
+      "--once"
+    ],
+    {
+      cwd: workerRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(readSpawnStatus(result), 2);
+  assert.match(result.stderr, /^Validation error: Missing --max-jobs <value> argument\.\r?\n$/u);
+  assert.equal(result.stdout, "");
+});
+
 test(
   "worker entrypoint exits 3 and preserves machine-readable offline-ingest remote rejections",
   { timeout: 120000 },

--- a/apps/worker/test/worker-cli-smoke.test.ts
+++ b/apps/worker/test/worker-cli-smoke.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { runProblem9AttemptCli } from "../src/lib/problem9-attempt-cli.ts";
 import { runProblem9AttemptInDevboxCli } from "../src/lib/problem9-attempt-devbox-cli.ts";
 import { runProblem9PackageCli } from "../src/lib/problem9-package-cli.ts";
 import { materializeProblem9Package } from "../src/lib/problem9-package.ts";
@@ -47,6 +48,18 @@ test("runProblem9PackageCli materializes the canonical package and prints JSON o
   assert.equal(payload.packageId, "firstproof/Problem9");
   assert.equal(payload.packageDigest, manifest.packageDigest);
   assert.equal(payload.packageVersion, manifest.packageVersion);
+});
+
+test("runProblem9PackageCli rejects missing required flag values before another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () => runProblem9PackageCli(["--output", "--ignored-flag"]),
+    /Missing required --output <directory> argument for materialize-problem9-package\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
 });
 
 test("runProblem9PromptPackageCli materializes a prompt package and prints its digest", async (t) => {
@@ -228,6 +241,112 @@ test("runProblem9RunBundleCli materializes a canonical run bundle and prints dig
   assert.equal(payload.bundleDigest, bundle.bundleDigest);
 });
 
+test("runProblem9RunBundleCli rejects missing required flag values before another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9RunBundleCli([
+        "--output",
+        "--benchmark-package-root",
+        "ignored-benchmark-package-root",
+        "--prompt-package-root",
+        "ignored-prompt-package-root",
+        "--candidate-source",
+        "ignored-candidate",
+        "--compiler-diagnostics",
+        "ignored-compiler-diagnostics",
+        "--compiler-output",
+        "ignored-compiler-output",
+        "--verifier-output",
+        "ignored-verifier-output",
+        "--environment-input",
+        "ignored-environment-input"
+      ]),
+    /Missing required --output <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
+test("runProblem9RunBundleCli rejects optional flag values that are followed by another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9RunBundleCli([
+        "--output",
+        "ignored-output",
+        "--benchmark-package-root",
+        "ignored-benchmark-package-root",
+        "--prompt-package-root",
+        "ignored-prompt-package-root",
+        "--candidate-source",
+        "ignored-candidate",
+        "--compiler-diagnostics",
+        "ignored-compiler-diagnostics",
+        "--compiler-output",
+        "ignored-compiler-output",
+        "--failure-classification",
+        "--verifier-output",
+        "ignored-verifier-output",
+        "--environment-input",
+        "ignored-environment-input"
+      ]),
+    /Missing --failure-classification <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
+test("runProblem9AttemptCli rejects missing required flag values before another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9AttemptCli([
+        "--benchmark-package-root",
+        "--prompt-package-root",
+        "ignored-prompt-package-root",
+        "--workspace",
+        "ignored-workspace-root",
+        "--output",
+        "ignored-output-root"
+      ]),
+    /Missing required --benchmark-package-root <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
+test("runProblem9AttemptCli rejects optional flag values that are followed by another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runProblem9AttemptCli([
+        "--benchmark-package-root",
+        "ignored-benchmark-package-root",
+        "--prompt-package-root",
+        "ignored-prompt-package-root",
+        "--workspace",
+        "ignored-workspace-root",
+        "--output",
+        "ignored-output-root",
+        "--provider-model",
+        "--stub-scenario",
+        "exact_canonical"
+      ]),
+    /Missing --provider-model <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
 test("runWorkerClaimLoopCli fails clearly when required worker identity flags are missing", async () => {
   await assert.rejects(
     () =>
@@ -246,6 +365,56 @@ test("runWorkerClaimLoopCli fails clearly when required worker identity flags ar
   );
 });
 
+test("runWorkerClaimLoopCli rejects required flag values before another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runWorkerClaimLoopCli([
+        "--worker-id",
+        "--worker-pool",
+        "modal-dev",
+        "--worker-version",
+        "worker-smoke-1",
+        "--workspace-root",
+        path.join(os.tmpdir(), "worker-workspace"),
+        "--output-root",
+        path.join(os.tmpdir(), "worker-output"),
+        "--once"
+      ]),
+    /Missing required --worker-id <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
+test("runWorkerClaimLoopCli rejects optional flag values that are followed by another flag", async (t) => {
+  const captured = captureConsole(t);
+
+  await assert.rejects(
+    () =>
+      runWorkerClaimLoopCli([
+        "--worker-id",
+        "worker-smoke-1",
+        "--worker-pool",
+        "modal-dev",
+        "--worker-version",
+        "worker-smoke-1",
+        "--workspace-root",
+        path.join(os.tmpdir(), "worker-workspace"),
+        "--output-root",
+        path.join(os.tmpdir(), "worker-output"),
+        "--max-jobs",
+        "--once"
+      ]),
+    /Missing --max-jobs <value> argument\./u
+  );
+
+  assert.equal(captured.stderrLines.length, 0);
+  assert.equal(captured.stdoutLines.length, 0);
+});
+
 test("runProblem9AttemptInDevboxCli rejects unsupported provider families before env preflight", async () => {
   await assert.rejects(
     () =>
@@ -256,6 +425,17 @@ test("runProblem9AttemptInDevboxCli rejects unsupported provider families before
         "anthropic"
       ]),
     /Trusted-local devbox runs currently support only provider-family openai, received anthropic\./
+  );
+});
+
+test("runProblem9AttemptInDevboxCli rejects missing valued flags before another flag", async () => {
+  await assert.rejects(
+    () =>
+      runProblem9AttemptInDevboxCli([
+        "--image",
+        "--preflight-only"
+      ]),
+    /Missing required --image <value> argument\./u
   );
 });
 


### PR DESCRIPTION
## Summary\n- unify valued-flag parsing across the worker CLI wrappers so --flag --next-flag fails immediately instead of being consumed as a value\n- preserve offline-ingest's machine-readable rejected stderr contract while classifying optional missing-value failures as validation errors at the real worker entrypoint\n- add regressions for package, prompt-package, run-bundle, attempt, devbox, claim-loop, and offline-ingest CLI flag parsing paths\n\n## Verification\n- 
ode --import tsx --test test/worker-cli-smoke.test.ts\n- 
ode --import tsx --test test/problem9-offline-ingest.test.ts\n- 
ode --import tsx --test test/worker-cli-contract.test.ts\n- un run build\n\nCloses #1010