### PR TITLE
Fix public navigation reloads and mobile header overload

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Test web auth relay functions
         run: bun --cwd apps/web test:functions
 
-      - name: Test web layout regressions
-        run: bun --cwd apps/web test:layout
+      - name: Test web UI regressions
+        run: bun --cwd apps/web test:ui
 
       - name: Typecheck workspace
         run: >-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js",
+    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js src/routes/public-header-layout.browser.test.js src/routes/public-navigation.browser.test.js",
+    "test:ui": "bun test src/lib/web-navigation.test.js src/routes/public-site.test.js && bun run test:layout",
     "test:functions": "bun test functions",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json",
     "pages:deploy": "wrangler pages deploy --project-name=paretoproof-web"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { useSurfaceNavigation } from "./lib/web-navigation";
 import { AccessCompletion } from "./routes/access-completion";
 import { AuthEntry } from "./routes/auth-entry";
 import { PortalBootstrap } from "./routes/portal-bootstrap";
@@ -10,6 +11,7 @@ import {
 
 export default function App() {
   const surface = resolveWebSurface();
+  useSurfaceNavigation(surface);
   const redirectPath = readPortalRedirectTarget();
   const authProvider = resolveAccessProviderHost();
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -14,8 +14,8 @@ const productionProviderAuthOrigins: Record<AccessProvider, string> = {
   google: "https://google.auth.paretoproof.com"
 };
 
-function readLocalSurfaceOverride() {
-  const params = new URLSearchParams(window.location.search);
+function readLocalSurfaceOverride(search = window.location.search) {
+  const params = new URLSearchParams(search);
   const surface = params.get("surface");
 
   return surface === "public" || surface === "auth" || surface === "portal"
@@ -35,7 +35,11 @@ function isLocalOrigin(hostname = window.location.hostname) {
   return isLocalHostname(hostname);
 }
 
-export function resolveWebSurface(hostname = window.location.hostname): WebSurface {
+export function resolveWebSurfaceFromUrl(
+  locationLike: Pick<Location, "hostname" | "search"> | URL = window.location
+): WebSurface {
+  const { hostname, search } = locationLike;
+
   if (
     hostname === "auth.paretoproof.com" ||
     hostname === "github.auth.paretoproof.com" ||
@@ -49,10 +53,21 @@ export function resolveWebSurface(hostname = window.location.hostname): WebSurfa
   }
 
   if (isLocalHostname(hostname)) {
-    return readLocalSurfaceOverride() ?? "public";
+    return readLocalSurfaceOverride(search) ?? "public";
   }
 
   return "public";
+}
+
+export function resolveWebSurface(hostname = window.location.hostname): WebSurface {
+  if (hostname === window.location.hostname) {
+    return resolveWebSurfaceFromUrl(window.location);
+  }
+
+  return resolveWebSurfaceFromUrl({
+    hostname,
+    search: ""
+  });
 }
 
 function normalizeTargetPath(targetPath: string) {

--- a/apps/web/src/lib/web-navigation.test.js
+++ b/apps/web/src/lib/web-navigation.test.js
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isInterceptablePublicNavigation,
+  navigateWithinPublicSurface
+} from "./web-navigation.ts";
+
+function withWindow(locationHref, run) {
+  const originalWindow = globalThis.window;
+  globalThis.window = {
+    location: new URL(locationHref)
+  };
+
+  try {
+    return run();
+  } finally {
+    globalThis.window = originalWindow;
+  }
+}
+
+describe("isInterceptablePublicNavigation", () => {
+  it("allows same-origin public route changes", () => {
+    withWindow("https://paretoproof.com/", () => {
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "https://paretoproof.com/",
+          currentSurface: "public",
+          nextHref: "https://paretoproof.com/project"
+        })
+      ).toBe(true);
+    });
+  });
+
+  it("does not intercept auth or portal transitions", () => {
+    withWindow("https://paretoproof.com/", () => {
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "https://paretoproof.com/",
+          currentSurface: "public",
+          nextHref: "https://auth.paretoproof.com/"
+        })
+      ).toBe(false);
+
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "https://paretoproof.com/",
+          currentSurface: "public",
+          nextHref: "https://portal.paretoproof.com/"
+        })
+      ).toBe(false);
+    });
+  });
+
+  it("does not intercept localhost auth or portal surface links", () => {
+    withWindow("http://127.0.0.1:4175/", () => {
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "http://127.0.0.1:4175/",
+          currentSurface: "public",
+          nextHref: "http://127.0.0.1:4175/?surface=auth"
+        })
+      ).toBe(false);
+
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "http://127.0.0.1:4175/",
+          currentSurface: "public",
+          nextHref: "http://127.0.0.1:4175/?surface=portal&access=approved"
+        })
+      ).toBe(false);
+    });
+  });
+
+  it("does not intercept external or same-path clicks", () => {
+    withWindow("https://paretoproof.com/", () => {
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "https://paretoproof.com/",
+          currentSurface: "public",
+          nextHref: "https://github.com/Tomodovodoo/ParetoProof"
+        })
+      ).toBe(false);
+    });
+
+    withWindow("https://paretoproof.com/project", () => {
+      expect(
+        isInterceptablePublicNavigation({
+          currentHref: "https://paretoproof.com/project",
+          currentSurface: "public",
+          nextHref: "https://paretoproof.com/project"
+        })
+      ).toBe(false);
+    });
+  });
+});
+
+describe("navigateWithinPublicSurface", () => {
+  it("pushes history, scrolls to top, and dispatches a navigation event for same-surface routes", () => {
+    const originalWindow = globalThis.window;
+    const dispatchedEvents = [];
+    const pushStateCalls = [];
+    const scrollCalls = [];
+
+    globalThis.window = {
+      dispatchEvent(event) {
+        dispatchedEvents.push(event.type);
+        return true;
+      },
+      history: {
+        pushState(_state, _title, nextUrl) {
+          pushStateCalls.push(String(nextUrl));
+        }
+      },
+      location: new URL("https://paretoproof.com/"),
+      scrollTo(options) {
+        scrollCalls.push(options);
+      }
+    };
+
+    try {
+      expect(navigateWithinPublicSurface("https://paretoproof.com/benchmarks")).toBe(true);
+      expect(pushStateCalls).toEqual(["https://paretoproof.com/benchmarks"]);
+      expect(scrollCalls).toEqual([{ left: 0, top: 0 }]);
+      expect(dispatchedEvents).toEqual(["paretoproof:navigation"]);
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("preserves anchor jumps for same-surface public links with hashes", () => {
+    const originalDocument = globalThis.document;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalWindow = globalThis.window;
+    const target = { scrollIntoViewCalls: 0, scrollIntoView() { this.scrollIntoViewCalls += 1; } };
+
+    globalThis.document = {
+      querySelector(selector) {
+        return selector === "#contributors" ? target : null;
+      }
+    };
+    globalThis.requestAnimationFrame = (callback) => {
+      callback();
+      return 0;
+    };
+    globalThis.window = {
+      dispatchEvent() {
+        return true;
+      },
+      history: {
+        pushState() {}
+      },
+      location: new URL("https://paretoproof.com/"),
+      scrollTo() {
+        throw new Error("Expected hash navigation to avoid top-level scroll reset");
+      }
+    };
+
+    try {
+      expect(
+        navigateWithinPublicSurface("https://paretoproof.com/project#contributors")
+      ).toBe(true);
+      expect(target.scrollIntoViewCalls).toBe(1);
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("skips transitions that should stay as normal browser navigations", () => {
+    const originalWindow = globalThis.window;
+    const pushStateCalls = [];
+
+    globalThis.window = {
+      dispatchEvent() {
+        return true;
+      },
+      history: {
+        pushState(_state, _title, nextUrl) {
+          pushStateCalls.push(String(nextUrl));
+        }
+      },
+      location: new URL("https://paretoproof.com/"),
+      scrollTo() {}
+    };
+
+    try {
+      expect(navigateWithinPublicSurface("https://auth.paretoproof.com/")).toBe(false);
+      expect(pushStateCalls).toEqual([]);
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});

--- a/apps/web/src/lib/web-navigation.ts
+++ b/apps/web/src/lib/web-navigation.ts
@@ -1,0 +1,156 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { resolveWebSurface, resolveWebSurfaceFromUrl, type WebSurface } from "./surface";
+
+const navigationEventName = "paretoproof:navigation";
+
+function readLocationKey() {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function subscribeToLocation(onStoreChange: () => void) {
+  window.addEventListener("popstate", onStoreChange);
+  window.addEventListener(navigationEventName, onStoreChange);
+
+  return () => {
+    window.removeEventListener("popstate", onStoreChange);
+    window.removeEventListener(navigationEventName, onStoreChange);
+  };
+}
+
+type InterceptableNavigationInput = {
+  currentHref: string;
+  currentSurface: WebSurface;
+  nextHref: string;
+};
+
+export function isInterceptablePublicNavigation({
+  currentHref,
+  currentSurface,
+  nextHref
+}: InterceptableNavigationInput) {
+  if (currentSurface !== "public") {
+    return false;
+  }
+
+  const currentUrl = new URL(currentHref);
+  const nextUrl = new URL(nextHref, currentUrl);
+
+  if (currentUrl.origin !== nextUrl.origin) {
+    return false;
+  }
+
+  if (resolveWebSurfaceFromUrl(nextUrl) !== "public") {
+    return false;
+  }
+
+  if (currentUrl.pathname === nextUrl.pathname && currentUrl.search === nextUrl.search) {
+    return false;
+  }
+
+  return true;
+}
+
+export function navigateWithinPublicSurface(nextHref: string) {
+  const currentHref = window.location.href;
+
+  if (
+    !isInterceptablePublicNavigation({
+      currentHref,
+      currentSurface: resolveWebSurface(),
+      nextHref
+    })
+  ) {
+    return false;
+  }
+
+  const nextUrl = new URL(nextHref, currentHref);
+  window.history.pushState({}, "", nextUrl);
+  window.dispatchEvent(new Event(navigationEventName));
+
+  if (nextUrl.hash) {
+    requestAnimationFrame(() => {
+      const target = document.querySelector(nextUrl.hash);
+
+      if (target && "scrollIntoView" in target) {
+        target.scrollIntoView();
+      }
+    });
+  } else {
+    window.scrollTo({ left: 0, top: 0 });
+  }
+
+  return true;
+}
+
+function isPrimaryNavigationClick(event: MouseEvent) {
+  return (
+    event.button === 0 &&
+    !event.defaultPrevented &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+function findLinkTarget(event: MouseEvent) {
+  const eventTarget = event.target;
+
+  if (!(eventTarget instanceof Element)) {
+    return null;
+  }
+
+  const link = eventTarget.closest("a");
+
+  if (!(link instanceof HTMLAnchorElement)) {
+    return null;
+  }
+
+  if (link.target && link.target !== "_self") {
+    return null;
+  }
+
+  if (link.hasAttribute("download")) {
+    return null;
+  }
+
+  return link;
+}
+
+export function useSurfaceNavigation(surface: WebSurface) {
+  const locationKey = useSyncExternalStore(
+    subscribeToLocation,
+    readLocationKey,
+    () => "/"
+  );
+
+  useEffect(() => {
+    if (surface !== "public") {
+      return;
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      if (!isPrimaryNavigationClick(event)) {
+        return;
+      }
+
+      const link = findLinkTarget(event);
+
+      if (!link) {
+        return;
+      }
+
+      if (navigateWithinPublicSurface(link.href)) {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener("click", handleClick);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  }, [surface]);
+
+  return locationKey;
+}

--- a/apps/web/src/routes/public-header-layout.browser.test.js
+++ b/apps/web/src/routes/public-header-layout.browser.test.js
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const appCss = readFileSync(
+  fileURLToPath(new URL("../styles/app.css", import.meta.url)),
+  "utf8"
+);
+
+const publicHeaderHtml = `
+  <div class="site-shell site-home-shell site-home-shell-compact">
+    <header class="site-header">
+      <div class="site-header-bar">
+        <a class="site-brand" href="http://127.0.0.1:4174/">
+          <span class="site-brand-mark" aria-hidden="true"></span>
+          <span class="site-brand-name">ParetoProof</span>
+        </a>
+        <nav class="site-primary-nav" aria-label="Primary">
+          <a class="site-nav-link site-nav-link-active" href="http://127.0.0.1:4174/">Home</a>
+          <a class="site-nav-link" href="http://127.0.0.1:4174/project">Project</a>
+          <a class="site-nav-link" href="http://127.0.0.1:4174/benchmarks">Benchmarks</a>
+          <a class="site-nav-link" href="https://github.com/Tomodovodoo/ParetoProof/blob/main/docs/README.md">Docs</a>
+        </nav>
+        <div class="site-header-actions">
+          <a class="button button-secondary site-header-github" href="https://github.com/Tomodovodoo/ParetoProof/discussions">GitHub</a>
+          <a class="button" href="http://127.0.0.1:4174/?surface=auth">Sign in</a>
+          <button class="site-mobile-toggle" type="button" aria-expanded="false" aria-label="Open menu">
+            <span class="site-mobile-toggle-icon" aria-hidden="true"></span>
+            <span class="site-mobile-toggle-label">Menu</span>
+          </button>
+        </div>
+      </div>
+    </header>
+  </div>
+`;
+
+test(
+  "public mobile header collapses inline CTAs and shows a labeled menu control at 390px",
+  { timeout: 20_000 },
+  async () => {
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      const context = await browser.newContext({
+        viewport: { width: 390, height: 844 },
+        isMobile: true,
+        hasTouch: true
+      });
+      const page = await context.newPage();
+
+      await page.setContent(
+        `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><style>${appCss}</style></head><body>${publicHeaderHtml}</body></html>`,
+        { waitUntil: "domcontentloaded" }
+      );
+
+      const [signInDisplay, githubDisplay, toggleDisplay, toggleText, bodyMetrics] =
+        await Promise.all([
+          page
+            .locator(".site-header-actions > a.button")
+            .nth(1)
+            .evaluate((element) => getComputedStyle(element).display),
+          page.locator(".site-header-github").evaluate((element) => getComputedStyle(element).display),
+          page.locator(".site-mobile-toggle").evaluate((element) => getComputedStyle(element).display),
+          page.locator(".site-mobile-toggle").innerText(),
+          page.evaluate(() => ({
+            clientWidth: document.documentElement.clientWidth,
+            scrollWidth: document.documentElement.scrollWidth
+          }))
+        ]);
+
+      assert.equal(signInDisplay, "none");
+      assert.equal(githubDisplay, "none");
+      assert.equal(toggleDisplay, "flex");
+      assert.match(toggleText, /Menu/);
+      assert.ok(bodyMetrics.scrollWidth <= bodyMetrics.clientWidth);
+    } finally {
+      await browser.close();
+    }
+  }
+);
+
+test(
+  "public compact home header still keeps the menu control visible at 360px",
+  { timeout: 20_000 },
+  async () => {
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      const context = await browser.newContext({
+        viewport: { width: 360, height: 800 },
+        isMobile: true,
+        hasTouch: true
+      });
+      const page = await context.newPage();
+
+      await page.setContent(
+        `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><style>${appCss}</style></head><body>${publicHeaderHtml}</body></html>`,
+        { waitUntil: "domcontentloaded" }
+      );
+
+      const [actionsDisplay, toggleDisplay, toggleText] = await Promise.all([
+        page.locator(".site-header-actions").evaluate((element) => getComputedStyle(element).display),
+        page.locator(".site-mobile-toggle").evaluate((element) => getComputedStyle(element).display),
+        page.locator(".site-mobile-toggle").innerText()
+      ]);
+
+      assert.equal(actionsDisplay, "flex");
+      assert.equal(toggleDisplay, "flex");
+      assert.match(toggleText, /Menu/);
+    } finally {
+      await browser.close();
+    }
+  }
+);

--- a/apps/web/src/routes/public-navigation.browser.test.js
+++ b/apps/web/src/routes/public-navigation.browser.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const webRoot = fileURLToPath(new URL("../..", import.meta.url));
+const testServerUrl = "http://127.0.0.1:4176";
+
+async function waitForServer(url, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+
+    await delay(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function stopServer(processHandle) {
+  if (!processHandle || processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+  await delay(500);
+
+  if (processHandle.exitCode === null && process.platform === "win32") {
+    await new Promise((resolve) => {
+      const killer = spawn("taskkill", ["/pid", String(processHandle.pid), "/f", "/t"], {
+        stdio: "ignore"
+      });
+      killer.on("close", resolve);
+      killer.on("error", resolve);
+    });
+  }
+}
+
+test(
+  "public same-surface navigation keeps the document alive and closes the mobile menu",
+  { timeout: 60_000 },
+  async () => {
+    const server =
+      process.platform === "win32"
+        ? spawn(
+            process.env.ComSpec || "cmd.exe",
+            ["/d", "/s", "/c", "bun run dev --host 127.0.0.1 --port 4176"],
+            {
+              cwd: webRoot,
+              stdio: "ignore"
+            }
+          )
+        : spawn("bun", ["run", "dev", "--host", "127.0.0.1", "--port", "4176"], {
+            cwd: webRoot,
+            stdio: "ignore"
+          });
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      await waitForServer(testServerUrl);
+
+      const context = await browser.newContext({
+        viewport: { width: 390, height: 844 },
+        isMobile: true,
+        hasTouch: true
+      });
+      const page = await context.newPage();
+
+      await page.goto(`${testServerUrl}/`, { waitUntil: "networkidle" });
+      const before = await page.evaluate(() => ({
+        href: window.location.href,
+        timeOrigin: performance.timeOrigin
+      }));
+
+      await page.getByRole("button", { name: "Open menu" }).click();
+      await page.getByRole("link", { name: "Project", exact: true }).click();
+      await page.waitForFunction(() => window.location.pathname === "/project");
+
+      const after = await page.evaluate(() => ({
+        href: window.location.href,
+        menuCount: document.querySelectorAll(".site-mobile-nav").length,
+        timeOrigin: performance.timeOrigin,
+        toggleLabel:
+          document.querySelector(".site-mobile-toggle")?.textContent?.trim() ?? ""
+      }));
+
+      assert.equal(before.timeOrigin, after.timeOrigin);
+      assert.equal(after.href, `${testServerUrl}/project`);
+      assert.equal(after.menuCount, 0);
+      assert.match(after.toggleLabel, /Menu/);
+    } finally {
+      await browser.close();
+      await stopServer(server);
+    }
+  }
+);

--- a/apps/web/src/routes/public-site.tsx
+++ b/apps/web/src/routes/public-site.tsx
@@ -429,6 +429,10 @@ function PublicHeader({
     currentPath.startsWith(reportsRoutePrefix);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [currentPath]);
+
   return (
     <header className="site-header">
       <div className="site-header-bar">
@@ -481,6 +485,9 @@ function PublicHeader({
             <span className="site-mobile-toggle-icon" aria-hidden="true">
               <AppIcon name={mobileNavOpen ? "panel-left" : "grid"} />
             </span>
+            <span className="site-mobile-toggle-label">
+              {mobileNavOpen ? "Close" : "Menu"}
+            </span>
           </button>
         </div>
       </div>
@@ -512,7 +519,7 @@ function PublicHeader({
             Docs
           </a>
           <a className="button site-mobile-nav-cta" href={buildAuthUrl("/")}>
-            Approved sign in
+            Sign in
           </a>
           <a className="button button-secondary site-mobile-nav-cta" href={buildAccessRequestUrl()}>
             Request access

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -256,21 +256,27 @@ a.button-secondary {
 
 .site-mobile-toggle {
   display: none;
-  width: 38px;
+  min-width: 38px;
   height: 38px;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: transparent;
   color: var(--ink);
-  padding: 0;
+  padding: 0 10px;
+  gap: 8px;
+  font-weight: 700;
 }
 
 .site-mobile-toggle-icon {
   display: inline-flex;
-  width: 100%;
-  height: 100%;
+  width: 18px;
+  height: 18px;
   align-items: center;
   justify-content: center;
+}
+
+.site-mobile-toggle-label {
+  line-height: 1;
 }
 
 .site-mobile-nav {
@@ -2676,6 +2682,21 @@ a.button-secondary {
 }
 
 @media (max-width: 640px) {
+  .site-header-actions {
+    gap: 8px;
+  }
+
+  .site-header-actions > .button,
+  .site-header-actions > a.button {
+    display: none;
+  }
+
+  .site-mobile-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .site-header,
   .site-header-main,
   .site-header-actions,
@@ -3855,7 +3876,8 @@ a.button-secondary {
   }
 
   .site-shell.site-home-shell .site-header-actions {
-    display: none;
+    display: flex;
+    justify-content: flex-end;
   }
 
   .site-shell.site-home-shell .site-header {


### PR DESCRIPTION
## Summary
- keep same-surface public route changes inside the running app instead of hard-reloading the document
- simplify the mobile public header to a labeled menu control and move duplicate CTAs into the menu
- add executable browser coverage for the mobile header and in-app public navigation flow, and wire the new web UI regression script into PR CI

## Testing
- bun run build:shared; bun --cwd apps/web test:ui
- bun --cwd apps/web typecheck
- bun run build

## Issue
- Closes #1086