### PR TITLE
Fix claim-loop terminal failure normalization

### DIFF
--- a/apps/api/src/lib/internal-worker-control.ts
+++ b/apps/api/src/lib/internal-worker-control.ts
@@ -947,6 +947,25 @@ function ensureManualCancellationWasRequested(
   );
 }
 
+function ensureCancelRequestedLeaseOnlyAcceptsCancelledTerminalization(
+  request: WorkerTerminalFailureRequest,
+  leaseState: LeaseStateRow
+) {
+  if (leaseState.jobState !== "cancel_requested" && leaseState.runState !== "cancel_requested") {
+    return;
+  }
+
+  if (request.terminalState === "cancelled" && request.failure.failureCode === "manual_cancelled") {
+    return;
+  }
+
+  throw createConflictError(
+    "worker_cancel_requested_requires_cancelled_terminalization",
+    "failure submission must finalize as manual_cancelled while the lease is cancel_requested.",
+    "terminalState"
+  );
+}
+
 async function promoteExecutionToRunning(
   db: ReadWriteExecutor,
   authContext: InternalWorkerJobAuthContext,
@@ -2188,6 +2207,7 @@ export function createInternalWorkerControlService(db: DbClient) {
           path: "failure submission"
         });
         ensureManualCancellationWasRequested(request, lease);
+        ensureCancelRequestedLeaseOnlyAcceptsCancelledTerminalization(request, lease);
 
         const artifactIds = request.artifactIds ?? [];
         const artifactRows = await loadArtifactsByIds(tx, authContext.attemptRowId, artifactIds);

--- a/apps/api/test/internal-worker.test.ts
+++ b/apps/api/test/internal-worker.test.ts
@@ -1749,6 +1749,57 @@ test("submitFailure rejects manual cancellation when cancel was not requested", 
   );
 });
 
