### PR TITLE
Fix compact portal information hierarchy

### DIFF
--- a/apps/web/src/routes/portal-access-request-panel.test.js
+++ b/apps/web/src/routes/portal-access-request-panel.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   describeAccessRequestActionState,
   describeAccessRequestTransition,
+  getCompactAccessRequestPageOrder,
   getCompactAccessRequestSectionOrder,
   isSelectedAccessRequestDetailCurrent,
   sortAccessRequestsForDisplay,
@@ -65,6 +66,15 @@ describe("getCompactAccessRequestSectionOrder", () => {
     expect(getCompactAccessRequestSectionOrder()).toEqual([
       "queueContent",
       "filterFields"
+    ]);
+  });
+});
+
+describe("getCompactAccessRequestPageOrder", () => {
+  it("keeps route context ahead of the compact review workspace", () => {
+    expect(getCompactAccessRequestPageOrder()).toEqual([
+      "introPanel",
+      "layout"
     ]);
   });
 });

--- a/apps/web/src/routes/portal-access-request-panel.tsx
+++ b/apps/web/src/routes/portal-access-request-panel.tsx
@@ -100,6 +100,10 @@ export function getCompactAccessRequestSectionOrder() {
   return ["queueContent", "filterFields"] as const;
 }
 
+export function getCompactAccessRequestPageOrder() {
+  return ["introPanel", "layout"] as const;
+}
+
 export function describeAccessRequestTransition(
   detail: Pick<PortalAdminAccessRequestDetail, "reviewedAt" | "reviewer" | "status">
 ) {
@@ -738,8 +742,16 @@ export function PortalAccessRequestPanel({ email }: PortalAccessRequestPanelProp
 
   return (
     <section className="portal-grid portal-grid-stack portal-grid-admin-workspace">
-      {isCompactLayout ? layout : introPanel}
-      {isCompactLayout ? introPanel : layout}
+      {isCompactLayout
+        ? getCompactAccessRequestPageOrder().map((sectionId) => (
+            <Fragment key={sectionId}>{sectionId === "introPanel" ? introPanel : layout}</Fragment>
+          ))
+        : (
+            <>
+              {introPanel}
+              {layout}
+            </>
+          )}
     </section>
   );
 }

--- a/apps/web/src/routes/portal-admin-users-panel.test.js
+++ b/apps/web/src/routes/portal-admin-users-panel.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  getCompactAdminUsersPageOrder,
   getCompactAdminUsersSectionOrder,
   isSelectedAdminUserDetailCurrent,
   resolveSelectedAdminUserId
@@ -41,6 +42,15 @@ describe("getCompactAdminUsersSectionOrder", () => {
     expect(getCompactAdminUsersSectionOrder()).toEqual([
       "userList",
       "filterFields"
+    ]);
+  });
+});
+
+describe("getCompactAdminUsersPageOrder", () => {
+  it("keeps route context ahead of the compact workspace", () => {
+    expect(getCompactAdminUsersPageOrder()).toEqual([
+      "introPanel",
+      "layout"
     ]);
   });
 });

--- a/apps/web/src/routes/portal-admin-users-panel.tsx
+++ b/apps/web/src/routes/portal-admin-users-panel.tsx
@@ -51,6 +51,10 @@ export function getCompactAdminUsersSectionOrder() {
   return ["userList", "filterFields"] as const;
 }
 
