### PR TITLE
Fix math-aware routing parity across auth and portal surfaces

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,9 +33,10 @@ CLOUDFLARE_ACCOUNT_ID=replace-with-your-cloudflare-account-id
 CORS_ALLOWED_ORIGINS=https://portal.paretoproof.com
 CORS_ALLOW_LOCALHOST=false
 
-# Optional non-prod portal/auth origin overrides. Leave unset for the canonical
-# hosted paretoproof.com surface pair.
+# Optional non-prod portal/auth/math origin overrides. Leave unset for the canonical
+# hosted paretoproof.com surface trio.
 # PORTAL_PUBLIC_ORIGIN=https://portal.preview.paretoproof.com
+# MATH_PUBLIC_ORIGIN=https://math.preview.paretoproof.com
 # AUTH_PUBLIC_ORIGIN=https://auth.preview.paretoproof.com
 # BRANDED_AUTH_ORIGINS=https://auth.preview.paretoproof.com,https://github.auth.preview.paretoproof.com,https://google.auth.preview.paretoproof.com
 

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -170,6 +170,7 @@ const trimmedOptionalCookieDomainSchema = z.preprocess(
 
 export const defaultApiPortalPublicOrigin = "https://portal.paretoproof.com";
 export const defaultApiAuthPublicOrigin = "https://auth.paretoproof.com";
+export const defaultApiMathPublicOrigin = "https://math.paretoproof.com";
 
 function buildBrandedAuthOrigin(
   authPublicOrigin: string,
@@ -247,6 +248,7 @@ export type ApiOriginRuntimeConfig = {
   authPublicOrigin: string;
   brandedAuthOrigins: string[];
   corsAllowLocalhost: boolean;
+  mathPublicOrigin: string;
   portalPublicOrigin: string;
 };
 
@@ -255,6 +257,8 @@ export function resolveApiOriginRuntimeConfig(
 ): ApiOriginRuntimeConfig {
   const authPublicOrigin =
     config?.authPublicOrigin ?? defaultApiAuthPublicOrigin;
+  const mathPublicOrigin =
+    config?.mathPublicOrigin ?? defaultApiMathPublicOrigin;
   const portalPublicOrigin =
     config?.portalPublicOrigin ?? defaultApiPortalPublicOrigin;
   const brandedAuthOrigins = [
@@ -268,7 +272,7 @@ export function resolveApiOriginRuntimeConfig(
         .filter((origin) => origin.length > 0),
     ),
   ];
-  const cookieOrigins = [portalPublicOrigin, ...brandedAuthOrigins];
+  const cookieOrigins = [portalPublicOrigin, mathPublicOrigin, ...brandedAuthOrigins];
 
   return {
     accessCookieDomain:
@@ -278,6 +282,7 @@ export function resolveApiOriginRuntimeConfig(
     authPublicOrigin,
     brandedAuthOrigins,
     corsAllowLocalhost: config?.corsAllowLocalhost ?? false,
+    mathPublicOrigin,
     portalPublicOrigin,
   };
 }
@@ -298,6 +303,7 @@ const rawApiRuntimeEnvSchema = z
     CORS_ALLOW_LOCALHOST: optionalBooleanStringSchema,
     DATABASE_URL: requiredTrimmedStringSchema,
     HOST: trimmedOptionalStringSchema,
+    MATH_PUBLIC_ORIGIN: trimmedOptionalOriginSchema,
     NODE_ENV: trimmedOptionalStringSchema,
     PORT: portSchema,
     PORTAL_PUBLIC_ORIGIN: trimmedOptionalOriginSchema,
@@ -326,6 +332,7 @@ export type ApiRuntimeEnv = {
   databaseUrl: string;
   host: string;
   internalAccessAudience: string;
+  mathPublicOrigin: string;
   nodeEnv?: string;
   port: number;
   portalAccessAudience: string;
@@ -403,6 +410,7 @@ export function parseApiRuntimeEnv(
     CORS_ALLOW_LOCALHOST,
     DATABASE_URL,
     HOST,
+    MATH_PUBLIC_ORIGIN,
     NODE_ENV,
     PORT,
     PORTAL_PUBLIC_ORIGIN,
@@ -420,6 +428,7 @@ export function parseApiRuntimeEnv(
     authPublicOrigin: AUTH_PUBLIC_ORIGIN,
     brandedAuthOrigins: BRANDED_AUTH_ORIGINS,
     corsAllowLocalhost: CORS_ALLOW_LOCALHOST === "true",
+    mathPublicOrigin: MATH_PUBLIC_ORIGIN,
     portalPublicOrigin: PORTAL_PUBLIC_ORIGIN,
   });
 
@@ -435,6 +444,7 @@ export function parseApiRuntimeEnv(
     databaseUrl: DATABASE_URL,
     host: HOST ?? "0.0.0.0",
     internalAccessAudience: CF_ACCESS_INTERNAL_AUD ?? portalAccessAudience,
+    mathPublicOrigin: originRuntimeConfig.mathPublicOrigin,
     nodeEnv: NODE_ENV,
     port: PORT === undefined ? 3000 : Number(PORT),
     portalAccessAudience,

--- a/apps/api/src/config/runtime.ts
+++ b/apps/api/src/config/runtime.ts
@@ -255,6 +255,7 @@ export type ApiOriginRuntimeConfig = {
 export function resolveApiOriginRuntimeConfig(
   config?: Partial<ApiOriginRuntimeConfig>,
 ): ApiOriginRuntimeConfig {
+  const usesExplicitMathPublicOrigin = config?.mathPublicOrigin !== undefined;
   const authPublicOrigin =
     config?.authPublicOrigin ?? defaultApiAuthPublicOrigin;
   const mathPublicOrigin =
@@ -272,7 +273,11 @@ export function resolveApiOriginRuntimeConfig(
         .filter((origin) => origin.length > 0),
     ),
   ];
-  const cookieOrigins = [portalPublicOrigin, mathPublicOrigin, ...brandedAuthOrigins];
+  const cookieOrigins = [
+    portalPublicOrigin,
+    ...brandedAuthOrigins,
+    ...(usesExplicitMathPublicOrigin ? [mathPublicOrigin] : []),
+  ];
 
   return {
     accessCookieDomain:

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -1,4 +1,5 @@
 import {
+  findAppRouteBySurface,
   portalBenchmarkOpsReadModelsContract,
   portalBenchmarkDatasetParamsSchema,
   portalBenchmarkExportQuerySchema,
@@ -69,6 +70,8 @@ import {
   normalizeOrigin,
 } from "../server/trusted-mutation-origin.js";
 
+type AuthenticatedSurface = "portal" | "math";
+
 class PortalAccessRequestConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -118,12 +121,27 @@ type PortalRouteRuntimeConfig = Pick<
   | "authPublicOrigin"
   | "brandedAuthOrigins"
   | "corsAllowLocalhost"
+  | "mathPublicOrigin"
   | "portalPublicOrigin"
 >;
 
-function sanitizePortalRedirectPath(
+function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
+  return surface === "math" ? "math" : "portal";
+}
+
+function readAuthenticatedSurfaceOrigin(
+  runtimeConfig: PortalRouteRuntimeConfig,
+  targetSurface: AuthenticatedSurface,
+) {
+  return targetSurface === "math"
+    ? runtimeConfig.mathPublicOrigin
+    : runtimeConfig.portalPublicOrigin;
+}
+
+function sanitizeAuthenticatedRedirectPath(
   rawRedirectPath: string | null,
-  portalPublicOrigin: string,
+  targetSurface: AuthenticatedSurface,
+  runtimeConfig: PortalRouteRuntimeConfig,
 ) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
@@ -137,12 +155,19 @@ function sanitizePortalRedirectPath(
   }
 
   try {
+    const targetOrigin = readAuthenticatedSurfaceOrigin(
+      runtimeConfig,
+      targetSurface,
+    );
     const candidateUrl = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      portalPublicOrigin,
+      targetOrigin,
     );
 
-    if (candidateUrl.origin !== portalPublicOrigin) {
+    if (
+      candidateUrl.origin !== targetOrigin ||
+      !findAppRouteBySurface(targetSurface, candidateUrl.pathname)
+    ) {
       return "/";
     }
 
@@ -153,6 +178,42 @@ function sanitizePortalRedirectPath(
   } catch {
     return "/";
   }
+}
+
+function readAuthenticatedContinuation(
+  request: FastifyRequest,
+  runtimeConfig: PortalRouteRuntimeConfig,
+) {
+  const parsedBody =
+    typeof request.body === "object" && request.body !== null
+      ? (request.body as { app?: string; redirect?: string })
+      : undefined;
+  const query =
+    (request.query as { app?: string; redirect?: string } | undefined) ?? {};
+  const targetSurface = readAuthenticatedSurface(
+    parsedBody?.app ?? query.app ?? null,
+  );
+  const redirectPath = sanitizeAuthenticatedRedirectPath(
+    parsedBody?.redirect ?? query.redirect ?? null,
+    targetSurface,
+    runtimeConfig,
+  );
+
+  return {
+    redirectPath,
+    targetSurface,
+  };
+}
+
+function buildAuthenticatedContinuationUrl(
+  redirectPath: string,
+  targetSurface: AuthenticatedSurface,
+  runtimeConfig: PortalRouteRuntimeConfig,
+) {
+  return new URL(
+    redirectPath,
+    readAuthenticatedSurfaceOrigin(runtimeConfig, targetSurface),
+  );
 }
 
 function clearSignedAccessCookie(
@@ -188,6 +249,7 @@ function buildPortalAuthStartUrl(options: {
     authUrl.searchParams.set("redirect", options.redirectPath);
   }
 
+  authUrl.searchParams.set("app", "portal");
   authUrl.searchParams.set("flow", "link");
 
   return authUrl.toString();
@@ -196,8 +258,10 @@ function buildPortalAuthStartUrl(options: {
 function buildPortalAuthRetryUrl(
   redirectPath: string,
   authPublicOrigin: string,
+  targetSurface: AuthenticatedSurface,
 ) {
   const authUrl = new URL(authPublicOrigin);
+  authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
     authUrl.searchParams.set("redirect", redirectPath);
@@ -261,8 +325,13 @@ function readTrustedBrandedAuthOrigin(
   return null;
 }
 
-function buildBrandedFinalizeRelayUrl(origin: string, redirectPath: string) {
+function buildBrandedFinalizeRelayUrl(
+  origin: string,
+  redirectPath: string,
+  targetSurface: AuthenticatedSurface,
+) {
   const relayUrl = new URL("/api/access/finalize", origin);
+  relayUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
     relayUrl.searchParams.set("redirect", redirectPath);
@@ -446,6 +515,7 @@ export function registerPortalRoutes(
     allowLocalhostOrigins?: ApiRuntimeEnv["corsAllowLocalhost"];
     authPublicOrigin?: ApiRuntimeEnv["authPublicOrigin"];
     brandedAuthOrigins?: ApiRuntimeEnv["brandedAuthOrigins"];
+    mathPublicOrigin?: ApiRuntimeEnv["mathPublicOrigin"];
     portalBenchmarkOpsReadModels?: PortalBenchmarkOpsReadModelService;
     portalPublicOrigin?: ApiRuntimeEnv["portalPublicOrigin"];
     rateLimitPreHandlers?: ReturnType<typeof createRateLimitPreHandlers>;
@@ -470,6 +540,7 @@ export function registerPortalRoutes(
     authPublicOrigin: options?.authPublicOrigin,
     brandedAuthOrigins: options?.brandedAuthOrigins,
     corsAllowLocalhost: options?.allowLocalhostOrigins,
+    mathPublicOrigin: options?.mathPublicOrigin,
     portalPublicOrigin: options?.portalPublicOrigin,
   });
   const withAuthenticatedRateLimit = (guard: preHandlerHookHandler) =>
@@ -481,9 +552,9 @@ export function registerPortalRoutes(
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
-    const redirectPath = sanitizePortalRedirectPath(
-      (request.query as { redirect?: string } | undefined)?.redirect ?? null,
-      runtimeConfig.portalPublicOrigin,
+    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+      request,
+      runtimeConfig,
     );
 
     reply.header(
@@ -491,7 +562,11 @@ export function registerPortalRoutes(
       clearSignedAccessCookie("PortalAccessSession", runtimeConfig),
     );
     reply.redirect(
-      buildPortalAuthRetryUrl(redirectPath, runtimeConfig.authPublicOrigin),
+      buildPortalAuthRetryUrl(
+        redirectPath,
+        runtimeConfig.authPublicOrigin,
+        targetSurface,
+      ),
     );
   };
 
@@ -505,17 +580,15 @@ export function registerPortalRoutes(
         : undefined;
     const identity = request.accessIdentity;
     const accessContext = request.accessRbacContext;
-    const parsedBody =
-      typeof request.body === "object" && request.body !== null
-        ? (request.body as { redirect?: string })
-        : undefined;
-    const redirectPath = sanitizePortalRedirectPath(
-      parsedBody?.redirect ??
-        (request.query as { redirect?: string } | undefined)?.redirect ??
-        null,
-      runtimeConfig.portalPublicOrigin,
+    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+      request,
+      runtimeConfig,
     );
-    const portalUrl = new URL(redirectPath, runtimeConfig.portalPublicOrigin);
+    const continuationUrl = buildAuthenticatedContinuationUrl(
+      redirectPath,
+      targetSurface,
+      runtimeConfig,
+    );
     const linkIntent = verifyAccessLinkIntent(cookieHeader, {
       secret: accessProviderStateSecret,
     });
@@ -604,7 +677,7 @@ export function registerPortalRoutes(
         return "linked";
       });
 
-      portalUrl.searchParams.set("link", linkStatus);
+      continuationUrl.searchParams.set("link", linkStatus);
 
       if (linkStatus === "linked") {
         resolvedAccessContext = await resolveAccessRbacContext(db, identity);
@@ -644,16 +717,28 @@ export function registerPortalRoutes(
 
     reply.header("set-cookie", responseCookies);
 
+    const redirectUrl =
+      resolvedAccessContext?.status === "pending"
+        ? new URL("/pending", runtimeConfig.portalPublicOrigin)
+        : resolvedAccessContext?.status === "denied"
+          ? new URL(
+              resolvedAccessContext.reason === "access_request_required"
+                ? "/access-request"
+                : "/denied",
+              runtimeConfig.portalPublicOrigin,
+            )
+          : continuationUrl;
+
     if (
       typeof request.headers.accept === "string" &&
       request.headers.accept.includes("application/json")
     ) {
       return reply.send({
-        redirectTo: portalUrl.toString(),
+        redirectTo: redirectUrl.toString(),
       });
     }
 
-    reply.redirect(portalUrl.toString());
+    reply.redirect(redirectUrl.toString());
   };
 
   const handlePortalSessionFinalizeGet = async (
@@ -698,15 +783,9 @@ export function registerPortalRoutes(
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
-    const parsedBody =
-      typeof request.body === "object" && request.body !== null
-        ? (request.body as { redirect?: string })
-        : undefined;
-    const redirectPath = sanitizePortalRedirectPath(
-      parsedBody?.redirect ??
-        (request.query as { redirect?: string } | undefined)?.redirect ??
-        null,
-      runtimeConfig.portalPublicOrigin,
+    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+      request,
+      runtimeConfig,
     );
 
     try {
@@ -723,7 +802,11 @@ export function registerPortalRoutes(
             .code(307)
             .header(
               "location",
-              buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath),
+              buildBrandedFinalizeRelayUrl(
+                brandedOrigin,
+                redirectPath,
+                targetSurface,
+              ),
             );
           return reply.send();
         }
@@ -745,7 +828,11 @@ export function registerPortalRoutes(
             .code(307)
             .header(
               "location",
-              buildBrandedFinalizeRelayUrl(brandedOrigin, redirectPath),
+              buildBrandedFinalizeRelayUrl(
+                brandedOrigin,
+                redirectPath,
+                targetSurface,
+              ),
             );
           return reply.send();
         }
@@ -1379,9 +1466,10 @@ export function registerPortalRoutes(
       }
 
       const targetProvider = parsedBody.data.provider;
-      const redirectPath = sanitizePortalRedirectPath(
+      const redirectPath = sanitizeAuthenticatedRedirectPath(
         parsedBody.data.redirectPath ?? "/profile",
-        runtimeConfig.portalPublicOrigin,
+        "portal",
+        runtimeConfig,
       );
 
       if (

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -2,7 +2,12 @@ import cors from "@fastify/cors";
 import formbody from "@fastify/formbody";
 import { sql } from "drizzle-orm";
 import Fastify from "fastify";
-import type { ApiRuntimeEnv } from "../config/runtime.js";
+import {
+  defaultApiAuthPublicOrigin,
+  defaultApiMathPublicOrigin,
+  defaultApiPortalPublicOrigin,
+  type ApiRuntimeEnv,
+} from "../config/runtime.js";
 import {
   createAccessGuard,
   runtimeEnvToAccessResolverOptions,
@@ -42,7 +47,16 @@ export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
   const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
   const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
   const mathPublicOrigin = normalizeOrigin(runtimeEnv.mathPublicOrigin);
-  const baselineOrigins = [portalPublicOrigin, mathPublicOrigin];
+  const includesDefaultSurfaceOrigins =
+    normalizeOrigin(runtimeEnv.authPublicOrigin) ===
+      normalizeOrigin(defaultApiAuthPublicOrigin) &&
+    portalPublicOrigin === normalizeOrigin(defaultApiPortalPublicOrigin);
+  const includeMathPublicOrigin =
+    mathPublicOrigin !== normalizeOrigin(defaultApiMathPublicOrigin) ||
+    includesDefaultSurfaceOrigins;
+  const baselineOrigins = includeMathPublicOrigin
+    ? [portalPublicOrigin, mathPublicOrigin]
+    : [portalPublicOrigin];
 
   return [
     ...new Set(

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -41,7 +41,8 @@ export function readBrandedAuthOrigins(runtimeEnv: ApiRuntimeEnv) {
 export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
   const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
   const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
-  const baselineOrigins = [portalPublicOrigin];
+  const mathPublicOrigin = normalizeOrigin(runtimeEnv.mathPublicOrigin);
+  const baselineOrigins = [portalPublicOrigin, mathPublicOrigin];
 
   return [
     ...new Set(
@@ -49,7 +50,25 @@ export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
         .map(normalizeOrigin)
         .filter(
           (origin) =>
-            origin === portalPublicOrigin || !brandedAuthOrigins.has(origin),
+            baselineOrigins.includes(origin) || !brandedAuthOrigins.has(origin),
+      ),
+    ),
+  ];
+}
+
+export function readTrustedMutationOrigins(runtimeEnv: ApiRuntimeEnv) {
+  const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
+  const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
+  const mathPublicOrigin = normalizeOrigin(runtimeEnv.mathPublicOrigin);
+
+  return [
+    ...new Set(
+      [portalPublicOrigin, ...runtimeEnv.corsAllowedOrigins]
+        .map(normalizeOrigin)
+        .filter(
+          (origin) =>
+            origin === portalPublicOrigin ||
+            (origin !== mathPublicOrigin && !brandedAuthOrigins.has(origin)),
         ),
     ),
   ];
@@ -147,7 +166,8 @@ export async function buildServer(
   const rateLimitPreHandlers = createRateLimitPreHandlers(
     createInMemoryRateLimiter(),
   );
-  const allowedOrigins = readAllowedCorsOrigins(runtimeEnv);
+  const corsAllowedOrigins = readAllowedCorsOrigins(runtimeEnv);
+  const trustedMutationOrigins = readTrustedMutationOrigins(runtimeEnv);
   const brandedAuthOrigins = readBrandedAuthOrigins(runtimeEnv);
   const allowLocalhostCors = runtimeEnv.corsAllowLocalhost;
   const checkReadiness =
@@ -171,7 +191,7 @@ export async function buildServer(
           if (
             isAllowedCorsOrigin({
               allowLocalhostCors,
-              allowedOrigins,
+              allowedOrigins: corsAllowedOrigins,
               brandedAuthOrigins,
               method: request.method,
               origin,
@@ -192,7 +212,7 @@ export async function buildServer(
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: allowLocalhostCors,
-      allowedOrigins,
+      allowedOrigins: trustedMutationOrigins,
       brandedAuthOrigins,
     }),
   );
@@ -209,6 +229,7 @@ export async function buildServer(
     allowLocalhostOrigins: runtimeEnv.corsAllowLocalhost,
     authPublicOrigin: runtimeEnv.authPublicOrigin,
     brandedAuthOrigins: runtimeEnv.brandedAuthOrigins,
+    mathPublicOrigin: runtimeEnv.mathPublicOrigin,
     portalPublicOrigin: runtimeEnv.portalPublicOrigin,
     rateLimitPreHandlers,
   });

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -7,6 +7,7 @@ import {
   readBrandedAuthOrigins,
   readCorsRoutePath,
   readAllowedCorsOrigins,
+  readTrustedMutationOrigins,
 } from "../src/server/build-server.ts";
 
 test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allowlist", () => {
@@ -20,10 +21,14 @@ test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allow
       "https://portal.preview.paretoproof.com",
       "https://github.auth.preview.paretoproof.com",
     ],
+    mathPublicOrigin: "https://math.preview.paretoproof.com",
     portalPublicOrigin: "https://portal.preview.paretoproof.com",
   } as never);
 
-  assert.deepEqual(origins, ["https://portal.preview.paretoproof.com"]);
+  assert.deepEqual(origins, [
+    "https://portal.preview.paretoproof.com",
+    "https://math.preview.paretoproof.com",
+  ]);
   assert.equal(origins.includes("https://auth.preview.paretoproof.com"), false);
   assert.equal(
     origins.includes("https://github.auth.preview.paretoproof.com"),
@@ -39,10 +44,42 @@ test("readAllowedCorsOrigins keeps the portal origin when auth and portal share 
   const origins = readAllowedCorsOrigins({
     brandedAuthOrigins: ["https://portal.preview.paretoproof.com"],
     corsAllowedOrigins: [],
+    mathPublicOrigin: "https://math.preview.paretoproof.com",
     portalPublicOrigin: "https://portal.preview.paretoproof.com",
   } as never);
 
-  assert.deepEqual(origins, ["https://portal.preview.paretoproof.com"]);
+  assert.deepEqual(origins, [
+    "https://portal.preview.paretoproof.com",
+    "https://math.preview.paretoproof.com",
+  ]);
+});
+
+test("readTrustedMutationOrigins keeps math out of the generic trusted portal mutation allowlist", () => {
+  const origins = readTrustedMutationOrigins({
+    brandedAuthOrigins: [
+      "https://auth.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+      "https://google.auth.preview.paretoproof.com",
+    ],
+    corsAllowedOrigins: [
+      "https://portal.preview.paretoproof.com",
+      "https://math.preview.paretoproof.com",
+      "https://portal-canary.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+    ],
+    mathPublicOrigin: "https://math.preview.paretoproof.com",
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
+  } as never);
+
+  assert.deepEqual(origins, [
+    "https://portal.preview.paretoproof.com",
+    "https://portal-canary.preview.paretoproof.com",
+  ]);
+  assert.equal(origins.includes("https://math.preview.paretoproof.com"), false);
+  assert.equal(
+    origins.includes("https://github.auth.preview.paretoproof.com"),
+    false,
+  );
 });
 
 test("readBrandedAuthOrigins excludes the portal origin when auth and portal share one origin", () => {
@@ -183,6 +220,7 @@ test("buildServer keeps the parsed runtime contract authoritative during boot an
       CF_ACCESS_PORTAL_AUD: "portal-audience",
       CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
       DATABASE_URL: "postgres://localhost:5432/paretoproof",
+      MATH_PUBLIC_ORIGIN: "https://math.preview.paretoproof.com",
       PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
       WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
     }),
@@ -223,6 +261,7 @@ test("buildServer maps default DB readiness failures to 503 health responses", a
       CF_ACCESS_PORTAL_AUD: "portal-audience",
       CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
       DATABASE_URL: "postgres://localhost:5432/paretoproof",
+      MATH_PUBLIC_ORIGIN: "https://math.preview.paretoproof.com",
       PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
       WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
     }),

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -12,6 +12,7 @@ import {
 
 test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allowlist", () => {
   const origins = readAllowedCorsOrigins({
+    authPublicOrigin: "https://auth.preview.paretoproof.com",
     brandedAuthOrigins: [
       "https://auth.preview.paretoproof.com",
       "https://github.auth.preview.paretoproof.com",
@@ -42,6 +43,7 @@ test("readAllowedCorsOrigins excludes branded auth hosts from the API CORS allow
 
 test("readAllowedCorsOrigins keeps the portal origin when auth and portal share one origin", () => {
   const origins = readAllowedCorsOrigins({
+    authPublicOrigin: "https://portal.preview.paretoproof.com",
     brandedAuthOrigins: ["https://portal.preview.paretoproof.com"],
     corsAllowedOrigins: [],
     mathPublicOrigin: "https://math.preview.paretoproof.com",
@@ -52,6 +54,27 @@ test("readAllowedCorsOrigins keeps the portal origin when auth and portal share 
     "https://portal.preview.paretoproof.com",
     "https://math.preview.paretoproof.com",
   ]);
+});
+
+test("readAllowedCorsOrigins excludes the default production math host when preview portal/auth origins are overridden without an explicit math override", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "https://auth.preview.paretoproof.com",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.deepEqual(readAllowedCorsOrigins(runtimeEnv), [
+    "https://portal.preview.paretoproof.com",
+  ]);
+  assert.equal(
+    readAllowedCorsOrigins(runtimeEnv).includes("https://math.paretoproof.com"),
+    false,
+  );
 });
 
 test("readTrustedMutationOrigins keeps math out of the generic trusted portal mutation allowlist", () => {

--- a/apps/api/test/portal-link-intent-cookie.test.ts
+++ b/apps/api/test/portal-link-intent-cookie.test.ts
@@ -135,7 +135,7 @@ test("POST /portal/profile/link-intents issues a Strict PortalLinkIntent cookie 
   assert.equal(response.statusCode, 200);
   assert.equal(
     response.json().intent.startUrl,
-    "https://auth.preview.paretoproof.com/api/access/start/github?redirect=%2Fprofile%3Ftab%3Didentities&flow=link",
+    "https://auth.preview.paretoproof.com/api/access/start/github?redirect=%2Fprofile%3Ftab%3Didentities&app=portal&flow=link",
   );
   assert.equal(
     insertedAuditEvents[0]?.eventId,

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -63,7 +63,7 @@ test("GET /portal/session/finalize/submit redirects back to the auth retry hando
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry",
+    "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry",
   );
   assert.equal(mutationAttempted, false);
 });
@@ -118,7 +118,7 @@ test("GET /portal/session/finalize/submit honors a runtime-provided link-intent 
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://auth.preview.paretoproof.com/?redirect=%2Fprofile&handoff=retry",
+    "https://auth.preview.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry",
   );
   assert.equal(mutationAttempted, false);
 });
@@ -410,6 +410,85 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
   assert.equal(insertedSessions.length, 1);
 });
 
+test("POST /portal/session/finalize/submit returns a math-surface redirect for approved users when app=math", async (t) => {
+  let mutationAttempted = false;
+  const insertedSessions: Array<typeof sessions.$inferInsert> = [];
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      insert() {
+        return {
+          values: async (value: unknown) => {
+            insertedSessions.push(value as typeof sessions.$inferInsert);
+            return value;
+          },
+        };
+      },
+      query: {
+        userIdentities: {
+          findFirst: async () => ({
+            id: "identity-1",
+            provider: "cloudflare_google",
+            providerSubject: "subject-1",
+            userId: "user-1",
+          }),
+        },
+      },
+      transaction: async () => {
+        mutationAttempted = true;
+        throw new Error(
+          "math finalize submit should not hit the identity-link mutation path",
+        );
+      },
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      mathPublicOrigin: "https://math.preview.paretoproof.com",
+      resolvePortalAccess: async (request) => {
+        request.accessIdentity = {
+          email: "person@example.com",
+          issuer: "https://paretoproof.cloudflareaccess.com",
+          provider: "cloudflare_google",
+          subject: "subject-1",
+        };
+        request.accessRbacContext = {
+          email: "person@example.com",
+          identityId: "identity-1",
+          role: "helper",
+          status: "approved",
+          subject: "subject-1",
+          userId: "user-1",
+        };
+
+        return request.accessRbacContext;
+      },
+    },
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit?app=math&redirect=/launch",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    redirectTo: "https://math.preview.paretoproof.com/launch",
+  });
+  assert.equal(mutationAttempted, false);
+  assert.equal(insertedSessions.length, 1);
+});
+
 test("POST /portal/session/finalize/submit bounces stale direct browser handoffs back to the branded auth relay", async (t) => {
   const app = Fastify();
 
@@ -441,7 +520,7 @@ test("POST /portal/session/finalize/submit bounces stale direct browser handoffs
   assert.equal(response.statusCode, 307);
   assert.equal(
     response.headers.location,
-    "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile",
+    "https://google.auth.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fprofile",
   );
 });
 
@@ -479,7 +558,7 @@ test("POST /portal/session/finalize/submit keeps the shared auth origin relay wh
   assert.equal(response.statusCode, 307);
   assert.equal(
     response.headers.location,
-    "https://portal.preview.paretoproof.com/api/access/finalize?redirect=%2Fprofile",
+    "https://portal.preview.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fprofile",
   );
 });
 
@@ -513,7 +592,7 @@ test("POST /portal/session/finalize/submit still returns JSON auth errors for no
   assert.equal(response.json().error, "access_assertion_required");
 });
 
-test("POST /portal/session/finalize/submit clears PortalAccessSession for pending users", async (t) => {
+test("POST /portal/session/finalize/submit clears PortalAccessSession and canonicalizes pending users to /pending", async (t) => {
   const app = Fastify();
   const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
   process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
@@ -581,7 +660,7 @@ test("POST /portal/session/finalize/submit clears PortalAccessSession for pendin
   assert.equal(response.statusCode, 302);
   assert.equal(
     response.headers.location,
-    "https://portal.paretoproof.com/access-request",
+    "https://portal.paretoproof.com/pending",
   );
 
   const setCookies = response.headers["set-cookie"];
@@ -593,6 +672,73 @@ test("POST /portal/session/finalize/submit clears PortalAccessSession for pendin
   assert.match(setCookies[1], /; SameSite=Strict;/);
   assert.match(setCookies[2], /^PortalLinkIntent=;/);
   assert.match(setCookies[2], /; SameSite=Strict;/);
+});
+
+test("POST /portal/session/finalize/submit canonicalizes pending math continuation back to the portal pending route", async (t) => {
+  const app = Fastify();
+  const originalSecret = process.env.ACCESS_PROVIDER_STATE_SECRET;
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "test-secret";
+
+  t.after(async () => {
+    process.env.ACCESS_PROVIDER_STATE_SECRET = originalSecret;
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {
+      transaction: async () => {
+        throw new Error(
+          "pending math finalize submit should not hit the identity-link mutation path",
+        );
+      },
+    } as never,
+    () => (_request, _reply, done) => {
+      done();
+    },
+    {
+      mathPublicOrigin: "https://math.preview.paretoproof.com",
+      resolvePortalAccess: async (request) => {
+        request.accessIdentity = {
+          email: "pending@example.com",
+          issuer: "https://paretoproof.cloudflareaccess.com",
+          provider: "cloudflare_google",
+          subject: "subject-pending",
+        };
+        request.accessRbacContext = {
+          email: "pending@example.com",
+          requestId: "request-pending",
+          status: "pending",
+          subject: "subject-pending",
+          userId: "user-pending",
+        };
+
+        return request.accessRbacContext;
+      },
+    },
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/portal/session/finalize/submit?app=math&redirect=/launch",
+    headers: {
+      accept: "application/json",
+      cookie: [
+        "CF_Authorization=session-cookie",
+        buildSignedAccessCookie(
+          "PortalAccessProvider",
+          "cloudflare_google|subject-pending",
+        ),
+      ].join("; "),
+      origin: "https://google.auth.paretoproof.com",
+      referer: "https://google.auth.paretoproof.com/",
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    redirectTo: "https://portal.paretoproof.com/pending",
+  });
 });
 
 test("POST /portal/session/sign-out revokes the active opaque session and clears portal cookies", async (t) => {

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -95,6 +95,23 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
   });
 });
 
+test("parseApiRuntimeEnv keeps preview cookie scope when portal/auth are overridden without an explicit math origin", () => {
+  const runtimeEnv = parseApiRuntimeEnv({
+    ACCESS_PROVIDER_STATE_SECRET: "state-secret",
+    AUTH_PUBLIC_ORIGIN: "https://auth.preview.paretoproof.com",
+    CF_ACCESS_BRANDED_AUDS: "github-audience,google-audience",
+    CF_ACCESS_PORTAL_AUD: "portal-audience",
+    CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
+    DATABASE_URL: "postgres://railway.internal:5432/paretoproof",
+    PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
+    WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
+  });
+
+  assert.equal(runtimeEnv.mathPublicOrigin, "https://math.paretoproof.com");
+  assert.equal(runtimeEnv.accessCookieDomain, ".preview.paretoproof.com");
+  assert.equal(runtimeEnv.accessCookieSecure, true);
+});
+
 test("parseApiRuntimeEnv derives host-only insecure cookie mode from explicit local origins", () => {
   const runtimeEnv = parseApiRuntimeEnv({
     ACCESS_PROVIDER_STATE_SECRET: "state-secret",

--- a/apps/api/test/runtime-env.test.ts
+++ b/apps/api/test/runtime-env.test.ts
@@ -28,6 +28,7 @@ test("parseApiRuntimeEnv accepts the documented local API runtime contract", () 
     databaseUrl: "postgres://localhost:5432/paretoproof",
     host: "0.0.0.0",
     internalAccessAudience: "portal-audience",
+    mathPublicOrigin: "https://math.paretoproof.com",
     nodeEnv: undefined,
     port: 3000,
     portalAccessAudience: "portal-audience",
@@ -56,6 +57,7 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
     CORS_ALLOW_LOCALHOST: "true",
     DATABASE_URL: "postgres://railway.internal:5432/paretoproof",
     HOST: "127.0.0.1",
+    MATH_PUBLIC_ORIGIN: "https://math.preview.paretoproof.com",
     NODE_ENV: "production",
     PORT: "4310",
     PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
@@ -82,6 +84,7 @@ test("parseApiRuntimeEnv accepts hosted-like API config with optional overrides"
     databaseUrl: "postgres://railway.internal:5432/paretoproof",
     host: "127.0.0.1",
     internalAccessAudience: "internal-audience",
+    mathPublicOrigin: "https://math.preview.paretoproof.com",
     nodeEnv: "production",
     port: 4310,
     portalAccessAudience: "legacy-audience",
@@ -100,6 +103,7 @@ test("parseApiRuntimeEnv derives host-only insecure cookie mode from explicit lo
     CF_ACCESS_PORTAL_AUD: "portal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
     DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    MATH_PUBLIC_ORIGIN: "http://localhost:4174",
     PORTAL_PUBLIC_ORIGIN: "http://localhost:4173",
     WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
@@ -123,6 +127,7 @@ test("parseApiRuntimeEnv always includes the configured auth origin in branded a
     CF_ACCESS_PORTAL_AUD: "portal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
     DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    MATH_PUBLIC_ORIGIN: "https://math.preview.paretoproof.com",
     PORTAL_PUBLIC_ORIGIN: "https://portal.preview.paretoproof.com",
     WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
@@ -143,6 +148,7 @@ test("parseApiRuntimeEnv avoids deriving cookie domains that are only public suf
     CF_ACCESS_PORTAL_AUD: "portal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
     DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    MATH_PUBLIC_ORIGIN: "https://math.co.uk",
     PORTAL_PUBLIC_ORIGIN: "https://portal.co.uk",
     WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
@@ -158,6 +164,7 @@ test("parseApiRuntimeEnv avoids deriving cookie domains that are private PSL suf
     CF_ACCESS_PORTAL_AUD: "portal-audience",
     CF_ACCESS_TEAM_DOMAIN: "paretoproof.cloudflareaccess.com",
     DATABASE_URL: "postgres://localhost:5432/paretoproof",
+    MATH_PUBLIC_ORIGIN: "https://math.github.io",
     PORTAL_PUBLIC_ORIGIN: "https://portal.github.io",
     WORKER_BOOTSTRAP_TOKEN: "worker-bootstrap-token",
   });
@@ -237,6 +244,7 @@ test("parseApiRuntimeEnv rejects missing and malformed values with explicit fiel
       CORS_ALLOW_LOCALHOST: "maybe",
       DATABASE_URL: "",
       PORT: "70000",
+      MATH_PUBLIC_ORIGIN: "https://math.example.com/path",
       PORTAL_PUBLIC_ORIGIN: "https://portal.example.com/path",
       WORKER_BOOTSTRAP_TOKEN: " ",
     });
@@ -266,6 +274,10 @@ test("parseApiRuntimeEnv rejects missing and malformed values with explicit fiel
   assert.match(String(thrownError), /CORS_ALLOW_LOCALHOST: Invalid enum value/);
   assert.match(String(thrownError), /DATABASE_URL: must not be empty/);
   assert.match(String(thrownError), /PORT: must be at most 65535/);
+  assert.match(
+    String(thrownError),
+    /MATH_PUBLIC_ORIGIN: must be an origin without path, search, or hash/,
+  );
   assert.match(
     String(thrownError),
     /PORTAL_PUBLIC_ORIGIN: must be an origin without path, search, or hash/,

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -192,6 +192,41 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
   });
 });
 
+test("trusted mutation origin hook still rejects math-origin portal mutations outside the finalize-submit boundary", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      brandedAuthOrigins: [],
+    }),
+  );
+
+  app.post("/portal/profile", async () => ({ ok: true }));
+
+  const response = await app.inject({
+    method: "POST",
+    payload: {
+      displayName: "Ada",
+    },
+    url: "/portal/profile",
+    headers: {
+      origin: "https://math.preview.paretoproof.com",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(response.json(), {
+    error: "trusted_origin_not_allowed",
+  });
+});
+
 test("trusted mutation origin hook only allows branded auth POSTs on the finalize-submit handoff boundary", async (t) => {
   const app = Fastify();
 

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -12,7 +12,7 @@ describe("handleAccessFinalize", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("relays a successful finalize response back to the portal and forwards cookies", async () => {
+  it("relays a successful portal finalize response back to the browser and forwards cookies", async () => {
     globalThis.fetch = async (input, init) => {
       expect(input).toBe("https://api.paretoproof.com/portal/session/finalize/submit");
       expect(init?.method).toBe("POST");
@@ -20,7 +20,7 @@ describe("handleAccessFinalize", () => {
       expect((init?.headers as Headers).get("cookie")).toContain("PortalAccessProvider=");
       expect((init?.headers as Headers).get("origin")).toBe("https://google.auth.paretoproof.com");
       expect(init?.redirect).toBe("manual");
-      expect(init?.body).toBe(JSON.stringify({ redirect: "/profile" }));
+      expect(init?.body).toBe(JSON.stringify({ app: "portal", redirect: "/profile" }));
 
       return new Response(
         JSON.stringify({
@@ -47,8 +47,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://google.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -77,6 +78,9 @@ describe("handleAccessFinalize", () => {
       expect((init?.headers as Headers).get("cf-access-jwt-assertion")).toBeNull();
       expect((init?.headers as Headers).get("cookie")).toContain("CF_Authorization=session-cookie");
       expect((init?.headers as Headers).get("origin")).toBe("https://github.auth.paretoproof.com");
+      expect(init?.body).toBe(
+        JSON.stringify({ app: "portal", redirect: "/access-request" })
+      );
 
       return new Response(
         JSON.stringify({
@@ -95,8 +99,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/access-request"
         }),
         headers: {
@@ -115,8 +120,9 @@ describe("handleAccessFinalize", () => {
   it("targets the API finalize-submit boundary for branded relay handoffs", async () => {
     const relayTargets: string[] = [];
 
-    globalThis.fetch = async (input) => {
+    globalThis.fetch = async (input, init) => {
       relayTargets.push(String(input));
+      expect(init?.body).toBe(JSON.stringify({ app: "portal", redirect: "/profile" }));
 
       return new Response(
         JSON.stringify({
@@ -129,8 +135,9 @@ describe("handleAccessFinalize", () => {
     };
 
     await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -159,8 +166,9 @@ describe("handleAccessFinalize", () => {
       );
 
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -175,6 +183,71 @@ describe("handleAccessFinalize", () => {
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
       "https://portal.paretoproof.com/admin/users?tab=review#pending"
+    );
+  });
+
+  it("preserves a math-surface continuation when the API returns a math redirect", async () => {
+    globalThis.fetch = async (_input, init) => {
+      expect(init?.body).toBe(JSON.stringify({ app: "math", redirect: "/launch" }));
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "https://math.paretoproof.com/launch"
+        }),
+        {
+          status: 200
+        }
+      );
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=math", {
+        body: new URLSearchParams({
+          app: "math",
+          redirect: "/launch"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-math",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://math.paretoproof.com/launch");
+  });
+
+  it("accepts a portal canonical state redirect even when the requested surface was math", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/access-request"
+        }),
+        {
+          status: 200
+        }
+      );
+
+    const response = await handleAccessFinalize(
+      new Request("https://google.auth.paretoproof.com/api/access/finalize?app=math", {
+        body: new URLSearchParams({
+          app: "math",
+          redirect: "/questions/problem-9"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-portal-fallback",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://google.auth.paretoproof.com"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://portal.paretoproof.com/access-request"
     );
   });
 
@@ -212,8 +285,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://google.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -262,8 +336,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://google.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://google.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -285,8 +360,9 @@ describe("handleAccessFinalize", () => {
 
   it("redirects back to the branded retry surface when the branded handoff lacks both Access header and session cookie", async () => {
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -298,14 +374,15 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
   });
 
   it("redirects back to the branded retry surface when branded state cookies exist without a usable Access session", async () => {
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -318,7 +395,7 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
   });
 
@@ -334,8 +411,9 @@ describe("handleAccessFinalize", () => {
       );
 
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -349,7 +427,7 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
   });
 
@@ -370,8 +448,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -395,8 +474,9 @@ describe("handleAccessFinalize", () => {
     };
 
     const response = await handleAccessFinalize(
-      new Request("https://github.auth.paretoproof.com/api/access/finalize", {
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
         body: new URLSearchParams({
+          app: "portal",
           redirect: "/profile"
         }),
         headers: {
@@ -410,7 +490,7 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
     expect(fetchCalled).toBe(false);
   });

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -517,7 +517,7 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
     expect(fetchCalled).toBe(false);
   });
@@ -577,7 +577,7 @@ describe("handleAccessFinalize", () => {
 
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fprofile&handoff=retry"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
     );
     expect(fetchCalled).toBe(false);
   });

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,5 +1,10 @@
+import { findAppRouteBySurface } from "@paretoproof/shared";
+
 const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
+const mathOrigin = "https://math.paretoproof.com";
+
+type AuthenticatedSurface = "portal" | "math";
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
@@ -26,6 +31,7 @@ const brandedHosts = new Set([
   "auth.paretoproof.com",
   "github.auth.paretoproof.com",
   "google.auth.paretoproof.com",
+  "math.paretoproof.com",
   "portal.paretoproof.com"
 ]);
 const brandedFinalizeRelayHosts = new Set([
@@ -105,7 +111,18 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
   return null;
 }
 
-function sanitizeRedirectPath(rawRedirectPath: string | null) {
+function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
+  return surface === "math" ? "math" : "portal";
+}
+
+function readSurfaceOrigin(surface: AuthenticatedSurface) {
+  return surface === "math" ? mathOrigin : portalOrigin;
+}
+
+function sanitizeRedirectPath(
+  rawRedirectPath: string | null,
+  targetSurface: AuthenticatedSurface
+) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
   }
@@ -117,10 +134,10 @@ function sanitizeRedirectPath(rawRedirectPath: string | null) {
   try {
     const url = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      portalOrigin
+      readSurfaceOrigin(targetSurface)
     );
 
-    if (url.origin !== portalOrigin) {
+    if (!findAppRouteBySurface(targetSurface, url.pathname)) {
       return "/";
     }
 
@@ -130,8 +147,12 @@ function sanitizeRedirectPath(rawRedirectPath: string | null) {
   }
 }
 
-function buildAuthRetryUrl(redirectPath: string) {
+function buildAuthRetryUrl(
+  redirectPath: string,
+  targetSurface: AuthenticatedSurface
+) {
   const authUrl = new URL(authOrigin);
+  authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
     authUrl.searchParams.set("redirect", redirectPath);
@@ -170,22 +191,42 @@ function resolveApiBaseUrl(requestUrl: URL) {
   return "https://api.paretoproof.com";
 }
 
-function resolvePortalRedirectTarget(rawRedirectTarget: unknown, fallbackRedirectPath: string) {
+function buildAuthenticatedRedirectUrl(
+  targetSurface: AuthenticatedSurface,
+  redirectPath: string
+) {
+  return new URL(redirectPath, readSurfaceOrigin(targetSurface)).toString();
+}
+
+function resolveAuthenticatedRedirectTarget(
+  rawRedirectTarget: unknown,
+  fallbackRedirectPath: string,
+  fallbackSurface: AuthenticatedSurface
+) {
   if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
-    return new URL(fallbackRedirectPath, portalOrigin).toString();
+    return buildAuthenticatedRedirectUrl(fallbackSurface, fallbackRedirectPath);
   }
 
+  let targetUrl: URL;
+
   try {
-    const targetUrl = new URL(rawRedirectTarget);
-
-    if (targetUrl.origin !== portalOrigin) {
-      return null;
-    }
-
-    return targetUrl.toString();
+    targetUrl = new URL(rawRedirectTarget);
   } catch {
     return null;
   }
+
+  const targetSurface =
+    targetUrl.origin === portalOrigin
+      ? "portal"
+      : targetUrl.origin === mathOrigin
+        ? "math"
+        : null;
+
+  if (!targetSurface || !findAppRouteBySurface(targetSurface, targetUrl.pathname)) {
+    return null;
+  }
+
+  return targetUrl.toString();
 }
 
 function splitCombinedSetCookieHeader(cookieHeader: string) {
@@ -217,12 +258,16 @@ function readSetCookieHeaders(headers: Headers) {
   return singleCookieHeader ? splitCombinedSetCookieHeader(singleCookieHeader) : [];
 }
 
-async function readRedirectPath(request: Request) {
+async function readRedirectOptions(request: Request) {
   const requestUrl = new URL(request.url);
+  const fallbackSurface = readAuthenticatedSurface(requestUrl.searchParams.get("app"));
   const fallbackRedirectPath = requestUrl.searchParams.get("redirect");
 
   if (request.method !== "POST") {
-    return sanitizeRedirectPath(fallbackRedirectPath);
+    return {
+      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      targetSurface: fallbackSurface
+    };
   }
 
   const contentType = request.headers.get("content-type") ?? "";
@@ -231,15 +276,27 @@ async function readRedirectPath(request: Request) {
     !contentType.includes("application/x-www-form-urlencoded") &&
     !contentType.includes("multipart/form-data")
   ) {
-    return sanitizeRedirectPath(fallbackRedirectPath);
+    return {
+      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      targetSurface: fallbackSurface
+    };
   }
 
   const formData = await request.formData();
   const redirectValue = formData.get("redirect");
+  const surfaceValue = formData.get("app");
+  const targetSurface =
+    typeof surfaceValue === "string"
+      ? readAuthenticatedSurface(surfaceValue)
+      : fallbackSurface;
 
-  return sanitizeRedirectPath(
-    typeof redirectValue === "string" ? redirectValue : fallbackRedirectPath
-  );
+  return {
+    redirectPath: sanitizeRedirectPath(
+      typeof redirectValue === "string" ? redirectValue : fallbackRedirectPath,
+      targetSurface
+    ),
+    targetSurface
+  };
 }
 
 function buildRedirectResponse(targetUrl: string, responseHeaders?: Headers) {
@@ -259,8 +316,8 @@ function buildRedirectResponse(targetUrl: string, responseHeaders?: Headers) {
 }
 
 export async function handleAccessFinalize(request: Request) {
-  const redirectPath = await readRedirectPath(request);
-  const retryUrl = buildAuthRetryUrl(redirectPath);
+  const { redirectPath, targetSurface } = await readRedirectOptions(request);
+  const retryUrl = buildAuthRetryUrl(redirectPath, targetSurface);
   const requestUrl = new URL(request.url);
   const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
   const trustedOrigin = readTrustedFinalizeRelayOrigin(request);
@@ -294,13 +351,14 @@ export async function handleAccessFinalize(request: Request) {
 
   try {
     finalizeResponse = await fetch(apiUrl.toString(), {
-      body: JSON.stringify(
-        redirectPath === "/"
+      body: JSON.stringify({
+        app: targetSurface,
+        ...(redirectPath === "/"
           ? {}
           : {
               redirect: redirectPath
-            }
-      ),
+            })
+      }),
       headers: forwardedHeaders,
       method: "POST",
       redirect: "manual"
@@ -321,9 +379,10 @@ export async function handleAccessFinalize(request: Request) {
     return buildRedirectResponse(retryUrl, finalizeResponse.headers);
   }
 
-  const redirectTarget = resolvePortalRedirectTarget(
+  const redirectTarget = resolveAuthenticatedRedirectTarget(
     (responseBody as { redirectTo?: unknown }).redirectTo,
-    redirectPath
+    redirectPath,
+    targetSurface
   );
 
   if (!redirectTarget) {

--- a/apps/web/functions/_shared/access-start.test.ts
+++ b/apps/web/functions/_shared/access-start.test.ts
@@ -8,7 +8,9 @@ function readSetCookies(response: Response) {
 describe("handleAccessStart", () => {
   it("starts Google sign-in with Strict provider state and clears abandoned link state", async () => {
     const response = await handleAccessStart(
-      new Request("https://auth.paretoproof.com/api/access/start/google?redirect=/profile"),
+      new Request(
+        "https://auth.paretoproof.com/api/access/start/google?app=portal&redirect=/profile"
+      ),
       {
         ACCESS_PROVIDER_STATE_SECRET: "test-secret"
       },
@@ -17,7 +19,7 @@ describe("handleAccessStart", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
-      "https://google.auth.paretoproof.com/?redirect=%2Fprofile"
+      "https://google.auth.paretoproof.com/?app=portal&redirect=%2Fprofile"
     );
 
     const setCookies = readSetCookies(response);
@@ -31,7 +33,7 @@ describe("handleAccessStart", () => {
   it("starts GitHub profile linking without clearing the existing link intent and keeps provider state Strict", async () => {
     const response = await handleAccessStart(
       new Request(
-        "https://auth.paretoproof.com/api/access/start/github?flow=link&redirect=/profile?tab=identities"
+        "https://auth.paretoproof.com/api/access/start/github?app=portal&flow=link&redirect=/profile?tab=identities"
       ),
       {
         ACCESS_PROVIDER_STATE_SECRET: "test-secret"
@@ -41,12 +43,29 @@ describe("handleAccessStart", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
-      "https://github.auth.paretoproof.com/?redirect=%2Fprofile%3Ftab%3Didentities&flow=link"
+      "https://github.auth.paretoproof.com/?app=portal&redirect=%2Fprofile%3Ftab%3Didentities&flow=link"
     );
 
     const setCookies = readSetCookies(response);
     expect(setCookies).toHaveLength(1);
     expect(setCookies[0]).toContain("PortalAccessProvider=");
     expect(setCookies[0]).toContain("SameSite=Strict");
+  });
+
+  it("preserves math-surface continuation on the branded provider handoff", async () => {
+    const response = await handleAccessStart(
+      new Request(
+        "https://auth.paretoproof.com/api/access/start/google?app=math&redirect=/questions/problem-9"
+      ),
+      {
+        ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+      },
+      "google"
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://google.auth.paretoproof.com/?app=math&redirect=%2Fquestions%2Fproblem-9"
+    );
   });
 });

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -1,8 +1,12 @@
+import { findAppRouteBySurface } from "@paretoproof/shared";
+
 const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
+const mathOrigin = "https://math.paretoproof.com";
 
 type Provider = "github" | "google";
 type PersistedProvider = "cloudflare_github" | "cloudflare_google";
+type AuthenticatedSurface = "portal" | "math";
 
 type AccessStartEnv = {
   ACCESS_PROVIDER_STATE_SECRET?: string;
@@ -18,7 +22,18 @@ const persistedProviders: Record<Provider, PersistedProvider> = {
   google: "cloudflare_google"
 };
 
-function sanitizeRedirectPath(rawRedirectPath: string | null) {
+function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
+  return surface === "math" ? "math" : "portal";
+}
+
+function readSurfaceOrigin(surface: AuthenticatedSurface) {
+  return surface === "math" ? mathOrigin : portalOrigin;
+}
+
+function sanitizeRedirectPath(
+  rawRedirectPath: string | null,
+  targetSurface: AuthenticatedSurface
+) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
   }
@@ -30,10 +45,10 @@ function sanitizeRedirectPath(rawRedirectPath: string | null) {
   try {
     const url = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      portalOrigin
+      readSurfaceOrigin(targetSurface)
     );
 
-    if (url.origin !== portalOrigin) {
+    if (!findAppRouteBySurface(targetSurface, url.pathname)) {
       return "/";
     }
 
@@ -95,8 +110,12 @@ function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkInten
   ].join("; ");
 }
 
-function buildAuthFailureUrl(redirectPath: string) {
+function buildAuthFailureUrl(
+  redirectPath: string,
+  targetSurface: AuthenticatedSurface
+) {
   const authUrl = new URL(authOrigin);
+  authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
     authUrl.searchParams.set("redirect", redirectPath);
@@ -113,12 +132,18 @@ export async function handleAccessStart(
   provider: Provider
 ) {
   const requestUrl = new URL(request.url);
-  const redirectPath = sanitizeRedirectPath(requestUrl.searchParams.get("redirect"));
+  const targetSurface = readAuthenticatedSurface(requestUrl.searchParams.get("app"));
+  const redirectPath = sanitizeRedirectPath(
+    requestUrl.searchParams.get("redirect"),
+    targetSurface
+  );
 
   try {
     const flow = requestUrl.searchParams.get("flow") === "link" ? "link" : "sign_in";
     const providerUrl = new URL("/", providerOrigins[provider]);
     const providerHintCookie = await buildProviderHintCookie(env, provider);
+
+    providerUrl.searchParams.set("app", targetSurface);
 
     if (redirectPath !== "/") {
       providerUrl.searchParams.set("redirect", redirectPath);
@@ -148,7 +173,7 @@ export async function handleAccessStart(
 
     return new Response(null, {
       headers: {
-        location: buildAuthFailureUrl(redirectPath)
+        location: buildAuthFailureUrl(redirectPath, targetSurface)
       },
       status: 302
     });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,7 +4,8 @@ import { AuthEntry } from "./routes/auth-entry";
 import { PortalBootstrap } from "./routes/portal-bootstrap";
 import { PublicSite } from "./routes/public-site";
 import {
-  readPortalRedirectTarget,
+  readAuthenticatedRedirectSurface,
+  readAuthenticatedRedirectTarget,
   resolveAccessProviderHost,
   resolveWebSurface
 } from "./lib/surface";
@@ -12,19 +13,30 @@ import {
 export default function App() {
   const surface = resolveWebSurface();
   useSurfaceNavigation(surface);
-  const redirectPath = readPortalRedirectTarget();
+  const redirectPath = readAuthenticatedRedirectTarget();
+  const redirectSurface = readAuthenticatedRedirectSurface();
   const authProvider = resolveAccessProviderHost();
 
   if (surface === "auth") {
     if (authProvider) {
-      return <AccessCompletion provider={authProvider} redirectPath={redirectPath} />;
+      return (
+        <AccessCompletion
+          provider={authProvider}
+          redirectPath={redirectPath}
+          redirectSurface={redirectSurface}
+        />
+      );
     }
 
-    return <AuthEntry redirectPath={redirectPath} />;
+    return <AuthEntry redirectPath={redirectPath} redirectSurface={redirectSurface} />;
   }
 
   if (surface === "portal") {
     return <PortalBootstrap />;
+  }
+
+  if (surface === "math") {
+    return <PortalBootstrap surface="math" />;
   }
 
   return <PublicSite />;

--- a/apps/web/src/lib/local-development.test.js
+++ b/apps/web/src/lib/local-development.test.js
@@ -18,6 +18,13 @@ describe("isLocalDevelopmentLocation", () => {
         protocol: "http:"
       })
     ).toBe(true);
+    expect(
+      isLocalDevelopmentLocation({
+        hostname: "math.paretoproof.com",
+        port: "4173",
+        protocol: "http:"
+      })
+    ).toBe(true);
   });
 
   it("keeps production branded hosts out of the local-dev path", () => {

--- a/apps/web/src/lib/local-development.ts
+++ b/apps/web/src/lib/local-development.ts
@@ -3,6 +3,7 @@ export const paretoProofBrandedHosts = [
   "auth.paretoproof.com",
   "github.auth.paretoproof.com",
   "google.auth.paretoproof.com",
+  "math.paretoproof.com",
   "portal.paretoproof.com"
 ] as const;
 

--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -175,18 +175,22 @@ describe("resolvePortalRouteRedirect", () => {
     expect(redirect.searchParams.get("access")).toBe("pending");
   });
 
-  it("redirects math-host portal state routes back onto the portal host even when the path matches", () => {
-    setWindowUrl("https://math.paretoproof.com/pending");
+  it("canonicalizes hosted pending math users onto the portal host even when the path already matches", () => {
+    setWindowUrl(
+      "https://math.paretoproof.com/pending?access=pending&email=ada@paretoproof.com"
+    );
 
-    expect(
-      resolveSurfaceRouteRedirect({
-        pathname: "/pending",
-        roles: [],
-        search: "",
-        status: "pending",
-        surface: "math"
-      })
-    ).toBe("https://portal.paretoproof.com/pending");
+    const redirect = resolveSurfaceRouteRedirect({
+      pathname: "/pending",
+      roles: [],
+      search: "?access=pending&email=ada@paretoproof.com",
+      status: "pending",
+      surface: "math"
+    });
+
+    expect(redirect).toBe(
+      "https://portal.paretoproof.com/pending"
+    );
   });
 
   it("redirects unknown approved math paths back to the math home surface", () => {

--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { resolvePortalRouteRedirect } from "./portal-route-access.ts";
+import {
+  resolvePortalRouteRedirect,
+  resolveSurfaceRouteRedirect
+} from "./portal-route-access.ts";
 
 const originalWindow = globalThis.window;
 
@@ -132,5 +135,79 @@ describe("resolvePortalRouteRedirect", () => {
     expect(redirect.pathname).toBe("/denied");
     expect(redirect.searchParams.get("surface")).toBe("portal");
     expect(redirect.searchParams.get("reason")).toBe("insufficient_role");
+  });
+
+  it("keeps approved users on owned math routes and preserves the math surface locally", () => {
+    setWindowUrl(
+      "http://localhost/questions/problem-9?surface=math&access=approved&roles=helper&email=lin@paretoproof.local"
+    );
+
+    expect(
+      resolveSurfaceRouteRedirect({
+        pathname: "/questions/problem-9",
+        roles: ["helper"],
+        search:
+          "?surface=math&access=approved&roles=helper&email=lin@paretoproof.local",
+        status: "approved",
+        surface: "math"
+      })
+    ).toBeNull();
+  });
+
+  it("redirects pending math users to the portal pending surface", () => {
+    setWindowUrl(
+      "http://localhost/launch?surface=math&access=pending&email=ada@paretoproof.local"
+    );
+
+    const redirect = new URL(
+      resolveSurfaceRouteRedirect({
+        pathname: "/launch",
+        roles: [],
+        search: "?surface=math&access=pending&email=ada@paretoproof.local",
+        status: "pending",
+        surface: "math"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/pending");
+    expect(redirect.searchParams.get("surface")).toBe("portal");
+    expect(redirect.searchParams.get("access")).toBe("pending");
+  });
+
+  it("redirects math-host portal state routes back onto the portal host even when the path matches", () => {
+    setWindowUrl("https://math.paretoproof.com/pending");
+
+    expect(
+      resolveSurfaceRouteRedirect({
+        pathname: "/pending",
+        roles: [],
+        search: "",
+        status: "pending",
+        surface: "math"
+      })
+    ).toBe("https://portal.paretoproof.com/pending");
+  });
+
+  it("redirects unknown approved math paths back to the math home surface", () => {
+    setWindowUrl(
+      "http://localhost/unknown?surface=math&access=approved&roles=helper&email=lin@paretoproof.local"
+    );
+
+    const redirect = new URL(
+      resolveSurfaceRouteRedirect({
+        pathname: "/unknown",
+        roles: ["helper"],
+        search:
+          "?surface=math&access=approved&roles=helper&email=lin@paretoproof.local",
+        status: "approved",
+        surface: "math"
+      }),
+      "http://localhost"
+    );
+
+    expect(redirect.pathname).toBe("/");
+    expect(redirect.searchParams.get("surface")).toBe("math");
+    expect(redirect.searchParams.get("access")).toBe("approved");
   });
 });

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -2,9 +2,14 @@ import {
   type AppRouteMatrixEntry,
   findAppRouteBySurface
 } from "@paretoproof/shared";
-import { buildPublicUrl, copyLocalPortalState, isLocalHostname } from "./surface";
+import {
+  buildMathUrl,
+  buildPortalUrl,
+  buildPublicUrl
+} from "./surface";
 
 type PortalAccessStatus = "approved" | "denied" | "pending" | "unauthenticated";
+type AuthenticatedSurface = "portal" | "math";
 
 type PortalRouteAccessContext = {
   pathname: string;
@@ -19,8 +24,12 @@ type PortalRouteAccessContext = {
   status: PortalAccessStatus;
 };
 
-function findPortalRoute(pathname: string) {
-  return findAppRouteBySurface("portal", pathname);
+type SurfaceRouteAccessContext = PortalRouteAccessContext & {
+  surface: AuthenticatedSurface;
+};
+
+function findSurfaceRoute(surface: AuthenticatedSurface, pathname: string) {
+  return findAppRouteBySurface(surface, pathname);
 }
 
 function hasRole(roles: string[], role: "admin" | "collaborator" | "helper") {
@@ -72,18 +81,6 @@ function canAccessRoute(
   return true;
 }
 
-function preserveLocalPortalState(targetPath: string, location = window.location) {
-  if (!isLocalHostname(location.hostname)) {
-    return targetPath;
-  }
-
-  const redirectUrl = new URL(targetPath, location.origin);
-  redirectUrl.searchParams.set("surface", "portal");
-  copyLocalPortalState(redirectUrl, location);
-
-  return `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
-}
-
 function stripRouteDeniedReason(search = "") {
   const params = new URLSearchParams(search);
   params.delete("reason");
@@ -122,31 +119,32 @@ function isCurrentRedirectTarget(
 ) {
   const targetUrl = new URL(targetPath, window.location.origin);
   return (
+    targetUrl.origin === window.location.origin &&
     targetUrl.pathname === context.pathname &&
     normalizeSearch(targetUrl.search) === normalizeSearch(context.search ?? "")
   );
 }
 
-function resolveCanonicalStateTarget(context: PortalRouteAccessContext) {
+function buildCanonicalPortalStateTarget(context: PortalRouteAccessContext) {
   if (context.status === "pending") {
-    return preserveLocalPortalState("/pending");
+    return buildPortalUrl("/pending");
   }
 
   if (context.status === "denied") {
     return context.reason === "access_request_required"
-      ? preserveLocalPortalState("/access-request")
-      : preserveLocalPortalState("/denied");
+      ? buildPortalUrl("/access-request")
+      : buildPortalUrl("/denied");
   }
 
   return null;
 }
 
-export function findMatchedPortalRoute(pathname: string) {
-  return findPortalRoute(pathname) ?? null;
+function buildSurfaceHomeUrl(surface: AuthenticatedSurface) {
+  return surface === "math" ? buildMathUrl("/") : buildPortalUrl("/");
 }
 
-export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
-  const matchedRoute = findPortalRoute(context.pathname);
+function resolvePortalSurfaceRouteRedirect(context: PortalRouteAccessContext) {
+  const matchedRoute = findSurfaceRoute("portal", context.pathname);
   const routeDeniedReason = readRouteDeniedReason(context.search);
 
   if (
@@ -154,26 +152,22 @@ export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
     routeDeniedReason &&
     matchedRoute?.id !== "portal.denied"
   ) {
-    return preserveLocalPortalState(
-      `${context.pathname}${stripRouteDeniedReason(context.search)}`
-    );
+    return buildPortalUrl(`${context.pathname}${stripRouteDeniedReason(context.search)}`);
   }
 
   if (context.status === "approved" && matchedRoute?.id === "portal.pending") {
-    return preserveLocalPortalState("/");
+    return buildPortalUrl("/");
   }
 
   if (context.status === "approved" && matchedRoute?.id === "portal.access-request") {
-    return preserveLocalPortalState("/");
+    return buildPortalUrl("/");
   }
 
   if (context.status === "approved" && matchedRoute?.id === "portal.denied") {
-    return routeDeniedReason === "insufficient_role"
-      ? null
-      : preserveLocalPortalState("/");
+    return routeDeniedReason === "insufficient_role" ? null : buildPortalUrl("/");
   }
 
-  const canonicalStateTarget = resolveCanonicalStateTarget(context);
+  const canonicalStateTarget = buildCanonicalPortalStateTarget(context);
 
   if (canonicalStateTarget && !isCurrentRedirectTarget(canonicalStateTarget, context)) {
     return canonicalStateTarget;
@@ -184,20 +178,77 @@ export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
   }
 
   if (context.status === "approved") {
-    return preserveLocalPortalState("/denied?reason=insufficient_role");
+    return buildPortalUrl("/denied?reason=insufficient_role");
   }
 
   if (context.status === "pending") {
-    return preserveLocalPortalState("/pending");
+    return buildPortalUrl("/pending");
   }
 
   if (context.status === "denied") {
     return context.reason === "access_request_required"
-      ? preserveLocalPortalState("/access-request")
-      : preserveLocalPortalState("/denied");
+      ? buildPortalUrl("/access-request")
+      : buildPortalUrl("/denied");
   }
 
   return matchedRoute.redirectIfDenied === "public_home"
     ? buildPublicUrl("/")
-    : preserveLocalPortalState("/");
+    : buildPortalUrl("/");
+}
+
+export function findMatchedPortalRoute(pathname: string) {
+  return findSurfaceRoute("portal", pathname) ?? null;
+}
+
+export function findMatchedSurfaceRoute(
+  surface: AuthenticatedSurface,
+  pathname: string
+) {
+  return findSurfaceRoute(surface, pathname) ?? null;
+}
+
+export function resolveSurfaceRouteRedirect(context: SurfaceRouteAccessContext) {
+  if (context.surface === "portal") {
+    return resolvePortalSurfaceRouteRedirect(context);
+  }
+
+  const matchedRoute = findSurfaceRoute("math", context.pathname);
+  const canonicalPortalTarget = buildCanonicalPortalStateTarget(context);
+
+  if (canonicalPortalTarget && !isCurrentRedirectTarget(canonicalPortalTarget, context)) {
+    return canonicalPortalTarget;
+  }
+
+  if (!matchedRoute) {
+    return context.status === "approved" ? buildSurfaceHomeUrl("math") : null;
+  }
+
+  if (canAccessRoute(matchedRoute, context)) {
+    return null;
+  }
+
+  if (context.status === "approved") {
+    return buildSurfaceHomeUrl("math");
+  }
+
+  if (context.status === "pending") {
+    return buildPortalUrl("/pending");
+  }
+
+  if (context.status === "denied") {
+    return context.reason === "access_request_required"
+      ? buildPortalUrl("/access-request")
+      : buildPortalUrl("/denied");
+  }
+
+  return matchedRoute.redirectIfDenied === "public_home"
+    ? buildPublicUrl("/")
+    : buildSurfaceHomeUrl("math");
+}
+
+export function resolvePortalRouteRedirect(context: PortalRouteAccessContext) {
+  return resolveSurfaceRouteRedirect({
+    ...context,
+    surface: "portal"
+  });
 }

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -28,7 +28,10 @@ type SurfaceRouteAccessContext = PortalRouteAccessContext & {
   surface: AuthenticatedSurface;
 };
 
-function findSurfaceRoute(surface: AuthenticatedSurface, pathname: string) {
+function findSurfaceRoute<TSurface extends AuthenticatedSurface>(
+  surface: TSurface,
+  pathname: string
+) {
   return findAppRouteBySurface(surface, pathname);
 }
 

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -3,8 +3,11 @@ import {
   buildAccessFinalizeUrl,
   buildAuthGuidanceUrl,
   buildAuthUrl,
+  buildMathUrl,
   buildPortalUrl,
   buildPublicUrl,
+  readAuthenticatedRedirectSurface,
+  readAuthenticatedRedirectTarget,
   readPortalRedirectTarget,
   resolveWebSurface
 } from "./surface.ts";
@@ -83,30 +86,39 @@ describe("buildPortalUrl", () => {
   });
 
   it("uses the local API finalize endpoint on loopback-mapped branded auth hosts", () => {
-    setWindowUrl("http://github.auth.paretoproof.com:4371/");
+    setWindowUrl("http://github.auth.paretoproof.com:4371/?surface=auth&app=math");
 
-    expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?redirect=%2Fprofile"
+    expect(
+      buildAccessFinalizeUrl("/launch", {
+        surface: "math"
+      })
+    ).toBe(
+      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?app=math&redirect=%2Flaunch"
     );
   });
 
   it("uses the branded finalize relay endpoint on branded auth hosts", () => {
     setWindowUrl("https://google.auth.paretoproof.com/");
 
-    expect(buildAccessFinalizeUrl("/profile")).toBe(
-      "https://google.auth.paretoproof.com/api/access/finalize?redirect=%2Fprofile"
+    expect(
+      buildAccessFinalizeUrl("/profile", {
+        surface: "portal"
+      })
+    ).toBe(
+      "https://google.auth.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fprofile"
     );
   });
 });
 
 describe("surface ownership helpers", () => {
-  it("classifies apex, auth, provider auth, portal, and local surfaces", () => {
+  it("classifies apex, auth, provider auth, portal, math, and local surfaces", () => {
     setWindowUrl("http://localhost/");
 
     expect(resolveWebSurface("paretoproof.com")).toBe("public");
     expect(resolveWebSurface("auth.paretoproof.com")).toBe("auth");
     expect(resolveWebSurface("github.auth.paretoproof.com")).toBe("auth");
     expect(resolveWebSurface("portal.paretoproof.com")).toBe("portal");
+    expect(resolveWebSurface("math.paretoproof.com")).toBe("math");
     expect(resolveWebSurface("localhost")).toBe("public");
   });
 
@@ -120,12 +132,13 @@ describe("surface ownership helpers", () => {
     expect(buildPublicUrl("/profile")).toBe("https://paretoproof.com/");
   });
 
-  it("routes loopback-mapped branded auth and portal hosts back to the local public apex", () => {
+  it("routes loopback-mapped branded auth, portal, and math hosts back to the local public apex", () => {
     const brandedHosts = [
       "auth.paretoproof.com",
       "github.auth.paretoproof.com",
       "google.auth.paretoproof.com",
-      "portal.paretoproof.com"
+      "portal.paretoproof.com",
+      "math.paretoproof.com"
     ];
 
     for (const host of brandedHosts) {
@@ -136,15 +149,31 @@ describe("surface ownership helpers", () => {
     }
   });
 
-  it("preserves only portal-owned redirect targets for auth URLs", () => {
+  it("preserves portal-owned redirect targets for auth URLs by default", () => {
     setWindowUrl("https://paretoproof.com/");
 
     expect(buildAuthUrl("/runs/run-123?tab=events#trace")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace"
     );
-    expect(buildAuthUrl("/benchmarks")).toBe("https://auth.paretoproof.com/");
-    expect(buildAuthUrl("https://math.paretoproof.com/runs/problem-9")).toBe(
-      "https://auth.paretoproof.com/"
+    expect(buildAuthUrl("/benchmarks")).toBe("https://auth.paretoproof.com/?app=portal");
+  });
+
+  it("preserves math-owned redirect targets when the caller explicitly targets math", () => {
+    setWindowUrl("https://math.paretoproof.com/launch");
+
+    expect(
+      buildAuthUrl("/launch", undefined, {
+        surface: "math"
+      })
+    ).toBe(
+      "https://auth.paretoproof.com/?app=math&redirect=%2Flaunch"
+    );
+    expect(
+      buildAuthUrl("https://math.paretoproof.com/questions/problem-9", undefined, {
+        surface: "math"
+      })
+    ).toBe(
+      "https://auth.paretoproof.com/?app=math&redirect=%2Fquestions%2Fproblem-9"
     );
   });
 
@@ -152,44 +181,70 @@ describe("surface ownership helpers", () => {
     setWindowUrl("https://paretoproof.com/");
 
     expect(buildAuthGuidanceUrl("/runs/run-123?tab=events#trace")).toBe(
-      "https://auth.paretoproof.com/?redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace&guidance=1"
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace&guidance=1"
     );
     expect(buildAuthGuidanceUrl("/benchmarks")).toBe(
-      "https://auth.paretoproof.com/?guidance=1"
+      "https://auth.paretoproof.com/?app=portal&guidance=1"
     );
   });
 
-  it("preserves only portal-owned redirect targets for finalize URLs", () => {
+  it("preserves the targeted authenticated surface for finalize URLs", () => {
     setWindowUrl("https://github.auth.paretoproof.com/");
 
-    expect(buildAccessFinalizeUrl("/admin/users?tab=review")).toBe(
-      "https://github.auth.paretoproof.com/api/access/finalize?redirect=%2Fadmin%2Fusers%3Ftab%3Dreview"
+    expect(
+      buildAccessFinalizeUrl("/admin/users?tab=review", {
+        surface: "portal"
+      })
+    ).toBe(
+      "https://github.auth.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fadmin%2Fusers%3Ftab%3Dreview"
     );
-    expect(buildAccessFinalizeUrl("/project")).toBe(
-      "https://github.auth.paretoproof.com/api/access/finalize"
+    expect(
+      buildAccessFinalizeUrl("/launch", {
+        surface: "math"
+      })
+    ).toBe(
+      "https://github.auth.paretoproof.com/api/access/finalize?app=math&redirect=%2Flaunch"
     );
   });
 
-  it("rejects public-site and external redirect targets when reading auth redirect state", () => {
+  it("reads math-aware auth redirect state and keeps portal compatibility", () => {
+    expect(
+      readAuthenticatedRedirectTarget(
+        "?app=math&redirect=%2Fquestions%2Fproblem-9%3Ftab%3Dreview"
+      )
+    ).toBe("/questions/problem-9?tab=review");
+    expect(
+      readAuthenticatedRedirectSurface(
+        "?app=math&redirect=%2Fquestions%2Fproblem-9%3Ftab%3Dreview"
+      )
+    ).toBe("math");
     expect(readPortalRedirectTarget("?redirect=%2Fprofile%3Ftab%3Ddetails")).toBe(
       "/profile?tab=details"
     );
-    expect(readPortalRedirectTarget("?redirect=%2Fbenchmarks")).toBe("/");
-    expect(
-      readPortalRedirectTarget(
-        "?redirect=https%3A%2F%2Fmath.paretoproof.com%2Fruns%2Fproblem-9"
-      )
-    ).toBe("/");
-    expect(readPortalRedirectTarget("?redirect=https%3A%2F%2Fparetoproof.com%2Fprofile")).toBe(
-      "/"
-    );
   });
 
-  it("rejects public-site targets when building portal URLs", () => {
+  it("rejects invalid authenticated redirect targets when reading auth redirect state", () => {
+    expect(readAuthenticatedRedirectTarget("?redirect=%2Fbenchmarks")).toBe("/");
+    expect(readAuthenticatedRedirectSurface("?redirect=%2Fbenchmarks")).toBe("portal");
+    expect(
+      readAuthenticatedRedirectTarget(
+        "?app=math&redirect=https%3A%2F%2Fmath.paretoproof.com%2Fruns%2Fproblem-9"
+      )
+    ).toBe("/");
+    expect(
+      readAuthenticatedRedirectTarget(
+        "?redirect=https%3A%2F%2Fparetoproof.com%2Fprofile"
+      )
+    ).toBe("/");
+  });
+
+  it("keeps portal and math builders scoped to their owned routes", () => {
     setWindowUrl("https://portal.paretoproof.com/");
 
     expect(buildPortalUrl("/workers")).toBe("https://portal.paretoproof.com/workers");
     expect(buildPortalUrl("/project")).toBe("https://portal.paretoproof.com/");
-    expect(buildPortalUrl("/math/problem-9")).toBe("https://portal.paretoproof.com/");
+
+    expect(buildMathUrl("/launch")).toBe("https://math.paretoproof.com/launch");
+    expect(buildMathUrl("/workers")).toBe("https://math.paretoproof.com/");
   });
 });

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -2,23 +2,39 @@ import { findAppRouteBySurface } from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
 import { isLocalDevelopmentLocation } from "./local-development";
 
-export type WebSurface = "public" | "auth" | "portal";
+export type WebSurface = "public" | "auth" | "portal" | "math";
+export type AuthenticatedSurface = "portal" | "math";
 export type AccessProvider = "github" | "google";
 
 const productionPublicOrigin = "https://paretoproof.com";
 const productionAuthOrigin = "https://auth.paretoproof.com";
 const productionPortalOrigin = "https://portal.paretoproof.com";
+const productionMathOrigin = "https://math.paretoproof.com";
 const localPortalStateParamKeys = ["access", "email"] as const;
+const authenticatedSurfaces = ["portal", "math"] as const;
 const productionProviderAuthOrigins: Record<AccessProvider, string> = {
   github: "https://github.auth.paretoproof.com",
   google: "https://google.auth.paretoproof.com"
+};
+const productionOriginByAuthenticatedSurface: Record<AuthenticatedSurface, string> = {
+  math: productionMathOrigin,
+  portal: productionPortalOrigin
+};
+
+type OwnedAppSurface = "public_site" | AuthenticatedSurface;
+type ResolvedOwnedTarget<TSurface extends OwnedAppSurface = OwnedAppSurface> = {
+  surface: TSurface;
+  targetPath: string;
 };
 
 function readLocalSurfaceOverride(search = window.location.search) {
   const params = new URLSearchParams(search);
   const surface = params.get("surface");
 
-  return surface === "public" || surface === "auth" || surface === "portal"
+  return surface === "public" ||
+    surface === "auth" ||
+    surface === "portal" ||
+    surface === "math"
     ? surface
     : null;
 }
@@ -46,12 +62,44 @@ function buildLocalPublicOrigin(locationLike = window.location) {
     hostname === "auth.paretoproof.com" ||
     hostname === "github.auth.paretoproof.com" ||
     hostname === "google.auth.paretoproof.com" ||
-    hostname === "portal.paretoproof.com"
+    hostname === "portal.paretoproof.com" ||
+    hostname === "math.paretoproof.com"
   ) {
     return `${protocol}//paretoproof.com${port ? `:${port}` : ""}`;
   }
 
   return origin;
+}
+
+function isAuthenticatedSurface(surface: string | null): surface is AuthenticatedSurface {
+  return surface === "portal" || surface === "math";
+}
+
+function mapAuthenticatedSurfaceToOrigin(surface: AuthenticatedSurface) {
+  return productionOriginByAuthenticatedSurface[surface];
+}
+
+function mapAuthenticatedSurfaceToLabel(surface: AuthenticatedSurface) {
+  return surface === "math" ? "math workspace" : "portal";
+}
+
+function mapWebSurfaceToAuthenticatedSurface(
+  surface: WebSurface
+): AuthenticatedSurface | null {
+  if (surface === "portal" || surface === "math") {
+    return surface;
+  }
+
+  return null;
+}
+
+function readAuthenticatedSurfaceParam(search = window.location.search) {
+  const surface = new URLSearchParams(search).get("app");
+  return isAuthenticatedSurface(surface) ? surface : null;
+}
+
+function resolvePreferredAuthenticatedSurface(hostname = window.location.hostname) {
+  return mapWebSurfaceToAuthenticatedSurface(resolveWebSurface(hostname)) ?? "portal";
 }
 
 export function resolveWebSurfaceFromUrl(
@@ -69,6 +117,10 @@ export function resolveWebSurfaceFromUrl(
 
   if (hostname === "portal.paretoproof.com") {
     return "portal";
+  }
+
+  if (hostname === "math.paretoproof.com") {
+    return "math";
   }
 
   if (isLocalHostname(hostname)) {
@@ -97,25 +149,131 @@ function normalizeTargetPath(targetPath: string) {
   return targetPath.startsWith("/") ? targetPath : `/${targetPath}`;
 }
 
-function sanitizeSurfaceTargetPath(
-  surface: "public_site" | "portal",
-  targetPath: string
-) {
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetPath) || targetPath.startsWith("//")) {
-    return "/";
-  }
-
+function tryResolveRelativeTarget(
+  targetPath: string,
+  allowedSurfaces: OwnedAppSurface[],
+  preferredSurface: OwnedAppSurface
+): ResolvedOwnedTarget | null {
   try {
-    const candidateUrl = new URL(normalizeTargetPath(targetPath), productionPortalOrigin);
+    const candidateUrl = new URL(
+      normalizeTargetPath(targetPath),
+      mapOwnedSurfaceToOrigin(preferredSurface)
+    );
+    const matchingSurface =
+      allowedSurfaces.find(
+        (surface) =>
+          surface === preferredSurface &&
+          findAppRouteBySurface(surface, candidateUrl.pathname)
+      ) ??
+      allowedSurfaces.find((surface) =>
+        findAppRouteBySurface(surface, candidateUrl.pathname)
+      );
 
-    if (!findAppRouteBySurface(surface, candidateUrl.pathname)) {
-      return "/";
+    if (!matchingSurface) {
+      return null;
     }
 
-    return `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/";
+    return {
+      surface: matchingSurface,
+      targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
+    };
   } catch {
-    return "/";
+    return null;
   }
+}
+
+function mapOwnedSurfaceToOrigin(surface: OwnedAppSurface) {
+  if (surface === "public_site") {
+    return productionPublicOrigin;
+  }
+
+  return mapAuthenticatedSurfaceToOrigin(surface);
+}
+
+function tryResolveAbsoluteTarget(
+  targetPath: string,
+  allowedSurfaces: OwnedAppSurface[]
+): ResolvedOwnedTarget | null {
+  let candidateUrl: URL;
+
+  try {
+    candidateUrl = new URL(targetPath);
+  } catch {
+    return null;
+  }
+
+  const matchingSurface = allowedSurfaces.find((surface) => {
+    if (candidateUrl.origin !== mapOwnedSurfaceToOrigin(surface)) {
+      return false;
+    }
+
+    return findAppRouteBySurface(surface, candidateUrl.pathname);
+  });
+
+  if (!matchingSurface) {
+    return null;
+  }
+
+  return {
+    surface: matchingSurface,
+    targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
+  };
+}
+
+function resolveOwnedTarget(
+  targetPath: string,
+  options: {
+    allowedSurfaces: OwnedAppSurface[];
+    preferredSurface: OwnedAppSurface;
+  }
+): ResolvedOwnedTarget | null {
+  if (!targetPath || targetPath === "/") {
+    return {
+      surface: options.preferredSurface,
+      targetPath: "/"
+    };
+  }
+
+  if (
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetPath) ||
+    targetPath.startsWith("//")
+  ) {
+    return tryResolveAbsoluteTarget(targetPath, options.allowedSurfaces);
+  }
+
+  return tryResolveRelativeTarget(
+    targetPath,
+    options.allowedSurfaces,
+    options.preferredSurface
+  );
+}
+
+function resolveAuthenticatedTarget(
+  targetPath: string,
+  options?: {
+    preferredSurface?: AuthenticatedSurface;
+    surface?: AuthenticatedSurface | null;
+  }
+) {
+  const preferredSurface =
+    options?.surface ?? options?.preferredSurface ?? "portal";
+  const allowedSurfaces = options?.surface
+    ? [options.surface]
+    : [...authenticatedSurfaces];
+
+  return resolveOwnedTarget(targetPath, {
+    allowedSurfaces,
+    preferredSurface
+  }) as ResolvedOwnedTarget<AuthenticatedSurface> | null;
+}
+
+function sanitizeSurfaceTargetPath(surface: OwnedAppSurface, targetPath: string) {
+  return (
+    resolveOwnedTarget(targetPath, {
+      allowedSurfaces: [surface],
+      preferredSurface: surface
+    })?.targetPath ?? "/"
+  );
 }
 
 function sanitizePortalTargetPath(targetPath: string) {
@@ -126,27 +284,67 @@ function sanitizePublicTargetPath(targetPath: string) {
   return sanitizeSurfaceTargetPath("public_site", targetPath);
 }
 
-export function readPortalRedirectTarget(search = window.location.search) {
+function sanitizeMathTargetPath(targetPath: string) {
+  return sanitizeSurfaceTargetPath("math", targetPath);
+}
+
+export function readAuthenticatedRedirectTarget(search = window.location.search) {
   const params = new URLSearchParams(search);
-  return sanitizePortalTargetPath(params.get("redirect") ?? "/");
+  const targetSurface = readAuthenticatedSurfaceParam(search);
+
+  return (
+    resolveAuthenticatedTarget(params.get("redirect") ?? "/", {
+      preferredSurface: targetSurface ?? "portal",
+      surface: targetSurface
+    })?.targetPath ?? "/"
+  );
+}
+
+export function readAuthenticatedRedirectSurface(search = window.location.search) {
+  const params = new URLSearchParams(search);
+  const explicitSurface = readAuthenticatedSurfaceParam(search);
+
+  return (
+    resolveAuthenticatedTarget(params.get("redirect") ?? "/", {
+      preferredSurface: explicitSurface ?? "portal",
+      surface: explicitSurface
+    })?.surface ??
+    explicitSurface ??
+    "portal"
+  );
+}
+
+export function readPortalRedirectTarget(search = window.location.search) {
+  return readAuthenticatedRedirectTarget(search);
 }
 
 function buildLocalSurfaceUrl(
   surface: Exclude<WebSurface, "public">,
   targetPath: string,
+  authenticatedSurface: AuthenticatedSurface,
   origin = window.location.origin
 ) {
-  const surfaceUrl = new URL(origin);
-  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
+  if (surface === "portal" || surface === "math") {
+    const surfaceUrl = new URL(
+      surface === "portal"
+        ? sanitizePortalTargetPath(targetPath)
+        : sanitizeMathTargetPath(targetPath),
+      origin
+    );
 
-  if (surface === "portal") {
-    const portalUrl = new URL(normalizedTargetPath, origin);
-    portalUrl.searchParams.set("surface", surface);
-    copyLocalPortalState(portalUrl);
-    return portalUrl.toString();
+    surfaceUrl.searchParams.set("surface", surface);
+    copyLocalPortalState(surfaceUrl);
+    return surfaceUrl.toString();
   }
 
+  const surfaceUrl = new URL(origin);
+  const normalizedTargetPath =
+    authenticatedSurface === "math"
+      ? sanitizeMathTargetPath(targetPath)
+      : sanitizePortalTargetPath(targetPath);
+
   surfaceUrl.searchParams.set("surface", "auth");
+  surfaceUrl.searchParams.set("app", authenticatedSurface);
 
   if (normalizedTargetPath !== "/") {
     surfaceUrl.searchParams.set("redirect", normalizedTargetPath);
@@ -222,17 +420,37 @@ export function copyLocalPortalState(targetUrl: URL, currentLocation = window.lo
   }
 }
 
-export function buildAuthUrl(targetPath = "/", hostname = window.location.hostname) {
-  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
+export function buildAuthUrl(
+  targetPath = "/",
+  hostname = window.location.hostname,
+  options?: {
+    surface?: AuthenticatedSurface;
+  }
+) {
+  const preferredSurface =
+    options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
+  const resolvedTarget =
+    resolveAuthenticatedTarget(targetPath, {
+      preferredSurface,
+      surface: options?.surface
+    }) ?? {
+      surface: preferredSurface,
+      targetPath: "/"
+    };
 
   if (isLocalOrigin(hostname)) {
-    return buildLocalSurfaceUrl("auth", normalizedTargetPath);
+    return buildLocalSurfaceUrl(
+      "auth",
+      resolvedTarget.targetPath,
+      resolvedTarget.surface
+    );
   }
 
   const authUrl = new URL(productionAuthOrigin);
+  authUrl.searchParams.set("app", resolvedTarget.surface);
 
-  if (normalizedTargetPath !== "/") {
-    authUrl.searchParams.set("redirect", normalizedTargetPath);
+  if (resolvedTarget.targetPath !== "/") {
+    authUrl.searchParams.set("redirect", resolvedTarget.targetPath);
   }
 
   return authUrl.toString();
@@ -240,15 +458,20 @@ export function buildAuthUrl(targetPath = "/", hostname = window.location.hostna
 
 export function buildAuthGuidanceUrl(
   targetPath = "/",
-  hostname = window.location.hostname
+  hostname = window.location.hostname,
+  options?: {
+    surface?: AuthenticatedSurface;
+  }
 ) {
-  const authUrl = new URL(buildAuthUrl(targetPath, hostname));
+  const authUrl = new URL(buildAuthUrl(targetPath, hostname, options));
   authUrl.searchParams.set("guidance", "1");
   return authUrl.toString();
 }
 
 export function buildAccessRequestUrl(hostname = window.location.hostname) {
-  return buildAuthUrl("/access-request", hostname);
+  return buildAuthUrl("/access-request", hostname, {
+    surface: "portal"
+  });
 }
 
 export function buildPublicUrl(targetPath = "/", hostname = window.location.hostname) {
@@ -265,10 +488,43 @@ export function buildPortalUrl(targetPath = "/", hostname = window.location.host
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
 
   if (isLocalOrigin(hostname)) {
-    return buildLocalSurfaceUrl("portal", normalizedTargetPath);
+    return buildLocalSurfaceUrl("portal", normalizedTargetPath, "portal");
   }
 
   return new URL(normalizedTargetPath, productionPortalOrigin).toString();
+}
+
+export function buildMathUrl(targetPath = "/", hostname = window.location.hostname) {
+  const normalizedTargetPath = sanitizeMathTargetPath(targetPath);
+
+  if (isLocalOrigin(hostname)) {
+    return buildLocalSurfaceUrl("math", normalizedTargetPath, "math");
+  }
+
+  return new URL(normalizedTargetPath, productionMathOrigin).toString();
+}
+
+export function buildAuthenticatedAppUrl(
+  targetPath = "/",
+  options?: {
+    surface?: AuthenticatedSurface;
+  },
+  hostname = window.location.hostname
+) {
+  const preferredSurface =
+    options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
+  const resolvedTarget =
+    resolveAuthenticatedTarget(targetPath, {
+      preferredSurface,
+      surface: options?.surface
+    }) ?? {
+      surface: preferredSurface,
+      targetPath: "/"
+    };
+
+  return resolvedTarget.surface === "math"
+    ? buildMathUrl(resolvedTarget.targetPath, hostname)
+    : buildPortalUrl(resolvedTarget.targetPath, hostname);
 }
 
 export function buildAccessStartUrl(
@@ -276,13 +532,31 @@ export function buildAccessStartUrl(
   targetPath = "/",
   options?: {
     flow?: "sign_in" | "link";
+    surface?: AuthenticatedSurface;
   },
   hostname = window.location.hostname
 ) {
-  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
+  const preferredSurface =
+    options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
+  const resolvedTarget =
+    resolveAuthenticatedTarget(targetPath, {
+      preferredSurface,
+      surface: options?.surface
+    }) ?? {
+      surface: preferredSurface,
+      targetPath: "/"
+    };
 
   if (isLocalOrigin(hostname)) {
-    const localUrl = new URL(buildPortalUrl(normalizedTargetPath, hostname));
+    const localUrl = new URL(
+      buildAuthenticatedAppUrl(
+        resolvedTarget.targetPath,
+        {
+          surface: resolvedTarget.surface
+        },
+        hostname
+      )
+    );
     const currentParams = new URLSearchParams(window.location.search);
     const approvedRole =
       currentParams.get("role") ??
@@ -301,9 +575,10 @@ export function buildAccessStartUrl(
   }
 
   const authUrl = new URL(`/api/access/start/${provider}`, productionAuthOrigin);
+  authUrl.searchParams.set("app", resolvedTarget.surface);
 
-  if (normalizedTargetPath !== "/") {
-    authUrl.searchParams.set("redirect", normalizedTargetPath);
+  if (resolvedTarget.targetPath !== "/") {
+    authUrl.searchParams.set("redirect", resolvedTarget.targetPath);
   }
 
   if (options?.flow === "link") {
@@ -313,29 +588,48 @@ export function buildAccessStartUrl(
   return authUrl.toString();
 }
 
-export function buildAccessFinalizeUrl(targetPath = "/") {
-  const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
+export function buildAccessFinalizeUrl(
+  targetPath = "/",
+  options?: {
+    surface?: AuthenticatedSurface;
+  },
+  hostname = window.location.hostname
+) {
+  const preferredSurface =
+    options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
+  const resolvedTarget =
+    resolveAuthenticatedTarget(targetPath, {
+      preferredSurface,
+      surface: options?.surface
+    }) ?? {
+      surface: preferredSurface,
+      targetPath: "/"
+    };
 
-  if (isLocalOrigin()) {
+  if (isLocalOrigin(hostname)) {
     const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
+    completionUrl.searchParams.set("app", resolvedTarget.surface);
 
-    if (normalizedTargetPath !== "/") {
-      completionUrl.searchParams.set("redirect", normalizedTargetPath);
+    if (resolvedTarget.targetPath !== "/") {
+      completionUrl.searchParams.set("redirect", resolvedTarget.targetPath);
     }
 
     return completionUrl.toString();
   }
 
   const completionUrl = new URL("/api/access/finalize", window.location.origin);
+  completionUrl.searchParams.set("app", resolvedTarget.surface);
 
-  if (normalizedTargetPath !== "/") {
-    completionUrl.searchParams.set("redirect", normalizedTargetPath);
+  if (resolvedTarget.targetPath !== "/") {
+    completionUrl.searchParams.set("redirect", resolvedTarget.targetPath);
   }
 
   return completionUrl.toString();
 }
 
-export function resolveAccessProviderHost(hostname = window.location.hostname): AccessProvider | null {
+export function resolveAccessProviderHost(
+  hostname = window.location.hostname
+): AccessProvider | null {
   if (hostname === "github.auth.paretoproof.com") {
     return "github";
   }
@@ -345,6 +639,10 @@ export function resolveAccessProviderHost(hostname = window.location.hostname): 
   }
 
   return null;
+}
+
+export function describeAuthenticatedSurface(surface: AuthenticatedSurface) {
+  return mapAuthenticatedSurfaceToLabel(surface);
 }
 
 export function getCurrentRelativeUrl(location = window.location) {

--- a/apps/web/src/routes/access-completion.tsx
+++ b/apps/web/src/routes/access-completion.tsx
@@ -3,19 +3,33 @@ import { AppIcon } from "../components/app-icon";
 import {
   buildAccessFinalizeUrl,
   buildAuthUrl,
+  describeAuthenticatedSurface,
+  type AuthenticatedSurface,
   isLocalHostname
 } from "../lib/surface";
 
 type AccessCompletionProps = {
   provider: "github" | "google";
   redirectPath: string;
+  redirectSurface: AuthenticatedSurface;
 };
 
-export function AccessCompletion({ provider, redirectPath }: AccessCompletionProps) {
-  const finalizeUrl = buildAccessFinalizeUrl(redirectPath);
+export function AccessCompletion({
+  provider,
+  redirectPath,
+  redirectSurface
+}: AccessCompletionProps) {
+  const finalizeUrl = buildAccessFinalizeUrl(redirectPath, {
+    surface: redirectSurface
+  });
   const finalizeFormRef = useRef<HTMLFormElement>(null);
-  const retryUrl = new URL(buildAuthUrl(redirectPath));
+  const retryUrl = new URL(
+    buildAuthUrl(redirectPath, undefined, {
+      surface: redirectSurface
+    })
+  );
   const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
+  const destinationLabel = describeAuthenticatedSurface(redirectSurface);
 
   retryUrl.searchParams.set("handoff", "retry");
 
@@ -36,11 +50,11 @@ export function AccessCompletion({ provider, redirectPath }: AccessCompletionPro
           <span className="inline-icon" aria-hidden="true">
             <AppIcon name="shield" />
           </span>
-          ParetoProof Portal
+          ParetoProof workspace
         </p>
         <h1>Completing {providerLabel} sign in</h1>
         <p>
-          Your session is active. Redirecting you to the portal now.
+          Your session is active. Redirecting you to the {destinationLabel} now.
         </p>
         <p>
           If you are not redirected automatically,{" "}
@@ -53,8 +67,9 @@ export function AccessCompletion({ provider, redirectPath }: AccessCompletionPro
           className="auth-form"
         >
           {redirectPath !== "/" ? <input type="hidden" name="redirect" value={redirectPath} /> : null}
+          <input type="hidden" name="app" value={redirectSurface} />
           <button type="submit" className="button">
-            Continue to the portal
+            Continue to the {destinationLabel}
           </button>
         </form>
       </section>

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -99,7 +99,7 @@ describe("resolveAuthEntrySessionCheckAction", () => {
           }
         }
       )
-    ).toBe("redirect_portal");
+    ).toBe("redirect_authenticated_app");
   });
 
   it("redirects pending users straight to the pending route", () => {

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -202,14 +202,14 @@ describe("buildLocalAuthEntryPreviewState", () => {
       location: new URL("http://127.0.0.1/?surface=auth")
     };
 
-    expect(buildLocalAuthEntryPreviewState("sign_in", "/runs/alpha")).toMatchObject({
+    expect(buildLocalAuthEntryPreviewState("sign_in", "/runs/alpha", "portal")).toMatchObject({
       actions: [
         {
           href: "http://127.0.0.1/runs/alpha?surface=portal",
           title: "Open local portal preview"
         },
         {
-          href: "http://127.0.0.1/?surface=auth&redirect=%2Faccess-request",
+          href: "http://127.0.0.1/?surface=auth&app=portal&redirect=%2Faccess-request",
           title: "Open local access-request preview"
         }
       ]
@@ -221,14 +221,16 @@ describe("buildLocalAuthEntryPreviewState", () => {
       location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
     };
 
-    expect(buildLocalAuthEntryPreviewState("access_request", "/access-request")).toMatchObject({
+    expect(
+      buildLocalAuthEntryPreviewState("access_request", "/access-request", "portal")
+    ).toMatchObject({
       actions: [
         {
           href: "http://127.0.0.1/access-request?surface=portal",
           title: "Open local access-request route"
         },
         {
-          href: "http://127.0.0.1/?surface=auth",
+          href: "http://127.0.0.1/?surface=auth&app=portal",
           title: "Open local sign-in guidance"
         }
       ]
@@ -242,7 +244,9 @@ describe("AuthEntry local rendering", () => {
       location: new URL("http://127.0.0.1/?surface=auth")
     };
 
-    const html = renderToStaticMarkup(<AuthEntry redirectPath="/runs/alpha" />);
+    const html = renderToStaticMarkup(
+      <AuthEntry redirectPath="/runs/alpha" redirectSurface="portal" />
+    );
 
     expect(html).toContain("Local development bypasses live provider sign-in.");
     expect(html).toContain("Open local portal preview");
@@ -259,7 +263,9 @@ describe("AuthEntry local rendering", () => {
       location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
     };
 
-    const html = renderToStaticMarkup(<AuthEntry redirectPath="/access-request" />);
+    const html = renderToStaticMarkup(
+      <AuthEntry redirectPath="/access-request" redirectSurface="portal" />
+    );
 
     expect(html).toContain("Local development bypasses provider verification here.");
     expect(html).toContain("Open local access-request route");
@@ -276,7 +282,9 @@ describe("AuthEntry hosted guidance rendering", () => {
       location: new URL("https://auth.paretoproof.com/?guidance=1&redirect=%2Fpending")
     };
 
-    const html = renderToStaticMarkup(<AuthEntry redirectPath="/pending" />);
+    const html = renderToStaticMarkup(
+      <AuthEntry redirectPath="/pending" redirectSurface="portal" />
+    );
 
     expect(html).not.toContain("Checking for an existing session...");
     expect(html).toContain("Continue with GitHub");

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -5,14 +5,18 @@ import { fetchApi } from "../lib/api-fetch";
 import {
   buildAccessRequestUrl,
   buildAccessStartUrl,
+  buildAuthenticatedAppUrl,
   buildAuthUrl,
   buildPortalUrl,
   buildPublicUrl,
+  describeAuthenticatedSurface,
+  type AuthenticatedSurface,
   isLocalHostname
 } from "../lib/surface";
 
 type AuthEntryProps = {
   redirectPath: string;
+  redirectSurface: AuthenticatedSurface;
 };
 
 type AuthEntrySessionCheckPayload = {
@@ -64,14 +68,14 @@ const accessRequestChecks = [
 
 const localSignInChecks = [
   "Local development bypasses live provider sign-in and uses this auth surface only for preview routing.",
-  "Open the portal preview when your local or configured API target is reachable.",
+  "Open the destination preview when your local or configured API target is reachable.",
   "Switch to the access-request entry preview to verify that path without a live identity handoff."
 ];
 
 const localAccessRequestChecks = [
   "Local development does not verify GitHub or Google identities before showing this entry.",
   "Use the access-request route preview when your API target is reachable and you need to inspect request-state UX.",
-  "If the API is offline, the portal surface will tell you exactly which backend target is missing."
+  "If the API is offline, the destination surface will tell you exactly which backend target is missing."
 ];
 
 export function resolveAuthEntryMode(redirectPath: string) {
@@ -84,7 +88,8 @@ export function resolveAuthEntryApprovedPortalTargetPath(redirectPath: string) {
 
 export function buildLocalAuthEntryPreviewState(
   mode: ReturnType<typeof resolveAuthEntryMode>,
-  redirectPath: string
+  redirectPath: string,
+  redirectSurface: AuthenticatedSurface
 ): AuthEntryLocalExperience {
   if (mode === "access_request") {
     return {
@@ -99,7 +104,9 @@ export function buildLocalAuthEntryPreviewState(
         {
           copy:
             "Return to the standard local auth guidance without triggering any provider handoff.",
-          href: buildAuthUrl("/"),
+          href: buildAuthUrl("/", undefined, {
+            surface: redirectSurface
+          }),
           icon: "shield",
           title: "Open local sign-in guidance"
         }
@@ -120,15 +127,27 @@ export function buildLocalAuthEntryPreviewState(
     actions: [
       {
         copy:
-          "Open the contributor portal shell directly against your local or configured API target.",
-        href: buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
+          redirectSurface === "math"
+            ? "Open the math workspace preview directly against your local or configured API target."
+            : "Open the contributor portal shell directly against your local or configured API target.",
+        href: buildAuthenticatedAppUrl(
+          resolveAuthEntryApprovedPortalTargetPath(redirectPath),
+          {
+            surface: redirectSurface
+          }
+        ),
         icon: "grid",
-        title: "Open local portal preview"
+        title:
+          redirectSurface === "math"
+            ? "Open local math preview"
+            : "Open local portal preview"
       },
       {
         copy:
           "Switch to the access-request entry preview without triggering a live provider handoff.",
-        href: buildAuthUrl("/access-request"),
+        href: buildAuthUrl("/access-request", undefined, {
+          surface: "portal"
+        }),
         icon: "key",
         title: "Open local access-request preview"
       }
@@ -137,7 +156,7 @@ export function buildLocalAuthEntryPreviewState(
     footerText:
       "Running locally - live provider sign-in is disabled here, so use the preview routes above or return to the public site.",
     lead:
-      "Local development bypasses live provider sign-in. Use this entry to move into the portal or access-request previews once your API target is reachable.",
+      "Local development bypasses live provider sign-in. Use this entry to move into the destination preview once your API target is reachable.",
     panelCopy:
       "Choose the local preview route you want to inspect next.",
     panelTag: "Local preview",
@@ -172,9 +191,9 @@ export function shouldSkipAuthEntrySessionCheck(search = window.location.search)
 
 export type AuthEntrySessionCheckAction =
   | "redirect_access_request"
+  | "redirect_authenticated_app"
   | "redirect_denied"
   | "redirect_pending"
-  | "redirect_portal"
   | "stay_on_auth_entry";
 
 export function resolveAuthEntrySessionCheckAction(
@@ -198,7 +217,7 @@ export function resolveAuthEntrySessionCheckAction(
       return "redirect_denied";
     }
 
-    return "redirect_portal";
+    return "redirect_authenticated_app";
   }
 
   if (response.type === "opaqueredirect" || response.status === 401) {
@@ -208,24 +227,37 @@ export function resolveAuthEntrySessionCheckAction(
   return "stay_on_auth_entry";
 }
 
-export function AuthEntry({ redirectPath }: AuthEntryProps) {
+export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
   const mode = resolveAuthEntryMode(redirectPath);
-  const githubStartUrl = buildAccessStartUrl("github", redirectPath);
-  const googleStartUrl = buildAccessStartUrl("google", redirectPath);
-  const approvedSignInUrl = buildAuthUrl("/");
+  const githubStartUrl = buildAccessStartUrl("github", redirectPath, {
+    surface: redirectSurface
+  });
+  const googleStartUrl = buildAccessStartUrl("google", redirectPath, {
+    surface: redirectSurface
+  });
+  const approvedSignInUrl = buildAuthUrl("/", undefined, {
+    surface: "portal"
+  });
   const accessRequestUrl = buildAccessRequestUrl();
   const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
-  const portalUrl = useMemo(
-    () => buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
-    [redirectPath]
+  const destinationUrl = useMemo(
+    () =>
+      buildAuthenticatedAppUrl(
+        resolveAuthEntryApprovedPortalTargetPath(redirectPath),
+        {
+          surface: redirectSurface
+        }
+      ),
+    [redirectPath, redirectSurface]
   );
+  const destinationLabel = describeAuthenticatedSurface(redirectSurface);
   const portalAccessRequestUrl = useMemo(() => buildPortalUrl("/access-request"), []);
   const portalDeniedUrl = useMemo(() => buildPortalUrl("/denied"), []);
   const portalPendingUrl = useMemo(() => buildPortalUrl("/pending"), []);
   const localExperience = useMemo(
-    () => (isLocal ? buildLocalAuthEntryPreviewState(mode, redirectPath) : null),
-    [isLocal, mode, redirectPath]
+    () => (isLocal ? buildLocalAuthEntryPreviewState(mode, redirectPath, redirectSurface) : null),
+    [isLocal, mode, redirectPath, redirectSurface]
   );
   const publicHomeLabel = isLocal ? "Back to local home" : "Back to paretoproof.com";
   const skipSessionCheck = shouldSkipAuthEntrySessionCheck();
@@ -265,7 +297,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
                 ? portalDeniedUrl
                 : action === "redirect_pending"
                   ? portalPendingUrl
-                  : portalUrl;
+                  : destinationUrl;
 
           window.location.replace(redirectTarget);
           return;
@@ -288,11 +320,11 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
     };
   }, [
     apiBaseUrl,
+    destinationUrl,
     isLocal,
     portalAccessRequestUrl,
     portalDeniedUrl,
     portalPendingUrl,
-    portalUrl,
     skipSessionCheck
   ]);
 
@@ -308,19 +340,19 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
             <span className="inline-icon" aria-hidden="true">
               <AppIcon name="shield" />
             </span>
-            ParetoProof portal
+            ParetoProof workspace
           </p>
           <h1>
             {mode === "access_request"
               ? "Request contributor access."
-              : "Sign in to the contributor portal."}
+              : "Sign in to your ParetoProof workspace."}
           </h1>
           <p className="auth-lead">
             {localExperience
               ? localExperience.lead
               : mode === "access_request"
                 ? "Use GitHub or Google to verify your identity. After that, we will take you to the access request form."
-                : "Use GitHub or Google to continue. If you already have an active session, we will take you straight into the portal."}
+                : `Use GitHub or Google to continue. If you already have an active session, we will take you straight into the ${destinationLabel}.`}
           </p>
           {showRetryNotice ? (
             <p className="auth-panel-copy">

--- a/apps/web/src/routes/math-shell.tsx
+++ b/apps/web/src/routes/math-shell.tsx
@@ -1,0 +1,91 @@
+import { AppIcon } from "../components/app-icon";
+import { buildMathUrl, buildPortalUrl } from "../lib/surface";
+
+type MathShellProps = {
+  email: string | null;
+  pathname: string;
+  roles: string[];
+};
+
+function describeMathPath(pathname: string) {
+  if (pathname === "/launch") {
+    return {
+      body:
+        "Question-centric launch now resolves onto the dedicated math surface. Execution evidence, worker posture, and admin controls still stay in the portal until later math product slices land.",
+      title: "Math launch entry"
+    };
+  }
+
+  if (pathname.startsWith("/questions/")) {
+    return {
+      body:
+        "Question-specific continuation now lands on the math host instead of collapsing back into the portal. Deeper question objects and review state land in later scopes.",
+      title: "Math question workflow"
+    };
+  }
+
+  if (pathname === "/questions") {
+    return {
+      body:
+        "The dedicated math workflow now has its own authenticated surface. Question catalog, submission, and review objects still arrive in later child scopes.",
+      title: "Math question catalog"
+    };
+  }
+
+  if (pathname === "/submissions") {
+    return {
+      body:
+        "Structured submission workflow belongs on the math surface, while profile, access, and operational evidence stay in the portal.",
+      title: "Math submissions"
+    };
+  }
+
+  if (pathname === "/reviews") {
+    return {
+      body:
+        "Reviewer continuation now preserves the math host boundary. Durable review objects and actions remain follow-on work after this routing slice.",
+      title: "Math reviews"
+    };
+  }
+
+  return {
+    body:
+      "The dedicated math surface is now a real authenticated destination instead of collapsing back into the portal. Later issues will fill in the question, submission, and review workflows that belong here.",
+    title: "Math workspace"
+  };
+}
+
+export function MathShell({ email, pathname, roles }: MathShellProps) {
+  const descriptor = describeMathPath(pathname);
+  const roleLabel = roles[0] ?? "approved contributor";
+
+  return (
+    <main className="auth-shell">
+      <section className="auth-card auth-card-polished auth-status-card">
+        <p className="eyebrow">
+          <span className="inline-icon" aria-hidden="true">
+            <AppIcon name="shield" />
+          </span>
+          ParetoProof math
+        </p>
+        <h1>{descriptor.title}</h1>
+        <p>{descriptor.body}</p>
+        <p>
+          Signed in
+          {email ? ` as ${email}` : ""} with {roleLabel} access.
+        </p>
+        <div className="auth-card-footer">
+          <a className="button" href={buildMathUrl("/")}>
+            Math home
+          </a>
+          <a className="button button-secondary" href={buildPortalUrl("/profile")}>
+            Open portal profile
+          </a>
+          <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+            Open run evidence
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -9,20 +9,23 @@ import { getApiBaseUrl } from "../lib/api-base-url";
 import { fetchApi, portalAuthExpiredEventName } from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { isLocalDevelopmentLocation } from "../lib/local-development";
-import { resolvePortalRouteRedirect } from "../lib/portal-route-access";
+import { resolveSurfaceRouteRedirect } from "../lib/portal-route-access";
 import { readWebRuntimeEnv } from "../lib/runtime-env";
+import {
+  buildAuthGuidanceUrl,
+  buildAuthUrl,
+  buildMathUrl,
+  buildPublicUrl,
+  buildPortalUrl,
+  getCurrentRelativeUrl,
+  type AuthenticatedSurface
+} from "../lib/surface";
 import { AccessRequestScreen } from "./access-request-screen";
+import { MathShell } from "./math-shell";
 import {
   reducePortalStateAfterAuthExpiry,
   type PortalAccessState
 } from "./portal-bootstrap-state";
-import {
-  buildPortalUrl,
-  buildAuthGuidanceUrl,
-  buildAuthUrl,
-  buildPublicUrl,
-  getCurrentRelativeUrl
-} from "../lib/surface";
 import { PortalShell } from "./portal-shell";
 
 type PortalMeResponse = {
@@ -135,21 +138,6 @@ export async function recoverPortalStateAfterAuthExpiry(
   }
 }
 
-function parseDeniedReason(
-  reason: string | null
-): PortalMeResponse["access"]["reason"] | null {
-  if (
-    reason === "access_request_required" ||
-    reason === "identity_recovery_required" ||
-    reason === "rejected_or_withdrawn" ||
-    reason === "unknown_identity"
-  ) {
-    return reason;
-  }
-
-  return null;
-}
-
 function readRouteDeniedReason(search = window.location.search) {
   const reason = new URLSearchParams(search).get("reason");
 
@@ -251,7 +239,19 @@ export function shouldRestartPortalAuthForMissingProvider(
   );
 }
 
-export function PortalBootstrap() {
+function describeSurfaceLabel(surface: AuthenticatedSurface) {
+  return surface === "math" ? "Math" : "Portal";
+}
+
+function describeSurfaceName(surface: AuthenticatedSurface) {
+  return surface === "math" ? "math workspace" : "portal";
+}
+
+type PortalBootstrapProps = {
+  surface?: AuthenticatedSurface;
+};
+
+export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const localPreviewMode = useMemo(() => isLocalDevelopmentLocation(window.location), []);
@@ -259,6 +259,7 @@ export function PortalBootstrap() {
   const currentRelativeUrl = useMemo(() => getCurrentRelativeUrl(), []);
   const recoveryInFlightRef = useRef(false);
   const stateRef = useRef<PortalAccessState>(state);
+  const surfaceLabel = describeSurfaceLabel(surface);
   const routeDeniedReason = readRouteDeniedReason();
   const routeRedirectTarget = useMemo(() => {
     if (
@@ -269,17 +270,18 @@ export function PortalBootstrap() {
       return null;
     }
 
-      return resolvePortalRouteRedirect({
-        pathname: window.location.pathname,
-        reason:
-          state.status === "denied"
-            ? state.reason
-            : routeDeniedReason ?? undefined,
-        roles: state.status === "approved" ? derivePortalRoles(state.role) : [],
-        search: window.location.search,
-        status: state.status
-      });
-  }, [routeDeniedReason, state]);
+    return resolveSurfaceRouteRedirect({
+      pathname: window.location.pathname,
+      reason:
+        state.status === "denied"
+          ? state.reason
+          : routeDeniedReason ?? undefined,
+      roles: state.status === "approved" ? derivePortalRoles(state.role) : [],
+      search: window.location.search,
+      status: state.status,
+      surface
+    });
+  }, [routeDeniedReason, state, surface]);
 
   useEffect(() => {
     stateRef.current = state;
@@ -358,8 +360,12 @@ export function PortalBootstrap() {
       return;
     }
 
-    window.location.replace(buildAuthUrl(currentRelativeUrl));
-  }, [currentRelativeUrl, localPreviewMode, state]);
+    window.location.replace(
+      buildAuthUrl(currentRelativeUrl, undefined, {
+        surface
+      })
+    );
+  }, [currentRelativeUrl, localPreviewMode, state, surface]);
 
   useEffect(() => {
     if (!routeRedirectTarget) {
@@ -419,24 +425,31 @@ export function PortalBootstrap() {
   if (state.status === "loading") {
     return (
       <PortalStatusCard
-        eyebrow="Portal"
+        eyebrow={surfaceLabel}
         title="Checking access"
-        body="Resolving your Cloudflare Access identity and portal approval state."
+        body={`Resolving your Cloudflare Access identity and ${describeSurfaceName(surface)} approval state.`}
       />
     );
   }
 
   if (state.status === "unauthenticated") {
     if (localPreviewMode) {
-      return renderLocalPortalUnauthenticatedCard(currentRelativeUrl);
+      return renderLocalPortalUnauthenticatedCard(currentRelativeUrl, surface);
     }
 
     return (
       <PortalStatusCard
-        eyebrow="Portal"
+        eyebrow={surfaceLabel}
         title="Redirecting to sign in"
-        body="The portal only loads after authentication. You are being sent to the auth entrypoint now."
-        actions={[{ href: buildAuthUrl(currentRelativeUrl), label: "Continue to sign in" }]}
+        body={`The ${describeSurfaceName(surface)} only loads after authentication. You are being sent to the auth entrypoint now.`}
+        actions={[
+          {
+            href: buildAuthUrl(currentRelativeUrl, undefined, {
+              surface
+            }),
+            label: "Continue to sign in"
+          }
+        ]}
       />
     );
   }
@@ -478,16 +491,26 @@ export function PortalBootstrap() {
   ) {
     return (
       <PortalStatusCard
-        eyebrow="Portal"
+        eyebrow={surfaceLabel}
         title="Permission denied"
-        body={`Signed in${state.email ? ` as ${state.email}` : ""}, but your current portal role does not allow this area.`}
+        body={`Signed in${state.email ? ` as ${state.email}` : ""}, but your current ${surface === "math" ? "workspace" : "portal"} role does not allow this area.`}
         actions={[{ href: buildPortalUrl("/"), label: "Return to portal home" }]}
       />
     );
   }
 
   if (state.status === "error") {
-    return renderPortalBootstrapErrorCard(state, currentRelativeUrl);
+    return renderPortalBootstrapErrorCard(state, currentRelativeUrl, surface);
+  }
+
+  if (surface === "math") {
+    return (
+      <MathShell
+        email={state.email}
+        pathname={window.location.pathname}
+        roles={derivePortalRoles(state.role)}
+      />
+    );
   }
 
   return (
@@ -500,29 +523,37 @@ export function PortalBootstrap() {
 
 export function renderPortalBootstrapErrorCard(
   state: Extract<PortalAccessState, { status: "error" }>,
-  currentRelativeUrl: string
+  currentRelativeUrl: string,
+  surface: AuthenticatedSurface = "portal"
 ) {
   const localPreviewMode = isLocalDevelopmentLocation(window.location);
 
   return (
     <PortalStatusCard
-      eyebrow="Portal"
+      eyebrow={describeSurfaceLabel(surface)}
       title={
         state.kind === "local_api_unavailable"
           ? "Local API unavailable"
-          : "Portal unavailable"
+          : `${describeSurfaceLabel(surface)} unavailable`
       }
       body={state.message}
       actions={[
         {
-          href: buildPortalUrl(currentRelativeUrl),
+          href:
+            surface === "math"
+              ? buildMathUrl(currentRelativeUrl)
+              : buildPortalUrl(currentRelativeUrl),
           label:
-            state.kind === "local_api_unavailable" ? "Retry after starting API" : "Retry portal"
+            state.kind === "local_api_unavailable"
+              ? "Retry after starting API"
+              : `Retry ${surface === "math" ? "math" : "portal"}`
         },
         {
           href:
             state.kind === "local_api_unavailable"
-              ? buildAuthUrl(currentRelativeUrl)
+              ? buildAuthUrl(currentRelativeUrl, undefined, {
+                  surface
+                })
               : buildPublicUrl("/"),
           label:
             state.kind === "local_api_unavailable"
@@ -537,15 +568,20 @@ export function renderPortalBootstrapErrorCard(
   );
 }
 
-export function renderLocalPortalUnauthenticatedCard(currentRelativeUrl: string) {
+export function renderLocalPortalUnauthenticatedCard(
+  currentRelativeUrl: string,
+  surface: AuthenticatedSurface = "portal"
+) {
   return (
     <PortalStatusCard
-      eyebrow="Portal"
+      eyebrow={describeSurfaceLabel(surface)}
       title="Local preview needs auth context"
-      body="This localhost portal route did not receive an authenticated access state from the API. Open the local auth guidance to choose the right preview path, or return to the public site."
+      body={`This localhost ${surface === "math" ? "math" : "portal"} route did not receive an authenticated access state from the API. Open the local auth guidance to choose the right preview path, or return to the public site.`}
       actions={[
         {
-          href: buildAuthUrl(currentRelativeUrl),
+          href: buildAuthUrl(currentRelativeUrl, undefined, {
+            surface
+          }),
           label: "Open local auth guidance"
         },
         {

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -138,7 +138,7 @@ const publicBands = [
 
 const packCoverage = [
   {
-    detail: "why the project exists, who it serves, and how the public/auth/portal split works",
+    detail: "why the project exists, who it serves, and how the public/auth/portal/math split works",
     label: "Project overview",
     value: "Overview"
   },
@@ -162,7 +162,7 @@ const projectOverviewPoints = [
   },
   {
     body:
-      "The public site explains released work, the auth surface handles sign-in, and the portal holds contributor and admin workflows.",
+      "The public site explains released work, the auth surface handles sign-in, the portal holds contributor and admin operations, and the math surface holds authenticated question workflow.",
     title: "How the surfaces split"
   },
   {
@@ -192,7 +192,7 @@ const contributorSteps: Array<{
   },
   {
     body:
-      "Approved contributors use the dedicated sign-in entry. GitHub and Google remain the supported human providers for reaching the portal flow.",
+      "Approved contributors use the dedicated sign-in entry. GitHub and Google remain the supported human providers for reaching either the portal or math workflow.",
     icon: "key",
     kicker: "Step 2",
     title: "Approved sign-in"
@@ -206,10 +206,10 @@ const contributorSteps: Array<{
   },
   {
     body:
-      "Approved work happens inside the portal, where profile, access, admin review, and future benchmark operations belong.",
+      "Approved work happens inside the portal or math surface, depending on whether the task is generic operations or math workflow.",
     icon: "server",
     kicker: "Step 4",
-    title: "Do the work in portal"
+    title: "Use the right authenticated surface"
   }
 ];
 
@@ -276,7 +276,7 @@ const projectResources: Array<{
   },
   {
     body:
-      "Check the route-ownership baseline for what belongs on the public apex, auth entry, and portal surfaces during MVP.",
+      "Check the route-ownership baseline for what belongs on the public apex, auth entry, portal, and math surfaces during MVP.",
     external: true,
     href: productSurfaceBoundaryDocsUrl,
     icon: "compass",
@@ -294,7 +294,7 @@ const projectResources: Array<{
   },
   {
     body:
-      "Read the short architecture summary for how the public site, auth entry, portal, API, and workers fit together.",
+      "Read the short architecture summary for how the public site, auth entry, portal, math surface, API, and workers fit together.",
     external: true,
     href: buildDocsUrl("architecture.md"),
     icon: "spark",
@@ -780,7 +780,8 @@ function PublicBenchmarkIndex() {
         <h2>No public run drilldown.</h2>
         <p>
           Per-run evidence, artifact inspection, and operational rerun context remain in the
-          authenticated portal. The public site only shows released benchmark slices.
+          authenticated portal, while math workflow stays on its dedicated host. The public site
+          only shows released benchmark slices.
         </p>
       </article>
     </section>
@@ -1048,8 +1049,8 @@ function PublicProjectPack() {
           </p>
           <p>
             That means one coherent public project route, one benchmark route, and one docs
-            index. Everything else should either live in the portal or stay in implementation
-            docs until it becomes a real user-facing surface.
+            index. Everything else should either live in portal or math, or stay in
+            implementation docs until it becomes a real user-facing surface.
           </p>
         </div>
         <div className="site-topic-list" aria-label="Project overview points">
@@ -1086,7 +1087,7 @@ function PublicProjectPack() {
         <p className="site-lead">
           Approved contributors sign in directly. New collaborators use the separate
           access-request entry, and approval stays manual before any contributor work
-          opens inside the portal.
+          opens inside portal or math.
         </p>
       </div>
 

--- a/apps/web/vite.config.test.js
+++ b/apps/web/vite.config.test.js
@@ -8,6 +8,7 @@ describe("web vite host allowlist", () => {
       "auth.paretoproof.com",
       "github.auth.paretoproof.com",
       "google.auth.paretoproof.com",
+      "math.paretoproof.com",
       "portal.paretoproof.com"
     ]);
 

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -68,6 +68,7 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
   - `CORS_ALLOWED_ORIGINS`
   - `CORS_ALLOW_LOCALHOST`
   - `PORTAL_PUBLIC_ORIGIN`
+  - `MATH_PUBLIC_ORIGIN`
   - `AUTH_PUBLIC_ORIGIN`
   - `BRANDED_AUTH_ORIGINS`
   - `ACCESS_COOKIE_DOMAIN`
@@ -81,10 +82,11 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
   - `CF_ACCESS_BRANDED_AUDS` is the comma-separated allowlist of branded provider-host Access audiences accepted only on the finalize-submit handoff boundary
   - set `CORS_ALLOW_LOCALHOST=true` when you need loopback-mapped branded auth hosts such as `http://github.auth.paretoproof.com:<port>` or `http://google.auth.paretoproof.com:<port>` to post directly to the local API finalize-submit boundary during auth-flow previews
   - `PORTAL_PUBLIC_ORIGIN` defaults to `https://portal.paretoproof.com`
+  - `MATH_PUBLIC_ORIGIN` defaults to `https://math.paretoproof.com`
   - `AUTH_PUBLIC_ORIGIN` defaults to `https://auth.paretoproof.com`
   - `BRANDED_AUTH_ORIGINS` defaults to the configured auth origin plus the matching GitHub and Google branded auth origins
-  - `ACCESS_COOKIE_DOMAIN` defaults to the shared domain suffix derived from the configured portal and branded auth origins when one exists
-  - `ACCESS_COOKIE_SECURE` defaults to `true` only when every configured portal/branded auth origin is `https`
+  - `ACCESS_COOKIE_DOMAIN` defaults to the shared domain suffix derived from the configured portal, math, and branded auth origins when one exists
+  - `ACCESS_COOKIE_SECURE` defaults to `true` only when every configured portal/math/branded auth origin is `https`
   - `HOST` defaults to `0.0.0.0`
   - `PORT` defaults to `3000`
 
@@ -108,6 +110,7 @@ Use this mode for the hosted `api.paretoproof.com` control plane.
   - `CORS_ALLOWED_ORIGINS`
   - `CORS_ALLOW_LOCALHOST`
   - `PORTAL_PUBLIC_ORIGIN`
+  - `MATH_PUBLIC_ORIGIN`
   - `AUTH_PUBLIC_ORIGIN`
   - `BRANDED_AUTH_ORIGINS`
   - `ACCESS_COOKIE_DOMAIN`
@@ -119,9 +122,9 @@ Use this mode for the hosted `api.paretoproof.com` control plane.
 - Platform notes:
   - Railway normally supplies `PORT`
   - keep migration credentials out of the live service runtime
-  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access because the portal SPA talks to it with cross-origin `fetch()` and needs JSON `200`/`401` responses, not Access redirects
+  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access because the portal and math SPAs talk to it with cross-origin `fetch()` and need JSON `200`/`401` responses, not Access redirects
   - keep `api.paretoproof.com/internal/*` on its own Cloudflare Access app for owner and service-token callers
-  - use the explicit portal/auth origin and cookie overrides when a hosted non-prod environment does not live on the canonical `*.paretoproof.com` pair
+  - use the explicit portal/auth/math origin and cookie overrides when a hosted non-prod environment does not live on the canonical `*.paretoproof.com` surface trio
 
 ### API migration mode
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -7,7 +7,7 @@ This repo uses a small number of runtime rules.
 - `apps/api/.env.example`, `apps/web/.env.example`, and `apps/worker/.env.example` are the local examples.
 - [runtime-env-mode-checklists.md](./runtime-env-mode-checklists.md) is the operator-facing per-mode checklist for the supported local, hosted, and owner-only runtime paths.
 - `bun run test:startup-validation` is the executable smoke owner for startup env validation across the currently supported runtime surfaces.
-- API portal/auth origin and shared-cookie deployment assumptions are runtime-configurable; keep non-prod hostnames and cookie policy in the API runtime instead of re-hard-coding them in route helpers.
+- API portal/auth/math origin and shared-cookie deployment assumptions are runtime-configurable; keep non-prod hostnames and cookie policy in the API runtime instead of re-hard-coding them in route helpers.
 - Keep browser env separate from Pages function secrets and worker machine credentials.
 - Do not store short-lived access assertions, human session data, or local auth caches in committed env files.
 - Do not copy `.codex/auth.json` or other trusted-local auth artifacts into the repository, Docker build contexts, or checked-in worker fixtures.
@@ -21,7 +21,7 @@ This repo uses a small number of runtime rules.
 - GHCR holds worker images.
 - Cloudflare R2 holds larger artifacts when the flow requires object storage.
 - Hosted Cloudflare Access split:
-  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access so `portal.paretoproof.com` can make cross-origin JSON `fetch()` calls without an opaque Access redirect.
+  - `api.paretoproof.com/portal/*` must bypass Cloudflare Access so `portal.paretoproof.com` and `math.paretoproof.com` can make cross-origin JSON `fetch()` calls without an opaque Access redirect.
   - `api.paretoproof.com/internal/*` stays behind its own Cloudflare Access app for owner and service-token callers.
 
 ## Worker rules

--- a/infra/scripts/check-runtime-env-examples.mjs
+++ b/infra/scripts/check-runtime-env-examples.mjs
@@ -12,7 +12,7 @@ const checks = [
       "# Owner-ops config. Only set these when you are intentionally running owner workflows.",
       "# App runtime config for local Cloudflare Access parity and internal worker auth.",
       "# Optional local runtime overrides. Expand only for deliberate local testing.",
-      "# Optional non-prod portal/auth origin overrides. Leave unset for the canonical",
+      "# Optional non-prod portal/auth/math origin overrides. Leave unset for the canonical",
       "# Optional portal/auth coordination cookie overrides. When unset, the API",
       "# Reserved later-scope runtime placeholders. Keep commented unless a later slice explicitly uses them."
     ],
@@ -38,6 +38,7 @@ const checks = [
       { name: "CORS_ALLOWED_ORIGINS", commented: false },
       { name: "CORS_ALLOW_LOCALHOST", commented: false },
       { name: "PORTAL_PUBLIC_ORIGIN", commented: true },
+      { name: "MATH_PUBLIC_ORIGIN", commented: true },
       { name: "AUTH_PUBLIC_ORIGIN", commented: true },
       { name: "BRANDED_AUTH_ORIGINS", commented: true },
       { name: "ACCESS_COOKIE_DOMAIN", commented: true },
@@ -118,7 +119,10 @@ const docsChecks = [
   },
   {
     file: "docs/runtime.md",
-    requiredSnippets: ["runtime-env-mode-checklists.md"]
+    requiredSnippets: [
+      "runtime-env-mode-checklists.md",
+      "portal/auth/math origin"
+    ]
   },
   {
     file: "docs/runtime-env-mode-checklists.md",
@@ -136,7 +140,9 @@ const docsChecks = [
       "### Local Problem 9 attempt with `trusted_local_user`",
       "### Trusted-local devbox wrapper",
       "### Offline ingest CLI",
-      "### Hosted claim loop with `machine_api_key`"
+      "### Hosted claim loop with `machine_api_key`",
+      "`MATH_PUBLIC_ORIGIN`",
+      "portal/auth/math origin"
     ]
   }
 ];

--- a/packages/shared/src/contracts/route-access.ts
+++ b/packages/shared/src/contracts/route-access.ts
@@ -141,6 +141,60 @@ export const appRouteAccessMatrix = [
     redirectIfDenied: "portal_denied",
     surface: "portal",
     summary: "Role management and contributor state inspection for admins."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.home",
+    path: "/",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Math workflow home for approved contributors."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.questions",
+    path: "/questions",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Question workflow index for math review and launch preparation."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.question-detail",
+    path: "/questions/:questionId",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Question-specific workflow shell on the dedicated math surface."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.submissions",
+    path: "/submissions",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Structured submission workflow placeholder for the math surface."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.reviews",
+    path: "/reviews",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Review workflow placeholder for the dedicated math surface."
+  }),
+  defineAppRouteEntry({
+    access: "approved_helper_or_higher",
+    host: "math.paretoproof.com",
+    id: "math.launch",
+    path: "/launch",
+    redirectIfDenied: "portal_pending",
+    surface: "math",
+    summary: "Question-centric launch entry on the dedicated math surface."
   })
 ] as const;
 

--- a/packages/shared/src/types/route-access.ts
+++ b/packages/shared/src/types/route-access.ts
@@ -1,11 +1,16 @@
-export type AppSurface = "public_site" | "portal";
+export type AppSurface = "public_site" | "portal" | "math";
 
 export type PublicRouteId = `public.${string}`;
 export type PortalRouteId = `portal.${string}`;
-export type AppRouteId = PublicRouteId | PortalRouteId;
+export type MathRouteId = `math.${string}`;
+export type AppRouteId = PublicRouteId | PortalRouteId | MathRouteId;
 
 export type AppRouteIdForSurface<TSurface extends AppSurface> =
-  TSurface extends "portal" ? PortalRouteId : PublicRouteId;
+  TSurface extends "portal"
+    ? PortalRouteId
+    : TSurface extends "math"
+      ? MathRouteId
+      : PublicRouteId;
 
 export type RouteAccessLevel =
   | "public"
@@ -21,7 +26,8 @@ export type RouteRedirectTarget =
   | "public_home"
   | "portal_home"
   | "portal_pending"
-  | "portal_denied";
+  | "portal_denied"
+  | "math_home";
 
 export type AppRouteMatrixEntry<TSurface extends AppSurface = AppSurface> = {
   access: RouteAccessLevel;

--- a/packages/shared/test/route-access.test.js
+++ b/packages/shared/test/route-access.test.js
@@ -28,6 +28,10 @@ describe("route ownership matrix helpers", () => {
     expect(findAppRouteBySurface("portal", "/runs/run-123")?.id).toBe(
       "portal.run-detail"
     );
+    expect(findAppRouteBySurface("math", "/questions/problem-9")?.id).toBe(
+      "math.question-detail"
+    );
+    expect(findAppRouteBySurface("math", "/workers")).toBeNull();
   });
 
   it("keeps portal route-linked catalogs aligned with the portal route matrix", () => {
@@ -35,6 +39,8 @@ describe("route ownership matrix helpers", () => {
       appRouteAccessMatrix.every((entry) =>
         entry.surface === "portal"
           ? entry.id.startsWith("portal.")
+          : entry.surface === "math"
+            ? entry.id.startsWith("math.")
           : entry.id.startsWith("public.")
       )
     ).toBe(true);


### PR DESCRIPTION
## Summary
- add math as a first-class authenticated surface in the shared route ownership contract and web surface helpers
- preserve portal vs math continuation through auth entry, access start/finalize, portal bootstrap, and the new minimal math shell
- keep math-origin browser/API parity for continuation and CORS without widening trusted portal mutations

## Testing
- bun run test:shared
- bun test apps/api/test/build-server.test.ts apps/api/test/trusted-mutation-origin.test.ts apps/api/test/portal-session-finalize.test.ts apps/api/test/runtime-env.test.ts apps/api/test/portal-link-intent-cookie.test.ts
- bun test apps/web/vite.config.test.js apps/web/src/lib/surface.test.js apps/web/src/lib/local-development.test.js apps/web/src/lib/portal-route-access.test.js apps/web/src/routes/auth-entry.test.js apps/web/functions/_shared/access-start.test.ts apps/web/functions/_shared/access-finalize.test.ts
- bun run build

Closes #1015