### PR TITLE
Fix local portal preview content posture

### DIFF
--- a/apps/web/src/lib/portal-admin.test.js
+++ b/apps/web/src/lib/portal-admin.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { portalAdminLocalTestUtils } from "./portal-admin.ts";
+
+describe("portal admin local preview fixtures", () => {
+  it("marks the seeded reviewer and user records as local preview content", () => {
+    const state = portalAdminLocalTestUtils.createLocalAdminState();
+
+    expect(portalAdminLocalTestUtils.localReviewer.label).toBe("Local preview reviewer");
+    expect(state.users.map((user) => user.displayName)).toEqual([
+      "Demo collaborator record",
+      "Demo pending requester",
+      "Demo former helper",
+      "Demo approved helper"
+    ]);
+    expect(state.users.every((user) => user.email.includes("@preview.paretoproof.local"))).toBe(
+      true
+    );
+  });
+
+  it("keeps local access-request narratives explicitly scoped to preview layout review", () => {
+    const state = portalAdminLocalTestUtils.createLocalAdminState();
+
+    expect(state.accessRequests.map((request) => request.rationale)).toEqual([
+      "Local preview request used to exercise collaborator approval layout.",
+      "Local preview recovery request for a rotated Google identity.",
+      "Local preview request used to exercise rejected helper review state.",
+      "Local preview request used to exercise pending helper review state."
+    ]);
+    expect(
+      state.accessRequests
+        .filter((request) => request.decisionNote !== null)
+        .map((request) => request.decisionNote)
+    ).toEqual(["Local preview rejection note for the review-state layout."]);
+    expect(
+      state.accessRequests
+        .filter((request) => request.reviewedAt !== null)
+        .map((request) => request.reviewer?.label)
+    ).toEqual(["Local preview reviewer"]);
+  });
+});

--- a/apps/web/src/lib/portal-admin.ts
+++ b/apps/web/src/lib/portal-admin.ts
@@ -38,9 +38,9 @@ type RevokeRoleInput = {
 const localAdminStateStorageKey = "paretoproof.portal.admin.workspace";
 
 const localReviewer: PortalAdminActorSummary = {
-  displayName: "Portal Admin",
-  email: "admin@paretoproof.local",
-  label: "Portal Admin",
+  displayName: "Local preview reviewer",
+  email: "reviewer@preview.paretoproof.local",
+  label: "Local preview reviewer",
   userId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 };
 
@@ -123,8 +123,8 @@ function createLocalAdminState(): LocalAdminState {
           }
         )
       ],
-      displayName: "Ada Researcher",
-      email: "ada@paretoproof.local",
+      displayName: "Demo collaborator record",
+      email: "collaborator-demo@preview.paretoproof.local",
       lastReviewedRequestStatus: "approved",
       linkedIdentities: [
         {
@@ -132,7 +132,7 @@ function createLocalAdminState(): LocalAdminState {
           id: "identity-ada-github",
           lastSeenAt: "2026-03-13T19:14:00.000Z",
           provider: "cloudflare_github",
-          providerEmail: "ada@paretoproof.local",
+          providerEmail: "collaborator-demo@preview.paretoproof.local",
           providerSubject: "github-ada"
         },
         {
@@ -140,7 +140,7 @@ function createLocalAdminState(): LocalAdminState {
           id: "identity-ada-google",
           lastSeenAt: "2026-03-13T17:06:00.000Z",
           provider: "cloudflare_google",
-          providerEmail: "ada@paretoproof.local",
+          providerEmail: "collaborator-demo@preview.paretoproof.local",
           providerSubject: "google-ada-new"
         }
       ],
@@ -171,13 +171,13 @@ function createLocalAdminState(): LocalAdminState {
           linUserId,
           {
             accessRequestId: "request-lin-rejected",
-            decisionNote: "Need a stronger benchmark contribution summary.",
+            decisionNote: "Local preview rejection note for the review-state layout.",
             targetUserId: linUserId
           }
         )
       ],
-      displayName: "Lin Contributor",
-      email: "lin@paretoproof.local",
+      displayName: "Demo pending requester",
+      email: "pending-request-demo@preview.paretoproof.local",
       lastReviewedRequestStatus: "rejected",
       linkedIdentities: [
         {
@@ -185,7 +185,7 @@ function createLocalAdminState(): LocalAdminState {
           id: "identity-lin-github",
           lastSeenAt: "2026-03-13T09:18:00.000Z",
           provider: "cloudflare_github",
-          providerEmail: "lin@paretoproof.local",
+          providerEmail: "pending-request-demo@preview.paretoproof.local",
           providerSubject: "github-lin"
         }
       ],
@@ -215,14 +215,14 @@ function createLocalAdminState(): LocalAdminState {
           "critical",
           theoUserId,
           {
-            revocationReason: "Access request was approved under a stale email domain.",
+            revocationReason: "Local preview revocation note for the audit-history layout.",
             revokedRole: "helper",
             targetUserId: theoUserId
           }
         )
       ],
-      displayName: "Theo Former Helper",
-      email: "theo@paretoproof.local",
+      displayName: "Demo former helper",
+      email: "former-helper-demo@preview.paretoproof.local",
       lastReviewedRequestStatus: "approved",
       linkedIdentities: [
         {
@@ -230,7 +230,7 @@ function createLocalAdminState(): LocalAdminState {
           id: "identity-theo-google",
           lastSeenAt: "2026-03-09T12:58:00.000Z",
           provider: "cloudflare_google",
-          providerEmail: "theo@paretoproof.local",
+          providerEmail: "former-helper-demo@preview.paretoproof.local",
           providerSubject: "google-theo"
         }
       ],
@@ -270,8 +270,8 @@ function createLocalAdminState(): LocalAdminState {
           }
         )
       ],
