### PR TITLE
[Finding][Worker] Enforce hosted Lean subprocess env isolation

### DIFF
--- a/apps/worker/src/lib/hosted-network-policy.ts
+++ b/apps/worker/src/lib/hosted-network-policy.ts
@@ -18,6 +18,14 @@ const hostedProviderOverrideEnvNames: Record<Problem9ProviderFamily, readonly st
   openai: ["OPENAI_API_BASE", "OPENAI_API_BASE_URL", "OPENAI_BASE_URL"]
 };
 
+const hostedLeanToolForbiddenEnvNames = [
+  "API_BASE_URL",
+  "CODEX_API_KEY",
+  "CODEX_HOME",
+  "PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT",
+  "WORKER_BOOTSTRAP_TOKEN"
+] as const;
+
 type HostedControlPlaneOriginOptions = {
   allowLoopback: boolean;
 };
@@ -111,6 +119,19 @@ export function buildHostedProviderCommandEnv(
   const sanitizedEnv = { ...env };
 
   for (const name of forbiddenOverrideNames) {
+    delete sanitizedEnv[name];
+  }
+
+  return sanitizedEnv;
+}
+
+export function buildHostedLeanToolCommandEnv(
+  env: NodeJS.ProcessEnv,
+  providerFamily: Problem9ProviderFamily
+): NodeJS.ProcessEnv {
+  const sanitizedEnv = buildHostedProviderCommandEnv(env, providerFamily);
+
+  for (const name of hostedLeanToolForbiddenEnvNames) {
     delete sanitizedEnv[name];
   }
 

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -17,7 +17,10 @@ import {
   type Problem9AuthPreflight,
   preflightProblem9AuthMode
 } from "./problem9-auth.js";
-import { buildHostedProviderCommandEnv } from "./hosted-network-policy.js";
+import {
+  buildHostedLeanToolCommandEnv,
+  buildHostedProviderCommandEnv
+} from "./hosted-network-policy.js";
 import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
@@ -188,6 +191,16 @@ type ProviderResponse = {
   };
 };
 