+test("submitFailure rejects non-cancel terminalization when only the run is cancel_requested", async () => {
+  const control = createInternalWorkerControlService({
+    transaction: async (callback: (tx: unknown) => Promise<WorkerTerminalFailureResponse>) => {
+      let selectCount = 0;
+      const tx = {
+        select() {
+          selectCount += 1;
+
+          if (selectCount === 1) {
+            return {
+              from() {
+                return {
+                  innerJoin() {
+                    return this;
+                  },
+                  where() {
+                    return this;
+                  },
+                  limit() {
+                    return Promise.resolve([
+                      buildLeaseStateRow({
+                        attemptState: "active",
+                        jobState: "running",
+                        runState: "cancel_requested"
+                      })
+                    ]);
+                  }
+                };
+              }
+            };
+          }
+
+          throw new Error("non-cancel terminalization should reject before artifact loading");
+        },
+        update() {
+          throw new Error("non-cancel terminalization should reject before writes");
+        }
+      };
+
+      return callback(tx);
+    }
+  } as never);
+
+  await assert.rejects(
+    () => control.submitFailure(buildFailureRequest(), buildJobAuthContext()),
+    (error: unknown) =>
+      error instanceof InternalWorkerControlError &&
+      error.code === "worker_cancel_requested_requires_cancelled_terminalization"
+  );
+});
+
 test("submitFailure accepts manual cancellation when the job is cancel_requested before run state catches up", async () => {
   const updateCalls: Array<{ target: unknown; values: Record<string, unknown> }> = [];
   let selectCount = 0;

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -225,6 +225,7 @@ export type RunWorkerClaimLoopResult = {
 type ActiveWorkerJob = Extract<WorkerClaimResponse, { leaseStatus: "active" }>["workerJob"];
 
 type ActiveLeaseState = {
+  backgroundControlError: unknown | null;
   cancelRequested: boolean;
   currentPhase: WorkerExecutionPhase;
   heartbeatErrorMessage: string | null;
@@ -398,6 +399,7 @@ async function processClaimedJob(
   dependencies: WorkerClaimLoopResolvedDependencies
 ): Promise<"completed" | "cancelled" | "lease_lost"> {
   const leaseState: ActiveLeaseState = {
+    backgroundControlError: null,
     cancelRequested: false,
     currentPhase: "prepare",
     heartbeatErrorMessage: null,
@@ -416,194 +418,45 @@ async function processClaimedJob(
     workspaceRoot: options.workspaceRoot
   });
   let heartbeatLoop = Promise.resolve();
+  let failureTerminalContext: CancellationTerminalContext | null = null;
 
   try {
     try {
       await prepareLeaseFilesystemRoots(leaseRoots);
     } catch (error) {
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        buildStaticFailure({
-          summary: error instanceof Error ? error.message : String(error),
-          failureCode: "tool_permission_violation",
-          phase: "prepare"
-        })
-      );
-      return "completed";
-    }
-
-    await refreshLease(leaseState, apiBaseUrl, dependencies);
-
-    if (
-      await submitCancellationIfRequested(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        "Worker received a control-plane cancellation request before execution started."
-      )
-    ) {
-      return "completed";
-    }
-
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
-
-    if (workerJob.target.runKind !== "single_run") {
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        buildStaticFailure({
-          summary: `Worker received unsupported run kind ${workerJob.target.runKind}.`,
-          failureCode: "run_configuration_invalid",
-          phase: "prepare"
-        })
-      );
-      return "completed";
-    }
-
-    if (workerJob.target.benchmarkItemId !== "Problem9") {
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        buildStaticFailure({
-          summary: `Worker received unsupported benchmark item ${workerJob.target.benchmarkItemId}.`,
-          failureCode: "run_configuration_invalid",
-          phase: "prepare"
-        })
-      );
-      return "completed";
-    }
-
-    if (workerJob.target.runMode === "pass_k_probe") {
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        buildStaticFailure({
-          summary: "Hosted worker single-run execution does not support pass_k_probe targets yet.",
-          failureCode: "run_configuration_invalid",
-          phase: "prepare"
-        })
-      );
-      return "completed";
-    }
-
-    try {
-      assertProblem9HostedCapability({
-        authMode: workerJob.target.authMode,
-        modelConfigId: workerJob.target.modelConfigId,
-        providerFamily: workerJob.target.providerFamily
-      });
-    } catch (error) {
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        buildStaticFailure({
-          summary: error instanceof Error ? error.message : String(error),
-          failureCode: "provider_unsupported_request",
-          phase: "prepare"
-        })
-      );
-      return "completed";
-    }
-
-    const benchmarkResult = await dependencies.materializeBenchmarkPackage({
-      outputRoot: leaseRoots.benchmarkPackageRoot
-    });
-
-    assertExpectedBenchmarkIdentity(workerJob.target, benchmarkResult);
-
-    const promptDefaults = getDefaultProblem9PromptPackageOptions();
-    const promptResult = await dependencies.materializePromptPackage({
-      attemptId: workerJob.attemptId,
-      authMode: workerJob.target.authMode,
-      benchmarkPackageRoot: benchmarkResult.outputRoot,
-      harnessRevision: workerJob.target.harnessRevision,
-      jobId: workerJob.jobId,
-      laneId: workerJob.target.laneId,
-      modelConfigId: workerJob.target.modelConfigId,
-      outputRoot: leaseRoots.promptPackageRoot,
-      passKCount: null,
-      passKIndex: null,
-      promptLayerVersions: promptDefaults.promptLayerVersions,
-      promptProtocolVersion: workerJob.target.promptProtocolVersion,
-      providerFamily: workerJob.target.providerFamily,
-      runId: workerJob.runId,
-      runMode: workerJob.target.runMode,
-      toolProfile: workerJob.target.toolProfile
-    });
-
-    if (promptResult.promptPackageDigest !== workerJob.target.promptPackageDigest) {
-      throw new Error(
-        `Prompt package digest mismatch: expected ${workerJob.target.promptPackageDigest}, got ${promptResult.promptPackageDigest}.`
-      );
-    }
-
-    await appendWorkerEvent(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      "attempt_started",
-      "prepare",
-      "Materialized benchmark and prompt package; starting Problem 9 attempt.",
-      {
-        benchmarkPackageDigest: benchmarkResult.packageDigest,
-        promptPackageDigest: promptResult.promptPackageDigest,
-        runMode: workerJob.target.runMode
+      try {
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          buildStaticFailure({
+            summary: error instanceof Error ? error.message : String(error),
+            failureCode: "tool_permission_violation",
+            phase: "prepare"
+          })
+        );
+      } catch (submissionError) {
+        return await normalizeUnhandledClaimLoopFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          submissionError,
+          null,
+          heartbeatLoop
+        );
       }
-    );
-
-    if (
-      await submitCancellationIfRequested(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        "Worker received a control-plane cancellation request before the attempt entered execution."
-      )
-    ) {
       return "completed";
     }
 
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
-
-    leaseState.currentPhase = "generate";
-    leaseState.progressMessage = "Running Problem 9 attempt.";
-    heartbeatLoop = startHeartbeatLoop(leaseState, apiBaseUrl, dependencies);
-
-    let attemptResult: Problem9AttemptResult;
-
     try {
-      attemptResult = await dependencies.attemptRunner({
-        authMode: workerJob.target.authMode,
-        benchmarkPackageRoot: benchmarkResult.outputRoot,
-        modelSnapshotId: workerJob.target.modelSnapshotId,
-        networkPolicyMode: "hosted",
-        outputRoot: leaseRoots.attemptOutputRoot,
-        promptPackageRoot: promptResult.outputRoot,
-        providerFamily: workerJob.target.providerFamily,
-        providerModel: resolveProviderModel({
-          providerFamily: workerJob.target.providerFamily,
-          configuredProviderModel: options.providerModel,
-          modelConfigId: workerJob.target.modelConfigId
-        }),
-        stubScenario: inferStubScenario(workerJob.target.modelSnapshotId),
-        workspaceRoot: leaseRoots.attemptWorkspaceRoot
-      });
-    } catch (error) {
+      await refreshLease(leaseState, apiBaseUrl, dependencies);
+
       if (
         await submitCancellationIfRequested(
           leaseState,
           apiBaseUrl,
           dependencies,
-          "Worker stopped after a control-plane cancellation request during attempt execution."
+          "Worker received a control-plane cancellation request before execution started."
         )
       ) {
         return "completed";
@@ -613,187 +466,467 @@ async function processClaimedJob(
         return "lease_lost";
       }
 
-      await submitHarnessFailure(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        classifyHostedAttemptError(error)
-      );
-      return "completed";
-    }
-
-    leaseState.currentPhase = "finalize";
-    leaseState.progressMessage = "Preparing terminal worker submission.";
-
-    if (
-      await submitCancellationIfRequested(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        "Worker received a control-plane cancellation request before terminal submission."
-      )
-    ) {
-      return "completed";
-    }
-
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
-
-    await refreshLease(leaseState, apiBaseUrl, dependencies);
-
-    if (
-      await submitCancellationIfRequested(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        "Worker received a control-plane cancellation request while preparing terminal submission."
-      )
-    ) {
-      return "completed";
-    }
-
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
-
-    let bundleSubmission: PreparedBundleSubmission;
-
-    try {
-      bundleSubmission = await readBundleSubmission(attemptResult.outputRoot);
-      assertBundleSubmissionMatchesJobTarget(bundleSubmission, {
-        attemptId: workerJob.attemptId,
-        authMode: workerJob.target.authMode,
-        benchmarkItemId: workerJob.target.benchmarkItemId,
-        benchmarkPackageDigest: workerJob.target.benchmarkPackageDigest,
-        benchmarkPackageId: workerJob.target.benchmarkPackageId,
-        benchmarkPackageVersion: workerJob.target.benchmarkPackageVersion,
-        bundleSchemaVersion: workerJob.runBundleSchemaVersion,
-        harnessRevision: workerJob.target.harnessRevision,
-        jobId: workerJob.jobId,
-        laneId: workerJob.target.laneId,
-        modelConfigId: workerJob.target.modelConfigId,
-        modelSnapshotId: workerJob.target.modelSnapshotId,
-        promptPackageDigest: workerJob.target.promptPackageDigest,
-        promptProtocolVersion: workerJob.target.promptProtocolVersion,
-        providerFamily: workerJob.target.providerFamily,
-        runId: workerJob.runId,
-        runMode: workerJob.target.runMode,
-        status: attemptResult.result === "pass" ? "success" : "failure",
-        stopReason: attemptResult.stopReason,
-        toolProfile: workerJob.target.toolProfile
-      });
-      assertRequiredArtifactRoles(bundleSubmission.artifactManifest, workerJob.requiredArtifactRoles);
-    } catch (error) {
-      if (error instanceof Error) {
+      if (workerJob.target.runKind !== "single_run") {
         await submitHarnessFailure(
           leaseState,
           apiBaseUrl,
           dependencies,
           buildStaticFailure({
-            summary: error.message,
-            failureCode: "harness_crashed",
-            phase: "finalize"
+            summary: `Worker received unsupported run kind ${workerJob.target.runKind}.`,
+            failureCode: "run_configuration_invalid",
+            phase: "prepare"
           })
         );
+        return "completed";
+      }
+
+      if (workerJob.target.benchmarkItemId !== "Problem9") {
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          buildStaticFailure({
+            summary: `Worker received unsupported benchmark item ${workerJob.target.benchmarkItemId}.`,
+            failureCode: "run_configuration_invalid",
+            phase: "prepare"
+          })
+        );
+        return "completed";
+      }
+
+      if (workerJob.target.runMode === "pass_k_probe") {
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          buildStaticFailure({
+            summary: "Hosted worker single-run execution does not support pass_k_probe targets yet.",
+            failureCode: "run_configuration_invalid",
+            phase: "prepare"
+          })
+        );
+        return "completed";
+      }
+
+      try {
+        assertProblem9HostedCapability({
+          authMode: workerJob.target.authMode,
+          modelConfigId: workerJob.target.modelConfigId,
+          providerFamily: workerJob.target.providerFamily
+        });
+      } catch (error) {
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          buildStaticFailure({
+            summary: error instanceof Error ? error.message : String(error),
+            failureCode: "provider_unsupported_request",
+            phase: "prepare"
+          })
+        );
+        return "completed";
+      }
+
+      const benchmarkResult = await dependencies.materializeBenchmarkPackage({
+        outputRoot: leaseRoots.benchmarkPackageRoot
+      });
+
+      assertExpectedBenchmarkIdentity(workerJob.target, benchmarkResult);
+
+      const promptDefaults = getDefaultProblem9PromptPackageOptions();
+      const promptResult = await dependencies.materializePromptPackage({
+        attemptId: workerJob.attemptId,
+        authMode: workerJob.target.authMode,
+        benchmarkPackageRoot: benchmarkResult.outputRoot,
+        harnessRevision: workerJob.target.harnessRevision,
+        jobId: workerJob.jobId,
+        laneId: workerJob.target.laneId,
+        modelConfigId: workerJob.target.modelConfigId,
+        outputRoot: leaseRoots.promptPackageRoot,
+        passKCount: null,
+        passKIndex: null,
+        promptLayerVersions: promptDefaults.promptLayerVersions,
+        promptProtocolVersion: workerJob.target.promptProtocolVersion,
+        providerFamily: workerJob.target.providerFamily,
+        runId: workerJob.runId,
+        runMode: workerJob.target.runMode,
+        toolProfile: workerJob.target.toolProfile
+      });
+
+      if (promptResult.promptPackageDigest !== workerJob.target.promptPackageDigest) {
+        throw new Error(
+          `Prompt package digest mismatch: expected ${workerJob.target.promptPackageDigest}, got ${promptResult.promptPackageDigest}.`
+        );
+      }
+
+      await appendWorkerEvent(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "attempt_started",
+        "prepare",
+        "Materialized benchmark and prompt package; starting Problem 9 attempt.",
+        {
+          benchmarkPackageDigest: benchmarkResult.packageDigest,
+          promptPackageDigest: promptResult.promptPackageDigest,
+          runMode: workerJob.target.runMode
+        }
+      );
+
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker received a control-plane cancellation request before the attempt entered execution."
+        )
+      ) {
+        return "completed";
+      }
+
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+
+      leaseState.currentPhase = "generate";
+      leaseState.progressMessage = "Running Problem 9 attempt.";
+      heartbeatLoop = startHeartbeatLoop(leaseState, apiBaseUrl, dependencies);
+
+      let attemptResult: Problem9AttemptResult;
+
+      try {
+        attemptResult = await dependencies.attemptRunner({
+          authMode: workerJob.target.authMode,
+          benchmarkPackageRoot: benchmarkResult.outputRoot,
+          modelSnapshotId: workerJob.target.modelSnapshotId,
+          networkPolicyMode: "hosted",
+          outputRoot: leaseRoots.attemptOutputRoot,
+          promptPackageRoot: promptResult.outputRoot,
+          providerFamily: workerJob.target.providerFamily,
+          providerModel: resolveProviderModel({
+            providerFamily: workerJob.target.providerFamily,
+            configuredProviderModel: options.providerModel,
+            modelConfigId: workerJob.target.modelConfigId
+          }),
+          stubScenario: inferStubScenario(workerJob.target.modelSnapshotId),
+          workspaceRoot: leaseRoots.attemptWorkspaceRoot
+        });
+      } catch (error) {
+        leaseState.stopped = true;
+        leaseState.stopHeartbeat?.();
+        await heartbeatLoop;
+
         if (
           await submitCancellationIfRequested(
             leaseState,
             apiBaseUrl,
             dependencies,
-            "Worker received a control-plane cancellation request while validating the terminal bundle."
+            "Worker stopped after a control-plane cancellation request during attempt execution."
           )
         ) {
           return "completed";
         }
 
-        return leaseState.leaseLost ? "lease_lost" : "completed";
+        if (leaseState.leaseLost) {
+          return "lease_lost";
+        }
+
+        const backgroundAttemptError = consumeBackgroundControlError(leaseState);
+
+        if (backgroundAttemptError) {
+          return await normalizeUnhandledClaimLoopFailure(
+            leaseState,
+            apiBaseUrl,
+            dependencies,
+            backgroundAttemptError,
+            failureTerminalContext,
+            heartbeatLoop
+          );
+        }
+
+        if (leaseState.cancelRequested) {
+          return await normalizeUnhandledClaimLoopFailure(
+            leaseState,
+            apiBaseUrl,
+            dependencies,
+            error,
+            failureTerminalContext,
+            heartbeatLoop
+          );
+        }
+
+        await submitHarnessFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          classifyHostedAttemptError(error)
+        );
+        return "completed";
       }
 
