### PR TITLE
Fix portal status escape routes

### DIFF
--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   buildAccessFinalizeUrl,
+  buildAuthGuidanceUrl,
   buildAuthUrl,
   buildPortalUrl,
   buildPublicUrl,
@@ -144,6 +145,17 @@ describe("surface ownership helpers", () => {
     expect(buildAuthUrl("/benchmarks")).toBe("https://auth.paretoproof.com/");
     expect(buildAuthUrl("https://math.paretoproof.com/runs/problem-9")).toBe(
       "https://auth.paretoproof.com/"
+    );
+  });
+
+  it("builds auth-guidance URLs that keep the redirect target but skip session reuse", () => {
+    setWindowUrl("https://paretoproof.com/");
+
+    expect(buildAuthGuidanceUrl("/runs/run-123?tab=events#trace")).toBe(
+      "https://auth.paretoproof.com/?redirect=%2Fruns%2Frun-123%3Ftab%3Devents%23trace&guidance=1"
+    );
+    expect(buildAuthGuidanceUrl("/benchmarks")).toBe(
+      "https://auth.paretoproof.com/?guidance=1"
     );
   });
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -238,6 +238,15 @@ export function buildAuthUrl(targetPath = "/", hostname = window.location.hostna
   return authUrl.toString();
 }
 
+export function buildAuthGuidanceUrl(
+  targetPath = "/",
+  hostname = window.location.hostname
+) {
+  const authUrl = new URL(buildAuthUrl(targetPath, hostname));
+  authUrl.searchParams.set("guidance", "1");
+  return authUrl.toString();
+}
+
 export function buildAccessRequestUrl(hostname = window.location.hostname) {
   return buildAuthUrl("/access-request", hostname);
 }

--- a/apps/web/src/routes/access-request-screen.test.js
+++ b/apps/web/src/routes/access-request-screen.test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AccessRequestScreen } from "./access-request-screen.tsx";
+
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
+
+describe("AccessRequestScreen", () => {
+  it("renders escape routes for contributor-access requests", () => {
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/access-request")
+    };
+
+    const html = renderToStaticMarkup(
+      <AccessRequestScreen email="collab@example.com" onSubmit={mock(async () => {})} />
+    );
+
+    expect(html).toContain("Restart from auth guidance");
+    expect(html).toContain("guidance=1");
+    expect(html).toContain("redirect=%2Faccess-request");
+    expect(html).toContain("Back to paretoproof.com");
+  });
+
+  it("renders truthful local escape routes for recovery requests", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/access-request?surface=portal")
+    };
+
+    const html = renderToStaticMarkup(
+      <AccessRequestScreen
+        email="owner@example.com"
+        mode="identity_recovery"
+        onSubmit={mock(async () => {})}
+      />
+    );
+
+    expect(html).toContain("Restart from auth guidance");
+    expect(html).toContain("guidance=1");
+    expect(html).toContain("redirect=%2Fprofile");
+    expect(html).toContain("Back to local home");
+  });
+});

--- a/apps/web/src/routes/access-request-screen.tsx
+++ b/apps/web/src/routes/access-request-screen.tsx
@@ -6,6 +6,8 @@ import {
 } from "@paretoproof/shared";
 import { useState } from "react";
 import { AppIcon } from "../components/app-icon";
+import { isLocalDevelopmentLocation } from "../lib/local-development";
+import { buildAuthGuidanceUrl, buildPublicUrl } from "../lib/surface";
 
 type AccessRequestScreenProps =
   | {
@@ -24,6 +26,13 @@ export function AccessRequestScreen({
   mode = "access_request",
   onSubmit
 }: AccessRequestScreenProps) {
+  const publicHomeLabel = isLocalDevelopmentLocation(window.location)
+    ? "Back to local home"
+    : "Back to paretoproof.com";
+  const authGuidanceTarget =
+    mode === "identity_recovery"
+      ? buildAuthGuidanceUrl("/profile")
+      : buildAuthGuidanceUrl("/access-request");
   const [requestedRole, setRequestedRole] =
     useState<PortalAccessRequestInput["requestedRole"]>("helper");
   const [rationale, setRationale] = useState("");
@@ -143,6 +152,14 @@ export function AccessRequestScreen({
                 : "Request access"}
           </button>
         </form>
+        <div className="auth-status-actions">
+          <a className="button button-secondary" href={authGuidanceTarget}>
+            Restart from auth guidance
+          </a>
+          <a className="button button-secondary" href={buildPublicUrl("/")}>
+            {publicHomeLabel}
+          </a>
+        </div>
       </section>
     </main>
   );

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -5,6 +5,7 @@ import {
   buildLocalAuthEntryPreviewState,
   resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
+  shouldSkipAuthEntrySessionCheck,
   shouldStayOnAuthEntryForProviderlessRecovery
 } from "./auth-entry.tsx";
 
@@ -45,6 +46,13 @@ describe("shouldStayOnAuthEntryForProviderlessRecovery", () => {
         }
       })
     ).toBe(false);