+export function buildProblem9LeanToolCommandEnv(
+  networkPolicyMode: "default" | "hosted",
+  env: NodeJS.ProcessEnv,
+  providerFamily: Problem9ProviderFamily
+): NodeJS.ProcessEnv {
+  return networkPolicyMode === "hosted"
+    ? buildHostedLeanToolCommandEnv(env, providerFamily)
+    : { ...env };
+}
+
 const forbiddenProblem9CandidateImports = new Set(["FirstProof.Problem9.Gold"]);
 const problem9ImportBoundaryKeywords = new Set([
   "#check",
@@ -287,6 +300,11 @@ export async function runProblem9Attempt(
 
   const compileRoot = path.join(workspaceRoot, "package");
   const tempArtifactsRoot = path.join(workspaceRoot, ".paretoproof-artifacts");
+  const leanToolEnv = buildProblem9LeanToolCommandEnv(
+    options.networkPolicyMode,
+    process.env,
+    effectiveProviderFamily
+  );
 
   await cp(benchmarkPackageRoot, compileRoot, { recursive: true });
   await mkdir(tempArtifactsRoot, { recursive: true });
@@ -372,6 +390,7 @@ export async function runProblem9Attempt(
     compileResult = await compileCandidate({
       candidatePath,
       compileRoot,
+      executionEnv: leanToolEnv,
       tempArtifactsRoot
     });
 
@@ -401,6 +420,7 @@ export async function runProblem9Attempt(
       canonicalTheoremHeader,
       compileResult,
       compileRoot,
+      executionEnv: leanToolEnv,
       tempArtifactsRoot
     });
 
@@ -449,6 +469,7 @@ export async function runProblem9Attempt(
     await buildEnvironmentInput({
       benchmarkManifest,
       compileRoot,
+      executionEnv: leanToolEnv,
       modelSnapshotId: resolveProblem9ModelSnapshotId({
         authMode: effectiveAuthMode,
         fallbackModelConfigId: promptManifest.modelConfigId,
@@ -745,6 +766,7 @@ async function buildProviderPrompt(options: {
 async function compileCandidate(options: {
   candidatePath: string;
   compileRoot: string;
+  executionEnv: NodeJS.ProcessEnv;
   tempArtifactsRoot: string;
 }): Promise<CompileResult> {
   const compileCommand = await runCommand(
@@ -752,7 +774,7 @@ async function compileCandidate(options: {
     ["build", "FirstProof.Problem9.Candidate"],
     {
       cwd: options.compileRoot,
-      env: process.env,
+      env: options.executionEnv,
       timeoutMs: 300000
     }
   );
@@ -780,6 +802,7 @@ async function verifyCandidate(options: {
   canonicalTheoremHeader: string;
   compileResult: CompileResult;
   compileRoot: string;
+  executionEnv: NodeJS.ProcessEnv;
   tempArtifactsRoot: string;
 }): Promise<VerificationResult> {
   const containsSorry = /\bsorry\b/.test(options.candidateSource);
@@ -814,7 +837,7 @@ async function verifyCandidate(options: {
     ["env", "lean", path.basename(semanticProbePath)],
     {
       cwd: options.compileRoot,
-      env: process.env,
+      env: options.executionEnv,
       timeoutMs: 300000
     }
   );
@@ -849,7 +872,7 @@ async function verifyCandidate(options: {
       ["env", "lean", path.basename(axiomProbePath)],
       {
         cwd: options.compileRoot,
-        env: process.env,
+        env: options.executionEnv,
         timeoutMs: 300000
       }
     );
@@ -1032,11 +1055,12 @@ function buildVerifierFailureSummary(
 async function buildEnvironmentInput(options: {
   benchmarkManifest: BenchmarkPackageManifest;
   compileRoot: string;
+  executionEnv: NodeJS.ProcessEnv;
   modelSnapshotId: string;
 }): Promise<Record<string, unknown>> {
   const leanVersionCommand = await runCommand("lake", ["env", "lean", "--version"], {
     cwd: options.compileRoot,
-    env: process.env,
+    env: options.executionEnv,
     timeoutMs: 120000
   });
   const leanVersion = (

--- a/apps/worker/test/hosted-network-policy.test.ts
+++ b/apps/worker/test/hosted-network-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildHostedLeanToolCommandEnv,
   buildHostedProviderCommandEnv,
   createHostedControlPlaneFetch,
   resolveHostedControlPlaneOrigin
@@ -62,4 +63,25 @@ test("buildHostedProviderCommandEnv rejects proxy and provider-base overrides", 
       ),
     /forbidden env override\(s\) HTTPS_PROXY, OPENAI_BASE_URL/
   );
+});
+
+test("buildHostedLeanToolCommandEnv strips hosted worker secrets while preserving toolchain env", () => {
+  const sanitized = buildHostedLeanToolCommandEnv(
+    {
+      API_BASE_URL: "https://api.paretoproof.test",
+      CODEX_API_KEY: "worker-api-key",
+      CODEX_HOME: "/run/paretoproof/codex-home",
+      PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: "readonly_auth_json",
+      PATH: "/usr/local/bin:/usr/bin",
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    },
+    "openai"
+  );
+
+  assert.equal(sanitized.API_BASE_URL, undefined);
+  assert.equal(sanitized.CODEX_API_KEY, undefined);
+  assert.equal(sanitized.CODEX_HOME, undefined);
+  assert.equal(sanitized.PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT, undefined);
+  assert.equal(sanitized.WORKER_BOOTSTRAP_TOKEN, undefined);
+  assert.equal(sanitized.PATH, "/usr/local/bin:/usr/bin");
 });

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { problem9AuthModes } from "../src/lib/problem9-auth.ts";
 import {
+  buildProblem9LeanToolCommandEnv,
   findForbiddenProblem9CandidateImports,
   resolveProblem9ModelSnapshotId,
   runProblem9Attempt
@@ -66,6 +67,50 @@ test("resolveProblem9ModelSnapshotId preserves explicit overrides and non-stub p
     }),
     "prompt/default-model"
   );
+});
+
+test("buildProblem9LeanToolCommandEnv strips hosted worker secrets while keeping PATH", () => {
+  const env = buildProblem9LeanToolCommandEnv(
+    "hosted",
+    {
+      API_BASE_URL: "https://api.paretoproof.test",
+      CODEX_API_KEY: "worker-api-key",
+      CODEX_HOME: "/run/paretoproof/codex-home",
+      PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: "readonly_auth_json",
+      PATH: "/usr/local/bin:/usr/bin",
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    },
+    "openai"
+  );
+
+  assert.equal(env.API_BASE_URL, undefined);
+  assert.equal(env.CODEX_API_KEY, undefined);
+  assert.equal(env.CODEX_HOME, undefined);
+  assert.equal(env.PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT, undefined);
+  assert.equal(env.WORKER_BOOTSTRAP_TOKEN, undefined);
+  assert.equal(env.PATH, "/usr/local/bin:/usr/bin");
+});
+
+test("buildProblem9LeanToolCommandEnv leaves local attempt env untouched", () => {
+  const env = buildProblem9LeanToolCommandEnv(
+    "default",
+    {
+      API_BASE_URL: "https://api.paretoproof.test",
+      CODEX_API_KEY: "worker-api-key",
+      CODEX_HOME: "/run/paretoproof/codex-home",
+      PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: "readonly_auth_json",
+      PATH: "/usr/local/bin:/usr/bin",
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    },
+    "openai"
+  );
+
+  assert.equal(env.API_BASE_URL, "https://api.paretoproof.test");
+  assert.equal(env.CODEX_API_KEY, "worker-api-key");
+  assert.equal(env.CODEX_HOME, "/run/paretoproof/codex-home");
+  assert.equal(env.PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT, "readonly_auth_json");
+  assert.equal(env.WORKER_BOOTSTRAP_TOKEN, "bootstrap-token");
+  assert.equal(env.PATH, "/usr/local/bin:/usr/bin");
 });
 
 test("findForbiddenProblem9CandidateImports flags benchmark-owned gold-proof imports", () => {


### PR DESCRIPTION
## Summary
- scrub hosted worker env for Lean compile, semantic probe, axiom probe, and Lean-version subprocesses instead of running those steps on raw ambient process env
- keep the existing provider subprocess and public/runtime interfaces unchanged while preserving required toolchain env like `PATH`
- add focused regressions for the hosted Lean-tool env helper and attempt runtime selection logic

## Verification
- `node --import tsx --test test/hosted-network-policy.test.ts`
- `bun test apps/worker/test/problem9-attempt.test.ts`
- `node --import tsx --test --test-name-pattern "runWorkerClaimLoop submits manifest and terminal result for a claimed single_run" test/worker-claim-loop.test.ts`
- `node --import tsx --test test/runtime-env.test.ts`
- `bun run build`

Closes #1011
