### PR TITLE
Fix Problem 9 environment provenance identity

### DIFF
--- a/apps/api/test/problem9-offline-ingest.test.ts
+++ b/apps/api/test/problem9-offline-ingest.test.ts
@@ -42,6 +42,12 @@ async function readTextFile(filePath: string): Promise<string> {
 }
 
 async function buildOfflineIngestRequest(options: {
+  environmentOverride?: Partial<{
+    executionImageDigest: string | null;
+    executionTargetKind: "paretoproof-worker" | "problem9-devbox" | "problem9-execution";
+    localDevboxDigest: string | null;
+    metadata: Record<string, string>;
+  }>;
   failureClassificationOverride?: Partial<{
     evidenceArtifactRefs: string[];
     failureCode: string;
@@ -155,12 +161,13 @@ async function buildOfflineIngestRequest(options: {
     JSON.stringify(
       {
         environmentSchemaVersion: "1",
-        executionImageDigest: null,
-        executionTargetKind: "problem9-devbox",
+        executionImageDigest: options.environmentOverride?.executionImageDigest ?? null,
+        executionTargetKind:
+          options.environmentOverride?.executionTargetKind ?? "problem9-devbox",
         lakeSnapshotId: "lake-snapshot-test",
         leanVersion: "4.22.0",
-        localDevboxDigest: null,
-        metadata: {
+        localDevboxDigest: options.environmentOverride?.localDevboxDigest ?? null,
+        metadata: options.environmentOverride?.metadata ?? {
           source: "api-test"
         },
         modelSnapshotId: `model-snapshot-${idSuffix}`,
@@ -435,6 +442,97 @@ test("buildProblem9OfflineIngestPlan accepts optional usage summary artifacts", 
   assert.equal(usageArtifact.requiredForIngest, false);
   assert.equal(usageArtifact.sha256, sha256Text(usageText));
   assert.equal(usageArtifact.storageProvider, "cloudflare_r2");
+});
+
+test("buildProblem9OfflineIngestPlan accepts hosted wrapper environment identity", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    environmentOverride: {
+      executionImageDigest: "7".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null,
+      metadata: {
+        source: "api-test"
+      }
+    },
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  const plan = buildProblem9OfflineIngestPlan(request);
+  const environmentArtifact = plan.artifacts.find(
+    (artifact) => artifact.relativePath === "environment/environment.json"
+  );
+  const manifestEnvironmentArtifact = request.bundle.artifactManifest.artifacts.find(
+    (artifact) => artifact.relativePath === "environment/environment.json"
+  );
+
+  assert.equal(request.bundle.environment.executionTargetKind, "paretoproof-worker");
+  assert.equal(plan.attempt.environmentDigest, request.bundle.runBundle.environmentDigest);
+  assert.equal(plan.run.environmentDigest, request.bundle.runBundle.environmentDigest);
+  assert.ok(environmentArtifact);
+  assert.ok(manifestEnvironmentArtifact);
+  assert.equal(environmentArtifact.sha256, manifestEnvironmentArtifact.sha256);
+});
+
+test("buildProblem9OfflineIngestPlan rejects hosted wrapper identity without an execution image digest", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    environmentOverride: {
+      executionImageDigest: "7".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null
+    },
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  request.bundle.environment.executionImageDigest = null;
+
+  assert.throws(
+    () => buildProblem9OfflineIngestPlan(request),
+    (error: unknown) =>
+      error instanceof Problem9OfflineIngestValidationError &&
+      error.code === "invalid_problem9_offline_ingest_payload" &&
+      error.issues.some(
+        (issue) =>
+          issue.path === "bundle.environment.executionImageDigest" &&
+          /required when executionTargetKind is paretoproof-worker/u.test(issue.message)
+      )
+  );
+});
+
+test("buildProblem9OfflineIngestPlan rejects hosted wrapper identity with a devbox digest", async (t) => {
+  const { request, tempRoot } = await buildOfflineIngestRequest({
+    environmentOverride: {
+      executionImageDigest: "7".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null
+    },
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  request.bundle.environment.localDevboxDigest = "8".repeat(64);
+
+  assert.throws(
+    () => buildProblem9OfflineIngestPlan(request),
+    (error: unknown) =>
+      error instanceof Problem9OfflineIngestValidationError &&
+      error.code === "invalid_problem9_offline_ingest_payload" &&
+      error.issues.some(
+        (issue) =>
+          issue.path === "bundle.environment.localDevboxDigest" &&
+          /must be null when executionTargetKind is paretoproof-worker/u.test(issue.message)
+      )
+  );
 });
 
 test("buildProblem9OfflineIngestPlan preserves failure metadata for canonical failing bundles", async (t) => {

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -10,11 +10,13 @@ API_BASE_URL=http://127.0.0.1:3000
 # portal-audience Cf-Access-Jwt-Assertion to the CLI at invocation time instead of storing
 # that short-lived admin credential in this file.
 # WORKER_BOOTSTRAP_TOKEN=replace-with-the-worker-bootstrap-token
+# PARETOPROOF_WORKER_IMAGE_DIGEST=replace-with-the-published-paretoproof-worker-sha256
 
 # Mode-specific hosted provider auth. Trusted-local Codex auth does not belong in this file.
 # CODEX_API_KEY=replace-with-a-machine-api-key-for-hosted-worker-modes
 # Hosted claim-loop modes also reject proxy and provider base-URL override env such as
 # HTTPS_PROXY, HTTP_PROXY, ALL_PROXY, NO_PROXY, OPENAI_BASE_URL, OPENAI_API_BASE, and OPENAI_API_BASE_URL.
+# PARETOPROOF_DEVBOX_IMAGE_DIGEST=optional-local-devbox-sha256
 
 # Offline ingest uses a short-lived admin Access assertion supplied explicitly at command runtime.
 # Do not store that assertion in this file.

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -10,13 +10,13 @@ API_BASE_URL=http://127.0.0.1:3000
 # portal-audience Cf-Access-Jwt-Assertion to the CLI at invocation time instead of storing
 # that short-lived admin credential in this file.
 # WORKER_BOOTSTRAP_TOKEN=replace-with-the-worker-bootstrap-token
-# PARETOPROOF_WORKER_IMAGE_DIGEST=replace-with-the-published-paretoproof-worker-sha256
+# PARETOPROOF_WORKER_IMAGE_DIGEST=replace-with-the-published-paretoproof-worker-digest
 
 # Mode-specific hosted provider auth. Trusted-local Codex auth does not belong in this file.
 # CODEX_API_KEY=replace-with-a-machine-api-key-for-hosted-worker-modes
 # Hosted claim-loop modes also reject proxy and provider base-URL override env such as
 # HTTPS_PROXY, HTTP_PROXY, ALL_PROXY, NO_PROXY, OPENAI_BASE_URL, OPENAI_API_BASE, and OPENAI_API_BASE_URL.
-# PARETOPROOF_DEVBOX_IMAGE_DIGEST=optional-local-devbox-sha256
+# PARETOPROOF_DEVBOX_IMAGE_DIGEST=optional-local-devbox-digest
 
 # Offline ingest uses a short-lived admin Access assertion supplied explicitly at command runtime.
 # Do not store that assertion in this file.

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -102,6 +102,7 @@ Local attempt execution:
 - the command copies the immutable benchmark package into a clean writable workspace, writes the candidate as `FirstProof/Problem9/Candidate.lean`, runs the authoritative Lean compile gate, runs theorem and axiom verification, and finalizes through the existing run-bundle materializer instead of inventing a second output shape
 - `trusted_local_user` runs fail fast if the resolved `CODEX_HOME/auth.json` is missing or unreadable or if `codex login status` fails; the command does not silently downgrade to machine auth
 - `machine_api_key` runs require `CODEX_API_KEY`
+- set `PARETOPROOF_DEVBOX_IMAGE_DIGEST` when you want locally emitted Problem 9 bundles to carry the exact devbox image digest instead of a null local-devbox provenance field
 - `local_stub` is the deterministic offline verification path for local dry runs and fixture generation
 - use `bun --cwd apps/worker test:attempt-smoke` or the root alias `bun run test:worker:attempt-smoke` for the deterministic local-stub worker smoke gate; it proves one exact-canonical pass path and one compile-failure path without any interactive auth or paid provider traffic
 - pull-request CI now runs `test:worker:verifier-smoke` after `build:shared` and `node infra/scripts/run-problem9-attempt-smoke.mjs --image paretoproof-problem9-devbox:pr-smoke` against the already-built devbox image; those two named CI steps are the authoritative pre-merge evidence for deterministic Problem 9 verifier and worker health
@@ -132,7 +133,10 @@ Hosted claim loop:
   - `API_BASE_URL`
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY`
+- hosted runtime provenance also requires:
+  - `PARETOPROOF_WORKER_IMAGE_DIGEST`
 - hosted claim-loop execution fails closed if proxy env or provider base-URL override env is present, and modal workers reject raw-IP or loopback control-plane origins instead of treating them as normal hosted targets
+- hosted bundles now emit `executionTargetKind: "paretoproof-worker"` and the matching wrapper digest from `PARETOPROOF_WORKER_IMAGE_DIGEST` instead of falling back to the local-devbox placeholder identity
 - hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home` `CODEX_HOME` contract instead of silently attempting to reuse contributor auth material
 - the hosted loop only accepts `single_run` claims with machine auth, materializes the canonical benchmark and prompt packages from repo-owned sources, reuses the same `runProblem9Attempt` inner runner as local single-run execution, and submits heartbeats, execution events, artifact manifests, and terminal success or failure objects through the internal API
 - if a heartbeat returns `cancel_requested` or `expired`, the loop exits that claim without sending a stale terminal finalize

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -102,7 +102,8 @@ Local attempt execution:
 - the command copies the immutable benchmark package into a clean writable workspace, writes the candidate as `FirstProof/Problem9/Candidate.lean`, runs the authoritative Lean compile gate, runs theorem and axiom verification, and finalizes through the existing run-bundle materializer instead of inventing a second output shape
 - `trusted_local_user` runs fail fast if the resolved `CODEX_HOME/auth.json` is missing or unreadable or if `codex login status` fails; the command does not silently downgrade to machine auth
 - `machine_api_key` runs require `CODEX_API_KEY`
-- set `PARETOPROOF_DEVBOX_IMAGE_DIGEST` when you want locally emitted Problem 9 bundles to carry the exact devbox image digest instead of a null local-devbox provenance field
+- direct host-side `run-problem9-attempt` runs now emit `executionTargetKind: "problem9-execution"` by default so the bundle does not pretend it ran inside the contributor devbox
+- set `PARETOPROOF_DEVBOX_IMAGE_DIGEST` only when the local attempt is actually running inside the canonical Problem 9 devbox and you want the emitted bundle to carry that exact devbox digest as `executionTargetKind: "problem9-devbox"`
 - `local_stub` is the deterministic offline verification path for local dry runs and fixture generation
 - use `bun --cwd apps/worker test:attempt-smoke` or the root alias `bun run test:worker:attempt-smoke` for the deterministic local-stub worker smoke gate; it proves one exact-canonical pass path and one compile-failure path without any interactive auth or paid provider traffic
 - pull-request CI now runs `test:worker:verifier-smoke` after `build:shared` and `node infra/scripts/run-problem9-attempt-smoke.mjs --image paretoproof-problem9-devbox:pr-smoke` against the already-built devbox image; those two named CI steps are the authoritative pre-merge evidence for deterministic Problem 9 verifier and worker health
@@ -135,6 +136,7 @@ Hosted claim loop:
   - `CODEX_API_KEY`
 - hosted runtime provenance also requires:
   - `PARETOPROOF_WORKER_IMAGE_DIGEST`
+- `PARETOPROOF_WORKER_IMAGE_DIGEST` and `PARETOPROOF_DEVBOX_IMAGE_DIGEST` accept either bare `64`-hex digests or the published `sha256:<hex>` form and normalize them into the stored bundle manifests
 - hosted claim-loop execution fails closed if proxy env or provider base-URL override env is present, and modal workers reject raw-IP or loopback control-plane origins instead of treating them as normal hosted targets
 - hosted bundles now emit `executionTargetKind: "paretoproof-worker"` and the matching wrapper digest from `PARETOPROOF_WORKER_IMAGE_DIGEST` instead of falling back to the local-devbox placeholder identity
 - hosted and packaged modes reject the trusted-local mount marker and the canonical `/run/paretoproof/codex-home` `CODEX_HOME` contract instead of silently attempting to reuse contributor auth material

--- a/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
+++ b/apps/worker/src/lib/problem9-attempt-devbox-cli.ts
@@ -36,6 +36,7 @@ type DevboxWrapperOptions = {
 type TrustedLocalDevboxDockerArgsOptions = {
   authJsonPath: string;
   benchmarkPackageRoot: string | null;
+  devboxImageDigest?: string;
   image: string;
   modelSnapshotId?: string;
   outputMountRoot: string | null;
@@ -57,7 +58,7 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
   }
 
   const options = parseDevboxWrapperOptions(args);
-  await parseWorkerRuntimeEnv({
+  const runtimeEnv = await parseWorkerRuntimeEnv({
     commandFamily: "trusted_local_devbox"
   });
   const authPreflight = await preflightProblem9AuthMode("trusted_local_user");
@@ -136,6 +137,7 @@ export async function runProblem9AttemptInDevboxCli(args: string[]): Promise<voi
   const dockerArgs = buildTrustedLocalDevboxDockerArgs({
     authJsonPath: authPreflight.authJsonPath,
     benchmarkPackageRoot,
+    devboxImageDigest: runtimeEnv.devboxImageDigest,
     image: options.image,
     modelSnapshotId: options.modelSnapshotId,
     outputMountRoot,
@@ -208,6 +210,13 @@ export function buildTrustedLocalDevboxDockerArgs(
       true
     )
   ];
+
+  if (options.devboxImageDigest) {
+    dockerArgs.push(
+      "--env",
+      `PARETOPROOF_DEVBOX_IMAGE_DIGEST=${options.devboxImageDigest}`
+    );
+  }
 
   if (options.benchmarkPackageRoot) {
     dockerArgs.push(

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -25,6 +25,16 @@ import { materializeProblem9RunBundle } from "./problem9-run-bundle.js";
 import { parseWorkerRuntimeEnv } from "./runtime.js";
 
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/i);
+const recordValueSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(recordValueSchema),
+    z.record(z.string(), recordValueSchema)
+  ])
+);
 
 const providerFamilySchema = z.enum(problem9ProviderFamilies);
 
@@ -116,9 +126,45 @@ const runEnvelopeSchema = z.object({
   toolProfile: toolProfileSchema
 });
 
+const problem9AttemptEnvironmentProvenanceSchema = z
+  .object({
+    executionImageDigest: sha256Schema.nullable().default(null),
+    executionTargetKind: z.enum([
+      "paretoproof-worker",
+      "problem9-devbox",
+      "problem9-execution"
+    ]),
+    localDevboxDigest: sha256Schema.nullable().default(null),
+    metadata: z.record(z.string(), recordValueSchema).default({})
+  })
+  .superRefine((value, context) => {
+    if (value.executionTargetKind !== "paretoproof-worker") {
+      return;
+    }
+
+    if (value.executionImageDigest === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "executionImageDigest is required when executionTargetKind is paretoproof-worker.",
+        path: ["executionImageDigest"]
+      });
+    }
+
+    if (value.localDevboxDigest !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "localDevboxDigest must be null when executionTargetKind is paretoproof-worker.",
+        path: ["localDevboxDigest"]
+      });
+    }
+  });
+
 const problem9AttemptOptionsSchema = z.object({
   authMode: authModeSchema.optional(),
   benchmarkPackageRoot: z.string().min(1),
+  environmentProvenance: problem9AttemptEnvironmentProvenanceSchema.optional(),
   modelSnapshotId: z.string().min(1).optional(),
   networkPolicyMode: z.enum(["default", "hosted"]).default("default"),
   outputRoot: z.string().min(1),
@@ -133,6 +179,9 @@ type Problem9AttemptOptions = z.input<typeof problem9AttemptOptionsSchema>;
 type BenchmarkPackageManifest = z.infer<typeof benchmarkPackageManifestSchema>;
 type PromptPackageManifest = z.infer<typeof promptPackageManifestSchema>;
 type RunEnvelope = z.infer<typeof runEnvelopeSchema>;
+type Problem9EnvironmentProvenance = NonNullable<
+  z.infer<typeof problem9AttemptOptionsSchema>["environmentProvenance"]
+>;
 
 type CompileResult = {
   diagnostics: Record<string, unknown>;
@@ -257,6 +306,34 @@ export type Problem9AttemptResult = {
   verdictDigest: string;
 };
 
+export function resolveProblem9AttemptEnvironmentProvenance(options: {
+  devboxImageDigest?: string;
+  hostedWorkerImageDigest?: string;
+  networkPolicyMode: "default" | "hosted";
+}): Problem9EnvironmentProvenance {
+  if (options.networkPolicyMode === "hosted") {
+    if (!options.hostedWorkerImageDigest) {
+      throw new Error(
+        "Hosted Problem 9 attempts require a paretoproof-worker image digest for environment provenance."
+      );
+    }
+
+    return {
+      executionImageDigest: options.hostedWorkerImageDigest,
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null,
+      metadata: {}
+    };
+  }
+
+  return {
+    executionImageDigest: null,
+    executionTargetKind: "problem9-devbox",
+    localDevboxDigest: options.devboxImageDigest ?? null,
+    metadata: {}
+  };
+}
+
 export async function runProblem9Attempt(
   rawOptions: Problem9AttemptOptions
 ): Promise<Problem9AttemptResult> {
@@ -289,11 +366,18 @@ export async function runProblem9Attempt(
 
   const effectiveProviderFamily = options.providerFamily ?? promptManifest.providerFamily;
   const effectiveAuthMode = (options.authMode ?? promptManifest.authMode) as Problem9AuthMode;
-  await parseWorkerRuntimeEnv({
+  const runtimeEnv = await parseWorkerRuntimeEnv({
     authMode: effectiveAuthMode,
     commandFamily: "problem9_attempt"
   });
   const authPreflight = await preflightProblem9AuthMode(effectiveAuthMode);
+  const environmentProvenance =
+    options.environmentProvenance ??
+    resolveProblem9AttemptEnvironmentProvenance({
+      devboxImageDigest: runtimeEnv.devboxImageDigest,
+      hostedWorkerImageDigest: runtimeEnv.hostedWorkerImageDigest,
+      networkPolicyMode: options.networkPolicyMode
+    });
 
   await rm(workspaceRoot, { force: true, recursive: true });
   await mkdir(workspaceRoot, { recursive: true });
@@ -469,6 +553,7 @@ export async function runProblem9Attempt(
     await buildEnvironmentInput({
       benchmarkManifest,
       compileRoot,
+      environmentProvenance,
       executionEnv: leanToolEnv,
       modelSnapshotId: resolveProblem9ModelSnapshotId({
         authMode: effectiveAuthMode,
@@ -1055,6 +1140,7 @@ function buildVerifierFailureSummary(
 async function buildEnvironmentInput(options: {
   benchmarkManifest: BenchmarkPackageManifest;
   compileRoot: string;
+  environmentProvenance: Problem9EnvironmentProvenance;
   executionEnv: NodeJS.ProcessEnv;
   modelSnapshotId: string;
 }): Promise<Record<string, unknown>> {
@@ -1073,12 +1159,12 @@ async function buildEnvironmentInput(options: {
 
   return {
     environmentSchemaVersion: "1",
-    executionImageDigest: null,
-    executionTargetKind: "problem9-devbox",
+    executionImageDigest: options.environmentProvenance.executionImageDigest,
+    executionTargetKind: options.environmentProvenance.executionTargetKind,
     lakeSnapshotId: options.benchmarkManifest.hashes["lake-manifest.json"] ?? "unknown",
     leanVersion,
-    localDevboxDigest: null,
-    metadata: {},
+    localDevboxDigest: options.environmentProvenance.localDevboxDigest,
+    metadata: options.environmentProvenance.metadata,
     modelSnapshotId: options.modelSnapshotId,
     os: {
       arch: os.arch(),

--- a/apps/worker/src/lib/problem9-attempt.ts
+++ b/apps/worker/src/lib/problem9-attempt.ts
@@ -310,6 +310,7 @@ export function resolveProblem9AttemptEnvironmentProvenance(options: {
   devboxImageDigest?: string;
   hostedWorkerImageDigest?: string;
   networkPolicyMode: "default" | "hosted";
+  trustedLocalContainerMount?: boolean;
 }): Problem9EnvironmentProvenance {
   if (options.networkPolicyMode === "hosted") {
     if (!options.hostedWorkerImageDigest) {
@@ -326,10 +327,19 @@ export function resolveProblem9AttemptEnvironmentProvenance(options: {
     };
   }
 
+  if (options.devboxImageDigest || options.trustedLocalContainerMount) {
+    return {
+      executionImageDigest: null,
+      executionTargetKind: "problem9-devbox",
+      localDevboxDigest: options.devboxImageDigest ?? null,
+      metadata: {}
+    };
+  }
+
   return {
     executionImageDigest: null,
-    executionTargetKind: "problem9-devbox",
-    localDevboxDigest: options.devboxImageDigest ?? null,
+    executionTargetKind: "problem9-execution",
+    localDevboxDigest: null,
     metadata: {}
   };
 }
@@ -376,7 +386,8 @@ export async function runProblem9Attempt(
     resolveProblem9AttemptEnvironmentProvenance({
       devboxImageDigest: runtimeEnv.devboxImageDigest,
       hostedWorkerImageDigest: runtimeEnv.hostedWorkerImageDigest,
-      networkPolicyMode: options.networkPolicyMode
+      networkPolicyMode: options.networkPolicyMode,
+      trustedLocalContainerMount: runtimeEnv.trustedLocalContainerMount
     });
 
   await rm(workspaceRoot, { force: true, recursive: true });

--- a/apps/worker/src/lib/problem9-run-bundle.ts
+++ b/apps/worker/src/lib/problem9-run-bundle.ts
@@ -203,27 +203,55 @@ const failureClassificationSchema = z.object({
   userVisibility: z.enum(["user_visible", "user_visible_sanitized", "internal_only"])
 });
 
-const environmentInputSchema = z.object({
-  environmentSchemaVersion: z.string().min(1).default("1"),
-  executionImageDigest: sha256Schema.nullable().default(null),
-  executionTargetKind: z.enum(["problem9-devbox", "problem9-execution"]),
-  lakeSnapshotId: z.string().min(1),
-  leanVersion: z.string().min(1),
-  localDevboxDigest: sha256Schema.nullable().default(null),
-  metadata: z.record(z.string(), recordValueSchema).default({}),
-  modelSnapshotId: z.string().min(1),
-  os: z.object({
-    arch: z.string().min(1),
-    platform: z.string().min(1),
-    release: z.string().min(1)
-  }),
-  runtime: z.object({
-    bunVersion: z.string().min(1).nullable().default(null),
-    nodeVersion: z.string().min(1),
-    tsxVersion: z.string().min(1).nullable().default(null)
-  }),
-  verifierVersion: z.string().min(1)
-});
+const environmentInputSchema = z
+  .object({
+    environmentSchemaVersion: z.string().min(1).default("1"),
+    executionImageDigest: sha256Schema.nullable().default(null),
+    executionTargetKind: z.enum([
+      "paretoproof-worker",
+      "problem9-devbox",
+      "problem9-execution"
+    ]),
+    lakeSnapshotId: z.string().min(1),
+    leanVersion: z.string().min(1),
+    localDevboxDigest: sha256Schema.nullable().default(null),
+    metadata: z.record(z.string(), recordValueSchema).default({}),
+    modelSnapshotId: z.string().min(1),
+    os: z.object({
+      arch: z.string().min(1),
+      platform: z.string().min(1),
+      release: z.string().min(1)
+    }),
+    runtime: z.object({
+      bunVersion: z.string().min(1).nullable().default(null),
+      nodeVersion: z.string().min(1),
+      tsxVersion: z.string().min(1).nullable().default(null)
+    }),
+    verifierVersion: z.string().min(1)
+  })
+  .superRefine((value, context) => {
+    if (value.executionTargetKind !== "paretoproof-worker") {
+      return;
+    }
+
+    if (value.executionImageDigest === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "executionImageDigest is required when executionTargetKind is paretoproof-worker.",
+        path: ["executionImageDigest"]
+      });
+    }
+
+    if (value.localDevboxDigest !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "localDevboxDigest must be null when executionTargetKind is paretoproof-worker.",
+        path: ["localDevboxDigest"]
+      });
+    }
+  });
 
 const bundleResultSchema = z.enum(["pass", "fail"]);
 const bundleSemanticEqualitySchema = z.enum(["matched", "mismatched", "not_evaluated"]);

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -27,6 +27,7 @@ const trimmedOptionalStringSchema = z.preprocess(
   normalizeOptionalEnvValue,
   z.string().trim().optional()
 );
+const sha256Pattern = /^[a-f0-9]{64}$/i;
 
 const workerRawRuntimeEnvSchema = z.object({
   ALL_PROXY: trimmedOptionalStringSchema,
@@ -42,7 +43,9 @@ const workerRawRuntimeEnvSchema = z.object({
   OPENAI_API_BASE: trimmedOptionalStringSchema,
   OPENAI_API_BASE_URL: trimmedOptionalStringSchema,
   OPENAI_BASE_URL: trimmedOptionalStringSchema,
+  PARETOPROOF_DEVBOX_IMAGE_DIGEST: trimmedOptionalStringSchema,
   [trustedLocalAuthMountMarkerEnvName]: trimmedOptionalStringSchema,
+  PARETOPROOF_WORKER_IMAGE_DIGEST: trimmedOptionalStringSchema,
   R2_ACCESS_KEY_ID: trimmedOptionalStringSchema,
   R2_SECRET_ACCESS_KEY: trimmedOptionalStringSchema,
   USERPROFILE: trimmedOptionalStringSchema,
@@ -75,6 +78,8 @@ export type WorkerRuntimeMode =
 export type WorkerRuntimeEnv = {
   apiBaseUrl?: string;
   codexApiKey?: string;
+  devboxImageDigest?: string;
+  hostedWorkerImageDigest?: string;
   trustedLocalAuthJsonPath?: string;
   trustedLocalCodexHome?: string;
   workerBootstrapToken?: string;
@@ -112,6 +117,45 @@ function resolveRequiredField(
   }
 
   return value;
+}
+
+function resolveOptionalDigest(
+  fieldName: "PARETOPROOF_DEVBOX_IMAGE_DIGEST" | "PARETOPROOF_WORKER_IMAGE_DIGEST",
+  value: string | undefined
+) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (!sha256Pattern.test(value)) {
+    throw new Error(
+      `Invalid worker runtime environment: ${fieldName}: must be a sha256 hex digest`
+    );
+  }
+
+  return value.toLowerCase();
+}
+
+function resolveRequiredDigest(
+  fieldName: "PARETOPROOF_WORKER_IMAGE_DIGEST",
+  value: string | undefined
+) {
+  const digest = resolveOptionalDigest(fieldName, value);
+
+  if (!digest) {
+    throw new Error(`Invalid worker runtime environment: ${fieldName}: is required`);
+  }
+
+  return digest;
+}
+
+function buildOptionalDevboxRuntimeEnv(rawEnv: z.output<typeof workerRawRuntimeEnvSchema>) {
+  const devboxImageDigest = resolveOptionalDigest(
+    "PARETOPROOF_DEVBOX_IMAGE_DIGEST",
+    rawEnv.PARETOPROOF_DEVBOX_IMAGE_DIGEST
+  );
+
+  return devboxImageDigest ? { devboxImageDigest } : {};
 }
 
 function assertRequiredFields(
@@ -314,17 +358,24 @@ export async function parseWorkerRuntimeEnv(
       switch (mode.authMode) {
         case "local_stub":
           rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
-          return {};
+          return buildOptionalDevboxRuntimeEnv(parsed.data);
         case "machine_api_key":
           rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
           return {
-            codexApiKey: resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY)
+            codexApiKey: resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY),
+            ...buildOptionalDevboxRuntimeEnv(parsed.data)
           };
         case "trusted_local_user":
-          return resolveTrustedLocalEnv(parsed.data);
+          return {
+            ...(await resolveTrustedLocalEnv(parsed.data)),
+            ...buildOptionalDevboxRuntimeEnv(parsed.data)
+          };
       }
     case "trusted_local_devbox":
-      return resolveTrustedLocalEnv(parsed.data);
+      return {
+        ...(await resolveTrustedLocalEnv(parsed.data)),
+        ...buildOptionalDevboxRuntimeEnv(parsed.data)
+      };
     case "worker_claim_loop":
       rejectTrustedLocalContainerMount(parsed.data, mode.commandFamily);
       assertRequiredFields([
@@ -348,6 +399,10 @@ export async function parseWorkerRuntimeEnv(
           mode.authMode === "machine_api_key"
             ? resolveRequiredField("CODEX_API_KEY", parsed.data.CODEX_API_KEY)
             : undefined,
+        hostedWorkerImageDigest: resolveRequiredDigest(
+          "PARETOPROOF_WORKER_IMAGE_DIGEST",
+          parsed.data.PARETOPROOF_WORKER_IMAGE_DIGEST
+        ),
         workerBootstrapToken: resolveRequiredField(
           "WORKER_BOOTSTRAP_TOKEN",
           parsed.data.WORKER_BOOTSTRAP_TOKEN

--- a/apps/worker/src/lib/runtime.ts
+++ b/apps/worker/src/lib/runtime.ts
@@ -27,7 +27,8 @@ const trimmedOptionalStringSchema = z.preprocess(
   normalizeOptionalEnvValue,
   z.string().trim().optional()
 );
-const sha256Pattern = /^[a-f0-9]{64}$/i;
+const bareSha256Pattern = /^[a-f0-9]{64}$/i;
+const prefixedSha256Pattern = /^sha256:([a-f0-9]{64})$/i;
 
 const workerRawRuntimeEnvSchema = z.object({
   ALL_PROXY: trimmedOptionalStringSchema,
@@ -80,6 +81,7 @@ export type WorkerRuntimeEnv = {
   codexApiKey?: string;
   devboxImageDigest?: string;
   hostedWorkerImageDigest?: string;
+  trustedLocalContainerMount?: true;
   trustedLocalAuthJsonPath?: string;
   trustedLocalCodexHome?: string;
   workerBootstrapToken?: string;
@@ -127,9 +129,14 @@ function resolveOptionalDigest(
     return undefined;
   }
 
-  if (!sha256Pattern.test(value)) {
+  const prefixedDigestMatch = prefixedSha256Pattern.exec(value);
+  if (prefixedDigestMatch) {
+    return prefixedDigestMatch[1].toLowerCase();
+  }
+
+  if (!bareSha256Pattern.test(value)) {
     throw new Error(
-      `Invalid worker runtime environment: ${fieldName}: must be a sha256 hex digest`
+      `Invalid worker runtime environment: ${fieldName}: must be a sha256 hex digest or sha256:<hex> digest`
     );
   }
 
@@ -333,9 +340,13 @@ async function resolveTrustedLocalEnv(rawEnv: z.output<typeof workerRawRuntimeEn
   );
 
   return {
+    ...(hasTrustedLocalContainerMount(rawEnv) ? { trustedLocalContainerMount: true as const } : {}),
     trustedLocalAuthJsonPath,
     trustedLocalCodexHome
-  } satisfies Pick<WorkerRuntimeEnv, "trustedLocalAuthJsonPath" | "trustedLocalCodexHome">;
+  } satisfies Pick<
+    WorkerRuntimeEnv,
+    "trustedLocalAuthJsonPath" | "trustedLocalCodexHome" | "trustedLocalContainerMount"
+  >;
 }
 
 export async function parseWorkerRuntimeEnv(

--- a/apps/worker/src/lib/worker-claim-loop.ts
+++ b/apps/worker/src/lib/worker-claim-loop.ts
@@ -36,7 +36,10 @@ import {
 } from "@paretoproof/shared";
 import { z } from "zod";
 import type { Problem9AttemptResult } from "./problem9-attempt.js";
-import { runProblem9Attempt } from "./problem9-attempt.js";
+import {
+  resolveProblem9AttemptEnvironmentProvenance,
+  runProblem9Attempt
+} from "./problem9-attempt.js";
 import {
   getDefaultProblem9PromptPackageOptions,
   materializeProblem9PromptPackage
@@ -243,6 +246,7 @@ type PreparedBundleSubmission = {
   artifactManifestDigest: string;
   bundleDigest: string;
   candidateDigest: string;
+  environment: z.output<typeof problem9EnvironmentManifestSchema>;
   environmentDigest: string;
   runBundle: z.output<typeof runBundleFileSchema>;
   verifierVerdict: WorkerVerifierVerdict & { runId: string };
@@ -298,6 +302,10 @@ export async function runWorkerClaimLoop(
     authMode: options.authMode,
     commandFamily: "worker_claim_loop"
   }, dependencies.rawEnv);
+  const hostedAttemptEnvironmentProvenance = resolveProblem9AttemptEnvironmentProvenance({
+    hostedWorkerImageDigest: runtimeEnv.hostedWorkerImageDigest,
+    networkPolicyMode: "hosted"
+  });
   const fetchImpl =
     options.workerRuntime === "modal"
       ? createHostedControlPlaneFetch(
@@ -364,6 +372,7 @@ export async function runWorkerClaimLoop(
       claimResponse.workerJob,
       options,
       runtimeEnv.apiBaseUrl!,
+      hostedAttemptEnvironmentProvenance,
       {
         attemptRunner,
         fetchImpl,
@@ -396,6 +405,9 @@ async function processClaimedJob(
   workerJob: NonNullable<ActiveWorkerJob>,
   options: WorkerClaimLoopResolvedOptions,
   apiBaseUrl: string,
+  hostedAttemptEnvironmentProvenance: ReturnType<
+    typeof resolveProblem9AttemptEnvironmentProvenance
+  >,
   dependencies: WorkerClaimLoopResolvedDependencies
 ): Promise<"completed" | "cancelled" | "lease_lost"> {
   const leaseState: ActiveLeaseState = {
@@ -599,6 +611,7 @@ async function processClaimedJob(
         attemptResult = await dependencies.attemptRunner({
           authMode: workerJob.target.authMode,
           benchmarkPackageRoot: benchmarkResult.outputRoot,
+          environmentProvenance: hostedAttemptEnvironmentProvenance,
           modelSnapshotId: workerJob.target.modelSnapshotId,
           networkPolicyMode: "hosted",
           outputRoot: leaseRoots.attemptOutputRoot,
@@ -754,6 +767,10 @@ async function processClaimedJob(
           stopReason: attemptResult.stopReason,
           toolProfile: workerJob.target.toolProfile
         });
+        assertBundleSubmissionMatchesExpectedEnvironmentProvenance(
+          bundleSubmission.environment,
+          hostedAttemptEnvironmentProvenance
+        );
         assertRequiredArtifactRoles(bundleSubmission.artifactManifest, workerJob.requiredArtifactRoles);
       } catch (error) {
         if (error instanceof Error) {
@@ -1570,6 +1587,7 @@ async function readBundleSubmission(bundleRoot: string): Promise<PreparedBundleS
     artifactManifestDigest,
     bundleDigest,
     candidateDigest,
+    environment,
     environmentDigest,
     runBundle,
     verifierVerdict,
@@ -1647,6 +1665,30 @@ function assertBundleSubmissionMatchesJobTarget(
   if (mismatchedVerdictField) {
     throw new BundleSubmissionIntegrityError(
       `verification/verdict.json ${mismatchedVerdictField[0]} does not match the claimed job target.`
+    );
+  }
+}
+
+function assertBundleSubmissionMatchesExpectedEnvironmentProvenance(
+  environment: z.output<typeof problem9EnvironmentManifestSchema>,
+  expectedEnvironmentProvenance: ReturnType<typeof resolveProblem9AttemptEnvironmentProvenance>
+): void {
+  const environmentChecks: Array<[field: string, actual: string | null, expectedValue: string | null]> = [
+    [
+      "executionImageDigest",
+      environment.executionImageDigest,
+      expectedEnvironmentProvenance.executionImageDigest
+    ],
+    ["executionTargetKind", environment.executionTargetKind, expectedEnvironmentProvenance.executionTargetKind],
+    ["localDevboxDigest", environment.localDevboxDigest, expectedEnvironmentProvenance.localDevboxDigest]
+  ];
+  const mismatchedEnvironmentField = environmentChecks.find(
+    ([field, actual, expectedValue]) => !isBundleFieldMatch(field, actual, expectedValue)
+  );
+
+  if (mismatchedEnvironmentField) {
+    throw new BundleSubmissionIntegrityError(
+      `environment/environment.json ${mismatchedEnvironmentField[0]} does not match the hosted worker runtime provenance.`
     );
   }
 }
@@ -2278,13 +2320,17 @@ function sortJsonValue(value: unknown): unknown {
   return value;
 }
 
-function isBundleFieldMatch(field: string, actual: string | null, expectedValue: string): boolean {
+function isBundleFieldMatch(
+  field: string,
+  actual: string | null,
+  expectedValue: string | null
+): boolean {
   if (actual === null) {
-    return false;
+    return expectedValue === null;
   }
 
   if (field.toLowerCase().endsWith("digest")) {
-    return normalizeDigest(actual) === normalizeDigest(expectedValue);
+    return expectedValue !== null && normalizeDigest(actual) === normalizeDigest(expectedValue);
   }
 
   return actual === expectedValue;

--- a/apps/worker/test/problem9-attempt-devbox-cli.test.ts
+++ b/apps/worker/test/problem9-attempt-devbox-cli.test.ts
@@ -12,9 +12,11 @@ import {
 
 test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Codex home", () => {
   const authJsonPath = "/host/.codex/auth.json";
+  const devboxImageDigest = "a".repeat(64);
   const dockerArgs = buildTrustedLocalDevboxDockerArgs({
     authJsonPath,
     benchmarkPackageRoot: "/host/benchmark",
+    devboxImageDigest,
     image: "paretoproof-problem9-devbox:local",
     outputMountRoot: "/host/outputs",
     outputRoot: "/host/outputs/output-run",
@@ -30,6 +32,7 @@ test("buildTrustedLocalDevboxDockerArgs mounts only auth.json from the host Code
   );
 
   assert.ok(dockerArgs.includes(`CODEX_HOME=${trustedLocalCodexContainerHome}`));
+  assert.ok(dockerArgs.includes(`PARETOPROOF_DEVBOX_IMAGE_DIGEST=${devboxImageDigest}`));
   assert.ok(
     dockerArgs.includes(
       `${trustedLocalAuthMountMarkerEnvName}=${trustedLocalAuthMountMarkerValue}`

--- a/apps/worker/test/problem9-attempt-smoke.test.ts
+++ b/apps/worker/test/problem9-attempt-smoke.test.ts
@@ -44,8 +44,9 @@ test(
       const environment = JSON.parse(
         await readFile(path.join(result.outputRoot, "environment", "environment.json"), "utf8")
       ) as Record<string, unknown>;
-      assert.equal(environment.executionTargetKind, "problem9-devbox");
+      assert.equal(environment.executionTargetKind, "problem9-execution");
       assert.equal(environment.executionImageDigest, null);
+      assert.equal(environment.localDevboxDigest, null);
 
       const verdict = JSON.parse(
         await readFile(path.join(result.outputRoot, "verification", "verdict.json"), "utf8")

--- a/apps/worker/test/problem9-attempt-smoke.test.ts
+++ b/apps/worker/test/problem9-attempt-smoke.test.ts
@@ -41,6 +41,12 @@ test(
       assert.equal(runBundle.status, "success");
       assert.equal(runBundle.stopReason, "verification_passed");
 
+      const environment = JSON.parse(
+        await readFile(path.join(result.outputRoot, "environment", "environment.json"), "utf8")
+      ) as Record<string, unknown>;
+      assert.equal(environment.executionTargetKind, "problem9-devbox");
+      assert.equal(environment.executionImageDigest, null);
+
       const verdict = JSON.parse(
         await readFile(path.join(result.outputRoot, "verification", "verdict.json"), "utf8")
       ) as Record<string, unknown>;

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -169,7 +169,7 @@ test("resolveProblem9AttemptEnvironmentProvenance emits hosted wrapper identity"
   );
 });
 
-test("resolveProblem9AttemptEnvironmentProvenance keeps local attempts on the devbox target", () => {
+test("resolveProblem9AttemptEnvironmentProvenance uses the devbox target when an explicit devbox digest is present", () => {
   assert.deepEqual(
     resolveProblem9AttemptEnvironmentProvenance({
       devboxImageDigest: "b".repeat(64),
@@ -179,6 +179,35 @@ test("resolveProblem9AttemptEnvironmentProvenance keeps local attempts on the de
       executionImageDigest: null,
       executionTargetKind: "problem9-devbox",
       localDevboxDigest: "b".repeat(64),
+      metadata: {}
+    }
+  );
+});
+
+test("resolveProblem9AttemptEnvironmentProvenance uses the devbox target for trusted-local container runs", () => {
+  assert.deepEqual(
+    resolveProblem9AttemptEnvironmentProvenance({
+      networkPolicyMode: "default",
+      trustedLocalContainerMount: true
+    }),
+    {
+      executionImageDigest: null,
+      executionTargetKind: "problem9-devbox",
+      localDevboxDigest: null,
+      metadata: {}
+    }
+  );
+});
+
+test("resolveProblem9AttemptEnvironmentProvenance keeps direct local host runs on the execution target", () => {
+  assert.deepEqual(
+    resolveProblem9AttemptEnvironmentProvenance({
+      networkPolicyMode: "default"
+    }),
+    {
+      executionImageDigest: null,
+      executionTargetKind: "problem9-execution",
+      localDevboxDigest: null,
       metadata: {}
     }
   );
@@ -342,6 +371,13 @@ test(
       ) as Record<string, unknown>;
       assert.equal(runBundle.status, "failure");
       assert.equal(runBundle.stopReason, "compile_failed");
+
+      const environment = JSON.parse(
+        await readFile(path.join(result.outputRoot, "environment", "environment.json"), "utf8")
+      ) as Record<string, unknown>;
+      assert.equal(environment.executionTargetKind, "problem9-execution");
+      assert.equal(environment.executionImageDigest, null);
+      assert.equal(environment.localDevboxDigest, null);
 
       const verdict = JSON.parse(
         await readFile(path.join(result.outputRoot, "verification", "verdict.json"), "utf8")

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -9,6 +9,7 @@ import { problem9AuthModes } from "../src/lib/problem9-auth.ts";
 import {
   buildProblem9LeanToolCommandEnv,
   findForbiddenProblem9CandidateImports,
+  resolveProblem9AttemptEnvironmentProvenance,
   resolveProblem9ModelSnapshotId,
   runProblem9Attempt
 } from "../src/lib/problem9-attempt.ts";
@@ -17,6 +18,12 @@ import {
   getDefaultProblem9PromptPackageOptions,
   materializeProblem9PromptPackage
 } from "../src/lib/problem9-prompt-package.ts";
+
+const bunInvocation = process.versions.bun
+  ? { command: process.execPath, prelude: [] as string[] }
+  : process.platform === "win32"
+    ? { command: process.env.ComSpec ?? "cmd.exe", prelude: ["/d", "/s", "/c", "bun"] }
+    : { command: "bun", prelude: [] as string[] };
 
 test("resolveProblem9ModelSnapshotId uses the selected local stub scenario by default", () => {
   assert.equal(
@@ -147,6 +154,36 @@ test("findForbiddenProblem9CandidateImports catches tab-separated and multiline 
   );
 });
 
+test("resolveProblem9AttemptEnvironmentProvenance emits hosted wrapper identity", () => {
+  assert.deepEqual(
+    resolveProblem9AttemptEnvironmentProvenance({
+      hostedWorkerImageDigest: "a".repeat(64),
+      networkPolicyMode: "hosted"
+    }),
+    {
+      executionImageDigest: "a".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null,
+      metadata: {}
+    }
+  );
+});
+
+test("resolveProblem9AttemptEnvironmentProvenance keeps local attempts on the devbox target", () => {
+  assert.deepEqual(
+    resolveProblem9AttemptEnvironmentProvenance({
+      devboxImageDigest: "b".repeat(64),
+      networkPolicyMode: "default"
+    }),
+    {
+      executionImageDigest: null,
+      executionTargetKind: "problem9-devbox",
+      localDevboxDigest: "b".repeat(64),
+      metadata: {}
+    }
+  );
+});
+
 test("materializeProblem9PromptPackage rejects modelConfigId values outside the supported auth matrix", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-prompt-contract-"));
 
@@ -190,8 +227,9 @@ test("run-problem9-attempt rejects unsupported auth-mode values at the CLI bound
     "../src/index.ts"
   );
   const result = spawnSync(
-    "bun",
+    bunInvocation.command,
     [
+      ...bunInvocation.prelude,
       workerEntryPoint,
       "run-problem9-attempt",
       "--benchmark-package-root",
@@ -226,6 +264,8 @@ test(
   { timeout: 60000 },
   async () => {
     const fixture = await createAttemptFixture();
+    const originalDevboxDigest = process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST;
+    process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST = "d".repeat(64);
 
     try {
       const result = await runProblem9Attempt({
@@ -251,6 +291,13 @@ test(
       assert.equal(runBundle.status, "success");
       assert.equal(runBundle.stopReason, "verification_passed");
 
+      const environment = JSON.parse(
+        await readFile(path.join(result.outputRoot, "environment", "environment.json"), "utf8")
+      ) as Record<string, unknown>;
+      assert.equal(environment.executionTargetKind, "problem9-devbox");
+      assert.equal(environment.executionImageDigest, null);
+      assert.equal(environment.localDevboxDigest, "d".repeat(64));
+
       const verdict = JSON.parse(
         await readFile(path.join(result.outputRoot, "verification", "verdict.json"), "utf8")
       ) as Record<string, unknown>;
@@ -258,6 +305,7 @@ test(
       assert.equal(verdict.semanticEquality, "matched");
       assert.equal(verdict.axiomCheck, "passed");
     } finally {
+      process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST = originalDevboxDigest;
       await rm(fixture.tempRoot, { force: true, recursive: true });
     }
   }
@@ -268,6 +316,8 @@ test(
   { timeout: 60000 },
   async () => {
     const fixture = await createAttemptFixture();
+    const originalDevboxDigest = process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST;
+    delete process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST;
 
     try {
       const result = await runProblem9Attempt({
@@ -306,6 +356,7 @@ test(
       );
       assert.equal((verdict.primaryFailure as Record<string, unknown>).phase, "compile");
     } finally {
+      process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST = originalDevboxDigest;
       await rm(fixture.tempRoot, { force: true, recursive: true });
     }
   }

--- a/apps/worker/test/problem9-attempt.test.ts
+++ b/apps/worker/test/problem9-attempt.test.ts
@@ -334,7 +334,7 @@ test(
       assert.equal(verdict.semanticEquality, "matched");
       assert.equal(verdict.axiomCheck, "passed");
     } finally {
-      process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST = originalDevboxDigest;
+      restoreOptionalEnvVar("PARETOPROOF_DEVBOX_IMAGE_DIGEST", originalDevboxDigest);
       await rm(fixture.tempRoot, { force: true, recursive: true });
     }
   }
@@ -392,7 +392,7 @@ test(
       );
       assert.equal((verdict.primaryFailure as Record<string, unknown>).phase, "compile");
     } finally {
-      process.env.PARETOPROOF_DEVBOX_IMAGE_DIGEST = originalDevboxDigest;
+      restoreOptionalEnvVar("PARETOPROOF_DEVBOX_IMAGE_DIGEST", originalDevboxDigest);
       await rm(fixture.tempRoot, { force: true, recursive: true });
     }
   }
@@ -451,4 +451,13 @@ async function createAttemptFixture(): Promise<{
     promptPackageRoot: promptPackage.outputRoot,
     tempRoot
   };
+}
+
+function restoreOptionalEnvVar(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
 }

--- a/apps/worker/test/problem9-integrity.test.ts
+++ b/apps/worker/test/problem9-integrity.test.ts
@@ -149,6 +149,76 @@ test("Problem 9 run-bundle materialization stays deterministic", async () => {
   }
 });
 
+test("Problem 9 run-bundle materialization rejects hosted worker provenance without a wrapper digest", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-integrity-"));
+
+  try {
+    const fixture = await createIntegrityFixture(tempRoot);
+    const promptPackage = await materializePromptPackage(
+      fixture,
+      path.join(tempRoot, "prompt-source")
+    );
+    const environmentInput = JSON.parse(
+      await readNormalizedText(fixture.bundleInputs.environmentInputPath)
+    ) as Record<string, unknown>;
+
+    await writeJsonFile(fixture.bundleInputs.environmentInputPath, {
+      ...environmentInput,
+      executionImageDigest: null,
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null
+    });
+
+    await assert.rejects(
+      materializeProblem9RunBundle({
+        benchmarkPackageRoot: fixture.benchmarkPackageRoot,
+        ...fixture.bundleInputs,
+        failureClassificationPath: null,
+        outputRoot: path.join(tempRoot, "bundle-invalid-hosted-digest"),
+        promptPackageRoot: promptPackage.outputRoot,
+      }),
+      /executionImageDigest is required when executionTargetKind is paretoproof-worker/u
+    );
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("Problem 9 run-bundle materialization rejects hosted worker provenance with a devbox digest", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-integrity-"));
+
+  try {
+    const fixture = await createIntegrityFixture(tempRoot);
+    const promptPackage = await materializePromptPackage(
+      fixture,
+      path.join(tempRoot, "prompt-source")
+    );
+    const environmentInput = JSON.parse(
+      await readNormalizedText(fixture.bundleInputs.environmentInputPath)
+    ) as Record<string, unknown>;
+
+    await writeJsonFile(fixture.bundleInputs.environmentInputPath, {
+      ...environmentInput,
+      executionImageDigest: "7".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: "8".repeat(64)
+    });
+
+    await assert.rejects(
+      materializeProblem9RunBundle({
+        benchmarkPackageRoot: fixture.benchmarkPackageRoot,
+        ...fixture.bundleInputs,
+        failureClassificationPath: null,
+        outputRoot: path.join(tempRoot, "bundle-invalid-hosted-devbox"),
+        promptPackageRoot: promptPackage.outputRoot,
+      }),
+      /localDevboxDigest must be null when executionTargetKind is paretoproof-worker/u
+    );
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("prompt-package materialization rejects tampered benchmark-package inputs", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "paretoproof-worker-integrity-"));
 

--- a/apps/worker/test/problem9-offline-ingest.test.ts
+++ b/apps/worker/test/problem9-offline-ingest.test.ts
@@ -13,6 +13,12 @@ import { runProblem9OfflineIngestCli } from "../src/lib/problem9-offline-ingest-
 import { runProblem9OfflineIngest } from "../src/lib/problem9-offline-ingest.ts";
 
 async function buildOfflineIngestBundleRoot(options: {
+  environmentOverride?: Partial<{
+    executionImageDigest: string | null;
+    executionTargetKind: "paretoproof-worker" | "problem9-devbox" | "problem9-execution";
+    localDevboxDigest: string | null;
+    metadata: Record<string, string>;
+  }>;
   result: "pass" | "fail";
 }): Promise<{
   bundleRoot: string;
@@ -99,12 +105,13 @@ async function buildOfflineIngestBundleRoot(options: {
     JSON.stringify(
       {
         environmentSchemaVersion: "1",
-        executionImageDigest: null,
-        executionTargetKind: "problem9-devbox",
+        executionImageDigest: options.environmentOverride?.executionImageDigest ?? null,
+        executionTargetKind:
+          options.environmentOverride?.executionTargetKind ?? "problem9-devbox",
         lakeSnapshotId: "lake-snapshot-test",
         leanVersion: "4.22.0",
-        localDevboxDigest: null,
-        metadata: {
+        localDevboxDigest: options.environmentOverride?.localDevboxDigest ?? null,
+        metadata: options.environmentOverride?.metadata ?? {
           source: "worker-test"
         },
         modelSnapshotId: `model-snapshot-${idSuffix}`,
@@ -285,6 +292,79 @@ test("runProblem9OfflineIngest posts canonical bundle requests with Access auth"
     },
     status: "accepted"
   });
+});
+
+test("runProblem9OfflineIngest preserves hosted wrapper environment identity", async (t) => {
+  const { bundleRoot, tempRoot } = await buildOfflineIngestBundleRoot({
+    environmentOverride: {
+      executionImageDigest: "7".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null,
+      metadata: {
+        source: "worker-test"
+      }
+    },
+    result: "pass"
+  });
+
+  t.after(async () => {
+    await rm(tempRoot, { force: true, recursive: true });
+  });
+
+  let receivedRequestBody: unknown = null;
+
+  await runProblem9OfflineIngest(
+    {
+      accessJwt: "test-access-jwt",
+      bundleRoot
+    },
+    {
+      fetchImpl: async (_input, init) => {
+        receivedRequestBody = init?.body ? JSON.parse(String(init.body)) : null;
+
+        return new Response(
+          JSON.stringify({
+            artifactCount: 24,
+            attempt: {
+              id: "attempt-row-1",
+              sourceAttemptId: "attempt-pass-1",
+              state: "succeeded",
+              verdictClass: "pass"
+            },
+            job: {
+              id: "job-row-1",
+              sourceJobId: "job-pass-1",
+              state: "completed"
+            },
+            run: {
+              id: "run-row-1",
+              sourceRunId: "run-pass-1",
+              state: "succeeded"
+            }
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 201
+          }
+        );
+      },
+      runtimeEnv: {
+        API_BASE_URL: "https://api.paretoproof.com"
+      }
+    }
+  );
+
+  const parsedRequest = receivedRequestBody as {
+    bundle: {
+      environment: Record<string, unknown>;
+    };
+  };
+
+  assert.equal(parsedRequest.bundle.environment.executionTargetKind, "paretoproof-worker");
+  assert.equal(parsedRequest.bundle.environment.executionImageDigest, "7".repeat(64));
+  assert.equal(parsedRequest.bundle.environment.localDevboxDigest, null);
 });
 
 test("runProblem9OfflineIngest rejects failing bundles that omit failure-classification artifacts", async (t) => {

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -34,6 +34,22 @@ test("parseWorkerRuntimeEnv keeps local stub attempts env-free", async () => {
   assert.deepEqual(runtimeEnv, {});
 });
 
+test("parseWorkerRuntimeEnv preserves an optional devbox digest for local attempts", async () => {
+  const runtimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "local_stub",
+      commandFamily: "problem9_attempt"
+    },
+    {
+      PARETOPROOF_DEVBOX_IMAGE_DIGEST: "a".repeat(64)
+    }
+  );
+
+  assert.deepEqual(runtimeEnv, {
+    devboxImageDigest: "a".repeat(64)
+  });
+});
+
 test("parseWorkerRuntimeEnv requires CODEX_API_KEY for machine_api_key attempts", async () => {
   await assert.rejects(
     () =>
@@ -127,6 +143,22 @@ test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop mac
     /WORKER_BOOTSTRAP_TOKEN: is required/
   );
 
+  await assert.rejects(
+    () =>
+      parseWorkerRuntimeEnv(
+        {
+          authMode: "machine_api_key",
+          commandFamily: "worker_claim_loop"
+        },
+        {
+          API_BASE_URL: "https://api.paretoproof.com",
+          CODEX_API_KEY: "worker-api-key",
+          WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+        }
+      ),
+    /PARETOPROOF_WORKER_IMAGE_DIGEST: is required/
+  );
+
   const runtimeEnv = await parseWorkerRuntimeEnv(
     {
       authMode: "machine_api_key",
@@ -135,6 +167,7 @@ test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop mac
     {
       API_BASE_URL: "https://api.paretoproof.com",
       CODEX_API_KEY: "worker-api-key",
+      PARETOPROOF_WORKER_IMAGE_DIGEST: "b".repeat(64),
       WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
     }
   );
@@ -142,6 +175,7 @@ test("parseWorkerRuntimeEnv requires hosted worker env for future claim-loop mac
   assert.deepEqual(runtimeEnv, {
     apiBaseUrl: "https://api.paretoproof.com",
     codexApiKey: "worker-api-key",
+    hostedWorkerImageDigest: "b".repeat(64),
     workerBootstrapToken: "bootstrap-token"
   });
 });

--- a/apps/worker/test/runtime-env.test.ts
+++ b/apps/worker/test/runtime-env.test.ts
@@ -50,6 +50,42 @@ test("parseWorkerRuntimeEnv preserves an optional devbox digest for local attemp
   });
 });
 
+test("parseWorkerRuntimeEnv normalizes published sha256-prefixed digests", async () => {
+  const localRuntimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "local_stub",
+      commandFamily: "problem9_attempt"
+    },
+    {
+      PARETOPROOF_DEVBOX_IMAGE_DIGEST: `sha256:${"a".repeat(64)}`
+    }
+  );
+
+  assert.deepEqual(localRuntimeEnv, {
+    devboxImageDigest: "a".repeat(64)
+  });
+
+  const hostedRuntimeEnv = await parseWorkerRuntimeEnv(
+    {
+      authMode: "machine_api_key",
+      commandFamily: "worker_claim_loop"
+    },
+    {
+      API_BASE_URL: "https://api.paretoproof.com",
+      CODEX_API_KEY: "worker-api-key",
+      PARETOPROOF_WORKER_IMAGE_DIGEST: `sha256:${"b".repeat(64)}`,
+      WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
+    }
+  );
+
+  assert.deepEqual(hostedRuntimeEnv, {
+    apiBaseUrl: "https://api.paretoproof.com",
+    codexApiKey: "worker-api-key",
+    hostedWorkerImageDigest: "b".repeat(64),
+    workerBootstrapToken: "bootstrap-token"
+  });
+});
+
 test("parseWorkerRuntimeEnv requires CODEX_API_KEY for machine_api_key attempts", async () => {
   await assert.rejects(
     () =>

--- a/apps/worker/test/worker-claim-loop.test.ts
+++ b/apps/worker/test/worker-claim-loop.test.ts
@@ -170,6 +170,7 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -184,6 +185,12 @@ test("runWorkerClaimLoop submits manifest and terminal result for a claimed sing
     });
     assert.equal(attemptCalls.length, 1);
     assert.equal(attemptCalls[0]?.authMode, "machine_api_key");
+    assert.deepEqual(attemptCalls[0]?.environmentProvenance, {
+      executionImageDigest: "9".repeat(64),
+      executionTargetKind: "paretoproof-worker",
+      localDevboxDigest: null,
+      metadata: {}
+    });
     assert.equal(attemptCalls[0]?.providerFamily, "openai");
     assert.equal(attemptCalls[0]?.networkPolicyMode, "hosted");
     assert.equal(attemptCalls[0]?.providerModel, "gpt-5");
@@ -367,6 +374,7 @@ test("runWorkerClaimLoop accepts uppercase verdict benchmarkPackageDigest hex", 
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -531,6 +539,7 @@ test("runWorkerClaimLoop registers failure-classification artifacts for failing 
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -635,6 +644,7 @@ test("runWorkerClaimLoop terminalizes cancellation after the first cancel-reques
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -775,6 +785,7 @@ test("runWorkerClaimLoop terminalizes cancellation after control-plane cancel du
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -921,6 +932,7 @@ test("runWorkerClaimLoop preserves cancelled terminalization when the first canc
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -1066,6 +1078,7 @@ test("runWorkerClaimLoop treats bounded cancel-finalization window loss as lease
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -1258,6 +1271,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {
@@ -1468,6 +1482,7 @@ test("runWorkerClaimLoop treats late-finalize cancel-window loss as lease loss a
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {
@@ -1620,6 +1635,7 @@ test("runWorkerClaimLoop converts non-lease finalize heartbeat failures into can
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -1785,6 +1801,7 @@ test("runWorkerClaimLoop converts non-lease background heartbeat failures into c
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {}
@@ -1956,6 +1973,7 @@ test("runWorkerClaimLoop falls back to an artifact-backed harness failure when t
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -2158,6 +2176,7 @@ test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel 
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {
@@ -2387,6 +2406,7 @@ test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel 
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {
@@ -2561,6 +2581,7 @@ test("runWorkerClaimLoop preserves lease_lost when terminal result submission lo
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -2746,6 +2767,7 @@ test("runWorkerClaimLoop retries failing-verdict terminalization with a canonica
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -2934,6 +2956,7 @@ test("runWorkerClaimLoop heartbeats do not advertise unsent finalize event seque
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {
@@ -3030,6 +3053,7 @@ test("runWorkerClaimLoop submits a canonical pre-bundle failure when the inner a
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -3176,6 +3200,7 @@ test("runWorkerClaimLoop preserves cancelled terminalization when a late cancel 
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: async () => {}
@@ -3290,6 +3315,7 @@ test("runWorkerClaimLoop constrains claimed job filesystem paths under the confi
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -3329,6 +3355,7 @@ test("runWorkerClaimLoop rejects modal control-plane raw IP origins before any h
           rawEnv: {
             API_BASE_URL: "http://127.0.0.1:3000",
             CODEX_API_KEY: "worker-api-key",
+            PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
             WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
           }
         }
@@ -3406,6 +3433,7 @@ test("runWorkerClaimLoop fails closed on pre-existing lease residue and skips ex
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -3506,6 +3534,7 @@ test("runWorkerClaimLoop recovers when the first prepare-phase failure submissio
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -3620,6 +3649,7 @@ test("runWorkerClaimLoop preserves cancelled terminalization when the first prep
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -3731,6 +3761,7 @@ test("runWorkerClaimLoop reports invalid hosted modelConfigId prefixes before at
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep
@@ -4059,7 +4090,8 @@ async function writeBundleOutputs(outputRoot: string, artifactEntries: WorkerArt
 async function writeBundleOutputsWithVerdict(
   outputRoot: string,
   artifactEntries: WorkerArtifactManifestEntry[],
-  verdictOverrides: Record<string, unknown> = {}
+  verdictOverrides: Record<string, unknown> = {},
+  environmentOverrides: Record<string, unknown> = {}
 ) : Promise<WrittenBundleDigests> {
   await mkdir(path.join(outputRoot, "package"), { recursive: true });
   await mkdir(path.join(outputRoot, "package", "FirstProof", "Problem9"), { recursive: true });
@@ -4205,8 +4237,8 @@ async function writeBundleOutputsWithVerdict(
   const environment = {
     authMode: "machine_api_key",
     environmentSchemaVersion: "1",
-    executionImageDigest: null,
-    executionTargetKind: "problem9-execution",
+    executionImageDigest: "9".repeat(64),
+    executionTargetKind: "paretoproof-worker",
     harnessRevision: "worker-harness.v1",
     lakeSnapshotId: "leanprover/lean4:v4.22.0",
     laneId: "lean422_exact",
@@ -4229,7 +4261,8 @@ async function writeBundleOutputsWithVerdict(
       tsxVersion: null
     },
     toolProfile: "workspace_edit_limited",
-    verifierVersion: "lean4.22.0"
+    verifierVersion: "lean4.22.0",
+    ...environmentOverrides
   };
   const baseVerdict = {
     attemptId: "attempt-1",
@@ -4693,6 +4726,58 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
       }
     },
     {
+      expectedSummary:
+        /environment\/environment\.json executionTargetKind does not match the hosted worker runtime provenance\./i,
+      name: "hosted provenance drift",
+      tamper: async (outputRoot: string) => {
+        const benchmarkPackage = await readJsonFile(path.join(outputRoot, "package", "benchmark-package.json"));
+        const promptPackage = await readJsonFile(path.join(outputRoot, "prompt", "prompt-package.json"));
+        const environment = await readJsonFile(path.join(outputRoot, "environment", "environment.json"));
+        const tamperedEnvironment = {
+          ...environment,
+          executionTargetKind: "problem9-execution"
+        };
+        const environmentDigest = sha256Text(stableStringify(tamperedEnvironment));
+
+        await writeFile(
+          path.join(outputRoot, "environment", "environment.json"),
+          `${stableStringify(tamperedEnvironment)}\n`,
+          "utf8"
+        );
+        await upsertArtifactManifestEntry(outputRoot, {
+          artifactRole: "environment_snapshot",
+          contentEncoding: null,
+          mediaType: "application/json",
+          relativePath: "environment/environment.json",
+          requiredForIngest: true
+        });
+        await refreshBundleDigests(outputRoot, (runBundle) => ({
+          ...runBundle,
+          environmentDigest,
+          runConfigDigest: computeRunConfigDigest({
+            benchmarkPackage: {
+              benchmarkItemId: String(benchmarkPackage.benchmarkItemId),
+              packageDigest: String(benchmarkPackage.packageDigest),
+              packageId: String(benchmarkPackage.packageId),
+              packageVersion: String(benchmarkPackage.packageVersion)
+            },
+            environmentDigest,
+            promptPackage: {
+              authMode: String(promptPackage.authMode),
+              harnessRevision: String(promptPackage.harnessRevision),
+              laneId: String(promptPackage.laneId),
+              modelConfigId: String(promptPackage.modelConfigId),
+              promptPackageDigest: String(promptPackage.promptPackageDigest),
+              promptProtocolVersion: String(promptPackage.promptProtocolVersion),
+              providerFamily: String(promptPackage.providerFamily),
+              runMode: String(promptPackage.runMode),
+              toolProfile: String(promptPackage.toolProfile)
+            }
+          })
+        }));
+      }
+    },
+    {
       expectedSummary: /bundleSchemaVersion does not match the claimed job target/i,
       name: "bundleSchemaVersion drift",
       tamper: async (outputRoot: string) => {
@@ -5139,6 +5224,7 @@ test("runWorkerClaimLoop rejects bundle digest drift before artifact registratio
             rawEnv: {
               API_BASE_URL: "https://api.paretoproof.test",
               CODEX_API_KEY: "worker-api-key",
+              PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
               WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
             },
             sleep: neverSleep
@@ -5284,6 +5370,7 @@ test("runWorkerClaimLoop rejects a failing verdict that omits primaryFailure bef
         rawEnv: {
           API_BASE_URL: "https://api.paretoproof.test",
           CODEX_API_KEY: "worker-api-key",
+          PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
           WORKER_BOOTSTRAP_TOKEN: "bootstrap-token"
         },
         sleep: neverSleep

--- a/apps/worker/test/worker-cli-contract.test.ts
+++ b/apps/worker/test/worker-cli-contract.test.ts
@@ -101,6 +101,7 @@ test("worker entrypoint exits 2 when hosted claim-loop env includes trusted-loca
         ...process.env,
         API_BASE_URL: "https://api.paretoproof.com",
         CODEX_API_KEY: "worker-api-key",
+        PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
         PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT: "readonly_auth_json",
         WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token"
       }
@@ -145,6 +146,7 @@ test("worker entrypoint exits 2 when hosted claim-loop env includes a provider-b
         OPENAI_API_BASE: "",
         OPENAI_API_BASE_URL: "",
         OPENAI_BASE_URL: "https://evil.example.test",
+        PARETOPROOF_WORKER_IMAGE_DIGEST: "9".repeat(64),
         WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
         all_proxy: "",
         http_proxy: "",

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -174,6 +174,9 @@ Use this mode for:
   - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Secret env: none
 - Notes:
+  - direct host-side runs default to `executionTargetKind: "problem9-execution"`
+  - set `PARETOPROOF_DEVBOX_IMAGE_DIGEST` only when the local attempt is actually running inside the canonical Problem 9 devbox and should record `executionTargetKind: "problem9-devbox"`
+  - digest env accepts either bare `64`-hex input or the published `sha256:<hex>` form
   - these commands are intentionally file-driven
   - do not inject `API_BASE_URL`, `WORKER_BOOTSTRAP_TOKEN`, or provider keys just because they exist in the worker example file
 
@@ -198,6 +201,10 @@ Use this mode for `run-problem9-attempt --auth-mode machine_api_key`.
   - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Secret env:
   - `CODEX_API_KEY`
+- Notes:
+  - direct host-side runs default to `executionTargetKind: "problem9-execution"`
+  - set `PARETOPROOF_DEVBOX_IMAGE_DIGEST` only when the local attempt is actually running inside the canonical Problem 9 devbox and should record `executionTargetKind: "problem9-devbox"`
+  - digest env accepts either bare `64`-hex input or the published `sha256:<hex>` form
 
 ### Local Problem 9 attempt with `trusted_local_user`
 
@@ -218,6 +225,8 @@ Use this mode for `run-problem9-attempt --auth-mode trusted_local_user`.
   - on non-Windows hosts, the default inferred path is `$HOME/.codex/auth.json`
   - malformed `auth.json` content is treated as a setup failure, not a runtime fallback
   - this is a trusted-local path only; do not reuse it for hosted worker modes
+  - direct host-side runs default to `executionTargetKind: "problem9-execution"` unless they are launched through the canonical trusted-local devbox wrapper or you set `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
+  - digest env accepts either bare `64`-hex input or the published `sha256:<hex>` form
 
 ### Trusted-local devbox wrapper
 
@@ -240,6 +249,8 @@ Use this mode for:
   - this wrapper mounts the auth file into the container read-only
   - the wrapper also sets `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT=readonly_auth_json` and expects `CODEX_HOME=/run/paretoproof/codex-home` inside the devbox
   - do not move trusted-local auth into `apps/worker/.env`
+  - if `PARETOPROOF_DEVBOX_IMAGE_DIGEST` is provided, the wrapper forwards it into the container so emitted bundles record the actual devbox digest
+  - digest env accepts either bare `64`-hex input or the published `sha256:<hex>` form
 
 ### Offline ingest CLI
 
@@ -279,6 +290,7 @@ Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key 
   - hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT` or point `CODEX_HOME` at `/run/paretoproof/codex-home`
   - hosted Problem 9 execution currently supports only provider family `openai`
   - hosted bundles emit `executionTargetKind: "paretoproof-worker"` and carry the exact wrapper digest from `PARETOPROOF_WORKER_IMAGE_DIGEST`
+  - digest env accepts either bare `64`-hex input or the published `sha256:<hex>` form
   - hosted claim-loop runs fail closed when proxy env or provider base-URL override env is present, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `OPENAI_BASE_URL`, `OPENAI_API_BASE`, and `OPENAI_API_BASE_URL`
 
 ## Reserved later-scope variables

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -170,7 +170,8 @@ Use this mode for:
 
 - Example file: `apps/worker/.env.example`
 - Required env: none
-- Optional env: none
+- Optional env:
+  - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Secret env: none
 - Notes:
   - these commands are intentionally file-driven
@@ -182,7 +183,8 @@ Use this mode for deterministic local dry runs of `run-problem9-attempt`.
 
 - Example file: `apps/worker/.env.example`
 - Required env: none
-- Optional env: none
+- Optional env:
+  - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Secret env: none
 
 ### Local Problem 9 attempt with `machine_api_key`
@@ -192,7 +194,8 @@ Use this mode for `run-problem9-attempt --auth-mode machine_api_key`.
 - Example file: `apps/worker/.env.example`
 - Required env:
   - `CODEX_API_KEY`
-- Optional env: none
+- Optional env:
+  - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Secret env:
   - `CODEX_API_KEY`
 
@@ -205,6 +208,7 @@ Use this mode for `run-problem9-attempt --auth-mode trusted_local_user`.
   - none if the default Codex home is correct
 - Optional env:
   - `CODEX_HOME` when the local auth cache is not under the default home directory
+  - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Required local file/state:
   - a readable `auth.json` under `CODEX_HOME` or the inferred home directory
   - a passing `codex login status`
@@ -227,6 +231,7 @@ Use this mode for:
   - none if the default Codex home is correct
 - Optional env:
   - `CODEX_HOME` when the local auth cache is not under the default home directory
+  - `PARETOPROOF_DEVBOX_IMAGE_DIGEST`
 - Required local file/state:
   - a readable `auth.json` under `CODEX_HOME` or the inferred home directory
   - a passing host `codex login status`
@@ -264,6 +269,7 @@ Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key 
   - `API_BASE_URL`
   - `WORKER_BOOTSTRAP_TOKEN`
   - `CODEX_API_KEY`
+  - `PARETOPROOF_WORKER_IMAGE_DIGEST`
 - Optional env: none
 - Secret env:
   - `WORKER_BOOTSTRAP_TOKEN`
@@ -272,6 +278,7 @@ Use this mode for `bun run run:worker-claim-loop -- --auth-mode machine_api_key 
   - this is the fully documented hosted worker path in the repository today
   - hosted modes must not set `PARETOPROOF_TRUSTED_LOCAL_AUTH_MOUNT` or point `CODEX_HOME` at `/run/paretoproof/codex-home`
   - hosted Problem 9 execution currently supports only provider family `openai`
+  - hosted bundles emit `executionTargetKind: "paretoproof-worker"` and carry the exact wrapper digest from `PARETOPROOF_WORKER_IMAGE_DIGEST`
   - hosted claim-loop runs fail closed when proxy env or provider base-URL override env is present, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `OPENAI_BASE_URL`, `OPENAI_API_BASE`, and `OPENAI_API_BASE_URL`
 
 ## Reserved later-scope variables

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -70,7 +70,9 @@ const checks = [
     variables: [
       { name: "API_BASE_URL", commented: false },
       { name: "WORKER_BOOTSTRAP_TOKEN", commented: true },
+      { name: "PARETOPROOF_WORKER_IMAGE_DIGEST", commented: true },
       { name: "CODEX_API_KEY", commented: true },
+      { name: "PARETOPROOF_DEVBOX_IMAGE_DIGEST", commented: true },
       { name: "CF_INTERNAL_API_SERVICE_TOKEN_ID", commented: true },
       { name: "CF_INTERNAL_API_SERVICE_TOKEN_SECRET", commented: true },
       { name: "R2_ACCESS_KEY_ID", commented: true },

--- a/infra/scripts/startup-validation-smoke.ts
+++ b/infra/scripts/startup-validation-smoke.ts
@@ -140,6 +140,8 @@ if (skipDockerStartupSmoke) {
       "--env",
       "CODEX_API_KEY=worker-api-key",
       "--env",
+      `PARETOPROOF_WORKER_IMAGE_DIGEST=${"9".repeat(64)}`,
+      "--env",
       "PARETOPROOF_STARTUP_VALIDATION_ONLY=1",
       startupSmokeExecutionImage,
       "node",
@@ -193,6 +195,40 @@ if (skipDockerStartupSmoke) {
   );
 
   expectCommandFailure(
+    "local Docker worker startup rejects a missing hosted worker image digest",
+    [
+      "run",
+      "--rm",
+      "--pull",
+      "never",
+      "--env",
+      "API_BASE_URL=https://api.paretoproof.com",
+      "--env",
+      "WORKER_BOOTSTRAP_TOKEN=worker-bootstrap-token",
+      "--env",
+      "CODEX_API_KEY=worker-api-key",
+      "--env",
+      "PARETOPROOF_STARTUP_VALIDATION_ONLY=1",
+      startupSmokeExecutionImage,
+      "node",
+      "apps/worker/dist/index.js",
+      "run-worker-claim-loop",
+      "--worker-id",
+      "startup-smoke-worker",
+      "--worker-pool",
+      "startup-smoke",
+      "--worker-version",
+      "startup-smoke-v1",
+      "--workspace-root",
+      "/tmp/worker-workspace",
+      "--output-root",
+      "/tmp/worker-output",
+      "--once"
+    ],
+    /Validation error: Invalid worker runtime environment: PARETOPROOF_WORKER_IMAGE_DIGEST: is required/
+  );
+
+  expectCommandFailure(
     "local Docker worker startup rejects a hosted provider-base override env",
     [
       "run",
@@ -205,6 +241,8 @@ if (skipDockerStartupSmoke) {
       "WORKER_BOOTSTRAP_TOKEN=worker-bootstrap-token",
       "--env",
       "CODEX_API_KEY=worker-api-key",
+      "--env",
+      `PARETOPROOF_WORKER_IMAGE_DIGEST=${"9".repeat(64)}`,
       "--env",
       "OPENAI_BASE_URL=https://evil.example.test",
       "--env",

--- a/packages/shared/src/schemas/problem9-offline-ingest.ts
+++ b/packages/shared/src/schemas/problem9-offline-ingest.ts
@@ -134,35 +134,63 @@ export const problem9PromptPackageManifestSchema = problem9PromptPackageManifest
   }
 });
 
-export const problem9EnvironmentManifestSchema = z.object({
-  authMode: problem9PromptPackageManifestBaseSchema.shape.authMode,
-  environmentSchemaVersion: z.string().min(1),
-  executionImageDigest: sha256Schema.nullable(),
-  executionTargetKind: z.enum(["problem9-devbox", "problem9-execution"]),
-  harnessRevision: z.string().min(1),
-  lakeSnapshotId: z.string().min(1),
-  laneId: z.string().min(1),
-  leanVersion: z.string().min(1),
-  localDevboxDigest: sha256Schema.nullable(),
-  metadata: z.record(z.string(), recordValueSchema),
-  modelConfigId: z.string().min(1),
-  modelSnapshotId: z.string().min(1),
-  os: z.object({
-    arch: z.string().min(1),
-    platform: z.string().min(1),
-    release: z.string().min(1)
-  }),
-  promptProtocolVersion: z.string().min(1),
-  providerFamily: problem9PromptPackageManifestBaseSchema.shape.providerFamily,
-  runMode: problem9PromptPackageManifestBaseSchema.shape.runMode,
-  runtime: z.object({
-    bunVersion: z.string().min(1).nullable(),
-    nodeVersion: z.string().min(1),
-    tsxVersion: z.string().min(1).nullable()
-  }),
-  toolProfile: problem9PromptPackageManifestBaseSchema.shape.toolProfile,
-  verifierVersion: z.string().min(1)
-});
+export const problem9EnvironmentManifestSchema = z
+  .object({
+    authMode: problem9PromptPackageManifestBaseSchema.shape.authMode,
+    environmentSchemaVersion: z.string().min(1),
+    executionImageDigest: sha256Schema.nullable(),
+    executionTargetKind: z.enum([
+      "paretoproof-worker",
+      "problem9-devbox",
+      "problem9-execution"
+    ]),
+    harnessRevision: z.string().min(1),
+    lakeSnapshotId: z.string().min(1),
+    laneId: z.string().min(1),
+    leanVersion: z.string().min(1),
+    localDevboxDigest: sha256Schema.nullable(),
+    metadata: z.record(z.string(), recordValueSchema),
+    modelConfigId: z.string().min(1),
+    modelSnapshotId: z.string().min(1),
+    os: z.object({
+      arch: z.string().min(1),
+      platform: z.string().min(1),
+      release: z.string().min(1)
+    }),
+    promptProtocolVersion: z.string().min(1),
+    providerFamily: problem9PromptPackageManifestBaseSchema.shape.providerFamily,
+    runMode: problem9PromptPackageManifestBaseSchema.shape.runMode,
+    runtime: z.object({
+      bunVersion: z.string().min(1).nullable(),
+      nodeVersion: z.string().min(1),
+      tsxVersion: z.string().min(1).nullable()
+    }),
+    toolProfile: problem9PromptPackageManifestBaseSchema.shape.toolProfile,
+    verifierVersion: z.string().min(1)
+  })
+  .superRefine((value, context) => {
+    if (value.executionTargetKind !== "paretoproof-worker") {
+      return;
+    }
+
+    if (value.executionImageDigest === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "executionImageDigest is required when executionTargetKind is paretoproof-worker.",
+        path: ["executionImageDigest"]
+      });
+    }
+
+    if (value.localDevboxDigest !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "localDevboxDigest must be null when executionTargetKind is paretoproof-worker.",
+        path: ["localDevboxDigest"]
+      });
+    }
+  });
 
 export const problem9RunBundleManifestSchema = z.object({
   artifactManifestDigest: sha256Schema,

--- a/packages/shared/src/types/problem9-offline-ingest.ts
+++ b/packages/shared/src/types/problem9-offline-ingest.ts
@@ -209,7 +209,7 @@ export type Problem9EnvironmentManifest = {
   authMode: Problem9PromptPackageManifest["authMode"];
   environmentSchemaVersion: string;
   executionImageDigest: string | null;
-  executionTargetKind: "problem9-devbox" | "problem9-execution";
+  executionTargetKind: "paretoproof-worker" | "problem9-devbox" | "problem9-execution";
   harnessRevision: string;
   lakeSnapshotId: string;
   laneId: string;

--- a/packages/shared/test/problem9-offline-ingest-schema.test.js
+++ b/packages/shared/test/problem9-offline-ingest-schema.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { problem9EnvironmentManifestSchema } from "../dist/index.js";
+
+function buildEnvironmentManifest(overrides = {}) {
+  return {
+    authMode: "machine_api_key",
+    environmentSchemaVersion: "1",
+    executionImageDigest: "7".repeat(64),
+    executionTargetKind: "paretoproof-worker",
+    harnessRevision: "worker-harness.v1",
+    lakeSnapshotId: "leanprover/lean4:v4.22.0",
+    laneId: "lean422_exact",
+    leanVersion: "4.22.0",
+    localDevboxDigest: null,
+    metadata: {},
+    modelConfigId: "openai/gpt-5",
+    modelSnapshotId: "openai/gpt-5.2026-03-13",
+    os: {
+      arch: "x64",
+      platform: "linux",
+      release: "test-kernel"
+    },
+    promptProtocolVersion: "problem9-prompt-protocol.v1",
+    providerFamily: "openai",
+    runMode: "bounded_agentic_attempt",
+    runtime: {
+      bunVersion: null,
+      nodeVersion: "v22.14.0",
+      tsxVersion: null
+    },
+    toolProfile: "workspace_edit_limited",
+    verifierVersion: "lean4.22.0",
+    ...overrides
+  };
+}
+
+describe("problem9 offline ingest environment schema", () => {
+  it("accepts hosted worker provenance when the wrapper digest is present", () => {
+    expect(problem9EnvironmentManifestSchema.parse(buildEnvironmentManifest())).toEqual(
+      buildEnvironmentManifest()
+    );
+  });
+
+  it("rejects hosted worker provenance without an execution image digest", () => {
+    expect(
+      problem9EnvironmentManifestSchema.safeParse(
+        buildEnvironmentManifest({ executionImageDigest: null })
+      ).success
+    ).toBe(false);
+  });
+
+  it("rejects hosted worker provenance with a local devbox digest", () => {
+    expect(
+      problem9EnvironmentManifestSchema.safeParse(
+        buildEnvironmentManifest({ localDevboxDigest: "8".repeat(64) })
+      ).success
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- carry explicit hosted and local Problem 9 environment provenance through worker runtime parsing and bundle materialization
- enforce hosted provenance invariants at bundle and offline-ingest schema boundaries and verify hosted claim-loop bundles against expected runtime provenance
- add regression coverage for hosted and local provenance emission, schema rejection paths, and trusted-local devbox wrapper propagation

## Testing
- bunx tsc --noEmit -p apps/worker/tsconfig.json
- bun --cwd apps/worker test
- bun run test:shared
- bun run test:api
- bun run check:env-contract
- PARETOPROOF_STARTUP_SMOKE_SKIP_DOCKER=true bun run test:startup-validation
- bun run build

Closes #1014