### PR TITLE
Retry portal bootstrap before auth restart

### DIFF
--- a/apps/web/src/routes/portal-bootstrap-state.ts
+++ b/apps/web/src/routes/portal-bootstrap-state.ts
@@ -39,5 +39,5 @@ export function reducePortalStateAfterAuthExpiry(currentState: PortalAccessState
     return currentState;
   }
 
-  return { status: "unauthenticated" } satisfies PortalAccessState;
+  return { status: "loading" } satisfies PortalAccessState;
 }

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -7,10 +7,11 @@ import {
   fetchPortalBootstrapState,
   derivePortalRoles,
   mapPortalMutationErrorMessage,
+  recoverPortalStateAfterAuthExpiry,
   shouldRestartPortalAuthForMissingProvider
 } from "./portal-bootstrap.tsx";
 
-describe("buildLocalPendingPortalUrl", () => {
+describe("portal bootstrap state", () => {
   it("promotes the local access state to pending and clears denial-only params", () => {
     expect(
       buildLocalPendingPortalUrl(
@@ -33,7 +34,7 @@ describe("buildLocalPendingPortalUrl", () => {
     ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
   });
 
-  it("collapses stale approved state back to unauthenticated after auth expiry", () => {
+  it("moves stale approved state into recovery loading after auth expiry", () => {
     expect(
       reducePortalStateAfterAuthExpiry({
         email: "tomthegreatest04@gmail.com",
@@ -41,7 +42,7 @@ describe("buildLocalPendingPortalUrl", () => {
         status: "approved"
       })
     ).toEqual({
-      status: "unauthenticated"
+      status: "loading"
     });
   });
 
@@ -49,6 +50,27 @@ describe("buildLocalPendingPortalUrl", () => {
     expect(
       reducePortalStateAfterAuthExpiry({
         status: "loading"
+      })
+    ).toEqual({
+      status: "loading"
+    });
+  });
+
+  it("keeps unauthenticated state untouched after auth expiry", () => {
+    expect(
+      reducePortalStateAfterAuthExpiry({
+        status: "unauthenticated"
+      })
+    ).toEqual({
+      status: "unauthenticated"
+    });
+  });
+
+  it("moves pending portal state into recovery loading instead of immediate logout", () => {
+    expect(
+      reducePortalStateAfterAuthExpiry({
+        email: "ada@paretoproof.local",
+        status: "pending"
       })
     ).toEqual({
       status: "loading"
@@ -132,5 +154,106 @@ describe("shouldRestartPortalAuthForMissingProvider", () => {
         }
       })
     ).toBe(false);
+  });
+});
+
+describe("recoverPortalStateAfterAuthExpiry", () => {
+  it("revalidates portal bootstrap once before deciding the user is unauthenticated", async () => {
+    const state = await recoverPortalStateAfterAuthExpiry(
+      {
+        email: "owner@example.com",
+        role: "admin",
+        status: "approved"
+      },
+      "https://api.paretoproof.test",
+      {
+        fetcher: async () => ({
+          json: async () => ({
+            access: {
+              email: "owner@example.com",
+              role: "admin",
+              status: "approved"
+            },
+            identity: {
+              provider: "cloudflare_google"
+            }
+          }),
+          ok: true,
+          status: 200,
+          type: "basic"
+        })
+      }
+    );
+
+    expect(state).toEqual({
+      email: "owner@example.com",
+      role: "admin",
+      status: "approved"
+    });
+  });
+
+  it("falls through to unauthenticated only when the recovery bootstrap still returns 401", async () => {
+    const state = await recoverPortalStateAfterAuthExpiry(
+      {
+        email: "owner@example.com",
+        role: "admin",
+        status: "approved"
+      },
+      "https://api.paretoproof.test",
+      {
+        fetcher: async () => ({
+          json: async () => ({ error: "access_assertion_required" }),
+          ok: false,
+          status: 401,
+          type: "basic"
+        })
+      }
+    );
+
+    expect(state).toEqual({
+      status: "unauthenticated"
+    });
+  });
+
+  it("does not re-fetch when the current state is already unauthenticated", async () => {
+    let fetchCalled = false;
+    const state = await recoverPortalStateAfterAuthExpiry(
+      {
+        status: "unauthenticated"
+      },
+      "https://api.paretoproof.test",
+      {
+        fetcher: async () => {
+          fetchCalled = true;
+          throw new Error("should not be called");
+        }
+      }
+    );
+
+    expect(state).toEqual({
+      status: "unauthenticated"
+    });
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("does not re-fetch when bootstrap is already loading", async () => {
+    let fetchCalled = false;
+    const state = await recoverPortalStateAfterAuthExpiry(
+      {
+        status: "loading"
+      },
+      "https://api.paretoproof.test",
+      {
+        fetcher: async () => {
+          fetchCalled = true;
+          throw new Error("should not be called");
+        }
+      }
+    );
+
+    expect(state).toEqual({
+      status: "loading"
+    });
+    expect(fetchCalled).toBe(false);
   });
 });

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -3,7 +3,7 @@ import type {
   PortalAccessRequestInput,
   PortalRole
 } from "@paretoproof/shared";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import { fetchApi, portalAuthExpiredEventName } from "../lib/api-fetch";
@@ -106,6 +106,30 @@ export async function fetchPortalBootstrapState(
     reason: payload.access.reason ?? "unknown_identity",
     status: "denied"
   };
+}
+
+export async function recoverPortalStateAfterAuthExpiry(
+  currentState: PortalAccessState,
+  apiBaseUrl: string,
+  options?: {
+    fetcher?: PortalBootstrapFetcher;
+    signal?: AbortSignal;
+  }
+): Promise<PortalAccessState> {
+  const reducedState = reducePortalStateAfterAuthExpiry(currentState);
+
+  if (reducedState === currentState || reducedState.status !== "loading") {
+    return reducedState;
+  }
+
+  try {
+    return await fetchPortalBootstrapState(apiBaseUrl, options);
+  } catch (error) {
+    return {
+      message: formatPortalBootstrapError(error),
+      status: "error"
+    };
+  }
 }
 
 function parseDeniedReason(
@@ -230,6 +254,8 @@ export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const currentRelativeUrl = useMemo(() => getCurrentRelativeUrl(), []);
+  const recoveryInFlightRef = useRef(false);
+  const stateRef = useRef<PortalAccessState>(state);
   const routeDeniedReason = readRouteDeniedReason();
   const routeRedirectTarget = useMemo(() => {
     if (
@@ -253,12 +279,18 @@ export function PortalBootstrap() {
   }, [routeDeniedReason, state]);
 
   useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
     const controller = new AbortController();
+    let active = true;
     const localAccessOverride = readLocalAccessOverride();
 
     if (localAccessOverride) {
       setState(localAccessOverride);
       return () => {
+        active = false;
         controller.abort();
       };
     }
@@ -271,7 +303,7 @@ export function PortalBootstrap() {
           })
         );
       } catch (error) {
-        if (controller.signal.aborted) {
+        if (controller.signal.aborted || !active) {
           return;
         }
 
@@ -284,22 +316,45 @@ export function PortalBootstrap() {
 
     void loadAccessState();
 
-    return () => {
-      controller.abort();
-    };
-  }, [apiBaseUrl]);
-
-  useEffect(() => {
     const handlePortalAuthExpired = () => {
-      setState((currentState) => reducePortalStateAfterAuthExpiry(currentState));
+      if (recoveryInFlightRef.current) {
+        return;
+      }
+
+      const currentState = stateRef.current;
+      const reducedState = reducePortalStateAfterAuthExpiry(currentState);
+
+      if (reducedState === currentState || reducedState.status !== "loading") {
+        setState(reducedState);
+        return;
+      }
+
+      recoveryInFlightRef.current = true;
+      setState(reducedState);
+
+      void recoverPortalStateAfterAuthExpiry(currentState, apiBaseUrl, {
+        signal: controller.signal
+      })
+        .then((recoveredState) => {
+          if (controller.signal.aborted || !active) {
+            return;
+          }
+
+          setState(recoveredState);
+        })
+        .finally(() => {
+          recoveryInFlightRef.current = false;
+        });
     };
 
     window.addEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
 
     return () => {
+      active = false;
+      controller.abort();
       window.removeEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
     };
-  }, []);
+  }, [apiBaseUrl]);
 
   useEffect(() => {
     if (state.status !== "unauthenticated") {


### PR DESCRIPTION
## Summary
- treat portal auth-expired events as one bounded bootstrap revalidation instead of immediate logout
- keep loading/unauthenticated states from double-triggering recovery fetches
- add recovery regression coverage for approved, 401, loading, and unauthenticated states

## Testing
- bun test apps/web/src/routes/portal-bootstrap.test.js
- bun --cwd apps/web typecheck
- bun run build

Closes #1069