### PR TITLE
Add explicit auth startup shell

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,9 +4,78 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ParetoProof</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          "Segoe UI",
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background:
+          radial-gradient(circle at top left, rgba(209, 215, 255, 0.9), transparent 48%),
+          linear-gradient(180deg, #f7f7fb 0%, #edf4ff 100%);
+        color: #13264f;
+      }
+
+      [data-startup-shell] {
+        box-sizing: border-box;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 32px 20px;
+      }
+
+      [data-startup-shell-card] {
+        width: min(560px, 100%);
+        border: 1px solid rgba(104, 118, 255, 0.14);
+        border-radius: 24px;
+        background: rgba(255, 255, 255, 0.94);
+        box-shadow: 0 24px 60px rgba(28, 44, 94, 0.14);
+        padding: 28px;
+      }
+
+      [data-startup-shell-eyebrow] {
+        margin: 0 0 10px;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: #5d5ce6;
+      }
+
+      [data-startup-shell-title] {
+        margin: 0 0 10px;
+        font-size: clamp(1.8rem, 5vw, 2.4rem);
+        line-height: 1.05;
+      }
+
+      [data-startup-shell-body] {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.55;
+        color: rgba(19, 38, 79, 0.78);
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main data-startup-shell aria-live="polite">
+        <section data-startup-shell-card>
+          <p data-startup-shell-eyebrow>ParetoProof</p>
+          <h1 data-startup-shell-title>Loading ParetoProof...</h1>
+          <p data-startup-shell-body>
+            Starting the application and checking the current surface.
+          </p>
+        </section>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/bootstrap-app.test.js
+++ b/apps/web/src/bootstrap-app.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bootstrapWebApp } from "./bootstrap-app.tsx";
+
+test("bootstrapWebApp renders the React app after startup dependencies load", async () => {
+  let renderCalls = 0;
+  let runtimeEnvReads = 0;
+  const rootElement = { innerHTML: "" };
+
+  const result = await bootstrapWebApp(rootElement, {
+    createRoot() {
+      return {
+        render() {
+          renderCalls += 1;
+        }
+      };
+    },
+    loadApp: async () => ({
+      default: () => null
+    }),
+    loadRuntimeEnv: async () => ({
+      readWebRuntimeEnv() {
+        runtimeEnvReads += 1;
+        return {};
+      }
+    }),
+    loadStyles: async () => ({})
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(renderCalls, 1);
+  assert.equal(runtimeEnvReads, 1);
+  assert.equal(rootElement.innerHTML, "");
+});
+
+test("bootstrapWebApp falls back to the startup error shell when startup throws", async () => {
+  const observedErrors = [];
+  const rootElement = { innerHTML: "" };
+
+  const result = await bootstrapWebApp(rootElement, {
+    createRoot() {
+      return {
+        render() {
+          throw new Error("render should not be reached");
+        }
+      };
+    },
+    loadApp: async () => {
+      throw new Error("Invalid web runtime environment: VITE_API_BASE_URL");
+    },
+    loadRuntimeEnv: async () => ({
+      readWebRuntimeEnv() {
+        return {};
+      }
+    }),
+    loadStyles: async () => ({}),
+    logger: {
+      error(error) {
+        observedErrors.push(error);
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(observedErrors.length, 1);
+  assert.match(rootElement.innerHTML, /ParetoProof could not start\./);
+  assert.match(
+    rootElement.innerHTML,
+    /Invalid web runtime environment: VITE_API_BASE_URL/
+  );
+});

--- a/apps/web/src/bootstrap-app.tsx
+++ b/apps/web/src/bootstrap-app.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { buildStartupFailureShellMarkup } from "./lib/startup-shell";
+
+type AppComponent = () => React.ReactElement;
+
+type BootstrapDependencies = {
+  createRoot?: typeof ReactDOM.createRoot;
+  loadApp?: () => Promise<{ default: AppComponent }>;
+  loadRuntimeEnv?: () => Promise<{ readWebRuntimeEnv: () => unknown }>;
+  loadStyles?: () => Promise<unknown>;
+  logger?: Pick<Console, "error">;
+};
+
+export async function bootstrapWebApp(
+  rootElement: HTMLElement,
+  dependencies: BootstrapDependencies = {}
+) {
+  const createRoot = dependencies.createRoot ?? ReactDOM.createRoot;
+  const loadApp = dependencies.loadApp ?? (() => import("./App"));
+  const loadRuntimeEnv =
+    dependencies.loadRuntimeEnv ?? (() => import("./lib/runtime-env"));
+  const loadStyles = dependencies.loadStyles ?? (() => import("./styles/app.css"));
+  const logger = dependencies.logger ?? console;
+
+  try {
+    const [{ default: App }, { readWebRuntimeEnv }] = await Promise.all([
+      loadApp(),
+      loadRuntimeEnv(),
+      loadStyles()
+    ]);
+
+    readWebRuntimeEnv();
+
+    createRoot(rootElement).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+
+    return { ok: true } as const;
+  } catch (error) {
+    logger.error(error);
+    rootElement.innerHTML = buildStartupFailureShellMarkup(error);
+
+    return {
+      error,
+      ok: false
+    } as const;
+  }
+}

--- a/apps/web/src/lib/startup-shell.test.js
+++ b/apps/web/src/lib/startup-shell.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildStartupFailureShellMarkup } from "./startup-shell.ts";
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+const indexHtmlPath = resolve(currentDirectory, "../../index.html");
+
+test("index.html ships a visible startup shell instead of an empty root", () => {
+  const html = readFileSync(indexHtmlPath, "utf8");
+
+  assert.match(html, /<main data-startup-shell aria-live="polite">/);
+  assert.match(html, /Loading ParetoProof\.\.\./);
+  assert.match(html, /Starting the application and checking the current surface\./);
+});
+
+test("buildStartupFailureShellMarkup renders an explicit startup failure shell", () => {
+  const html = buildStartupFailureShellMarkup(
+    new Error("Invalid web runtime environment: VITE_API_BASE_URL")
+  );
+
+  assert.match(html, /ParetoProof could not start\./);
+  assert.match(
+    html,
+    /The app could not finish starting\. Refresh and try again\. Invalid web runtime environment: VITE_API_BASE_URL/
+  );
+  assert.match(html, /data-startup-shell/);
+});

--- a/apps/web/src/lib/startup-shell.ts
+++ b/apps/web/src/lib/startup-shell.ts
@@ -1,0 +1,34 @@
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formatStartupFailureDetail(error: unknown) {
+  if (!(error instanceof Error)) {
+    return "The app could not finish starting. Refresh and try again.";
+  }
+
+  const message = error.message.trim();
+
+  if (message.length === 0) {
+    return "The app could not finish starting. Refresh and try again.";
+  }
+
+  return `The app could not finish starting. Refresh and try again. ${message}`;
+}
+
+export function buildStartupFailureShellMarkup(error: unknown) {
+  return [
+    '<main data-startup-shell aria-live="assertive">',
+    '  <section data-startup-shell-card>',
+    '    <p data-startup-shell-eyebrow>ParetoProof</p>',
+    '    <h1 data-startup-shell-title> ParetoProof could not start. </h1>',
+    `    <p data-startup-shell-body>${escapeHtml(formatStartupFailureDetail(error))}</p>`,
+    "  </section>",
+    "</main>"
+  ].join("");
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,13 +1,9 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
-import { readWebRuntimeEnv } from "./lib/runtime-env";
-import "./styles/app.css";
+import { startParetoProof } from "./start-app";
 
-readWebRuntimeEnv();
+const rootElement = document.getElementById("root");
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+if (!rootElement) {
+  throw new Error("ParetoProof could not find the web root element.");
+}
+
+void startParetoProof(rootElement);

--- a/apps/web/src/start-app.test.js
+++ b/apps/web/src/start-app.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { startParetoProof } from "./start-app.ts";
+
+test("startParetoProof delegates to the bootstrap module on success", async () => {
+  const rootElement = { innerHTML: "" };
+  let bootstrapCalls = 0;
+
+  const result = await startParetoProof(rootElement, {
+    loadBootstrapApp: async () => ({
+      async bootstrapWebApp() {
+        bootstrapCalls += 1;
+        return { ok: true };
+      }
+    })
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(bootstrapCalls, 1);
+  assert.equal(rootElement.innerHTML, "");
+});
+
+test("startParetoProof shows a visible startup error shell when the bootstrap module fails to load", async () => {
+  const rootElement = { innerHTML: "" };
+  const observedErrors = [];
+
+  const result = await startParetoProof(rootElement, {
+    loadBootstrapApp: async () => {
+      throw new Error("bootstrap module failed");
+    },
+    logger: {
+      error(error) {
+        observedErrors.push(error);
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(observedErrors.length, 1);
+  assert.match(rootElement.innerHTML, /ParetoProof could not start\./);
+  assert.match(rootElement.innerHTML, /bootstrap module failed/);
+});

--- a/apps/web/src/start-app.ts
+++ b/apps/web/src/start-app.ts
@@ -1,0 +1,54 @@
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function buildFatalStartupShellMarkup(error: unknown) {
+  const detail =
+    error instanceof Error && error.message.trim().length > 0
+      ? `The app could not finish starting. Refresh and try again. ${error.message.trim()}`
+      : "The app could not finish starting. Refresh and try again.";
+
+  return [
+    '<main data-startup-shell aria-live="assertive">',
+    '  <section data-startup-shell-card>',
+    '    <p data-startup-shell-eyebrow>ParetoProof</p>',
+    '    <h1 data-startup-shell-title>ParetoProof could not start.</h1>',
+    `    <p data-startup-shell-body>${escapeHtml(detail)}</p>`,
+    "  </section>",
+    "</main>"
+  ].join("");
+}
+
+type StartAppDependencies = {
+  loadBootstrapApp?: () => Promise<{
+    bootstrapWebApp: (rootElement: HTMLElement) => Promise<{ ok: boolean }>;
+  }>;
+  logger?: Pick<Console, "error">;
+};
+
+export async function startParetoProof(
+  rootElement: HTMLElement,
+  dependencies: StartAppDependencies = {}
+) {
+  const loadBootstrapApp =
+    dependencies.loadBootstrapApp ?? (() => import("./bootstrap-app"));
+  const logger = dependencies.logger ?? console;
+
+  try {
+    const { bootstrapWebApp } = await loadBootstrapApp();
+    return await bootstrapWebApp(rootElement);
+  } catch (error) {
+    logger.error(error);
+    rootElement.innerHTML = buildFatalStartupShellMarkup(error);
+
+    return {
+      error,
+      ok: false
+    } as const;
+  }
+}


### PR DESCRIPTION
## Summary
- ship a visible static startup shell in the web entry HTML instead of an empty root
- guard both bootstrap failures and bootstrap-module load failures with explicit startup error shells
- add focused bootstrap and startup-shell regression coverage

## Testing
- bun test apps/web/src/start-app.test.js apps/web/src/bootstrap-app.test.js apps/web/src/lib/startup-shell.test.js apps/web/src/routes/auth-entry.test.js
- bun --cwd apps/web typecheck
- bun run build

Closes #1071