### PR TITLE
Restore portal overview api-boundary parity

### DIFF
--- a/packages/shared/src/contracts/api-call-boundary.ts
+++ b/packages/shared/src/contracts/api-call-boundary.ts
@@ -99,6 +99,14 @@ export const apiCallBoundaryCatalog = [
   },
   {
     credential: "cloudflare_access_jwt",
+    endpointId: "portal.overview.read",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "Approved helpers read the portal landing overview directly from the protected portal surface without introducing a separate backend proxy."
+  },
+  {
+    credential: "cloudflare_access_jwt",
     endpointId: "portal.benchmarks.list",
     mode: "browser_direct",
     origin: "portal_browser",


### PR DESCRIPTION
## Summary
- restore the missing `portal.overview.read` call-boundary entry in the shared boundary catalog
- bring the endpoint, schema, and boundary catalogs back into lockstep without changing any route semantics

## Testing
- `bun run test:shared`
- `bun run typecheck:shared`
- `bun run build:shared`

Closes #1098