-      displayName: "Morgan Already Approved",
-      email: "morgan@paretoproof.local",
+      displayName: "Demo approved helper",
+      email: "approved-helper-demo@preview.paretoproof.local",
       lastReviewedRequestStatus: "approved",
       linkedIdentities: [
         {
@@ -279,7 +279,7 @@ function createLocalAdminState(): LocalAdminState {
           id: "identity-stale-github",
           lastSeenAt: "2026-03-13T19:00:00.000Z",
           provider: "cloudflare_github",
-          providerEmail: "morgan@paretoproof.local",
+          providerEmail: "approved-helper-demo@preview.paretoproof.local",
           providerSubject: "github-morgan"
         }
       ],
@@ -341,12 +341,12 @@ function createLocalAdminState(): LocalAdminState {
       ],
       createdAt: "2026-03-13T18:12:00.000Z",
       decisionNote: null,
-      email: "lin@paretoproof.local",
+      email: "pending-request-demo@preview.paretoproof.local",
       id: "request-lin-pending",
       linkedIdentities: users[1].linkedIdentities,
       matchedUser: toMatchedUserSummary(users[1]),
       matchedUserPosture: toPostureSummary(users[1]),
-      rationale: "I need collaborator access to compare offline Problem 9 runs.",
+      rationale: "Local preview request used to exercise collaborator approval layout.",
       recovery: null,
       relatedRequests: [],
       requestKind: "access_request",
@@ -375,12 +375,12 @@ function createLocalAdminState(): LocalAdminState {
       ],
       createdAt: "2026-03-13T17:00:00.000Z",
       decisionNote: null,
-      email: "ada@paretoproof.local",
+      email: "collaborator-demo@preview.paretoproof.local",
       id: "request-ada-recovery",
       linkedIdentities: users[0].linkedIdentities,
       matchedUser: toMatchedUserSummary(users[0]),
       matchedUserPosture: toPostureSummary(users[0]),
-      rationale: "My Google Access identity rotated after a device reset.",
+      rationale: "Local preview recovery request for a rotated Google identity.",
       recovery: {
         conflictingUser: null,
         preserveExistingRole: "collaborator",
@@ -408,19 +408,19 @@ function createLocalAdminState(): LocalAdminState {
           linUserId,
           {
             accessRequestId: "request-lin-rejected",
-            decisionNote: "Need a stronger benchmark contribution summary.",
+            decisionNote: "Local preview rejection note for the review-state layout.",
             targetUserId: linUserId
           }
         )
       ],
       createdAt: "2026-03-12T08:18:00.000Z",
-      decisionNote: "Need a stronger benchmark contribution summary.",
-      email: "lin@paretoproof.local",
+      decisionNote: "Local preview rejection note for the review-state layout.",
+      email: "pending-request-demo@preview.paretoproof.local",
       id: "request-lin-rejected",
       linkedIdentities: users[1].linkedIdentities,
       matchedUser: toMatchedUserSummary(users[1]),
       matchedUserPosture: toPostureSummary(users[1]),
-      rationale: "I want to help with benchmark result review.",
+      rationale: "Local preview request used to exercise rejected helper review state.",
       recovery: null,
       relatedRequests: [],
       requestKind: "access_request",
@@ -449,12 +449,12 @@ function createLocalAdminState(): LocalAdminState {
       ],
       createdAt: "2026-03-13T18:25:00.000Z",
       decisionNote: null,
-      email: "morgan@paretoproof.local",
+      email: "approved-helper-demo@preview.paretoproof.local",
       id: "request-stale-pending",
       linkedIdentities: users[3].linkedIdentities,
       matchedUser: toMatchedUserSummary(users[3]),
       matchedUserPosture: toPostureSummary(users[3]),
-      rationale: "Re-open contributor access after a temporary pause.",
+      rationale: "Local preview request used to exercise pending helper review state.",
       recovery: null,
       relatedRequests: [],
       requestKind: "access_request",
@@ -1269,6 +1269,11 @@ export function summarizeUserPosture(item: PortalAdminUserListItem) {
 
   return "No active role";
 }
+
+export const portalAdminLocalTestUtils = {
+  createLocalAdminState,
+  localReviewer
+};
 
 export function toAccessRequestSummaryFromAdminItem(
   item: PortalAdminAccessRequestListItem

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -635,4 +635,26 @@ describe("local benchmark ops sorting", () => {
 
     expect(dataset.runs.map((run) => run.runId)).toEqual(["PP-318", "PP-321", "PP-319"]);
   });
+
+  it("marks local runs and worker incidents as preview fixtures instead of live operational facts", () => {
+    const runs = portalBenchmarkOpsLocalTestUtils.buildLocalRunsListResponse(defaultPortalRunsQuery);
+    const workers = portalBenchmarkOpsLocalTestUtils.buildLocalWorkersViewResponse();
+
+    expect(runs.items.map((item) => item.benchmarkLabel)).toEqual(
+      expect.arrayContaining([
+        "Local preview / axiom slice example",
+        "Local preview / induction example",
+        "Local preview / simplification example",
+        "Local preview / worker handoff example"
+      ])
+    );
+    expect(workers.incidents.map((incident) => incident.summary)).toEqual([
+      "Local preview fixture: a stale lease expired on the local-preview pool while PP-320 was retrying.",
+      "Local preview fixture: queued slice work is waiting on modal-preview capacity."
+    ]);
+    expect(workers.workerPools.map((pool) => pool.workerPool)).toEqual([
+      "modal-preview",
+      "local-preview"
+    ]);
+  });
 });