+  });
+});
+
+describe("shouldSkipAuthEntrySessionCheck", () => {
+  it("skips automatic session reuse when guidance mode is requested explicitly", () => {
+    expect(shouldSkipAuthEntrySessionCheck("?guidance=1")).toBe(true);
+    expect(shouldSkipAuthEntrySessionCheck("?redirect=%2Fpending")).toBe(false);
   });
 });
 
@@ -257,5 +265,19 @@ describe("AuthEntry local rendering", () => {
     expect(html).toContain("Open local sign-in guidance");
     expect(html).toContain("Back to local home");
     expect(html).not.toContain("Use GitHub or Google to verify your identity.");
+  });
+});
+
+describe("AuthEntry hosted guidance rendering", () => {
+  it("does not show the session-checking state when guidance mode is requested", () => {
+    globalThis.window = {
+      location: new URL("https://auth.paretoproof.com/?guidance=1&redirect=%2Fpending")
+    };
+
+    const html = renderToStaticMarkup(<AuthEntry redirectPath="/pending" />);
+
+    expect(html).not.toContain("Checking for an existing session...");
+    expect(html).toContain("Continue with GitHub");
+    expect(html).toContain("Continue with Google");
   });
 });

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -174,6 +174,10 @@ export function shouldStayOnAuthEntryForProviderlessRecovery(
   );
 }
 
+export function shouldSkipAuthEntrySessionCheck(search = window.location.search) {
+  return new URLSearchParams(search).get("guidance") === "1";
+}
+
 export type AuthEntrySessionCheckAction =
   | "redirect_access_request"
   | "redirect_denied"
@@ -232,7 +236,8 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
     [isLocal, mode, redirectPath]
   );
   const publicHomeLabel = isLocal ? "Back to local home" : "Back to paretoproof.com";
-  const [isCheckingSession, setIsCheckingSession] = useState(!isLocal);
+  const skipSessionCheck = shouldSkipAuthEntrySessionCheck();
+  const [isCheckingSession, setIsCheckingSession] = useState(!isLocal && !skipSessionCheck);
   const handoffMode = new URLSearchParams(window.location.search).get("handoff");
   const showFailedNotice = handoffMode === "failed";
   const showRetryNotice = handoffMode === "retry";
