### PR TITLE
Fix local auth and portal guidance states

### DIFF
--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -119,6 +119,22 @@ describe("surface ownership helpers", () => {
     expect(buildPublicUrl("/profile")).toBe("https://paretoproof.com/");
   });
 
+  it("routes loopback-mapped branded auth and portal hosts back to the local public apex", () => {
+    const brandedHosts = [
+      "auth.paretoproof.com",
+      "github.auth.paretoproof.com",
+      "google.auth.paretoproof.com",
+      "portal.paretoproof.com"
+    ];
+
+    for (const host of brandedHosts) {
+      setWindowUrl(`http://${host}:4173/runs`);
+
+      expect(buildPublicUrl("/")).toBe("http://paretoproof.com:4173/");
+      expect(buildPublicUrl("/project")).toBe("http://paretoproof.com:4173/project");
+    }
+  });
+
   it("preserves only portal-owned redirect targets for auth URLs", () => {
     setWindowUrl("https://paretoproof.com/");
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -35,6 +35,25 @@ function isLocalOrigin(hostname = window.location.hostname) {
   return isLocalHostname(hostname);
 }
 
+function buildLocalPublicOrigin(locationLike = window.location) {
+  const { hostname, origin, port, protocol } = locationLike;
+
+  if (!isLocalDevelopmentLocation(locationLike)) {
+    return origin;
+  }
+
+  if (
+    hostname === "auth.paretoproof.com" ||
+    hostname === "github.auth.paretoproof.com" ||
+    hostname === "google.auth.paretoproof.com" ||
+    hostname === "portal.paretoproof.com"
+  ) {
+    return `${protocol}//paretoproof.com${port ? `:${port}` : ""}`;
+  }
+
+  return origin;
+}
+
 export function resolveWebSurfaceFromUrl(
   locationLike: Pick<Location, "hostname" | "search"> | URL = window.location
 ): WebSurface {
@@ -227,7 +246,7 @@ export function buildPublicUrl(targetPath = "/", hostname = window.location.host
   const normalizedTargetPath = sanitizePublicTargetPath(targetPath);
 
   if (isLocalOrigin(hostname)) {
-    return new URL(normalizedTargetPath, window.location.origin).toString();
+    return new URL(normalizedTargetPath, buildLocalPublicOrigin()).toString();
   }
 
   return new URL(normalizedTargetPath, productionPublicOrigin).toString();

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -190,10 +190,10 @@ describe("buildLocalAuthEntryPreviewState", () => {
       location: new URL("http://127.0.0.1/?surface=auth")
     };
 
-    expect(buildLocalAuthEntryPreviewState("sign_in")).toMatchObject({
+    expect(buildLocalAuthEntryPreviewState("sign_in", "/runs/alpha")).toMatchObject({
       actions: [
         {
-          href: "http://127.0.0.1/?surface=portal",
+          href: "http://127.0.0.1/runs/alpha?surface=portal",
           title: "Open local portal preview"
         },
         {
@@ -202,7 +202,7 @@ describe("buildLocalAuthEntryPreviewState", () => {
         }
       ],
       footerCta: {
-        href: "http://127.0.0.1/?surface=portal",
+        href: "http://127.0.0.1/runs/alpha?surface=portal",
         label: "Open local portal preview"
       }
     });
@@ -213,7 +213,7 @@ describe("buildLocalAuthEntryPreviewState", () => {
       location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
     };
 
-    expect(buildLocalAuthEntryPreviewState("access_request")).toMatchObject({
+    expect(buildLocalAuthEntryPreviewState("access_request", "/access-request")).toMatchObject({
       actions: [
         {
           href: "http://127.0.0.1/access-request?surface=portal",
@@ -234,11 +234,12 @@ describe("AuthEntry local rendering", () => {
       location: new URL("http://127.0.0.1/?surface=auth")
     };
 
-    const html = renderToStaticMarkup(<AuthEntry redirectPath="/" />);
+    const html = renderToStaticMarkup(<AuthEntry redirectPath="/runs/alpha" />);
 
     expect(html).toContain("Local development bypasses live provider sign-in.");
     expect(html).toContain("Open local portal preview");
     expect(html).toContain("Open local access-request preview");
+    expect(html).toContain("http://127.0.0.1/runs/alpha?surface=portal");
     expect(html).toContain("Back to local home");
     expect(html).not.toContain("Continue with GitHub");
     expect(html).not.toContain("Continue with Google");

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -1,9 +1,23 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
 import {
+  AuthEntry,
+  buildLocalAuthEntryPreviewState,
   resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
   shouldStayOnAuthEntryForProviderlessRecovery
 } from "./auth-entry.tsx";
+
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
 
 describe("shouldStayOnAuthEntryForProviderlessRecovery", () => {
   it("keeps auth entry active when /portal/me reports providerless recovery drift", () => {
@@ -167,5 +181,80 @@ describe("resolveAuthEntryApprovedPortalTargetPath", () => {
 
   it("preserves ordinary approved portal redirects", () => {
     expect(resolveAuthEntryApprovedPortalTargetPath("/profile")).toBe("/profile");
+  });
+});
+
+describe("buildLocalAuthEntryPreviewState", () => {
+  it("builds a local sign-in preview with portal and access-request entry routes", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=auth")
+    };
+
+    expect(buildLocalAuthEntryPreviewState("sign_in")).toMatchObject({
+      actions: [
+        {
+          href: "http://127.0.0.1/?surface=portal",
+          title: "Open local portal preview"
+        },
+        {
+          href: "http://127.0.0.1/?surface=auth&redirect=%2Faccess-request",
+          title: "Open local access-request preview"
+        }
+      ],
+      footerCta: {
+        href: "http://127.0.0.1/?surface=portal",
+        label: "Open local portal preview"
+      }
+    });
+  });
+
+  it("builds a local access-request preview with a direct portal route handoff", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
+    };
+
+    expect(buildLocalAuthEntryPreviewState("access_request")).toMatchObject({
+      actions: [
+        {
+          href: "http://127.0.0.1/access-request?surface=portal",
+          title: "Open local access-request route"
+        },
+        {
+          href: "http://127.0.0.1/?surface=auth",
+          title: "Open local sign-in guidance"
+        }
+      ]
+    });
+  });
+});
+
+describe("AuthEntry local rendering", () => {
+  it("renders truthful local sign-in guidance instead of provider sign-in CTAs", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=auth")
+    };
+
+    const html = renderToStaticMarkup(<AuthEntry redirectPath="/" />);
+
+    expect(html).toContain("Local development bypasses live provider sign-in.");
+    expect(html).toContain("Open local portal preview");
+    expect(html).toContain("Open local access-request preview");
+    expect(html).toContain("Back to local home");
+    expect(html).not.toContain("Continue with GitHub");
+    expect(html).not.toContain("Continue with Google");
+  });
+
+  it("renders truthful local access-request guidance instead of identity-verification promises", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
+    };
+
+    const html = renderToStaticMarkup(<AuthEntry redirectPath="/access-request" />);
+
+    expect(html).toContain("Local development bypasses provider verification here.");
+    expect(html).toContain("Open local access-request route");
+    expect(html).toContain("Open local sign-in guidance");
+    expect(html).toContain("Back to local home");
+    expect(html).not.toContain("Use GitHub or Google to verify your identity.");
   });
 });

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AppIcon } from "../components/app-icon";
+import { AppIcon, type AppIconName } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import { fetchApi } from "../lib/api-fetch";
 import {
@@ -29,6 +29,27 @@ type AuthEntrySessionCheckPayload = {
   } | null;
 };
 
+type AuthEntryAction = {
+  copy: string;
+  href: string;
+  icon: AppIconName;
+  title: string;
+};
+
+type AuthEntryLocalExperience = {
+  actions: AuthEntryAction[];
+  checks: string[];
+  footerCta: {
+    href: string;
+    label: string;
+  };
+  footerText: string;
+  lead: string;
+  panelCopy: string;
+  panelTag: string;
+  panelTitle: string;
+};
+
 const signInChecks = [
   "We match this provider to your existing ParetoProof account whenever possible.",
   "If your account still needs approval, we will let you know clearly before portal entry.",
@@ -38,7 +59,19 @@ const signInChecks = [
 const accessRequestChecks = [
   "New collaborators verify identity before submitting an access request.",
   "After verification, you will be taken to the contributor access request form.",
-  "Approval is manual — requesting access is separate from approved sign-in."
+  "Approval is manual - requesting access is separate from approved sign-in."
+];
+
+const localSignInChecks = [
+  "Local development bypasses live provider sign-in and uses this auth surface only for preview routing.",
+  "Open the portal preview when your local or configured API target is reachable.",
+  "Switch to the access-request entry preview to verify that path without a live identity handoff."
+];
+
+const localAccessRequestChecks = [
+  "Local development does not verify GitHub or Google identities before showing this entry.",
+  "Use the access-request route preview when your API target is reachable and you need to inspect request-state UX.",
+  "If the API is offline, the portal surface will tell you exactly which backend target is missing."
 ];
 
 export function resolveAuthEntryMode(redirectPath: string) {
@@ -47,6 +80,76 @@ export function resolveAuthEntryMode(redirectPath: string) {
 
 export function resolveAuthEntryApprovedPortalTargetPath(redirectPath: string) {
   return redirectPath === "/access-request" ? "/" : redirectPath;
+}
+
+export function buildLocalAuthEntryPreviewState(
+  mode: ReturnType<typeof resolveAuthEntryMode>
+): AuthEntryLocalExperience {
+  if (mode === "access_request") {
+    return {
+      actions: [
+        {
+          copy:
+            "Continue into the access-request route preview once your local or configured API is reachable.",
+          href: buildPortalUrl("/access-request"),
+          icon: "key",
+          title: "Open local access-request route"
+        },
+        {
+          copy:
+            "Return to the standard local auth guidance without triggering any provider handoff.",
+          href: buildAuthUrl("/"),
+          icon: "shield",
+          title: "Open local sign-in guidance"
+        }
+      ],
+      checks: localAccessRequestChecks,
+      footerCta: {
+        href: buildPortalUrl("/access-request"),
+        label: "Open local access-request route"
+      },
+      footerText:
+        "Running locally - this entry explains the request path, but the actual portal route still needs a reachable API target.",
+      lead:
+        "Local development bypasses provider verification here. Use this entry to inspect request guidance, then open the access-request route preview against your API target.",
+      panelCopy:
+        "Choose which local preview path you want to inspect next.",
+      panelTag: "Local preview",
+      panelTitle: "Choose the next local access step"
+    };
+  }
+
+  return {
+    actions: [
+      {
+        copy:
+          "Open the contributor portal shell directly against your local or configured API target.",
+        href: buildPortalUrl("/"),
+        icon: "grid",
+        title: "Open local portal preview"
+      },
+      {
+        copy:
+          "Switch to the access-request entry preview without triggering a live provider handoff.",
+        href: buildAuthUrl("/access-request"),
+        icon: "key",
+        title: "Open local access-request preview"
+      }
+    ],
+    checks: localSignInChecks,
+    footerCta: {
+      href: buildPortalUrl("/"),
+      label: "Open local portal preview"
+    },
+    footerText:
+      "Running locally - live provider sign-in is disabled here, so use the preview routes above or return to the public site.",
+    lead:
+      "Local development bypasses live provider sign-in. Use this entry to move into the portal or access-request previews once your API target is reachable.",
+    panelCopy:
+      "Choose the local preview route you want to inspect next.",
+    panelTag: "Local preview",
+    panelTitle: "Choose a local preview"
+  };
 }
 
 export function buildAuthEntrySessionCheckRequestInit(signal: AbortSignal): RequestInit {
@@ -123,12 +226,21 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const portalAccessRequestUrl = useMemo(() => buildPortalUrl("/access-request"), []);
   const portalDeniedUrl = useMemo(() => buildPortalUrl("/denied"), []);
   const portalPendingUrl = useMemo(() => buildPortalUrl("/pending"), []);
+  const localExperience = useMemo(
+    () => (isLocal ? buildLocalAuthEntryPreviewState(mode) : null),
+    [isLocal, mode]
+  );
+  const publicHomeLabel = isLocal ? "Back to local home" : "Back to paretoproof.com";
   const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);
   const handoffMode = new URLSearchParams(window.location.search).get("handoff");
   const showFailedNotice = handoffMode === "failed";
   const showRetryNotice = handoffMode === "retry";
   const showAuxiliaryStatus = showFailedNotice || showRetryNotice || isCheckingSession;
-  const authChecks = mode === "access_request" ? accessRequestChecks : signInChecks;
+  const authChecks = localExperience
+    ? localExperience.checks
+    : mode === "access_request"
+      ? accessRequestChecks
+      : signInChecks;
 
   useEffect(() => {
     if (isLocal) {
@@ -198,9 +310,11 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
               : "Sign in to the contributor portal."}
           </h1>
           <p className="auth-lead">
-            {mode === "access_request"
-              ? "Use GitHub or Google to verify your identity. After that, we will take you to the access request form."
-              : "Use GitHub or Google to continue. If you already have an active session, we will take you straight into the portal."}
+            {localExperience
+              ? localExperience.lead
+              : mode === "access_request"
+                ? "Use GitHub or Google to verify your identity. After that, we will take you to the access request form."
+                : "Use GitHub or Google to continue. If you already have an active session, we will take you straight into the portal."}
           </p>
           {showRetryNotice ? (
             <p className="auth-panel-copy">
@@ -222,43 +336,70 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
         <div className="auth-provider-layout">
           <section className="auth-provider-panel">
             <p className="section-tag">
-              {mode === "access_request" ? "Verify identity" : "Sign in"}
+              {localExperience
+                ? localExperience.panelTag
+                : mode === "access_request"
+                  ? "Verify identity"
+                  : "Sign in"}
             </p>
             <h2>
-              {mode === "access_request"
-                ? "Choose the identity you want reviewed"
-                : "Choose a sign-in method"}
+              {localExperience
+                ? localExperience.panelTitle
+                : mode === "access_request"
+                  ? "Choose the identity you want reviewed"
+                  : "Choose a sign-in method"}
             </h2>
             <p className="auth-panel-copy">
-              {mode === "access_request"
-                ? "Choose the provider you want linked to your access request."
-                : "Choose the provider linked to your ParetoProof account."}
+              {localExperience
+                ? localExperience.panelCopy
+                : mode === "access_request"
+                  ? "Choose the provider you want linked to your access request."
+                  : "Choose the provider linked to your ParetoProof account."}
             </p>
             <div className="auth-provider-list">
-              <a className="auth-provider-button" href={githubStartUrl}>
-                <span className="auth-provider-mark" aria-hidden="true">
-                  <AppIcon name="github" />
-                </span>
-                <span>
-                  <strong>Continue with GitHub</strong>
-                  <small>Best for contributors working from GitHub-linked repositories.</small>
-                </span>
-                <span className="auth-provider-arrow" aria-hidden="true">
-                  <AppIcon name="arrow-right" />
-                </span>
-              </a>
-              <a className="auth-provider-button" href={googleStartUrl}>
-                <span className="auth-provider-mark" aria-hidden="true">
-                  <AppIcon name="google" />
-                </span>
-                <span>
-                  <strong>Continue with Google</strong>
-                  <small>Use Google when your approved ParetoProof identity lives outside GitHub.</small>
-                </span>
-                <span className="auth-provider-arrow" aria-hidden="true">
-                  <AppIcon name="arrow-right" />
-                </span>
-              </a>
+              {localExperience ? (
+                localExperience.actions.map((action) => (
+                  <a className="auth-provider-button" href={action.href} key={action.title}>
+                    <span className="auth-provider-mark" aria-hidden="true">
+                      <AppIcon name={action.icon} />
+                    </span>
+                    <span>
+                      <strong>{action.title}</strong>
+                      <small>{action.copy}</small>
+                    </span>
+                    <span className="auth-provider-arrow" aria-hidden="true">
+                      <AppIcon name="arrow-right" />
+                    </span>
+                  </a>
+                ))
+              ) : (
+                <>
+                  <a className="auth-provider-button" href={githubStartUrl}>
+                    <span className="auth-provider-mark" aria-hidden="true">
+                      <AppIcon name="github" />
+                    </span>
+                    <span>
+                      <strong>Continue with GitHub</strong>
+                      <small>Best for contributors working from GitHub-linked repositories.</small>
+                    </span>
+                    <span className="auth-provider-arrow" aria-hidden="true">
+                      <AppIcon name="arrow-right" />
+                    </span>
+                  </a>
+                  <a className="auth-provider-button" href={googleStartUrl}>
+                    <span className="auth-provider-mark" aria-hidden="true">
+                      <AppIcon name="google" />
+                    </span>
+                    <span>
+                      <strong>Continue with Google</strong>
+                      <small>Use Google when your approved ParetoProof identity lives outside GitHub.</small>
+                    </span>
+                    <span className="auth-provider-arrow" aria-hidden="true">
+                      <AppIcon name="arrow-right" />
+                    </span>
+                  </a>
+                </>
+              )}
             </div>
           </section>
 
@@ -280,22 +421,30 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
 
         <div className="auth-card-footer">
           <p>
-            {isLocal
-              ? "Running locally — authentication is bypassed for development."
+            {localExperience
+              ? localExperience.footerText
               : mode === "access_request"
                 ? "Already have an account? Use the sign-in entry instead."
                 : "New here? Request contributor access to get started."}
           </p>
           <a
             className="button"
-            href={mode === "access_request" ? approvedSignInUrl : accessRequestUrl}
+            href={
+              localExperience
+                ? localExperience.footerCta.href
+                : mode === "access_request"
+                  ? approvedSignInUrl
+                  : accessRequestUrl
+            }
           >
-            {mode === "access_request"
-              ? "Approved contributor sign in"
-              : "Request collaborator access"}
+            {localExperience
+              ? localExperience.footerCta.label
+              : mode === "access_request"
+                ? "Approved contributor sign in"
+                : "Request collaborator access"}
           </a>
           <a className="button button-secondary" href={buildPublicUrl("/")}>
-            Back to paretoproof.com
+            {publicHomeLabel}
           </a>
         </div>
       </section>

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -83,7 +83,8 @@ export function resolveAuthEntryApprovedPortalTargetPath(redirectPath: string) {
 }
 
 export function buildLocalAuthEntryPreviewState(
-  mode: ReturnType<typeof resolveAuthEntryMode>
+  mode: ReturnType<typeof resolveAuthEntryMode>,
+  redirectPath: string
 ): AuthEntryLocalExperience {
   if (mode === "access_request") {
     return {
@@ -124,7 +125,7 @@ export function buildLocalAuthEntryPreviewState(
       {
         copy:
           "Open the contributor portal shell directly against your local or configured API target.",
-        href: buildPortalUrl("/"),
+        href: buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
         icon: "grid",
         title: "Open local portal preview"
       },
@@ -138,7 +139,7 @@ export function buildLocalAuthEntryPreviewState(
     ],
     checks: localSignInChecks,
     footerCta: {
-      href: buildPortalUrl("/"),
+      href: buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
       label: "Open local portal preview"
     },
     footerText:
@@ -227,8 +228,8 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
   const portalDeniedUrl = useMemo(() => buildPortalUrl("/denied"), []);
   const portalPendingUrl = useMemo(() => buildPortalUrl("/pending"), []);
   const localExperience = useMemo(
-    () => (isLocal ? buildLocalAuthEntryPreviewState(mode) : null),
-    [isLocal, mode]
+    () => (isLocal ? buildLocalAuthEntryPreviewState(mode, redirectPath) : null),
+    [isLocal, mode, redirectPath]
   );
   const publicHomeLabel = isLocal ? "Back to local home" : "Back to paretoproof.com";
   const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -10,6 +10,7 @@ import {
   derivePortalRoles,
   mapPortalMutationErrorMessage,
   recoverPortalStateAfterAuthExpiry,
+  renderLocalPortalUnauthenticatedCard,
   renderPortalBootstrapErrorCard,
   shouldRestartPortalAuthForMissingProvider
 } from "./portal-bootstrap.tsx";
@@ -199,7 +200,65 @@ describe("mapPortalMutationErrorMessage", () => {
 
     expect(html).toContain("Local API unavailable");
     expect(html).toContain("Retry after starting API");
+    expect(html).toContain("Open local auth guidance");
     expect(html).toContain("http://127.0.0.1:3000");
+  });
+
+  it("renders hosted portal outages with a secondary escape route back to the public site", () => {
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/runs")
+    };
+
+    const html = renderToStaticMarkup(
+      renderPortalBootstrapErrorCard(
+        {
+          kind: "portal_unavailable",
+          message:
+            "The portal could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+          status: "error"
+        },
+        "/runs"
+      )
+    );
+
+    expect(html).toContain("Portal unavailable");
+    expect(html).toContain("Retry portal");
+    expect(html).toContain("Back to paretoproof.com");
+  });
+
+  it("renders localhost explicit-target outages with a secondary escape route back to the local public surface", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=portal")
+    };
+
+    const html = renderToStaticMarkup(
+      renderPortalBootstrapErrorCard(
+        {
+          kind: "portal_unavailable",
+          message:
+            "The portal could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+          status: "error"
+        },
+        "/"
+      )
+    );
+
+    expect(html).toContain("Portal unavailable");
+    expect(html).toContain("Retry portal");
+    expect(html).toContain("Back to local home");
+  });
+
+  it("renders localhost unauthenticated bootstrap as guidance instead of an immediate redirect loop", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/?surface=portal")
+    };
+
+    const html = renderToStaticMarkup(renderLocalPortalUnauthenticatedCard("/"));
+
+    expect(html).toContain("Local preview needs auth context");
+    expect(html).toContain("Open local auth guidance");
+    expect(html).toContain("Back to local home");
+    expect(html).not.toContain("Continue to sign in");
   });
 });
 

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -19,6 +19,7 @@ import {
 import {
   buildPortalUrl,
   buildAuthUrl,
+  buildPublicUrl,
   getCurrentRelativeUrl
 } from "../lib/surface";
 import { PortalShell } from "./portal-shell";
@@ -252,6 +253,7 @@ export function shouldRestartPortalAuthForMissingProvider(
 export function PortalBootstrap() {
   const [state, setState] = useState<PortalAccessState>({ status: "loading" });
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
+  const localPreviewMode = useMemo(() => isLocalDevelopmentLocation(window.location), []);
   const localApiFallback = useMemo(() => isUsingImplicitLocalPortalApi(), []);
   const currentRelativeUrl = useMemo(() => getCurrentRelativeUrl(), []);
   const recoveryInFlightRef = useRef(false);
@@ -351,12 +353,12 @@ export function PortalBootstrap() {
   }, [apiBaseUrl, localApiFallback]);
 
   useEffect(() => {
-    if (state.status !== "unauthenticated") {
+    if (state.status !== "unauthenticated" || localPreviewMode) {
       return;
     }
 
     window.location.replace(buildAuthUrl(currentRelativeUrl));
-  }, [currentRelativeUrl, state]);
+  }, [currentRelativeUrl, localPreviewMode, state]);
 
   useEffect(() => {
     if (!routeRedirectTarget) {
@@ -424,12 +426,16 @@ export function PortalBootstrap() {
   }
 
   if (state.status === "unauthenticated") {
+    if (localPreviewMode) {
+      return renderLocalPortalUnauthenticatedCard(currentRelativeUrl);
+    }
+
     return (
       <PortalStatusCard
         eyebrow="Portal"
         title="Redirecting to sign in"
         body="The portal only loads after authentication. You are being sent to the auth entrypoint now."
-        action={{ href: buildAuthUrl(currentRelativeUrl), label: "Continue to sign in" }}
+        actions={[{ href: buildAuthUrl(currentRelativeUrl), label: "Continue to sign in" }]}
       />
     );
   }
@@ -472,12 +478,12 @@ export function PortalBootstrap() {
         eyebrow="Portal"
         title="Access denied"
         body={`Signed in${state.email ? ` as ${state.email}` : ""}, but this account is not allowed to open the portal.`}
-        action={
+        actions={
           state.reason === "access_request_required"
-            ? {
+            ? [{
                 href: buildPortalUrl("/access-request"),
                 label: "Request contributor access"
-              }
+              }]
             : undefined
         }
       />
@@ -494,7 +500,7 @@ export function PortalBootstrap() {
         eyebrow="Portal"
         title="Permission denied"
         body={`Signed in${state.email ? ` as ${state.email}` : ""}, but your current portal role does not allow this area.`}
-        action={{ href: buildPortalUrl("/"), label: "Return to portal home" }}
+        actions={[{ href: buildPortalUrl("/"), label: "Return to portal home" }]}
       />
     );
   }
@@ -515,6 +521,8 @@ export function renderPortalBootstrapErrorCard(
   state: Extract<PortalAccessState, { status: "error" }>,
   currentRelativeUrl: string
 ) {
+  const localPreviewMode = isLocalDevelopmentLocation(window.location);
+
   return (
     <PortalStatusCard
       eyebrow="Portal"
@@ -524,26 +532,63 @@ export function renderPortalBootstrapErrorCard(
           : "Portal unavailable"
       }
       body={state.message}
-      action={{
-        href: buildPortalUrl(currentRelativeUrl),
-        label:
-          state.kind === "local_api_unavailable" ? "Retry after starting API" : "Retry portal"
-      }}
+      actions={[
+        {
+          href: buildPortalUrl(currentRelativeUrl),
+          label:
+            state.kind === "local_api_unavailable" ? "Retry after starting API" : "Retry portal"
+        },
+        {
+          href:
+            state.kind === "local_api_unavailable"
+              ? buildAuthUrl(currentRelativeUrl)
+              : buildPublicUrl("/"),
+          label:
+            state.kind === "local_api_unavailable"
+              ? "Open local auth guidance"
+              : localPreviewMode
+                ? "Back to local home"
+                : "Back to paretoproof.com",
+          variant: "secondary"
+        }
+      ]}
+    />
+  );
+}
+
+export function renderLocalPortalUnauthenticatedCard(currentRelativeUrl: string) {
+  return (
+    <PortalStatusCard
+      eyebrow="Portal"
+      title="Local preview needs auth context"
+      body="This localhost portal route did not receive an authenticated access state from the API. Open the local auth guidance to choose the right preview path, or return to the public site."
+      actions={[
+        {
+          href: buildAuthUrl(currentRelativeUrl),
+          label: "Open local auth guidance"
+        },
+        {
+          href: buildPublicUrl("/"),
+          label: "Back to local home",
+          variant: "secondary"
+        }
+      ]}
     />
   );
 }
 
 type PortalStatusCardProps = {
-  action?: {
+  actions?: Array<{
     href: string;
     label: string;
-  };
+    variant?: "primary" | "secondary";
+  }>;
   body: string;
   eyebrow: string;
   title: string;
 };
 
-function PortalStatusCard({ action, body, eyebrow, title }: PortalStatusCardProps) {
+function PortalStatusCard({ actions = [], body, eyebrow, title }: PortalStatusCardProps) {
   return (
     <main className="auth-shell">
       <section className="auth-card auth-card-polished auth-status-card">
@@ -555,10 +600,20 @@ function PortalStatusCard({ action, body, eyebrow, title }: PortalStatusCardProp
         </p>
         <h1>{title}</h1>
         <p>{body}</p>
-        {action ? (
-          <a className="button" href={action.href}>
-            {action.label}
-          </a>
+        {actions.length ? (
+          <div className="auth-status-actions">
+            {actions.map((action) => (
+              <a
+                className={`button${
+                  action.variant === "secondary" ? " button-secondary" : ""
+                }`}
+                href={action.href}
+                key={`${action.href}:${action.label}`}
+              >
+                {action.label}
+              </a>
+            ))}
+          </div>
         ) : null}
       </section>
     </main>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1006,6 +1006,12 @@ a.button-secondary {
   width: min(840px, 100%);
 }
 
+.auth-status-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .auth-access-request-card {
   width: min(780px, 100%);
   border-color: var(--violet-border);
@@ -3205,6 +3211,10 @@ a.button-secondary {
     padding-top: 10px;
     gap: 10px;
     align-items: stretch;
+  }
+
+  .auth-status-actions {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace localhost auth provider CTAs with truthful local preview actions and copy
- add clear secondary escape routes for portal-unavailable and localhost unauthenticated states
- cover the localhost guidance and escape-route paths with focused auth/bootstrap regressions

## Testing
- `bun test src/routes/auth-entry.test.js src/routes/portal-bootstrap.test.js`
- `bun --cwd apps/web typecheck`
- `bun run build`
- manual Playwright pass on localhost auth and portal bootstrap states

Closes #1087