-      throw error;
-    }
+      await Promise.resolve();
 
-    const manifestResponse = await submitArtifactManifest(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      {
-        artifacts: bundleSubmission.artifactManifest,
+      const backgroundAttemptError = consumeBackgroundControlError(leaseState);
+
+      if (backgroundAttemptError) {
+        return await normalizeUnhandledClaimLoopFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          backgroundAttemptError,
+          failureTerminalContext,
+          heartbeatLoop
+        );
+      }
+
+      leaseState.currentPhase = "finalize";
+      leaseState.progressMessage = "Preparing terminal worker submission.";
+
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker received a control-plane cancellation request before terminal submission."
+        )
+      ) {
+        return "completed";
+      }
+
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+
+      await refreshLease(leaseState, apiBaseUrl, dependencies);
+
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker received a control-plane cancellation request while preparing terminal submission."
+        )
+      ) {
+        return "completed";
+      }
+
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+
+      const preFinalizeBackgroundError = consumeBackgroundControlError(leaseState);
+
+      if (preFinalizeBackgroundError) {
+        return await normalizeUnhandledClaimLoopFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          preFinalizeBackgroundError,
+          failureTerminalContext,
+          heartbeatLoop
+        );
+      }
+
+      let bundleSubmission: PreparedBundleSubmission;
+
+      try {
+        bundleSubmission = await readBundleSubmission(attemptResult.outputRoot);
+        assertBundleSubmissionMatchesJobTarget(bundleSubmission, {
+          attemptId: workerJob.attemptId,
+          authMode: workerJob.target.authMode,
+          benchmarkItemId: workerJob.target.benchmarkItemId,
+          benchmarkPackageDigest: workerJob.target.benchmarkPackageDigest,
+          benchmarkPackageId: workerJob.target.benchmarkPackageId,
+          benchmarkPackageVersion: workerJob.target.benchmarkPackageVersion,
+          bundleSchemaVersion: workerJob.runBundleSchemaVersion,
+          harnessRevision: workerJob.target.harnessRevision,
+          jobId: workerJob.jobId,
+          laneId: workerJob.target.laneId,
+          modelConfigId: workerJob.target.modelConfigId,
+          modelSnapshotId: workerJob.target.modelSnapshotId,
+          promptPackageDigest: workerJob.target.promptPackageDigest,
+          promptProtocolVersion: workerJob.target.promptProtocolVersion,
+          providerFamily: workerJob.target.providerFamily,
+          runId: workerJob.runId,
+          runMode: workerJob.target.runMode,
+          status: attemptResult.result === "pass" ? "success" : "failure",
+          stopReason: attemptResult.stopReason,
+          toolProfile: workerJob.target.toolProfile
+        });
+        assertRequiredArtifactRoles(bundleSubmission.artifactManifest, workerJob.requiredArtifactRoles);
+      } catch (error) {
+        if (error instanceof Error) {
+          await submitHarnessFailure(
+            leaseState,
+            apiBaseUrl,
+            dependencies,
+            buildStaticFailure({
+              summary: error.message,
+              failureCode: "harness_crashed",
+              phase: "finalize"
+            })
+          );
+          if (
+            await submitCancellationIfRequested(
+              leaseState,
+              apiBaseUrl,
+              dependencies,
+              "Worker received a control-plane cancellation request while validating the terminal bundle."
+            )
+          ) {
+            return "completed";
+          }
+
+          return leaseState.leaseLost ? "lease_lost" : "completed";
+        }
+
+        throw error;
+      }
+
+      const manifestResponse = await submitArtifactManifest(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        {
+          artifacts: bundleSubmission.artifactManifest,
+          artifactManifestDigest: bundleSubmission.artifactManifestDigest,
+          attemptId: workerJob.attemptId,
+          jobId: workerJob.jobId,
+          leaseId: workerJob.leaseId,
+          recordedAt: dependencies.now().toISOString()
+        }
+      );
+      const cancellationTerminalContext: CancellationTerminalContext = {
+        artifactIds: manifestResponse.artifacts.map((artifact) => artifact.artifactId),
         artifactManifestDigest: bundleSubmission.artifactManifestDigest,
-        attemptId: workerJob.attemptId,
-        jobId: workerJob.jobId,
-        leaseId: workerJob.leaseId,
-        recordedAt: dependencies.now().toISOString()
-      }
-    );
-    const cancellationTerminalContext: CancellationTerminalContext = {
-      artifactIds: manifestResponse.artifacts.map((artifact) => artifact.artifactId),
-      artifactManifestDigest: bundleSubmission.artifactManifestDigest,
-      artifacts: manifestResponse.artifacts,
-      bundleDigest: bundleSubmission.bundleDigest,
-      candidateDigest: bundleSubmission.candidateDigest
-    };
-
-    await appendWorkerEvent(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      "artifact_manifest_written",
-      "finalize",
-      "Registered artifact manifest for Problem 9 attempt bundle.",
-      {
-        artifactCount: bundleSubmission.artifactManifest.length,
-        artifactManifestDigest: bundleSubmission.artifactManifestDigest
-      }
-    );
-
-    if (
-      await submitCancellationIfRequested(
-        leaseState,
-        apiBaseUrl,
-        dependencies,
-        "Worker received a control-plane cancellation request after artifact registration.",
-        cancellationTerminalContext
-      )
-    ) {
-      return "completed";
-    }
-
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
-
-    await appendWorkerEvent(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      "bundle_finalized",
-      "finalize",
-      `Finalized offline-compatible run bundle with ${bundleSubmission.verifierVerdict.result} verdict.`,
-      {
+        artifacts: manifestResponse.artifacts,
         bundleDigest: bundleSubmission.bundleDigest,
-        verdictDigest: bundleSubmission.verdictDigest
-      }
-    );
+        candidateDigest: bundleSubmission.candidateDigest
+      };
+      failureTerminalContext = cancellationTerminalContext;
 