@@ -244,7 +249,7 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
       : signInChecks;
 
   useEffect(() => {
-    if (isLocal) {
+    if (isLocal || skipSessionCheck) {
       return;
     }
 
@@ -289,7 +294,15 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
     return () => {
       controller.abort();
     };
-  }, [apiBaseUrl, isLocal, portalAccessRequestUrl, portalDeniedUrl, portalPendingUrl, portalUrl]);
+  }, [
+    apiBaseUrl,
+    isLocal,
+    portalAccessRequestUrl,
+    portalDeniedUrl,
+    portalPendingUrl,
+    portalUrl,
+    skipSessionCheck
+  ]);
 
   return (
     <main className="auth-shell">
@@ -434,8 +447,8 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
               localExperience
                 ? localExperience.footerCta.href
                 : mode === "access_request"
-                  ? approvedSignInUrl
-                  : accessRequestUrl
+                ? approvedSignInUrl
+                : accessRequestUrl
             }
           >
             {localExperience

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -10,6 +10,8 @@ import {
   derivePortalRoles,
   mapPortalMutationErrorMessage,
   recoverPortalStateAfterAuthExpiry,
+  renderPortalDeniedCard,
+  renderPortalPendingCard,
   renderLocalPortalUnauthenticatedCard,
   renderPortalBootstrapErrorCard,
   shouldRestartPortalAuthForMissingProvider
@@ -202,6 +204,55 @@ describe("mapPortalMutationErrorMessage", () => {
     expect(html).toContain("Retry after starting API");
     expect(html).toContain("Open local auth guidance");
     expect(html).toContain("http://127.0.0.1:3000");
+  });
+
+  it("renders pending access state with a clear escape route", () => {
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/pending")
+    };
+
+    const html = renderToStaticMarkup(renderPortalPendingCard("collab@example.com"));
+
+    expect(html).toContain("Approval pending");
+    expect(html).toContain("Restart from auth guidance");
+    expect(html).toContain("guidance=1");
+    expect(html).toContain("Back to paretoproof.com");
+  });
+
+  it("renders access-request-required denied state with both request and escape routes", () => {
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/denied")
+    };
+
+    const html = renderToStaticMarkup(
+      renderPortalDeniedCard({
+        email: "collab@example.com",
+        reason: "access_request_required",
+        status: "denied"
+      })
+    );
+
+    expect(html).toContain("Request contributor access");
+    expect(html).toContain("Back to paretoproof.com");
+  });
+
+  it("renders denied access state with auth and public escape routes", () => {
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/denied")
+    };
+
+    const html = renderToStaticMarkup(
+      renderPortalDeniedCard({
+        email: "collab@example.com",
+        reason: "rejected_or_withdrawn",
+        status: "denied"
+      })
+    );
+
+    expect(html).toContain("Access denied");
+    expect(html).toContain("Restart from auth guidance");
+    expect(html).toContain("guidance=1");
+    expect(html).toContain("Back to paretoproof.com");
   });
 
   it("renders hosted portal outages with a secondary escape route back to the public site", () => {

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -18,6 +18,7 @@ import {
 } from "./portal-bootstrap-state";
 import {
   buildPortalUrl,
+  buildAuthGuidanceUrl,
   buildAuthUrl,
   buildPublicUrl,
   getCurrentRelativeUrl
@@ -441,13 +442,7 @@ export function PortalBootstrap() {
   }
 
   if (state.status === "pending") {
-    return (
-      <PortalStatusCard
-        eyebrow="Portal"
-        title="Approval pending"
-        body={`Signed in${state.email ? ` as ${state.email}` : ""}, but your contributor access is still pending review.`}
-      />
-    );
+    return renderPortalPendingCard(state.email);
   }
 
   if (state.status === "denied") {
@@ -473,21 +468,7 @@ export function PortalBootstrap() {
       );
     }
 
-    return (
-      <PortalStatusCard
-        eyebrow="Portal"
-        title="Access denied"
-        body={`Signed in${state.email ? ` as ${state.email}` : ""}, but this account is not allowed to open the portal.`}
-        actions={
-          state.reason === "access_request_required"
-            ? [{
-                href: buildPortalUrl("/access-request"),
-                label: "Request contributor access"
-              }]
-            : undefined
-        }
-      />
-    );
+    return renderPortalDeniedCard(state);
   }
 
   if (
@@ -573,6 +554,61 @@ export function renderLocalPortalUnauthenticatedCard(currentRelativeUrl: string)
           variant: "secondary"
         }
       ]}
+    />
+  );
+}
+
+function buildPortalPublicReturnAction() {
+  return {
+    href: buildPublicUrl("/"),
+    label: isLocalDevelopmentLocation(window.location)
+      ? "Back to local home"
+      : "Back to paretoproof.com",
+    variant: "secondary" as const
+  };
+}
+
+export function renderPortalPendingCard(email: string | null) {
+  return (
+    <PortalStatusCard
+      eyebrow="Portal"
+      title="Approval pending"
+      body={`Signed in${email ? ` as ${email}` : ""}, but your contributor access is still pending review.`}
+      actions={[
+        {
+          href: buildAuthGuidanceUrl("/"),
+          label: "Restart from auth guidance"
+        },
+        buildPortalPublicReturnAction()
+      ]}
+    />
+  );
+}
+
+export function renderPortalDeniedCard(state: Extract<PortalAccessState, { status: "denied" }>) {
+  const actions =
+    state.reason === "access_request_required"
+      ? [
+          {
+            href: buildPortalUrl("/access-request"),
+            label: "Request contributor access"
+          },
+          buildPortalPublicReturnAction()
+        ]
+      : [
+          {
+            href: buildAuthGuidanceUrl("/"),
+            label: "Restart from auth guidance"
+          },
+          buildPortalPublicReturnAction()
+        ];
+
+  return (
+    <PortalStatusCard
+      eyebrow="Portal"
+      title="Access denied"
+      body={`Signed in${state.email ? ` as ${state.email}` : ""}, but this account is not allowed to open the portal.`}
+      actions={actions}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add real auth-guidance escape routes for pending, denied, and request/recovery screens
- teach auth-entry to honor an explicit guidance mode instead of auto-bouncing through existing session state
- extend surface, auth-entry, and portal bootstrap coverage so the guidance URLs and destinations stay pinned

## Testing
- bun test src/routes/access-request-screen.test.js src/routes/portal-bootstrap.test.js src/routes/auth-entry.test.js src/lib/surface.test.js
- bun --cwd apps/web typecheck
- bun run build

Closes #1090