+export function getCompactAdminUsersPageOrder() {
+  return ["introPanel", "layout"] as const;
+}
+
 export function isSelectedAdminUserDetailCurrent(
   detailItem: Awaited<ReturnType<typeof loadPortalAdminUserDetail>> | null,
   selectedUserId: string | null
@@ -658,8 +662,16 @@ export function PortalAdminUsersPanel({ email }: PortalAdminUsersPanelProps) {
 
   return (
     <section className="portal-grid portal-grid-stack portal-grid-admin-workspace">
-      {isCompactLayout ? layout : introPanel}
-      {isCompactLayout ? introPanel : layout}
+      {isCompactLayout
+        ? getCompactAdminUsersPageOrder().map((sectionId) => (
+            <Fragment key={sectionId}>{sectionId === "introPanel" ? introPanel : layout}</Fragment>
+          ))
+        : (
+            <>
+              {introPanel}
+              {layout}
+            </>
+          )}
     </section>
   );
 }

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -41,10 +41,10 @@ describe("portal benchmark ops route targets", () => {
 
   it("keeps the compact runs slice ahead of the deeper support panel", () => {
     expect(getCompactRunsSectionOrder()).toEqual([
-      "runsSlice",
-      "quickFilters",
       "resultsPanel",
-      "supportPanel"
+      "quickFilters",
+      "supportPanel",
+      "runsSlice"
     ]);
   });
 

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -140,7 +140,7 @@ export function buildRunDetailHref(runId: string, search = "") {
 }
 
 export function getCompactRunsSectionOrder() {
-  return ["runsSlice", "quickFilters", "resultsPanel", "supportPanel"] as const;
+  return ["resultsPanel", "quickFilters", "supportPanel", "runsSlice"] as const;
 }
 
 export function isCurrentPortalRequest(requestId: number, latestRequestId: number) {
@@ -623,8 +623,8 @@ function PortalRunsSurface({
     <article className="portal-panel portal-runs-quick-filter-panel">
       <div className="portal-panel-header">
         <div>
-          <p className="section-tag">Quick filters</p>
-          <h2>Trim the current slice before opening a detail view.</h2>
+          <p className="section-tag">Slice controls</p>
+          <h2>Refine the current slice before opening one run&apos;s evidence.</h2>
         </div>
       </div>
       <div className="portal-form-grid portal-runs-quick-filter-grid">
@@ -674,130 +674,6 @@ function PortalRunsSurface({
             {benchmarkPackageOptions.map((packageId) => (
               <option key={packageId} value={packageId}>
                 {packageId}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-    </article>
-  );
-
-  const resultsPanel = (
-    <article className="portal-panel portal-results-panel portal-results-panel-compact">
-      <div className="portal-panel-header">
-        <div>
-          <p className="section-tag">Benchmark operations</p>
-          <h2>Runs keeps search, export, and evidence drill-down on the portal.</h2>
-        </div>
-        <div className="portal-toolbar">
-          <button
-            className="button button-secondary"
-            disabled={!loadState.data?.items.length}
-            onClick={() => {
-              if (loadState.data) {
-                downloadRunsCsv(loadState.data.items);
-              }
-            }}
-            type="button"
-          >
-            Export CSV
-          </button>
-          <button
-            className="button button-secondary"
-            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
-            onClick={() => {
-              void handleDatasetExport("json");
-            }}
-            type="button"
-          >
-            {datasetExportState.format === "json" ? "Exporting JSON" : "Export package JSON"}
-          </button>
-          <button
-            className="button button-secondary"
-            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
-            onClick={() => {
-              void handleDatasetExport("csv");
-            }}
-            type="button"
-          >
-            {datasetExportState.format === "csv" ? "Exporting CSV" : "Export package CSV"}
-          </button>
-          <a className="button button-secondary" href={buildPortalUrl("/")}>
-            Overview
-          </a>
-        </div>
-      </div>
-      <div className="portal-chip-row">
-        <span className="role-chip role-chip-tonal">
-          {loadState.data?.summary.totalMatches ?? 0} matches
-        </span>
-        <span className="role-chip role-chip-muted">
-          {loadState.data?.summary.activeRuns ?? 0} active
-        </span>
-        <span className="role-chip role-chip-muted">
-          {loadState.data?.summary.failedRuns ?? 0} failed
-        </span>
-        {selectedBenchmarkPackageId ? (
-          <span className="role-chip role-chip-muted">
-            package {selectedBenchmarkPackageId}
-          </span>
-        ) : null}
-      </div>
-      {datasetExportState.error ? <PortalErrorState error={datasetExportState.error} /> : null}
-    </article>
-  );
-
-  const supportPanel = (
-    <article className="portal-panel portal-runs-support-panel">
-      <div className="portal-panel-header">
-        <div>
-          <p className="section-tag">Current controls</p>
-          <h2>Refresh and refine the shared run index.</h2>
-        </div>
-      </div>
-      <p className="portal-panel-muted">
-        Filter, export, and triage runs here, then open one run&apos;s evidence in
-        <code className="portal-inline-code"> /runs/:runId</code>.
-      </p>
-      <p className="portal-panel-muted">
-        Package dataset export unlocks once one benchmark package is selected in the current slice.
-      </p>
-      <PortalFreshnessCard
-        isRefreshing={loadState.isLoading}
-        lastUpdatedAt={loadState.lastUpdatedAt}
-        onRefresh={() => {
-          void onRefresh();
-        }}
-        routeId={activeRouteId}
-      />
-      <div className="portal-form-grid">
-        <label className="portal-field">
-          <span>Search</span>
-          <input
-            className="input"
-            onChange={(event) => {
-              updateRunsQuery(pathname, query, onReplaceLocation, { q: event.target.value || null });
-            }}
-            placeholder="run id, package, model, failure"
-            type="search"
-            value={query.q ?? ""}
-          />
-        </label>
-        <label className="portal-field">
-          <span>Lifecycle bucket</span>
-          <select
-            className="input"
-            onChange={(event) => {
-              updateRunsQuery(pathname, query, onReplaceLocation, {
-                lifecycleBucket: (event.target.value || null) as PortalRunsLifecycleBucket | null
-              });
-            }}
-            value={query.lifecycleBucket ?? ""}
-          >
-            <option value="">All buckets</option>
-            {portalRunsLifecycleBuckets.map((bucket) => (
-              <option key={bucket.id} value={bucket.id}>
-                {bucket.label}
               </option>
             ))}
           </select>
@@ -887,6 +763,97 @@ function PortalRunsSurface({
           Reset filters
         </button>
       </div>
+    </article>
+  );
+
+  const resultsPanel = (
+    <article className="portal-panel portal-results-panel portal-results-panel-compact">
+      <div className="portal-panel-header">
+        <div>
+          <p className="section-tag">Benchmark operations</p>
+          <h2>Runs keeps search, export, and evidence drill-down on the portal.</h2>
+        </div>
+        <div className="portal-toolbar">
+          <button
+            className="button button-secondary"
+            disabled={!loadState.data?.items.length}
+            onClick={() => {
+              if (loadState.data) {
+                downloadRunsCsv(loadState.data.items);
+              }
+            }}
+            type="button"
+          >
+            Export CSV
+          </button>
+          <button
+            className="button button-secondary"
+            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
+            onClick={() => {
+              void handleDatasetExport("json");
+            }}
+            type="button"
+          >
+            {datasetExportState.format === "json" ? "Exporting JSON" : "Export package JSON"}
+          </button>
+          <button
+            className="button button-secondary"
+            disabled={!selectedBenchmarkPackageId || datasetExportState.format !== null}
+            onClick={() => {
+              void handleDatasetExport("csv");
+            }}
+            type="button"
+          >
+            {datasetExportState.format === "csv" ? "Exporting CSV" : "Export package CSV"}
+          </button>
+          <a className="button button-secondary" href={buildPortalUrl("/")}>
+            Overview
+          </a>
+        </div>
+      </div>
+      <div className="portal-chip-row">
+        <span className="role-chip role-chip-tonal">
+          {loadState.data?.summary.totalMatches ?? 0} matches
+        </span>
+        <span className="role-chip role-chip-muted">
+          {loadState.data?.summary.activeRuns ?? 0} active
+        </span>
+        <span className="role-chip role-chip-muted">
+          {loadState.data?.summary.failedRuns ?? 0} failed
+        </span>
+        {selectedBenchmarkPackageId ? (
+          <span className="role-chip role-chip-muted">
+            package {selectedBenchmarkPackageId}
+          </span>
+        ) : null}
+      </div>
+      {datasetExportState.error ? <PortalErrorState error={datasetExportState.error} /> : null}
+    </article>
+  );
+
+  const supportPanel = (
+    <article className="portal-panel portal-runs-support-panel">
+      <div className="portal-panel-header">
+        <div>
+          <p className="section-tag">Freshness</p>
+          <h2>Keep the current slice grounded before drilling into one run.</h2>
+        </div>
+      </div>
+      <p className="portal-panel-muted">
+        Filter and export from the portal, then open one run&apos;s evidence in
+        <code className="portal-inline-code"> /runs/:runId</code>.
+      </p>
+      <p className="portal-panel-muted">
+        Package dataset export unlocks once one benchmark package is selected in the current slice.
+      </p>
+      <PortalFreshnessCard
+        isRefreshing={loadState.isLoading}
+        lastUpdatedAt={loadState.lastUpdatedAt}
+        onRefresh={() => {
+          void onRefresh();
+        }}
+        routeId={activeRouteId}
+      />
     </article>
   );
 

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -119,6 +119,25 @@ describe("PortalShell benchmark ops routes", () => {
     expect(html).toContain("Loading run index.");
   });
 
+  it("puts compact run context and one control surface ahead of the run slice", async () => {
+    const html = await renderPortalShell({
+      email: "helper@paretoproof.local",
+      roles: ["helper"],
+      url: "http://127.0.0.1/runs?surface=portal&access=approved&roles=helper&email=helper%40paretoproof.local",
+      width: 320
+    });
+
+    expect(html).toContain("Runs keeps search, export, and evidence drill-down on the portal.");
+    expect(html).toContain("Open one run&#x27;s evidence from the current slice.");
+    expect(html).toContain("Slice controls");
+    expect(html).toContain("Freshness");
+    expect(html.indexOf("Runs keeps search, export, and evidence drill-down on the portal.")).toBeLessThan(
+      html.indexOf("Open one run&#x27;s evidence from the current slice.")
+    );
+    expect(html.match(/>Search<\/span>/g)?.length ?? 0).toBe(1);
+    expect(html).not.toContain("Current controls");
+  });
+
   it("renders run detail as portal-owned evidence with next-route actions", async () => {
     const html = await renderPortalShell({
       email: "helper@paretoproof.local",


### PR DESCRIPTION
## Summary
- move compact users and access-request routes so intro and freshness context render ahead of the workspace
- consolidate compact runs controls into one slice-control panel and put route context ahead of the run slice
- add compact-order regression coverage for helper seams and the rendered compact runs route

## Verification
- `bun test apps/web/src/routes/portal-benchmark-ops-surfaces.test.js apps/web/src/routes/portal-admin-users-panel.test.js apps/web/src/routes/portal-access-request-panel.test.js apps/web/src/routes/portal-shell.test.js`
- `bun --cwd apps/web typecheck`
- `bun run build`

Closes #1065