-    if (
-      await submitCancellationIfRequested(
+      await appendWorkerEvent(
         leaseState,
         apiBaseUrl,
         dependencies,
-        "Worker received a control-plane cancellation request after bundle finalization.",
-        cancellationTerminalContext
-      )
-    ) {
-      return "completed";
-    }
+        "artifact_manifest_written",
+        "finalize",
+        "Registered artifact manifest for Problem 9 attempt bundle.",
+        {
+          artifactCount: bundleSubmission.artifactManifest.length,
+          artifactManifestDigest: bundleSubmission.artifactManifestDigest
+        }
+      );
 
-    if (leaseState.leaseLost) {
-      return "lease_lost";
-    }
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker received a control-plane cancellation request after artifact registration.",
+          cancellationTerminalContext
+        )
+      ) {
+        return "completed";
+      }
 
-    if (bundleSubmission.verifierVerdict.result === "pass") {
-      const resultResponse = await submitWorkerResult(
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+
+      const postManifestBackgroundError = consumeBackgroundControlError(leaseState);
+
+      if (postManifestBackgroundError) {
+        return await normalizeUnhandledClaimLoopFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          postManifestBackgroundError,
+          failureTerminalContext,
+          heartbeatLoop
+        );
+      }
+
+      await appendWorkerEvent(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        "bundle_finalized",
+        "finalize",
+        `Finalized offline-compatible run bundle with ${bundleSubmission.verifierVerdict.result} verdict.`,
+        {
+          bundleDigest: bundleSubmission.bundleDigest,
+          verdictDigest: bundleSubmission.verdictDigest
+        }
+      );
+
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          "Worker received a control-plane cancellation request after bundle finalization.",
+          cancellationTerminalContext
+        )
+      ) {
+        return "completed";
+      }
+
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+
+      const postBundleBackgroundError = consumeBackgroundControlError(leaseState);
+
+      if (postBundleBackgroundError) {
+        return await normalizeUnhandledClaimLoopFailure(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          postBundleBackgroundError,
+          failureTerminalContext,
+          heartbeatLoop
+        );
+      }
+
+      if (bundleSubmission.verifierVerdict.result === "pass") {
+        const resultResponse = await submitWorkerResult(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          {
+            artifactIds: manifestResponse.artifacts.map((artifact) => artifact.artifactId),
+            artifactManifestDigest: bundleSubmission.artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            bundleDigest: bundleSubmission.bundleDigest,
+            candidateDigest: bundleSubmission.candidateDigest,
+            completedAt: dependencies.now().toISOString(),
+            environmentDigest: bundleSubmission.environmentDigest,
+            jobId: workerJob.jobId,
+            leaseId: workerJob.leaseId,
+            offlineBundleCompatible: true,
+            runId: workerJob.runId,
+            summary: "Problem 9 attempt passed the authoritative verifier.",
+            usageSummary: {
+              compileRepairCount: attemptResult.compileRepairCount,
+              providerTurnsUsed: attemptResult.providerTurnsUsed,
+              stopReason: attemptResult.stopReason,
+              verifierRepairCount: attemptResult.verifierRepairCount
+            },
+            verifierVerdict: bundleSubmission.verifierVerdict,
+            verdictDigest: bundleSubmission.verdictDigest
+          }
+        );
+
+        if (resultResponse.runState !== "succeeded") {
+          throw new Error(`Unexpected worker result terminal state ${resultResponse.runState}.`);
+        }
+
+        return "completed";
+      }
+
+      await submitWorkerFailure(
         leaseState,
         apiBaseUrl,
         dependencies,
@@ -803,62 +936,37 @@ async function processClaimedJob(
           attemptId: workerJob.attemptId,
           bundleDigest: bundleSubmission.bundleDigest,
           candidateDigest: bundleSubmission.candidateDigest,
-          completedAt: dependencies.now().toISOString(),
-          environmentDigest: bundleSubmission.environmentDigest,
+          failedAt: dependencies.now().toISOString(),
+          failure:
+            bundleSubmission.verifierVerdict.primaryFailure ??
+            buildSelectedArtifactFallbackFailure(manifestResponse.artifacts, {
+              summary: "Worker produced a failing verdict without a canonical primaryFailure payload.",
+              failureCode: "proof_policy_failed",
+              phase: "verify"
+            }),
           jobId: workerJob.jobId,
           leaseId: workerJob.leaseId,
-          offlineBundleCompatible: true,
           runId: workerJob.runId,
-          summary: "Problem 9 attempt passed the authoritative verifier.",
-          usageSummary: {
-            compileRepairCount: attemptResult.compileRepairCount,
-            providerTurnsUsed: attemptResult.providerTurnsUsed,
-            stopReason: attemptResult.stopReason,
-            verifierRepairCount: attemptResult.verifierRepairCount
-          },
+          summary:
+            bundleSubmission.verifierVerdict.primaryFailure?.summary ??
+            "Problem 9 attempt failed verification.",
+          terminalState: "failed",
           verifierVerdict: bundleSubmission.verifierVerdict,
           verdictDigest: bundleSubmission.verdictDigest
         }
       );
 
