### PR TITLE
Derive public homepage signals from release data

### DIFF
--- a/apps/web/src/routes/public-site.test.js
+++ b/apps/web/src/routes/public-site.test.js
@@ -72,6 +72,33 @@ describe("resolvePublicSiteRoute", () => {
   });
 });
 
+describe("buildPublicSignalsFromReleaseData", () => {
+  it("derives homepage signals from the published release data instead of standalone literals", async () => {
+    setWindow("http://127.0.0.1/");
+    const { buildPublicSignalsFromReleaseData } = await loadPublicSiteModule();
+
+    expect(buildPublicSignalsFromReleaseData()).toEqual([
+      {
+        detail:
+          "Derived from the 2 public release summaries currently published on this site (Release 2026-03, Release 2026-02).",
+        label: "Released slices",
+        value: "2"
+      },
+      {
+        detail:
+          "Release-derived total across the currently published benchmark summaries, not a live operations counter.",
+        label: "Released items",
+        value: "93"
+      },
+      {
+        detail: "3 model families appear in the released summary rows currently published on this site.",
+        label: "Model families",
+        value: "3"
+      }
+    ]);
+  });
+});
+
 describe("PublicSite", () => {
   it("renders the benchmark index on /benchmarks", async () => {
     const html = await renderPublicSiteAt("http://127.0.0.1/benchmarks");
@@ -131,7 +158,7 @@ describe("PublicSite", () => {
     const html = await renderPublicSiteAt("http://127.0.0.1/", 320);
 
     expect(html).toContain("site-home-shell-compact");
-    expect(html.indexOf("Every run is verifiable")).toBeLessThan(html.indexOf("Benchmark types"));
+    expect(html.indexOf("Every run is verifiable")).toBeLessThan(html.indexOf("Released items"));
   });
 
   it("keeps the wide home signal rail in the hero", async () => {
@@ -139,6 +166,11 @@ describe("PublicSite", () => {
 
     expect(html).not.toContain("site-home-shell-compact");
     expect(html).not.toContain("Project signal cues stay available after the summary bands.");
+    expect(html).toContain("Released slices");
+    expect(html).toContain("Released items");
+    expect(html).toContain(
+      "Release-derived total across the currently published benchmark summaries, not a live operations counter."
+    );
   });
 
   it("keeps the project pack route intact", async () => {

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -134,23 +134,38 @@ const publicBenchmarkReports = {
   }
 } as const;
 
-const publicSignals = [
-  {
-    detail: "versioned harness, locked inputs, full environment metadata per run",
-    label: "Reproducible runs",
-    value: "22"
-  },
-  {
-    detail: "proof generation and statement formalization with public release tracking",
-    label: "Benchmark types",
-    value: "2 active"
-  },
-  {
-    detail: "GPT, Claude, and Gemini families evaluated under identical conditions",
-    label: "Models tested",
-    value: "3 families"
-  }
-];
+export function buildPublicSignalsFromReleaseData() {
+  const reportRows = Object.values(publicBenchmarkReports);
+  const uniqueModelFamilies = new Set(
+    reportRows.flatMap((report) => report.results.map((row) => row.providerLabel))
+  );
+  const publishedReleaseLabels = [...new Set(reportRows.map((report) => report.releaseLabel))];
+  const totalReleasedItems = reportRows.reduce((sum, report) => {
+    const evaluatedItemsCard = report.summaryCards.find((card) => card.label === "Evaluated items");
+    const evaluatedItems = Number(evaluatedItemsCard?.value ?? "0");
+    return sum + (Number.isFinite(evaluatedItems) ? evaluatedItems : 0);
+  }, 0);
+
+  return [
+    {
+      detail: `Derived from the ${reportRows.length} public release summaries currently published on this site (${publishedReleaseLabels.join(", ")}).`,
+      label: "Released slices",
+      value: reportRows.length.toString()
+    },
+    {
+      detail: `Release-derived total across the currently published benchmark summaries, not a live operations counter.`,
+      label: "Released items",
+      value: totalReleasedItems.toString()
+    },
+    {
+      detail: `${uniqueModelFamilies.size} model families appear in the released summary rows currently published on this site.`,
+      label: "Model families",
+      value: uniqueModelFamilies.size.toString()
+    }
+  ] as const;
+}
+
+const publicSignals = buildPublicSignalsFromReleaseData();
 
 const publicBands = [
   {


### PR DESCRIPTION
## Summary
- derive the homepage signal rail from the published public release summaries instead of a separate hardcoded metric table
- remove the separate homepage-only truth surface and label the signals as release-derived rather than live operational facts
- add regression coverage for the derived homepage signal contract

## Testing
- bun test apps/web/src/routes/public-site.test.js
- bun --cwd apps/web typecheck
- bun run build

Closes #1072