--- a/apps/web/src/lib/portal-benchmark-ops.ts
+++ b/apps/web/src/lib/portal-benchmark-ops.ts
@@ -159,7 +159,7 @@ const localRunItems: PortalRunListItem[] = [
   {
     authMode: "oidc",
     benchmarkItemId: "item-simplify-001",
-    benchmarkLabel: "mathlib4 / simplification",
+    benchmarkLabel: "Local preview / simplification example",
     benchmarkPackageDigest: "sha256:3f91c1",
     benchmarkPackageId: "problem9-core",
     benchmarkPackageVersion: "2026.03.11",
@@ -194,7 +194,7 @@ const localRunItems: PortalRunListItem[] = [
   {
     authMode: "oidc",
     benchmarkItemId: "item-induction-022",
-    benchmarkLabel: "proof search / induction",
+    benchmarkLabel: "Local preview / induction example",
     benchmarkPackageDigest: "sha256:3f91c1",
     benchmarkPackageId: "problem9-core",
     benchmarkPackageVersion: "2026.03.11",
@@ -229,7 +229,7 @@ const localRunItems: PortalRunListItem[] = [
   {
     authMode: "service_token",
     benchmarkItemId: "item-queue-003",
-    benchmarkLabel: "worker smoke / queue handoff",
+    benchmarkLabel: "Local preview / worker handoff example",
     benchmarkPackageDigest: "sha256:c28a7b",
     benchmarkPackageId: "problem9-smoke",
     benchmarkPackageVersion: "2026.03.12",
@@ -239,7 +239,7 @@ const localRunItems: PortalRunListItem[] = [
     failure: {
       code: "worker_lease_lost",
       family: "provider",
-      summary: "Worker lease heartbeat expired during provider retry recovery."
+      summary: "Local preview fixture: worker lease heartbeat expired during retry recovery."
     },
     laneId: "worker-smoke",
     latestAttemptId: "ATT-320-3",
@@ -268,7 +268,7 @@ const localRunItems: PortalRunListItem[] = [
   {
     authMode: "oidc",
     benchmarkItemId: "slice-axioms-004",
-    benchmarkLabel: "axioms slice / dependency drift",
+    benchmarkLabel: "Local preview / axiom slice example",
     benchmarkPackageDigest: "sha256:3f91c1",
     benchmarkPackageId: "problem9-core",
     benchmarkPackageVersion: "2026.03.11",
@@ -365,10 +365,10 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
     ],
     recentWorkerEvents: [
       {
-        label: "Artifact upload finished",
+        label: "Local preview artifact upload finished",
         occurredAt: "2026-03-13T15:37:55.000Z",
         scope: "worker",
-        sourceId: "worker-modal-eu-1",
+        sourceId: "worker-modal-preview-1",
         state: "available"
       }
     ],
@@ -393,8 +393,8 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         lastHeartbeatAt: "2026-03-13T15:37:50.000Z",
         leaseExpiresAt: "2026-03-13T15:39:50.000Z",
         runId: "PP-318",
-        workerId: "worker-modal-eu-1",
-        workerPool: "modal-proof",
+        workerId: "worker-modal-preview-1",
+        workerPool: "modal-preview",
         workerRuntime: "modal",
         workerVersion: "2026.03.12"
       }
@@ -409,7 +409,7 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         failure: {
           code: "provider_rate_limited",
           family: "provider",
-          summary: "Anthropic rate limit hit while warming the first attempt."
+          summary: "Local preview fixture: the first attempt hit a provider rate limit during warm-up."
         },
         jobId: "JOB-319-1",
         runId: "PP-319",
@@ -446,17 +446,17 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
     ],
     recentWorkerEvents: [
       {
-        label: "Heartbeat received",
+        label: "Local preview heartbeat received",
         occurredAt: "2026-03-13T16:05:58.000Z",
         scope: "worker",
-        sourceId: "worker-modal-eu-2",
+        sourceId: "worker-modal-preview-2",
         state: "healthy"
       }
     ],
     timeline: [
       ...baseDetail(localRunItems[1]).timeline,
       {
-        label: "Attempt 1 failed with provider rate limit",
+        label: "Local preview attempt 1 hit provider rate limit",
         occurredAt: "2026-03-13T15:47:08.000Z",
         scope: "attempt",
         sourceId: "ATT-319-1",
@@ -474,8 +474,8 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         lastHeartbeatAt: "2026-03-13T16:05:58.000Z",
         leaseExpiresAt: "2026-03-13T16:07:58.000Z",
         runId: "PP-319",
-        workerId: "worker-modal-eu-2",
-        workerPool: "modal-proof",
+        workerId: "worker-modal-preview-2",
+        workerPool: "modal-preview",
         workerRuntime: "modal",
         workerVersion: "2026.03.12"
       }
@@ -502,7 +502,7 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         failure: {
           code: "worker_lease_lost",
           family: "provider",
-          summary: "Worker lease heartbeat expired during provider retry recovery."
+          summary: "Local preview fixture: worker lease heartbeat expired during retry recovery."
         },
         jobId: "JOB-320-3",
         runId: "PP-320",
@@ -519,7 +519,7 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         failure: {
           code: "worker_lease_lost",
           family: "provider",
-          summary: "Worker lease heartbeat expired during provider retry recovery."
+          summary: "Local preview fixture: worker lease heartbeat expired during retry recovery."
         },
         jobId: "JOB-320-3",
         runId: "PP-320",
@@ -534,7 +534,7 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         label: "Lease marked stale",
         occurredAt: "2026-03-13T15:03:55.000Z",
         scope: "worker",
-        sourceId: "worker-local-3",
+        sourceId: "worker-local-preview-3",
         state: "stale"
       }
     ],
@@ -559,8 +559,8 @@ const localRunDetailById: Record<string, PortalRunDetailResponse> = {
         lastHeartbeatAt: "2026-03-13T15:01:55.000Z",
         leaseExpiresAt: "2026-03-13T15:03:55.000Z",
         runId: "PP-320",
-        workerId: "worker-local-3",
-        workerPool: "local-devbox",
+        workerId: "worker-local-preview-3",
+        workerPool: "local-preview",
         workerRuntime: "local_docker",
         workerVersion: "2026.03.11"
       }
@@ -585,7 +585,7 @@ const localLaunchView: PortalLaunchViewResponse = {
   benchmarks: [
     {
       benchmarkItemCount: 128,
-      benchmarkLabel: "Problem 9 core benchmark",
+      benchmarkLabel: "Problem 9 local preview benchmark",
       benchmarkPackageDigest: "sha256:3f91c1",
       benchmarkPackageId: "problem9-core",
       benchmarkPackageVersion: "2026.03.11",
@@ -595,7 +595,7 @@ const localLaunchView: PortalLaunchViewResponse = {
     },
     {
       benchmarkItemCount: 12,
-      benchmarkLabel: "Problem 9 smoke benchmark",
+      benchmarkLabel: "Problem 9 smoke preview benchmark",
       benchmarkPackageDigest: "sha256:c28a7b",
       benchmarkPackageId: "problem9-smoke",
       benchmarkPackageVersion: "2026.03.12",
@@ -718,8 +718,8 @@ const localWorkersView: PortalWorkersViewResponse = {
       lastHeartbeatAt: "2026-03-13T16:05:58.000Z",
       leaseExpiresAt: "2026-03-13T16:07:58.000Z",
       runId: "PP-319",
-      workerId: "worker-modal-eu-2",
-      workerPool: "modal-proof",
+      workerId: "worker-modal-preview-2",
+      workerPool: "modal-preview",
       workerRuntime: "modal",
       workerVersion: "2026.03.12"
     },
@@ -733,8 +733,8 @@ const localWorkersView: PortalWorkersViewResponse = {
       lastHeartbeatAt: "2026-03-13T15:01:55.000Z",
       leaseExpiresAt: "2026-03-13T15:03:55.000Z",
       runId: "PP-320",
-      workerId: "worker-local-3",
-      workerPool: "local-devbox",
+      workerId: "worker-local-preview-3",
+      workerPool: "local-preview",
       workerRuntime: "local_docker",
       workerVersion: "2026.03.11"
     }
@@ -746,16 +746,16 @@ const localWorkersView: PortalWorkersViewResponse = {
       kind: "stale_lease",
       observedAt: "2026-03-13T15:03:55.000Z",
       severity: "critical",
-      summary: "A stale lease expired on the local-devbox pool while PP-320 was retrying.",
-      workerPool: "local-devbox"
+      summary: "Local preview fixture: a stale lease expired on the local-preview pool while PP-320 was retrying.",
+      workerPool: "local-preview"
     },
     {
       affectedRunIds: ["PP-321"],
       kind: "queue_backlog",
       observedAt: "2026-03-13T16:16:00.000Z",
       severity: "warning",
-      summary: "Queued slice work is waiting on modal-proof capacity.",
-      workerPool: "modal-proof"
+      summary: "Local preview fixture: queued slice work is waiting on modal-preview capacity.",
+      workerPool: "modal-preview"
     }
   ],
   queueSummary: {
@@ -771,7 +771,7 @@ const localWorkersView: PortalWorkersViewResponse = {
       activeLeaseCount: 1,
       activeRunIds: ["PP-319"],
       staleLeaseCount: 0,
-      workerPool: "modal-proof",
+      workerPool: "modal-preview",
       workerRuntime: "modal",
       workerVersion: "2026.03.12"
     },
@@ -779,7 +779,7 @@ const localWorkersView: PortalWorkersViewResponse = {
       activeLeaseCount: 1,
       activeRunIds: ["PP-320"],
       staleLeaseCount: 1,
-      workerPool: "local-devbox",
+      workerPool: "local-preview",
       workerRuntime: "local_docker",
       workerVersion: "2026.03.11"
     }
@@ -1447,9 +1447,19 @@ function escapeCsvValue(value: string) {
   return safeValue;
 }
 
+function buildLocalRunsListResponse(query: PortalRunsListQuery = defaultPortalRunsQuery) {
+  return portalRunsListResponseSchema.parse(createRunsListResponse(query));
+}
+
+function buildLocalWorkersViewResponse() {
+  return portalWorkersViewResponseSchema.parse(localWorkersView);
+}
+
 export const portalBenchmarkOpsLocalTestUtils = {
   buildLocalBenchmarkDataset,
   buildLocalBenchmarksListResponse,
+  buildLocalRunsListResponse,
+  buildLocalWorkersViewResponse,
   compareBenchmarkLatestCompletedAtDesc,
   compareBenchmarkLatestRunDesc,
   compareNullableTimestampDesc,
@@ -1465,14 +1475,14 @@ export function getWorkerIncidentTone(severity: PortalWorkerIncidentSeverity) {
 export function getLocalOverviewTimeline() {
   return [
     {
-      detail: "PP-319 is active on modal-proof, while PP-320 is the current worker incident anchor.",
-      meta: "Benchmark ops",
-      title: "Runs and workers share one evidence trail"
+      detail: "The local preview keeps runs and workers on one fixture-backed evidence trail so layout can be reviewed without the API.",
+      meta: "Local preview",
+      title: "Runs and workers share demo fixtures"
     },
     {
-      detail: "Problem 9 core remains the default launch package with one queued slice run ready to inspect.",
-      meta: "Launch",
-      title: "Launch stays preflight-only until create-run lands"
+      detail: "The launch route keeps schema-faithful preview benchmark options without claiming they are the current live queue.",
+      meta: "Launch preview",
+      title: "Launch keeps preview-only options"
     },
     {
       detail: "Overview routes into Runs, Launch, and Workers without duplicating their state tables.",

--- a/apps/web/src/routes/portal-access-request-panel.test.js
+++ b/apps/web/src/routes/portal-access-request-panel.test.js
@@ -134,11 +134,11 @@ describe("describeAccessRequestTransition", () => {
       describeAccessRequestTransition({
         reviewedAt: "2026-03-13T09:30:00.000Z",
         reviewer: {
-          label: "Portal Admin"
+          label: "Local preview reviewer"
         },
         status: "approved"
       })
-    ).toContain("Approved by Portal Admin");
+    ).toContain("Approved by Local preview reviewer");
   });
 });
 

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -75,10 +75,15 @@ describe("PortalShell overview ordering", () => {
     });
 
     expect(html).toContain("Review access requests");
-    expect(html.indexOf("Recent runs route back into the canonical cluster.")).toBeLessThan(
-      html.indexOf("Approval state")
+    expect(html).toContain("Local preview");
+    expect(html).toContain("demo fixture data stored in this browser");
+    expect(html).toContain("Runs route");
+    expect(html).not.toContain("Live benchmark data");
+    expect(html).not.toContain(">API-backed<");
+    expect(html.indexOf("Portal sections")).toBeLessThan(
+      html.indexOf("Runs route")
     );
-    expect(html.indexOf("Recent runs route back into the canonical cluster.")).toBeLessThan(
+    expect(html.indexOf("Portal sections")).toBeLessThan(
       html.indexOf("Review runs")
     );
   });
@@ -92,7 +97,9 @@ describe("PortalShell overview ordering", () => {
     });
 
     expect(html).toContain("Review access requests");
-    expect(html.indexOf("Approval state")).toBeLessThan(html.indexOf("Review runs"));
+    expect(html).toContain("Runs route");
+    expect(html).not.toContain("Live benchmark data");
+    expect(html.indexOf("Runs route")).toBeLessThan(html.indexOf("Review runs"));
   });
 });
 

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -3,27 +3,16 @@ import {
   getPortalActionsForRoles,
   getPortalLiveViewFreshness,
   getPortalSectionsForRoles,
-  type EvaluationVerdictClass,
   type PortalActionDefinition,
   type PortalRole,
   type PortalRouteId,
-  type PortalSectionDefinition,
-  type RunLifecycleState
+  type PortalSectionDefinition
 } from "@paretoproof/shared";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { findMatchedPortalRoute } from "../lib/portal-route-access";
-import {
-  buildPortalResultsQueryString,
-  evaluationVerdictLabels,
-  examplePortalResultsQueryState,
-  portalResultsExportHeaders,
-  portalResultsLifecycleBuckets,
-  portalResultsSortOptions,
-  runLifecycleStateLabels
-} from "../lib/results-state";
-import { buildPortalUrl } from "../lib/surface";
+import { buildPortalUrl, isLocalHostname } from "../lib/surface";
 import { PortalAccessRequestPanel } from "./portal-access-request-panel";
 import { PortalAdminUsersPanel } from "./portal-admin-users-panel";
 import { PortalBenchmarkOpsSurface } from "./portal-benchmark-ops-surfaces";
@@ -39,6 +28,16 @@ type PortalNavGroup = {
   id: "account" | "benchmark_ops" | "admin";
   label: string;
   sections: PortalSectionDefinition[];
+};
+
+type OverviewSurfaceRow = {
+  entryHref: string;
+  entryLabel: string;
+  freshnessLabel: string;
+  id: PortalSectionDefinition["id"];
+  scopeLabel: string;
+  sourceLabel: string;
+  summary: string;
 };
 
 const portalRoutePathById = new Map<PortalRouteId, string>(
@@ -80,72 +79,91 @@ const portalSectionIconById: Record<PortalSectionDefinition["id"], AppIconName> 
   workers: "server"
 };
 
-const overviewMetrics = [
+const defaultOverviewMetrics = [
   {
-    label: "Approval state",
-    note: "role-linked and current",
-    value: "approved"
+    label: "Live benchmark data",
+    note: "Runs remains the API-backed source for benchmark evidence and exports.",
+    value: "/runs"
   },
   {
-    label: "API health",
-    note: "Railway to Neon responding",
-    value: "green"
+    label: "Launch review",
+    note: "Launch keeps run-shape and governance preflight inside the portal.",
+    value: "/launch"
   },
   {
-    label: "Recent runs",
-    note: "2 active, 1 terminal failure",
-    value: "08"
+    label: "Worker operations",
+    note: "Workers is the API-backed view for queue, lease, and incident posture.",
+    value: "/workers"
   },
   {
-    label: "Identity links",
-    note: "GitHub and Google attached",
-    value: "02"
+    label: "Access and profile",
+    note: "Admin and profile routes stay separate from benchmark operational views.",
+    value: "portal"
   }
 ];
 
-const overviewRuns = [
+const localPreviewMetrics = [
   {
-    branch: "main",
-    id: "PP-318",
-    model: "gpt-oss",
-    runState: "succeeded" as RunLifecycleState,
-    target: "mathlib4 / simplification",
-    verdict: "pass" as EvaluationVerdictClass
+    label: "Runs route",
+    note: "Local preview fixtures keep the run index and evidence layout visible on localhost.",
+    value: "/runs"
   },
   {
-    branch: "auth-fix",
-    id: "PP-319",
-    model: "claude",
-    runState: "running" as RunLifecycleState,
-    target: "proof search / induction",
-    verdict: null
+    label: "Launch route",
+    note: "Local preview fixtures keep benchmark and governance preflight screens reviewable.",
+    value: "/launch"
   },
   {
-    branch: "railway-host",
-    id: "PP-320",
-    model: "gemini",
-    runState: "failed" as RunLifecycleState,
-    target: "worker smoke / queue handoff",
-    verdict: "invalid_result" as EvaluationVerdictClass
+    label: "Workers route",
+    note: "Local preview fixtures keep queue, lease, and incident layouts visible without the API.",
+    value: "/workers"
+  },
+  {
+    label: "Access and profile",
+    note: "Admin and profile routes are using browser-local demo state, not live records.",
+    value: "preview"
   }
 ];
 
-const overviewTimeline = [
+const defaultOverviewNotes = [
   {
     detail:
-      "A contributor linked GitHub and entered the portal without the Access handoff breaking.",
-    meta: "11:24 UTC",
-    title: "Access request approved"
+      "This overview intentionally avoids inventing live runs, incidents, or user posture. Use the deeper portal routes for API-backed state.",
+    meta: "Portal",
+    title: "Overview is route guidance"
   },
   {
-    detail: "A stale Google-only identity needs relink confirmation before approval is restored.",
-    meta: "09:10 UTC",
-    title: "Recovery check required"
+    detail:
+      "Runs, Launch, and Workers remain the benchmark-ops surfaces; access requests, users, and profile stay on their own routes.",
+    meta: "Surface boundaries",
+    title: "Operational state lives deeper"
   },
   {
-    detail: "Railway health and Neon connectivity both reported green after the last deploy.",
-    meta: "07:42 UTC",
-    title: "API host validation"
+    detail:
+      "The header shows the signed-in identity and approved roles, while the route cards below point to the appropriate next step.",
+    meta: "Account context",
+    title: "Use the route cards"
+  }
+];
+
+const localPreviewOverviewNotes = [
+  {
+    detail:
+      "This localhost portal is rendering demo fixture content kept in browser storage. Treat all identities, runs, and incidents as examples rather than live operational facts.",
+    meta: "Local preview",
+    title: "Demo data only"
+  },
+  {
+    detail:
+      "The local admin and benchmark-ops panels keep schema-faithful example states so layout and transitions can be reviewed without the API.",
+    meta: "Fixture posture",
+    title: "Schema-faithful examples"
+  },
+  {
+    detail:
+      "When the backend is available, use the same routes to review API-backed runs, users, and worker state instead of these browser-local fixtures.",
+    meta: "Route parity",
+    title: "API-backed paths stay the same"
   }
 ];
 
@@ -172,10 +190,6 @@ function coercePortalRoles(rawRoles: string[]): PortalRole[] {
 
 function getSectionHref(section: PortalSectionDefinition) {
   return buildPortalUrl(portalRoutePathById.get(section.routeId) ?? "/");
-}
-
-function buildRunDetailHref(runId: string) {
-  return buildPortalUrl(`/runs/${encodeURIComponent(runId)}`);
 }
 
 function readActiveRunId(pathname: string) {
@@ -237,12 +251,24 @@ function resolveActiveSection(
   return sections[0];
 }
 
-function formatRunLifecycleState(state: RunLifecycleState) {
-  return runLifecycleStateLabels[state];
+function getOverviewSourceLabel(sectionId: PortalSectionDefinition["id"]) {
+  if (sectionId === "profile" || sectionId === "overview") {
+    return "Account";
+  }
+
+  if (sectionId === "access_requests" || sectionId === "users") {
+    return "Admin";
+  }
+
+  return "Benchmark ops";
 }
 
-function formatVerdictClass(verdict: EvaluationVerdictClass | null) {
-  return verdict ? evaluationVerdictLabels[verdict] : "Pending";
+function getOverviewFreshnessLabel(routeId: PortalRouteId, isLocalPreview: boolean) {
+  if (isLocalPreview) {
+    return "Demo fixture";
+  }
+
+  return getPortalLiveViewFreshness(routeId) ? "API-backed" : "Navigation";
 }
 
 export function getCompactOverviewSectionOrder() {
@@ -252,6 +278,7 @@ export function getCompactOverviewSectionOrder() {
 export function PortalShell({ email, roles }: PortalShellProps) {
   const [navigationCollapsed, setNavigationCollapsed] = useState(false);
   const compactLayout = useCompactLayout();
+  const isLocalPreview = isLocalHostname(window.location.hostname);
   const approvedRoles = useMemo(() => coercePortalRoles(roles), [roles]);
   const sections = useMemo(
     () => getPortalSectionsForRoles(approvedRoles),
@@ -292,6 +319,29 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     () => getPortalLiveViewFreshness(activeRouteId),
     [activeRouteId]
   );
+  const overviewSurfaceRows = useMemo<OverviewSurfaceRow[]>(
+    () =>
+      sections
+        .filter((section) => section.id !== "overview")
+        .map((section) => {
+          const entryHref = getSectionHref(section);
+
+          return {
+            entryHref,
+            entryLabel: new URL(entryHref).pathname,
+            freshnessLabel: getOverviewFreshnessLabel(section.routeId, isLocalPreview),
+            id: section.id,
+            scopeLabel: section.description,
+            sourceLabel: getOverviewSourceLabel(section.id),
+            summary: portalSectionBodyCopy[section.id]
+          };
+        }),
+    [isLocalPreview, sections]
+  );
+  const overviewMetricsCopy = isLocalPreview ? localPreviewMetrics : defaultOverviewMetrics;
+  const overviewNotes = isLocalPreview
+    ? localPreviewOverviewNotes
+    : defaultOverviewNotes;
 
   useEffect(() => {
     if (matchedPortalRoute || pathname === activeSectionHref || pathname.startsWith("/runs/")) {
@@ -353,7 +403,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   );
   const overviewMetricStrip = (
     <section className="portal-metric-strip" aria-label="Portal metrics">
-      {overviewMetrics.map((metric) => (
+      {overviewMetricsCopy.map((metric) => (
         <article className="portal-metric-cell" key={metric.label}>
           <span>{metric.label}</span>
           <strong>{metric.value}</strong>
@@ -366,8 +416,9 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     <section className="portal-overview-grid">
       <article className="portal-panel portal-overview-lead">
         <p>
-          Scan service posture, spot active benchmark work, and jump into Runs,
-          Launch, or Workers.
+          {isLocalPreview
+            ? "Review the localhost portal structure against schema-faithful demo fixtures. Real run, worker, and admin posture still belongs to the API-backed routes."
+            : "Use this overview to orient around the portal routes without inventing live operational facts. Real run, worker, and admin posture appears on the deeper API-backed surfaces."}
         </p>
         {activeFreshnessPolicy ? (
           <PortalFreshnessCard lastUpdatedAt={null} routeId={activeRouteId} />
@@ -381,50 +432,42 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     <section className="portal-overview-grid portal-overview-grid-secondary">
       <article className="portal-panel-table-flat">
         <div className="portal-panel-header">
-          <h2>Recent runs</h2>
+          <h2>Portal sections</h2>
           <a className="button button-secondary" href={buildPortalUrl("/runs")}>
-            View all
+            Open runs
           </a>
         </div>
 
-        <div className="portal-table-shell" role="table" aria-label="Recent runs">
+        <div className="portal-table-shell" role="table" aria-label="Portal sections">
           <div className="portal-table-head" role="row">
-            <span>Run</span>
-            <span>Model</span>
-            <span>Target</span>
-            <span>Branch</span>
-            <span>Lifecycle</span>
-            <span>Verdict</span>
+            <span>Surface</span>
+            <span>Source</span>
+            <span>What it shows</span>
+            <span>Entry</span>
+            <span>Mode</span>
+            <span>Scope</span>
           </div>
-          {overviewRuns.map((row) => (
+          {overviewSurfaceRows.map((row) => (
             <div className="portal-table-row" key={row.id} role="row">
               <span>
-                <a className="portal-inline-link" href={buildRunDetailHref(row.id)}>
+                <a className="portal-inline-link" href={row.entryHref}>
                   {row.id}
                 </a>
               </span>
-              <span>{row.model}</span>
-              <span>{row.target}</span>
-              <span>{row.branch}</span>
-              <span className={`portal-state-badge portal-state-${row.runState}`}>
-                {formatRunLifecycleState(row.runState)}
-              </span>
-              <span
-                className={`portal-verdict-badge${
-                  row.verdict ? ` portal-verdict-${row.verdict}` : ""
-                }`}
-              >
-                {formatVerdictClass(row.verdict)}
-              </span>
+              <span>{row.sourceLabel}</span>
+              <span>{row.summary}</span>
+              <span>{row.entryLabel}</span>
+              <span>{row.freshnessLabel}</span>
+              <span>{row.scopeLabel}</span>
             </div>
           ))}
         </div>
       </article>
 
       <aside className="portal-overview-timeline">
-        <h2>Recent activity</h2>
+        <h2>{isLocalPreview ? "Local preview notes" : "Overview notes"}</h2>
         <div className="portal-timeline">
-          {overviewTimeline.map((item) => (
+          {overviewNotes.map((item) => (
             <article className="portal-timeline-item" key={item.title}>
               <strong>{item.title}</strong>
               <p>{item.detail}</p>
@@ -545,6 +588,16 @@ export function PortalShell({ email, roles }: PortalShellProps) {
             ))}
           </div>
         </header>
+
+        {isLocalPreview ? (
+          <section className="portal-panel" aria-label="Local portal preview">
+            <p className="eyebrow">Local preview</p>
+            <p>
+              This localhost portal is rendering demo fixture data stored in this browser.
+              It is not live API or operational state.
+            </p>
+          </section>
+        ) : null}
 
         {activeSection?.id === "overview" ? (
           <>


### PR DESCRIPTION
## Summary
- add an explicit localhost portal preview banner instead of presenting fallback data as live operational truth
- replace local portal overview facts with route guidance and demo-fixture labeling
- sanitize local admin and benchmark-ops fixtures so identities, incidents, and worker posture read as preview content
- add regressions for the preview reviewer/admin fixtures and the local benchmark-ops labeling

## Verification
- `bun test src/routes/portal-shell.test.js src/lib/portal-admin.test.js src/lib/portal-benchmark-ops.test.js src/routes/portal-access-request-panel.test.js src/routes/portal-admin-users-panel.test.js src/routes/portal-benchmark-ops-surfaces.test.js`
- `bun --cwd apps/web typecheck`
- `bun run build`

Closes #1073