### PR TITLE
Tighten hosted worker startup policy

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -133,7 +133,7 @@ Hosted claim loop:
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY`
 - hosted claim-loop execution fails closed if proxy env or provider base-URL override env is present, and modal workers reject raw-IP or loopback control-plane origins instead of treating them as normal hosted targets
-- hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home/auth.json` path instead of silently attempting to reuse contributor auth material
+- hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home` `CODEX_HOME` contract instead of silently attempting to reuse contributor auth material
 - the hosted loop only accepts `single_run` claims with machine auth, materializes the canonical benchmark and prompt packages from repo-owned sources, reuses the same `runProblem9Attempt` inner runner as local single-run execution, and submits heartbeats, execution events, artifact manifests, and terminal success or failure objects through the internal API
 - if a heartbeat returns `cancel_requested` or `expired`, the loop exits that claim without sending a stale terminal finalize
 - use `--max-jobs <n>` to bound a longer poller run, `--provider-model <model>` to override the provider model derived from `modelConfigId`, and `--worker-runtime` to choose the runtime label sent in claim requests

--- a/apps/worker/src/lib/hosted-network-policy.ts
+++ b/apps/worker/src/lib/hosted-network-policy.ts
@@ -17,6 +17,9 @@ const hostedProxyEnvNames = [
 const hostedProviderOverrideEnvNames: Record<Problem9ProviderFamily, readonly string[]> = {
   openai: ["OPENAI_API_BASE", "OPENAI_API_BASE_URL", "OPENAI_BASE_URL"]
 };
+const allHostedProviderOverrideEnvNames = [
+  ...new Set(Object.values(hostedProviderOverrideEnvNames).flat())
+];
 
 const hostedLeanToolForbiddenEnvNames = [
   "API_BASE_URL",
@@ -104,17 +107,8 @@ export function buildHostedProviderCommandEnv(
   env: NodeJS.ProcessEnv,
   providerFamily: Problem9ProviderFamily
 ): NodeJS.ProcessEnv {
-  const forbiddenOverrideNames = [
-    ...hostedProxyEnvNames,
-    ...hostedProviderOverrideEnvNames[providerFamily]
-  ];
-  const offendingNames = forbiddenOverrideNames.filter((name) => hasNonEmptyEnvValue(env[name]));
-
-  if (offendingNames.length > 0) {
-    throw new Error(
-      `Hosted network policy blocked provider execution: forbidden env override(s) ${offendingNames.join(", ")}.`
-    );
-  }
+  const forbiddenOverrideNames = [...hostedProxyEnvNames, ...hostedProviderOverrideEnvNames[providerFamily]];
+  assertHostedEnvOverridesForbidden(env, forbiddenOverrideNames, "provider execution");
 
   const sanitizedEnv = { ...env };
 
@@ -138,6 +132,14 @@ export function buildHostedLeanToolCommandEnv(
   return sanitizedEnv;
 }
 
+export function assertHostedClaimLoopStartupEnv(env: NodeJS.ProcessEnv): void {
+  assertHostedEnvOverridesForbidden(
+    env,
+    [...hostedProxyEnvNames, ...allHostedProviderOverrideEnvNames],
+    "worker startup"
+  );
+}
+
 function resolveRequestUrl(input: URL | RequestInfo): URL {
   if (input instanceof URL) {
     return input;
@@ -156,6 +158,22 @@ function resolveRequestUrl(input: URL | RequestInfo): URL {
 
 function hasNonEmptyEnvValue(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function assertHostedEnvOverridesForbidden(
+  env: NodeJS.ProcessEnv,
+  forbiddenOverrideNames: readonly string[],
+  context: string
+): void {
+  const offendingNames = forbiddenOverrideNames.filter((name) => hasNonEmptyEnvValue(env[name]));
+
+  if (offendingNames.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Hosted network policy blocked ${context}: forbidden env override(s) ${offendingNames.join(", ")}.`
+  );
 }
 
 function isIpLiteral(hostname: string): boolean {

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -12,6 +12,7 @@ import {
   trustedLocalCodexContainerAuthJsonPath,
   trustedLocalCodexContainerHome
 } from "./trusted-local-auth-contract.js";
+import { assertHostedClaimLoopStartupEnv } from "./hosted-network-policy.js";
 
 function normalizeOptionalEnvValue(value: unknown) {
   if (typeof value !== "string") {
@@ -28,17 +29,28 @@ const trimmedOptionalStringSchema = z.preprocess(
 );
 
 const workerRawRuntimeEnvSchema = z.object({
+  ALL_PROXY: trimmedOptionalStringSchema,
   API_BASE_URL: trimmedOptionalStringSchema,
   CF_INTERNAL_API_SERVICE_TOKEN_ID: trimmedOptionalStringSchema,
   CF_INTERNAL_API_SERVICE_TOKEN_SECRET: trimmedOptionalStringSchema,
   CODEX_API_KEY: trimmedOptionalStringSchema,
   CODEX_HOME: trimmedOptionalStringSchema,
   HOME: trimmedOptionalStringSchema,
+  HTTPS_PROXY: trimmedOptionalStringSchema,
+  HTTP_PROXY: trimmedOptionalStringSchema,
+  NO_PROXY: trimmedOptionalStringSchema,
+  OPENAI_API_BASE: trimmedOptionalStringSchema,
+  OPENAI_API_BASE_URL: trimmedOptionalStringSchema,
+  OPENAI_BASE_URL: trimmedOptionalStringSchema,
   [trustedLocalAuthMountMarkerEnvName]: trimmedOptionalStringSchema,
   R2_ACCESS_KEY_ID: trimmedOptionalStringSchema,
   R2_SECRET_ACCESS_KEY: trimmedOptionalStringSchema,
   USERPROFILE: trimmedOptionalStringSchema,
-  WORKER_BOOTSTRAP_TOKEN: trimmedOptionalStringSchema
+  WORKER_BOOTSTRAP_TOKEN: trimmedOptionalStringSchema,
+  all_proxy: trimmedOptionalStringSchema,
+  http_proxy: trimmedOptionalStringSchema,
+  https_proxy: trimmedOptionalStringSchema,
+  no_proxy: trimmedOptionalStringSchema
 });
 
 export type WorkerRuntimeMode =
@@ -322,6 +334,13 @@ export async function parseWorkerRuntimeEnv(
           ? [["CODEX_API_KEY", parsed.data.CODEX_API_KEY] as const]
           : [])
       ]);
+      try {
+        assertHostedClaimLoopStartupEnv(parsed.data);
+      } catch (error) {
+        throw new Error(
+          `Invalid worker runtime environment: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
 
       return {
         apiBaseUrl: resolveRequiredField("API_BASE_URL", parsed.data.API_BASE_URL),

--- a/apps/worker/test/hosted-network-policy.test.ts
+++ b/apps/worker/test/hosted-network-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  assertHostedClaimLoopStartupEnv,
   buildHostedLeanToolCommandEnv,
   buildHostedProviderCommandEnv,
   createHostedControlPlaneFetch,
@@ -61,6 +62,19 @@ test("buildHostedProviderCommandEnv rejects proxy and provider-base overrides", 
         },
         "openai"
       ),
+    /forbidden env override\(s\) HTTPS_PROXY, OPENAI_BASE_URL/
+  );
+});
+
+test("assertHostedClaimLoopStartupEnv rejects proxy and provider-base overrides before startup", () => {
+  assert.throws(
+    () =>
+      assertHostedClaimLoopStartupEnv({
+        CODEX_API_KEY: "worker-api-key",
+        HTTPS_PROXY: "https://proxy.example.test",
+        OPENAI_BASE_URL: "https://evil.example.test",
+        WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+      }),
     /forbidden env override\(s\) HTTPS_PROXY, OPENAI_BASE_URL/
   );
 });

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -165,6 +165,45 @@ test("parseWorkerRuntimeEnv rejects trusted-local mount markers for hosted claim
   );
 });
 
+test("parseWorkerRuntimeEnv rejects canonical trusted-local CODEX_HOME for hosted claim loops", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "machine_api_key",
+          commandFamily: "worker_claim_loop"
+        },
+        {
+          API_BASE_URL: "https://api.paretoproof.com",
+          CODEX_API_KEY: "worker-api-key",
+          CODEX_HOME: "/run/paretoproof/codex-home",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        }
+      ),
+    /trusted-local auth mounts are not allowed for worker_claim_loop/
+  );
+});
+
+test("parseWorkerRuntimeEnv rejects hosted proxy and provider-base override env for claim loops", async () => {
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "machine_api_key",
+          commandFamily: "worker_claim_loop"
+        },
+        {
+          API_BASE_URL: "https://api.paretoproof.com",
+          CODEX_API_KEY: "worker-api-key",
+          HTTPS_PROXY: "https://proxy.example.test",
+          OPENAI_BASE_URL: "https://evil.example.test",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        }
+      ),
+    /Invalid worker runtime environment: Hosted network policy blocked worker startup: forbidden env override\(s\) HTTPS_PROXY, OPENAI_BASE_URL\./
+  );
+});
+
 test("parseWorkerRuntimeEnv requires API base URL for offline ingest", async () => {
   await assert.rejects(
     () =>

--- a/apps/worker/test/worker-cli-contract.test.ts
+++ b/apps/worker/test/worker-cli-contract.test.ts
@@ -115,6 +115,53 @@ test("worker entrypoint exits 2 when hosted claim-loop env includes trusted-loca
   assert.equal(result.stdout, "");
 });
 
+test("worker entrypoint exits 2 when hosted claim-loop env includes a provider-base override", () => {
+  const result = spawnWorkerCli(
+    [
+      "run-worker-claim-loop",
+      "--worker-id",
+      "worker-contract-test",
+      "--worker-pool",
+      "modal-dev",
+      "--worker-version",
+      "worker-smoke-1",
+      "--workspace-root",
+      path.join(os.tmpdir(), "worker-workspace"),
+      "--output-root",
+      path.join(os.tmpdir(), "worker-output"),
+      "--once"
+    ],
+    {
+      cwd: workerRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ALL_PROXY: "",
+        API_BASE_URL: "https://api.paretoproof.com",
+        CODEX_API_KEY: "worker-api-key",
+        HTTP_PROXY: "",
+        HTTPS_PROXY: "",
+        NO_PROXY: "",
+        OPENAI_API_BASE: "",
+        OPENAI_API_BASE_URL: "",
+        OPENAI_BASE_URL: "https://evil.example.test",
+        WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+        all_proxy: "",
+        http_proxy: "",
+        https_proxy: "",
+        no_proxy: ""
+      }
+    }
+  );
+
+  assert.equal(readSpawnStatus(result), 2);
+  assert.match(
+    result.stderr,
+    /^Validation error: Invalid worker runtime environment: Hosted network policy blocked worker startup: forbidden env override\(s\) OPENAI_BASE_URL\.\r?\n$/u
+  );
+  assert.equal(result.stdout, "");
+});
+
 test("worker entrypoint exits 2 for unsupported hosted auth-mode input", () => {
   const result = spawnWorkerCli(
     [

--- a/docs/hosted-worker-provider-capability-baseline.md
+++ b/docs/hosted-worker-provider-capability-baseline.md
@@ -205,7 +205,7 @@ Hosted worker startup should validate the provider posture before claiming work.
 For the current supported hosted path, that means:
 
 - `CODEX_API_KEY` is required
-- trusted-local mount markers must be absent
+- trusted-local mount markers must be absent, and hosted modes must not point `CODEX_HOME` at `/run/paretoproof/codex-home`
 - the worker should not advertise unsupported hosted auth modes
 - the worker should not continue with a provider-family configuration it cannot execute
 

--- a/infra/scripts/check-trusted-local-boundaries.mjs
+++ b/infra/scripts/check-trusted-local-boundaries.mjs
@@ -15,12 +15,12 @@ const requiredWorkerReadmeSnippets = [
   "mounts only that file read-only at `/run/paretoproof/codex-home/auth.json`",
   "PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json",
   "do not copy `.codex/auth.json` into this repository, worker fixtures, or Docker build contexts; trusted-local auth stays host-local and enters the devbox only through the read-only file mount above",
-  "hosted and packaged modes reject the trusted-local mount marker"
+  "hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home` `CODEX_HOME` contract"
 ];
 const requiredChecklistSnippets = [
   "do not move trusted-local auth into `apps/worker/.env`",
   "this wrapper mounts the auth file into the container read-only",
-  "hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT`"
+  "hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT` or point `CODEX_HOME` at `/run/paretoproof/codex-home`"
 ];
 const forbiddenDockerfileSnippets = [
   "COPY . .",

--- a/infra/scripts/startup-validation-smoke.ts
+++ b/infra/scripts/startup-validation-smoke.ts
@@ -191,6 +191,42 @@ if (skipDockerStartupSmoke) {
     ],
     /Validation error: Invalid worker runtime environment: WORKER_BOOTSTRAP_TOKEN: is required/
   );
+
+  expectCommandFailure(
+    "local Docker worker startup rejects a hosted provider-base override env",
+    [
+      "run",
+      "--rm",
+      "--pull",
+      "never",
+      "--env",
+      "API_BASE_URL=https://api.paretoproof.com",
+      "--env",
+      "WORKER_BOOTSTRAP_TOKEN=worker-bootstrap-token",
+      "--env",
+      "CODEX_API_KEY=worker-api-key",
+      "--env",
+      "OPENAI_BASE_URL=https://evil.example.test",
+      "--env",
+      "PARETOPROOF_STARTUP_VALIDATION_ONLY=1",
+      startupSmokeExecutionImage,
+      "node",
+      "apps/worker/dist/index.js",
+      "run-worker-claim-loop",
+      "--worker-id",
+      "startup-smoke-worker",
+      "--worker-pool",
+      "startup-smoke",
+      "--worker-version",
+      "startup-smoke-v1",
+      "--workspace-root",
+      "/tmp/worker-workspace",
+      "--output-root",
+      "/tmp/worker-output",
+      "--once"
+    ],
+    /Validation error: Invalid worker runtime environment: Hosted network policy blocked worker startup: forbidden env override\(s\) OPENAI_BASE_URL\./
+  );
 }
 
 console.log(


### PR DESCRIPTION
## Summary
- reject hosted proxy and provider-base override env during `worker_claim_loop` startup instead of waiting until attempt execution
- add helper/runtime/CLI/startup-smoke regressions for the hosted startup contract and the canonical `CODEX_HOME` rejection path
- align worker/docs boundary text and the trusted-local doc gate with the actual hosted `CODEX_HOME` contract

## Testing
- bun test apps/worker/test/hosted-network-policy.test.ts
- bun test apps/worker/test/runtime-env.test.ts
- bun test apps/worker/test/worker-cli-contract.test.ts
- node infra/scripts/check-trusted-local-boundaries.mjs
- PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER=true bun run test:startup-validation
- bun run build

## Local note
- Full Docker-backed `bun run test:startup-validation` is still blocked on this machine because the local Docker daemon is unavailable.

Closes #1013