-      if (resultResponse.runState !== "succeeded") {
-        throw new Error(`Unexpected worker result terminal state ${resultResponse.runState}.`);
-      }
-
       return "completed";
+    } catch (error) {
+      return await normalizeUnhandledClaimLoopFailure(
+        leaseState,
+        apiBaseUrl,
+        dependencies,
+        error,
+        failureTerminalContext,
+        heartbeatLoop
+      );
     }
-
-    await submitWorkerFailure(
-      leaseState,
-      apiBaseUrl,
-      dependencies,
-      {
-        artifactIds: manifestResponse.artifacts.map((artifact) => artifact.artifactId),
-        artifactManifestDigest: bundleSubmission.artifactManifestDigest,
-        attemptId: workerJob.attemptId,
-        bundleDigest: bundleSubmission.bundleDigest,
-        candidateDigest: bundleSubmission.candidateDigest,
-        failedAt: dependencies.now().toISOString(),
-        failure:
-          bundleSubmission.verifierVerdict.primaryFailure ??
-          buildSelectedArtifactFallbackFailure(manifestResponse.artifacts, {
-            summary: "Worker produced a failing verdict without a canonical primaryFailure payload.",
-            failureCode: "proof_policy_failed",
-            phase: "verify"
-          }),
-        jobId: workerJob.jobId,
-        leaseId: workerJob.leaseId,
-        runId: workerJob.runId,
-        summary:
-          bundleSubmission.verifierVerdict.primaryFailure?.summary ??
-          "Problem 9 attempt failed verification.",
-        terminalState: "failed",
-        verifierVerdict: bundleSubmission.verifierVerdict,
-        verdictDigest: bundleSubmission.verdictDigest
-      }
-    );
-
-    return "completed";
   } finally {
     leaseState.stopped = true;
     leaseState.stopHeartbeat?.();
@@ -925,8 +1033,12 @@ function startHeartbeatLoop(
       try {
         await refreshLease(leaseState, apiBaseUrl, dependencies);
       } catch (error) {
-        leaseState.leaseLost = true;
         leaseState.heartbeatErrorMessage = error instanceof Error ? error.message : String(error);
+        if (isLeaseLossControlError(error)) {
+          leaseState.leaseLost = true;
+        } else {
+          leaseState.backgroundControlError = error;
+        }
         return;
       }
     }
@@ -1181,6 +1293,129 @@ async function submitCancellationIfRequested(
   return true;
 }
 
+async function normalizeUnhandledClaimLoopFailure(
+  leaseState: ActiveLeaseState,
+  apiBaseUrl: string,
+  dependencies: WorkerClaimLoopResolvedDependencies,
+  error: unknown,
+  terminalContext: CancellationTerminalContext | null,
+  heartbeatLoop: Promise<void>
+): Promise<"completed" | "lease_lost"> {
+  leaseState.stopped = true;
+  leaseState.stopHeartbeat?.();
+  await heartbeatLoop;
+
+  if (isLeaseLossControlError(error)) {
+    leaseState.heartbeatErrorMessage = error instanceof Error ? error.message : String(error);
+    leaseState.leaseLost = true;
+    return "lease_lost";
+  }
+
+  const cancellationSummary =
+    "Worker received a control-plane cancellation request while recovering from an internal worker control failure.";
+  let recoveryError = error;
+  let retryCancelledTerminalization = isCancelRequestedTerminalizationConflict(error);
+
+  if (retryCancelledTerminalization) {
+    leaseState.cancelRequested = true;
+  }
+
+  if (leaseState.cancelRequested) {
+    try {
+      if (
+        await submitCancellationIfRequested(
+          leaseState,
+          apiBaseUrl,
+          dependencies,
+          cancellationSummary,
+          terminalContext
+        )
+      ) {
+        return "completed";
+      }
+
+      if (leaseState.leaseLost) {
+        return "lease_lost";
+      }
+    } catch (cancelError) {
+      if (isLeaseLossControlError(cancelError)) {
+        leaseState.heartbeatErrorMessage =
+          cancelError instanceof Error ? cancelError.message : String(cancelError);
+        leaseState.leaseLost = true;
+        return "lease_lost";
+      }
+
+      recoveryError = cancelError;
+      retryCancelledTerminalization = true;
+    }
+  }
+
+  const summary = retryCancelledTerminalization
+    ? cancellationSummary
+    : recoveryError instanceof Error
+      ? recoveryError.message
+      : String(recoveryError);
+  const failure = retryCancelledTerminalization
+    ? terminalContext
+      ? buildSelectedArtifactFallbackFailure(terminalContext.artifacts, {
+          summary,
+          failureCode: "manual_cancelled",
+          phase: "cancel"
+        })
+      : buildStaticFailure({
+          summary,
+          failureCode: "manual_cancelled",
+          phase: "cancel"
+        })
+    : terminalContext
+      ? buildSelectedArtifactFallbackFailure(terminalContext.artifacts, {
+          summary,
+          failureCode: "harness_crashed",
+          phase: leaseState.currentPhase
+        })
+      : buildStaticFailure({
+          summary,
+          failureCode: "harness_crashed",
+          phase: leaseState.currentPhase
+        });
+
+  try {
+    await submitWorkerFailure(leaseState, apiBaseUrl, dependencies, {
+      artifactIds: terminalContext?.artifactIds,
+      artifactManifestDigest: terminalContext?.artifactManifestDigest ?? null,
+      attemptId: leaseState.job.attemptId,
+      bundleDigest: terminalContext?.bundleDigest ?? null,
+      candidateDigest: terminalContext?.candidateDigest ?? null,
+      failedAt: dependencies.now().toISOString(),
+      failure,
+      jobId: leaseState.job.jobId,
+      leaseId: leaseState.job.leaseId,
+      runId: leaseState.job.runId,
+      summary,
+      terminalState: retryCancelledTerminalization ? "cancelled" : "failed",
+      verifierVerdict: null,
+      verdictDigest: null
+    });
+  } catch (submissionError) {
+    if (isLeaseLossControlError(submissionError)) {
+      leaseState.heartbeatErrorMessage =
+        submissionError instanceof Error ? submissionError.message : String(submissionError);
+      leaseState.leaseLost = true;
+      return "lease_lost";
+    }
+
+    throw submissionError;
+  }
+
+  return "completed";
+}
+
+function consumeBackgroundControlError(leaseState: ActiveLeaseState): unknown | null {
+  const backgroundControlError = leaseState.backgroundControlError;
+  leaseState.backgroundControlError = null;
+  return backgroundControlError;
+}
+
 function isLeaseLossControlError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -1188,6 +1423,13 @@ function isLeaseLossControlError(error: unknown): boolean {
 
   return /invalid_worker_job_token|worker_lease_not_active|worker_lease_not_found/u.test(
     error.message
+  );
+}
+
+function isCancelRequestedTerminalizationConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /worker_cancel_requested_requires_cancelled_terminalization/u.test(error.message)
   );
 }
 

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -810,6 +810,158 @@ test("runWorkerClaimLoop terminalizes cancellation after control-plane cancel du
   }
 });
 
