### PR TITLE
Keep project-pack anchors clear of sticky header

### DIFF
--- a/apps/web/src/routes/public-navigation.browser.test.js
+++ b/apps/web/src/routes/public-navigation.browser.test.js
@@ -45,24 +45,27 @@ async function stopServer(processHandle) {
   }
 }
 
+function startServer() {
+  return process.platform === "win32"
+    ? spawn(
+        process.env.ComSpec || "cmd.exe",
+        ["/d", "/s", "/c", "bun run dev --host 127.0.0.1 --port 4176"],
+        {
+          cwd: webRoot,
+          stdio: "ignore"
+        }
+      )
+    : spawn("bun", ["run", "dev", "--host", "127.0.0.1", "--port", "4176"], {
+        cwd: webRoot,
+        stdio: "ignore"
+      });
+}
+
 test(
   "public same-surface navigation keeps the document alive and closes the mobile menu",
   { timeout: 60_000 },
   async () => {
-    const server =
-      process.platform === "win32"
-        ? spawn(
-            process.env.ComSpec || "cmd.exe",
-            ["/d", "/s", "/c", "bun run dev --host 127.0.0.1 --port 4176"],
-            {
-              cwd: webRoot,
-              stdio: "ignore"
-            }
-          )
-        : spawn("bun", ["run", "dev", "--host", "127.0.0.1", "--port", "4176"], {
-            cwd: webRoot,
-            stdio: "ignore"
-          });
+    const server = startServer();
     const browser = await chromium.launch({ headless: true });
 
     try {
@@ -97,6 +100,88 @@ test(
       assert.equal(after.href, `${testServerUrl}/project`);
       assert.equal(after.menuCount, 0);
       assert.match(after.toggleLabel, /Menu/);
+    } finally {
+      await browser.close();
+      await stopServer(server);
+    }
+  }
+);
+
+test(
+  "project-pack anchor targets stay clear of the sticky header on direct loads and pill clicks",
+  { timeout: 60_000 },
+  async () => {
+    const server = startServer();
+    const browser = await chromium.launch({ headless: true });
+
+    try {
+      await waitForServer(testServerUrl);
+
+      for (const viewport of [
+        { width: 1600, height: 900 },
+        { width: 390, height: 844, isMobile: true, hasTouch: true }
+      ]) {
+        const context = await browser.newContext(viewport);
+        const page = await context.newPage();
+
+        await page.goto(`${testServerUrl}/project#contact`, { waitUntil: "networkidle" });
+
+        const directLoad = await page.evaluate(() => {
+          const target = document.querySelector("#contact");
+          const header = document.querySelector(".site-header");
+
+          if (!(target instanceof HTMLElement) || !(header instanceof HTMLElement)) {
+            return null;
+          }
+
+          const targetRect = target.getBoundingClientRect();
+          const headerRect = header.getBoundingClientRect();
+
+          return {
+            headerBottom: Math.round(headerRect.bottom),
+            targetTop: Math.round(targetRect.top)
+          };
+        });
+
+        assert.ok(directLoad, "expected the contact section and sticky header to exist");
+        assert.ok(
+          directLoad.targetTop >= directLoad.headerBottom + 8,
+          `expected direct hash load target (${directLoad.targetTop}) to clear sticky header (${directLoad.headerBottom})`
+        );
+
+        await page.goto(`${testServerUrl}/project`, { waitUntil: "networkidle" });
+
+        await page
+          .locator(".site-pill-row")
+          .getByRole("link", { name: "Contact rules", exact: true })
+          .click();
+        await page.waitForFunction(() => window.location.hash === "#contact");
+
+        const pillClick = await page.evaluate(() => {
+          const target = document.querySelector("#contact");
+          const header = document.querySelector(".site-header");
+
+          if (!(target instanceof HTMLElement) || !(header instanceof HTMLElement)) {
+            return null;
+          }
+
+          const targetRect = target.getBoundingClientRect();
+          const headerRect = header.getBoundingClientRect();
+
+          return {
+            headerBottom: Math.round(headerRect.bottom),
+            targetTop: Math.round(targetRect.top)
+          };
+        });
+
+        assert.ok(pillClick, "expected the contact section and sticky header after pill click");
+        assert.ok(
+          pillClick.targetTop >= pillClick.headerBottom + 8,
+          `expected pill-click target (${pillClick.targetTop}) to clear sticky header (${pillClick.headerBottom})`
+        );
+
+        await context.close();
+      }
     } finally {
       await browser.close();
       await stopServer(server);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -559,6 +559,10 @@ a.button-secondary {
   gap: 18px;
 }
 
+.site-project-section[id] {
+  scroll-margin-top: 108px;
+}
+
 .site-section-copy {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## Summary
- add sticky-header compensation for anchored project-pack sections
- cover direct hash loads and project-pill clicks in the browser regression suite
- keep the project-pack section heading visible on both desktop and mobile

## Testing
- node --test src/routes/public-navigation.browser.test.js
- bun --cwd apps/web test:layout
- bun --cwd apps/web typecheck
- bun run build

Closes #1096