### PR TITLE
Remove duplicated local auth-entry CTAs

### DIFF
--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -11,6 +11,10 @@ import {
 
 const originalWindow = globalThis.window;
 
+function countOccurrences(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
 afterEach(() => {
   if (originalWindow) {
     globalThis.window = originalWindow;
@@ -208,11 +212,7 @@ describe("buildLocalAuthEntryPreviewState", () => {
           href: "http://127.0.0.1/?surface=auth&redirect=%2Faccess-request",
           title: "Open local access-request preview"
         }
-      ],
-      footerCta: {
-        href: "http://127.0.0.1/runs/alpha?surface=portal",
-        label: "Open local portal preview"
-      }
+      ]
     });
   });
 
@@ -249,6 +249,7 @@ describe("AuthEntry local rendering", () => {
     expect(html).toContain("Open local access-request preview");
     expect(html).toContain("http://127.0.0.1/runs/alpha?surface=portal");
     expect(html).toContain("Back to local home");
+    expect(countOccurrences(html, "Open local portal preview")).toBe(1);
     expect(html).not.toContain("Continue with GitHub");
     expect(html).not.toContain("Continue with Google");
   });
@@ -264,6 +265,7 @@ describe("AuthEntry local rendering", () => {
     expect(html).toContain("Open local access-request route");
     expect(html).toContain("Open local sign-in guidance");
     expect(html).toContain("Back to local home");
+    expect(countOccurrences(html, "Open local access-request route")).toBe(1);
     expect(html).not.toContain("Use GitHub or Google to verify your identity.");
   });
 });

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -39,7 +39,7 @@ type AuthEntryAction = {
 type AuthEntryLocalExperience = {
   actions: AuthEntryAction[];
   checks: string[];
-  footerCta: {
+  footerCta?: {
     href: string;
     label: string;
   };
@@ -105,10 +105,6 @@ export function buildLocalAuthEntryPreviewState(
         }
       ],
       checks: localAccessRequestChecks,
-      footerCta: {
-        href: buildPortalUrl("/access-request"),
-        label: "Open local access-request route"
-      },
       footerText:
         "Running locally - this entry explains the request path, but the actual portal route still needs a reachable API target.",
       lead:
@@ -138,10 +134,6 @@ export function buildLocalAuthEntryPreviewState(
       }
     ],
     checks: localSignInChecks,
-    footerCta: {
-      href: buildPortalUrl(resolveAuthEntryApprovedPortalTargetPath(redirectPath)),
-      label: "Open local portal preview"
-    },
     footerText:
       "Running locally - live provider sign-in is disabled here, so use the preview routes above or return to the public site.",
     lead:
@@ -441,22 +433,21 @@ export function AuthEntry({ redirectPath }: AuthEntryProps) {
                 ? "Already have an account? Use the sign-in entry instead."
                 : "New here? Request contributor access to get started."}
           </p>
-          <a
-            className="button"
-            href={
-              localExperience
-                ? localExperience.footerCta.href
-                : mode === "access_request"
-                ? approvedSignInUrl
-                : accessRequestUrl
-            }
-          >
-            {localExperience
-              ? localExperience.footerCta.label
-              : mode === "access_request"
+          {!localExperience?.footerCta ? null : (
+            <a className="button" href={localExperience.footerCta.href}>
+              {localExperience.footerCta.label}
+            </a>
+          )}
+          {!localExperience ? (
+            <a
+              className="button"
+              href={mode === "access_request" ? approvedSignInUrl : accessRequestUrl}
+            >
+              {mode === "access_request"
                 ? "Approved contributor sign in"
                 : "Request collaborator access"}
-          </a>
+            </a>
+          ) : null}
           <a className="button button-secondary" href={buildPublicUrl("/")}>
             {publicHomeLabel}
           </a>


### PR DESCRIPTION
## Summary
- remove the duplicated footer primary CTA from local auth-entry preview surfaces
- keep the local preview actions in the main panel and leave the footer as the escape/back area
- tighten auth-entry rendering tests so the local primary preview actions only appear once

## Testing
- bun test src/routes/auth-entry.test.js
- bun --cwd apps/web typecheck
- bun run build

Closes #1092