+test("runWorkerClaimLoop preserves cancelled terminalization when the first cancel submit fails transiently", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-finalize-cancel-retry-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1,
+            cancelRequested: true,
+            jobToken: "job-token-3",
+            leaseStatus: "cancel_requested"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            error: "failure_write_failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`,
+          status: 500
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "cancelled",
+            jobState: "cancelled",
+            runState: "cancelled"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const firstFailureBody = calls.at(-2)?.body as WorkerTerminalFailureRequest;
+    const recoveredFailureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(firstFailureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(firstFailureBody.terminalState, "cancelled");
+    assert.equal(recoveredFailureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(recoveredFailureBody.failure.phase, "cancel");
+    assert.equal(recoveredFailureBody.terminalState, "cancelled");
+    assert.deepEqual(recoveredFailureBody.failure.evidenceArtifactRefs, [
+      "worker-control/pre-bundle-failure"
+    ]);
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("runWorkerClaimLoop treats bounded cancel-finalization window loss as lease loss instead of crashing", async () => {
   const tempRoot = await mkdtemp(
     path.join(os.tmpdir(), "paretoproof-worker-claim-finalize-cancel-expired-")
@@ -1366,6 +1518,1282 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
   }
 });
 
+test("runWorkerClaimLoop converts non-lease finalize heartbeat failures into canonical pre-bundle failures", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-finalize-heartbeat-failure-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            error: "backend_unavailable"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+          status: 500
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "harness_crashed");
+    assert.match(failureBody.failure.summary, /Worker control request failed \(500\).*\/heartbeat/u);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+    assert.equal(failureBody.artifactIds, undefined);
+    assert.equal(failureBody.artifactManifestDigest, null);
+    assert.equal(failureBody.bundleDigest, null);
+    assert.equal(failureBody.candidateDigest, null);
+    assert.equal(failureBody.verifierVerdict, null);
+    assert.equal(failureBody.verdictDigest, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop converts non-lease background heartbeat failures into canonical pre-bundle failures", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-background-heartbeat-failure-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    let heartbeatCount = 0;
+    let resolveHeartbeatFailureSeen: (() => void) | null = null;
+    const heartbeatFailureSeen = new Promise<void>((resolve) => {
+      resolveHeartbeatFailureSeen = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+
+      calls.push({
+        body: bodyText.length > 0 ? JSON.parse(bodyText) : null,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          resolveHeartbeatFailureSeen?.();
+          return new Response(JSON.stringify({ error: "backend_unavailable" }), {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 500
+          });
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: 1
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          attemptState: "failed",
+          jobState: "failed",
+          runState: "failed"
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await heartbeatFailureSeen;
+          await writeBundleOutputs(options.outputRoot, buildArtifactEntries());
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {}
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "harness_crashed");
+    assert.match(failureBody.failure.summary, /Worker control request failed \(500\).*\/heartbeat/u);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+    assert.equal(failureBody.artifactIds, undefined);
+    assert.equal(failureBody.bundleDigest, null);
+    assert.equal(failureBody.verifierVerdict, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop falls back to an artifact-backed harness failure when terminal result submission fails", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-result-submit-failure-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    let writtenBundle: WrittenBundleDigests | null = null;
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            error: "result_write_failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/result`,
+          status: 500
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          writtenBundle = await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/result`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "harness_crashed");
+    assert.match(failureBody.failure.summary, /Worker control request failed \(500\).*\/result/u);
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.deepEqual(failureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(failureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(failureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(failureBody.candidateDigest, writtenBundle?.candidateDigest);
+    assert.equal(failureBody.verdictDigest, null);
+    assert.equal(failureBody.verifierVerdict, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel arrives during result-submit recovery", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-result-submit-cancel-race-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    let sleepCount = 0;
+    let heartbeatCount = 0;
+    let releaseLateCancelHeartbeat: (() => void) | null = null;
+    const lateCancelHeartbeatReleased = new Promise<void>((resolve) => {
+      releaseLateCancelHeartbeat = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+      const body = bodyText.length > 0 ? JSON.parse(bodyText) : null;
+
+      calls.push({
+        body,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 1
+            })
+          );
+        }
+
+        if (heartbeatCount === 3) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 3,
+              cancelRequested: true,
+              jobToken: "job-token-3",
+              leaseStatus: "cancel_requested"
+            })
+          );
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: body.sequence
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/artifacts`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          artifactManifestDigest,
+          artifacts: artifactEntries.map((artifact, index) => ({
+            artifactId: `artifact-${index + 1}`,
+            artifactRole: artifact.artifactRole,
+            relativePath: artifact.relativePath
+          }))
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/result`) {
+        releaseLateCancelHeartbeat?.();
+        return new Response(JSON.stringify({ error: "result_write_failed" }), {
+          headers: {
+            "content-type": "application/json"
+          },
+          status: 500
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          attemptState: "cancelled",
+          jobState: "cancelled",
+          runState: "cancelled"
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {
+          sleepCount += 1;
+
+          if (sleepCount === 1) {
+            await lateCancelHeartbeatReleased;
+          }
+        }
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/result`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(failureBody.failure.phase, "cancel");
+    assert.equal(failureBody.terminalState, "cancelled");
+    assert.deepEqual(failureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.deepEqual(failureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel arrives during failing-verdict submission", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-failing-verdict-cancel-race-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const baseWorkerJob = buildWorkerJob();
+    const workerJob = {
+      ...baseWorkerJob,
+      requiredArtifactRoles: [...baseWorkerJob.requiredArtifactRoles, "failure_classification" as const]
+    };
+    const artifactEntries = buildArtifactEntries({ includeFailureClassification: true });
+    let heartbeatCount = 0;
+    let writtenBundle: WrittenBundleDigests | null = null;
+    let releaseLateCancelHeartbeat: (() => void) | null = null;
+    const lateCancelHeartbeatReleased = new Promise<void>((resolve) => {
+      releaseLateCancelHeartbeat = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+      const body = bodyText.length > 0 ? JSON.parse(bodyText) : null;
+
+      calls.push({
+        body,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 1
+            })
+          );
+        }
+
+        if (heartbeatCount === 3) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 3,
+              cancelRequested: true,
+              jobToken: "job-token-3",
+              leaseStatus: "cancel_requested"
+            })
+          );
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: body.sequence
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/artifacts`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          artifactManifestDigest,
+          artifacts: artifactEntries.map((artifact, index) => ({
+            artifactId: `artifact-${index + 1}`,
+            artifactRole: artifact.artifactRole,
+            relativePath: artifact.relativePath
+          }))
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        if (body.terminalState === "failed") {
+          releaseLateCancelHeartbeat?.();
+          return new Response(
+            JSON.stringify({
+              error: "worker_cancel_requested_requires_cancelled_terminalization"
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 409
+            }
+          );
+        }
+
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          attemptState: "cancelled",
+          jobState: "cancelled",
+          runState: "cancelled"
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          writtenBundle = await writeBundleOutputsWithVerdict(options.outputRoot, artifactEntries, {
+            diagnosticGate: "failed",
+            failureCode: "proof_policy_failed",
+            primaryFailure: {
+              evidenceArtifactRefs: ["verification/failure-classification.json"],
+              failureCode: "proof_policy_failed",
+              failureFamily: "verification",
+              phase: "verify",
+              retryEligibility: "never",
+              summary: "Canonical verifier failure payload.",
+              terminality: "terminal_attempt",
+              userVisibility: "internal_only"
+            },
+            result: "fail"
+          });
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "fail",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verifier_failed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {
+          await lateCancelHeartbeatReleased;
+        }
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const firstFailureBody = calls.at(-3)?.body as WorkerTerminalFailureRequest;
+    const recoveredFailureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(firstFailureBody.failure.failureCode, "proof_policy_failed");
+    assert.equal(firstFailureBody.terminalState, "failed");
+    assert.equal(recoveredFailureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(recoveredFailureBody.failure.phase, "cancel");
+    assert.equal(recoveredFailureBody.terminalState, "cancelled");
+    assert.deepEqual(recoveredFailureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.deepEqual(recoveredFailureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.equal(recoveredFailureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(recoveredFailureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(recoveredFailureBody.candidateDigest, writtenBundle?.candidateDigest);
+    assert.equal(recoveredFailureBody.verdictDigest, null);
+    assert.equal(recoveredFailureBody.verifierVerdict, null);
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop preserves lease_lost when terminal result submission loses the lease", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-result-lease-loss-"));
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const artifactEntries = buildArtifactEntries();
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            error: "worker_lease_not_active"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/result`,
+          status: 409
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          await writeBundleOutputs(options.outputRoot, artifactEntries);
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "pass",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verification_passed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 0,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/result`
+      ]
+    );
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop retries failing-verdict terminalization with a canonical harness failure when the first failure submit fails", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-failure-submit-recovery-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const baseWorkerJob = buildWorkerJob();
+    const workerJob = {
+      ...baseWorkerJob,
+      requiredArtifactRoles: [...baseWorkerJob.requiredArtifactRoles, "failure_classification" as const]
+    };
+    const artifactEntries = buildArtifactEntries({ includeFailureClassification: true });
+    let writtenBundle: WrittenBundleDigests | null = null;
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 0,
+            jobToken: "job-token-2"
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 1
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: buildHeartbeatResponse({
+            acknowledgedEventSequence: 1
+          }),
+          path: `/internal/worker/jobs/${workerJob.jobId}/heartbeat`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            artifactManifestDigest,
+            artifacts: artifactEntries.map((artifact, index) => ({
+              artifactId: `artifact-${index + 1}`,
+              artifactRole: artifact.artifactRole,
+              relativePath: artifact.relativePath
+            }))
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/artifacts`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 2
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            acknowledgedSequence: 3
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/events`
+        },
+        {
+          body: {
+            error: "failure_write_failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`,
+          status: 500
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async (options) => {
+          writtenBundle = await writeBundleOutputsWithVerdict(options.outputRoot, artifactEntries, {
+            diagnosticGate: "failed",
+            failureCode: "proof_policy_failed",
+            primaryFailure: {
+              evidenceArtifactRefs: ["verification/failure-classification.json"],
+              failureCode: "proof_policy_failed",
+              failureFamily: "verification",
+              phase: "verify",
+              retryEligibility: "never",
+              summary: "Canonical verifier failure payload.",
+              terminality: "terminal_attempt",
+              userVisibility: "internal_only"
+            },
+            result: "fail"
+          });
+
+          return {
+            artifactManifestDigest,
+            attemptId: workerJob.attemptId,
+            authMode: "machine_api_key",
+            bundleDigest,
+            compileRepairCount: 0,
+            outputRoot: options.outputRoot,
+            promptPackageDigest: promptDigest,
+            providerFamily: "openai",
+            providerTurnsUsed: 1,
+            result: "fail",
+            runConfigDigest: "2".repeat(64),
+            runId: workerJob.runId,
+            stopReason: "verifier_failed",
+            verifierRepairCount: 0,
+            verdictDigest
+          };
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/artifacts`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const firstFailureBody = calls.at(-2)?.body as WorkerTerminalFailureRequest;
+    const recoveredFailureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(firstFailureBody.failure.failureCode, "proof_policy_failed");
+    assert.equal(recoveredFailureBody.failure.failureCode, "harness_crashed");
+    assert.match(
+      recoveredFailureBody.failure.summary,
+      /Worker control request failed \(500\).*\/failure/u
+    );
+    assert.deepEqual(recoveredFailureBody.failure.evidenceArtifactRefs, ["verification/verdict.json"]);
+    assert.deepEqual(recoveredFailureBody.artifactIds, expectedArtifactIds(artifactEntries));
+    assert.equal(recoveredFailureBody.artifactManifestDigest, writtenBundle?.artifactManifestDigest);
+    assert.equal(recoveredFailureBody.bundleDigest, writtenBundle?.bundleDigest);
+    assert.equal(recoveredFailureBody.candidateDigest, writtenBundle?.candidateDigest);
+    assert.equal(recoveredFailureBody.verdictDigest, null);
+    assert.equal(recoveredFailureBody.verifierVerdict, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("runWorkerClaimLoop heartbeats do not advertise unsent finalize event sequences", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-sequence-"));
 
@@ -1628,6 +3056,160 @@ test("runWorkerClaimLoop submits a canonical pre-bundle failure when the inner a
   }
 });
 
+test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel arrives during attempt-failure recovery", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-attempt-failure-cancel-race-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    let heartbeatCount = 0;
+    let releasePendingHeartbeat: (() => void) | null = null;
+    let resolvePendingHeartbeatStarted: (() => void) | null = null;
+    const pendingHeartbeatStarted = new Promise<void>((resolve) => {
+      resolvePendingHeartbeatStarted = resolve;
+    });
+    const fetchImpl = async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      const bodyText = typeof init?.body === "string" ? init.body : "";
+
+      calls.push({
+        body: bodyText.length > 0 ? JSON.parse(bodyText) : null,
+        path: url.pathname,
+        token:
+          new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "") ?? ""
+      });
+
+      if (url.pathname === "/internal/worker/claims") {
+        return jsonResponse({
+          leaseStatus: "active",
+          pollAfterSeconds: 0,
+          workerJob
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/heartbeat`) {
+        heartbeatCount += 1;
+
+        if (heartbeatCount === 1) {
+          return jsonResponse(
+            buildHeartbeatResponse({
+              acknowledgedEventSequence: 0,
+              jobToken: "job-token-2"
+            })
+          );
+        }
+
+        if (heartbeatCount === 2) {
+          resolvePendingHeartbeatStarted?.();
+          return await new Promise<Response>((resolve) => {
+            releasePendingHeartbeat = () => {
+              resolve(
+                jsonResponse(
+                  buildHeartbeatResponse({
+                    acknowledgedEventSequence: 1,
+                    cancelRequested: true,
+                    jobToken: "job-token-3",
+                    leaseStatus: "cancel_requested"
+                  })
+                )
+              );
+            };
+          });
+        }
+
+        throw new Error(`Unexpected extra heartbeat ${heartbeatCount}.`);
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/events`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          acknowledgedSequence: 1
+        });
+      }
+
+      if (url.pathname === `/internal/worker/jobs/${workerJob.jobId}/failure`) {
+        return jsonResponse({
+          acceptedAt: fixedNow.toISOString(),
+          attemptState: "cancelled",
+          jobState: "cancelled",
+          runState: "cancelled"
+        });
+      }
+
+      throw new Error(`Unexpected fetch path ${url.pathname}.`);
+    };
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async () => {
+          await pendingHeartbeatStarted;
+          queueMicrotask(() => {
+            releasePendingHeartbeat?.();
+          });
+          throw new Error("provider auth failed for hosted attempt");
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: async () => {}
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/events`,
+        `/internal/worker/jobs/${workerJob.jobId}/heartbeat`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(failureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(failureBody.failure.phase, "cancel");
+    assert.equal(failureBody.terminalState, "cancelled");
+    assert.equal(calls.at(-1)?.token, "job-token-3");
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("runWorkerClaimLoop constrains claimed job filesystem paths under the configured roots", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-claim-paths-"));
 
@@ -1841,6 +3423,233 @@ test("runWorkerClaimLoop fails closed on pre-existing lease residue and skips ex
     const failureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
     assert.equal(failureBody.failure.failureCode, "tool_permission_violation");
     assert.match(failureBody.failure.summary, /Unsafe hosted residue detected/);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop recovers when the first prepare-phase failure submission itself fails", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-prepare-submit-recovery-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const leaseWorkspaceRoot = buildLeaseScopedRoot(path.join(tempRoot, "workspace"), workerJob);
+    const leaseStagingRoot = buildLeaseScopedRoot(path.join(tempRoot, "output"), workerJob);
+    await mkdir(leaseWorkspaceRoot, { recursive: true });
+    await mkdir(leaseStagingRoot, { recursive: true });
+    await writeFile(path.join(leaseWorkspaceRoot, "stale.txt"), "stale workspace", "utf8");
+    await writeFile(path.join(leaseStagingRoot, "stale.txt"), "stale staging", "utf8");
+
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: {
+            error: "failure_write_failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`,
+          status: 500
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "failed",
+            jobState: "failed",
+            runState: "failed"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async () => {
+          throw new Error("attempt runner should not execute");
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/failure`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const firstFailureBody = calls.at(-2)?.body as WorkerTerminalFailureRequest;
+    const recoveredFailureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(firstFailureBody.failure.failureCode, "tool_permission_violation");
+    assert.equal(recoveredFailureBody.failure.failureCode, "harness_crashed");
+    assert.match(
+      recoveredFailureBody.failure.summary,
+      /Worker control request failed \(500\).*\/failure/u
+    );
+    assert.deepEqual(recoveredFailureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+    assert.equal(recoveredFailureBody.artifactIds, undefined);
+    assert.equal(recoveredFailureBody.verifierVerdict, null);
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
+    await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("runWorkerClaimLoop preserves cancelled terminalization when the first prepare-phase failure submit races a server-side cancel", async () => {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "paretoproof-worker-claim-prepare-submit-cancel-race-")
+  );
+
+  try {
+    const calls: ApiCall[] = [];
+    const workerJob = buildWorkerJob();
+    const leaseWorkspaceRoot = buildLeaseScopedRoot(path.join(tempRoot, "workspace"), workerJob);
+    const leaseStagingRoot = buildLeaseScopedRoot(path.join(tempRoot, "output"), workerJob);
+    await mkdir(leaseWorkspaceRoot, { recursive: true });
+    await mkdir(leaseStagingRoot, { recursive: true });
+    await writeFile(path.join(leaseWorkspaceRoot, "stale.txt"), "stale workspace", "utf8");
+    await writeFile(path.join(leaseStagingRoot, "stale.txt"), "stale staging", "utf8");
+
+    const fetchImpl = createFetchMock(
+      [
+        {
+          body: {
+            leaseStatus: "active",
+            pollAfterSeconds: 0,
+            workerJob
+          },
+          path: "/internal/worker/claims"
+        },
+        {
+          body: {
+            error: "worker_cancel_requested_requires_cancelled_terminalization"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`,
+          status: 409
+        },
+        {
+          body: {
+            acceptedAt: fixedNow.toISOString(),
+            attemptState: "cancelled",
+            jobState: "cancelled",
+            runState: "cancelled"
+          },
+          path: `/internal/worker/jobs/${workerJob.jobId}/failure`
+        }
+      ],
+      calls
+    );
+
+    const result = await runWorkerClaimLoop(
+      {
+        authMode: "machine_api_key",
+        maxJobs: 1,
+        once: true,
+        outputRoot: path.join(tempRoot, "output"),
+        workerId: "worker-1",
+        workerPool: "modal-dev",
+        workerRuntime: "modal",
+        workerVersion: "worker.v1",
+        workspaceRoot: path.join(tempRoot, "workspace")
+      },
+      {
+        attemptRunner: async () => {
+          throw new Error("attempt runner should not execute");
+        },
+        fetchImpl,
+        materializeBenchmarkPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          packageDigest: benchmarkDigest,
+          packageId: "firstproof/Problem9",
+          packageVersion: "2026.03.13"
+        }),
+        materializePromptPackage: async ({ outputRoot }) => ({
+          outputRoot,
+          promptPackageDigest: promptDigest
+        }),
+        now: () => fixedNow,
+        rawEnv: {
+          API_BASE_URL: "https://api.paretoproof.test",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        },
+        sleep: neverSleep
+      }
+    );
+
+    assert.deepEqual(result, {
+      claimedJobs: 1,
+      completedJobs: 1,
+      idlePollCount: 0,
+      stoppedReason: "max_jobs_reached"
+    });
+    assert.deepEqual(
+      calls.map((call) => call.path),
+      [
+        "/internal/worker/claims",
+        `/internal/worker/jobs/${workerJob.jobId}/failure`,
+        `/internal/worker/jobs/${workerJob.jobId}/failure`
+      ]
+    );
+    const firstFailureBody = calls.at(-2)?.body as WorkerTerminalFailureRequest;
+    const recoveredFailureBody = calls.at(-1)?.body as WorkerTerminalFailureRequest;
+    assert.equal(firstFailureBody.failure.failureCode, "tool_permission_violation");
+    assert.equal(firstFailureBody.terminalState, "failed");
+    assert.equal(recoveredFailureBody.failure.failureCode, "manual_cancelled");
+    assert.equal(recoveredFailureBody.failure.phase, "cancel");
+    assert.equal(recoveredFailureBody.terminalState, "cancelled");
+    assert.deepEqual(recoveredFailureBody.failure.evidenceArtifactRefs, ["worker-control/pre-bundle-failure"]);
+    assert.deepEqual(recoveredFailureBody.artifactIds, []);
+    assert.equal(recoveredFailureBody.verifierVerdict, null);
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "workspace"));
     await assertDirectoryEmptyOrMissing(path.join(tempRoot, "output"));
   } finally {


### PR DESCRIPTION
## Summary
- normalize non-lease worker control failures into canonical terminal submissions instead of bubbling out of the claim loop
- treat `worker_cancel_requested_requires_cancelled_terminalization` as authoritative cancel state so late server-side cancels converge to `manual_cancelled`
- lock the new cancel and failure recovery paths with worker and internal-worker regressions

## Testing
- bun test apps/worker/test/worker-claim-loop.test.ts
- node --import tsx --test test/worker-claim-loop.test.ts
- node --import tsx --test test/internal-worker.test.ts
- bun run test:api
- bun run typecheck
- bun run build

Closes #1012