### PR TITLE
Fix auth entry portal bounce reloads

### DIFF
--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
   shouldStayOnAuthEntryForProviderlessRecovery
 } from "./auth-entry.tsx";
@@ -73,5 +74,98 @@ describe("resolveAuthEntrySessionCheckAction", () => {
         }
       )
     ).toBe("redirect_portal");
+  });
+
+  it("redirects pending users straight to the pending route", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            status: "pending"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }
+      )
+    ).toBe("redirect_pending");
+  });
+
+  it("redirects access-request-required users straight to the access-request route", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            reason: "access_request_required",
+            status: "denied"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }
+      )
+    ).toBe("redirect_access_request");
+  });
+
+  it("redirects signed-in denied users to the denied route when no recovery flow applies", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            reason: "rejected_or_withdrawn",
+            status: "denied"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }
+      )
+    ).toBe("redirect_denied");
+  });
+
+  it("redirects provider-backed identity recovery users to the denied route instead of reusing access-request routing", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        {
+          access: {
+            reason: "identity_recovery_required",
+            status: "denied"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        }
+      )
+    ).toBe("redirect_denied");
+  });
+});
+
+describe("resolveAuthEntryApprovedPortalTargetPath", () => {
+  it("sends approved users from the access-request entry to portal home instead of back through /access-request", () => {
+    expect(resolveAuthEntryApprovedPortalTargetPath("/access-request")).toBe("/");
+  });
+
+  it("preserves ordinary approved portal redirects", () => {
+    expect(resolveAuthEntryApprovedPortalTargetPath("/profile")).toBe("/profile");
   });
 });

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -45,6 +45,10 @@ export function resolveAuthEntryMode(redirectPath: string) {
   return redirectPath === "/access-request" ? "access_request" : "sign_in";
 }
 
+export function resolveAuthEntryApprovedPortalTargetPath(redirectPath: string) {
+  return redirectPath === "/access-request" ? "/" : redirectPath;
+}
+
 export function buildAuthEntrySessionCheckRequestInit(signal: AbortSignal): RequestInit {
   return {
     credentials: "include",
@@ -66,13 +70,32 @@ export function shouldStayOnAuthEntryForProviderlessRecovery(
   );
 }
 
+export type AuthEntrySessionCheckAction =
+  | "redirect_access_request"
+  | "redirect_denied"
+  | "redirect_pending"
+  | "redirect_portal"
+  | "stay_on_auth_entry";
+
 export function resolveAuthEntrySessionCheckAction(
   response: Pick<Response, "ok" | "status" | "type">,
   payload: AuthEntrySessionCheckPayload | null = null
-) {
+): AuthEntrySessionCheckAction {
   if (response.ok) {
     if (shouldStayOnAuthEntryForProviderlessRecovery(payload)) {
       return "stay_on_auth_entry";
+    }
+
+    if (payload?.access.status === "pending") {
+      return "redirect_pending";
+    }
+
+    if (payload?.access.status === "denied") {
+      if (payload.access.reason === "access_request_required") {
+        return "redirect_access_request";
+      }
+
+      return "redirect_denied";
     }
 
     return "redirect_portal";
@@ -93,7 +116,13 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const accessRequestUrl = buildAccessRequestUrl();
   const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
-  const portalUrl = useMemo(() => buildPortalUrl(redirectPath), [redirectPath]);
+  const portalUrl = useMemo(
+    () => buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
+    [redirectPath]
+  );
+  const portalAccessRequestUrl = useMemo(() => buildPortalUrl("/access-request"), []);
+  const portalDeniedUrl = useMemo(() => buildPortalUrl("/denied"), []);
+  const portalPendingUrl = useMemo(() => buildPortalUrl("/pending"), []);
   const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);
   const handoffMode = new URLSearchParams(window.location.search).get("handoff");
   const showFailedNotice = handoffMode === "failed";
@@ -118,8 +147,17 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
           response.ok ? ((await response.json()) as AuthEntrySessionCheckPayload) : null;
         const action = resolveAuthEntrySessionCheckAction(response, payload);
 
-        if (action === "redirect_portal") {
-          window.location.replace(portalUrl);
+        if (action !== "stay_on_auth_entry") {
+          const redirectTarget =
+            action === "redirect_access_request"
+              ? portalAccessRequestUrl
+              : action === "redirect_denied"
+                ? portalDeniedUrl
+                : action === "redirect_pending"
+                  ? portalPendingUrl
+                  : portalUrl;
+
+          window.location.replace(redirectTarget);
           return;
         }
       } catch (error) {
@@ -138,7 +176,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
     return () => {
       controller.abort();
     };
-  }, [apiBaseUrl, isLocal, portalUrl]);
+  }, [apiBaseUrl, isLocal, portalAccessRequestUrl, portalDeniedUrl, portalPendingUrl, portalUrl]);
 
   return (
     <main className="auth-shell">


### PR DESCRIPTION
## Summary\n- route approved, pending, and denied auth-entry session checks to their canonical portal destinations instead of sending every successful /portal/me through the requested portal route\n- keep providerless recovery on the auth surface while sending provider-backed recovery through the canonical denied route\n- add auth-entry tests for pending, denied, recovery, and approved access-request-entry normalization\n\nCloses #1070\n\n## Verification\n- bun test apps/web/src/routes/auth-entry.test.js\n- bun --cwd apps/web typecheck\n- bun run build