### PR TITLE
Make portal launch preflight truthful

### DIFF
--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -54,6 +54,119 @@ function createUnavailableLoadState() {
   };
 }
 
+function createLaunchLoadState() {
+  return {
+    data: {
+      benchmarks: [
+        {
+          benchmarkItemCount: 19,
+          benchmarkLabel: "firstproof/problem9 @ v1",
+          benchmarkPackageDigest: "sha256:abc123",
+          benchmarkPackageId: "firstproof/problem9",
+          benchmarkPackageVersion: "v1",
+          benchmarkVersionId: "bench-v1",
+          laneIds: ["lean4"],
+          lastSeenRunId: "run-last-seen"
+        }
+      ],
+      governance: {
+        defaultPolicy: {
+          budget: {
+            budgetExceededTerminalState: "failed",
+            maxEstimatedUsdPerRun: 25,
+            maxInputTokensPerRun: 200000,
+            maxOutputTokensPerRun: 60000,
+            maxWallClockMinutesPerRun: 120
+          },
+          cancellation: {
+            cancelRequestGraceSeconds: 60,
+            forcedCancelAfterSeconds: 300,
+            heartbeatStaleSeconds: 120
+          },
+          concurrency: {
+            maxActiveRunsGlobal: 10,
+            maxActiveRunsPerContributor: 2,
+            maxConcurrentJobsPerRun: 4,
+            maxQueuedRunsPerContributor: 4
+          },
+          retry: {
+            backoffMultiplier: 2,
+            initialBackoffSeconds: 10,
+            maxAttemptsPerJob: 3,
+            maxAttemptsPerRun: 6,
+            maxBackoffSeconds: 120,
+            retryableReasons: ["provider_transport_error", "internal_transient"]
+          }
+        },
+        runKindConcurrencyOverrides: [
+          {
+            id: "full_benchmark",
+            maxConcurrentJobsPerRun: 8,
+            rationale: "Full benchmark fanout"
+          },
+          {
+            id: "benchmark_slice",
+            maxConcurrentJobsPerRun: 4,
+            rationale: "Slice fanout"
+          },
+          {
+            id: "single_run",
+            maxConcurrentJobsPerRun: 1,
+            rationale: "Single item"
+          },
+          {
+            id: "repeated_n",
+            maxConcurrentJobsPerRun: 2,
+            rationale: "Repeat envelope"
+          }
+        ]
+      },
+      modelConfigs: [
+        {
+          authModes: ["machine_api_key"],
+          modelConfigId: "gpt-5.4",
+          modelConfigLabel: "GPT-5.4",
+          modelSnapshotIds: ["gpt-5.4-2026-04-01"],
+          providerFamily: "openai",
+          runModes: ["hosted"],
+          toolProfiles: ["default"]
+        }
+      ],
+      redirectPattern: "/runs/:runId",
+      runKinds: [
+        {
+          description:
+            "Launch the full published benchmark version against one model configuration.",
+          id: "full_benchmark",
+          requiredFields: ["benchmarkVersionId", "modelConfigId"]
+        },
+        {
+          description:
+            "Launch a bounded subset of one benchmark version, typically for smoke checks or focused regression work.",
+          id: "benchmark_slice",
+          requiredFields: ["benchmarkVersionId", "modelConfigId", "sliceDefinition"]
+        },
+        {
+          description:
+            "Execute one benchmark item or one curated prompt/problem pair end-to-end.",
+          id: "single_run",
+          requiredFields: ["benchmarkItemId", "modelConfigId"]
+        },
+        {
+          description:
+            "Repeat the same benchmark item or slice multiple times to measure variance or flaky behavior.",
+          id: "repeated_n",
+          requiredFields: ["benchmarkTargetId", "modelConfigId", "repeatCount"]
+        }
+      ],
+      submissionMode: "preflight_only"
+    },
+    error: null,
+    isLoading: false,
+    lastUpdatedAt: "2026-04-17T04:00:00.000Z"
+  };
+}
+
 describe("portal benchmark ops route targets", () => {
   it("keeps the current runs query when routing into run detail", () => {
     expect(
@@ -158,5 +271,56 @@ describe("portal benchmark ops route targets", () => {
       })
     );
     expect(workersHtml).toContain("Worker operations are unavailable.");
+  });
+
+  it("keeps launch preflight truthful when only full benchmark is currently parameterizable", () => {
+    setWindow("http://127.0.0.1/launch?surface=portal&access=approved", 1280);
+
+    const html = renderToStaticMarkup(
+      createElement(PortalLaunchSurface, {
+        activeRouteId: "portal.launch",
+        loadState: createLaunchLoadState(),
+        onRefresh: async () => {},
+        selection: {
+          benchmarkVersionId: "bench-v1",
+          modelConfigId: "gpt-5.4",
+          runKind: "single_run"
+        },
+        setSelection() {}
+      })
+    );
+
+    expect(html).toContain("Max per run: 8");
+    expect(html).toContain("Observed in 19 prior runs across lean4.");
+    expect(html).toContain(
+      "benchmark slice, single run, repeated n still need slice definition, benchmark item, benchmark target, repeat count."
+    );
+    expect(html).toContain("Required preflight fields: benchmark version, model config");
+    expect(html).not.toContain(">single run</option>");
+    expect(html).not.toContain(">benchmark slice</option>");
+    expect(html).not.toContain(">repeated n</option>");
+  });
+
+  it("falls back to an unavailable state when no returned run kind is actually parameterizable", () => {
+    setWindow("http://127.0.0.1/launch?surface=portal&access=approved", 1280);
+    const loadState = createLaunchLoadState();
+    loadState.data.runKinds = loadState.data.runKinds.filter((item) => item.id !== "full_benchmark");
+
+    const html = renderToStaticMarkup(
+      createElement(PortalLaunchSurface, {
+        activeRouteId: "portal.launch",
+        loadState,
+        onRefresh: async () => {},
+        selection: {
+          benchmarkVersionId: "bench-v1",
+          modelConfigId: "gpt-5.4",
+          runKind: "single_run"
+        },
+        setSelection() {}
+      })
+    );
+
+    expect(html).toContain("Launch options are not ready yet.");
+    expect(html).not.toContain("Run kind");
   });
 });

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -111,6 +111,51 @@ function formatSubmissionMode(value: string) {
   return value.replaceAll("_", " ");
 }
 
+const launchPreflightSupportedFieldIds = new Set([
+  "benchmarkVersionId",
+  "modelConfigId"
+]);
+
+function getSupportedLaunchRunKinds(data: PortalLaunchViewResponse | null) {
+  return (data?.runKinds ?? []).filter((item) =>
+    item.requiredFields.every((fieldId) => launchPreflightSupportedFieldIds.has(fieldId))
+  );
+}
+
+function getUnsupportedLaunchRunKinds(data: PortalLaunchViewResponse | null) {
+  return (data?.runKinds ?? []).filter((item) =>
+    item.requiredFields.some((fieldId) => !launchPreflightSupportedFieldIds.has(fieldId))
+  );
+}
+
+function getEffectiveLaunchConcurrencyCap(
+  data: PortalLaunchViewResponse | null,
+  runKind: RunKind
+) {
+  const override = data?.governance.runKindConcurrencyOverrides.find((item) => item.id === runKind);
+
+  return override?.maxConcurrentJobsPerRun ?? data?.governance.defaultPolicy.concurrency.maxConcurrentJobsPerRun;
+}
+
+function formatLaunchFieldLabel(fieldId: string) {
+  switch (fieldId) {
+    case "benchmarkVersionId":
+      return "benchmark version";
+    case "modelConfigId":
+      return "model config";
+    case "benchmarkItemId":
+      return "benchmark item";
+    case "sliceDefinition":
+      return "slice definition";
+    case "benchmarkTargetId":
+      return "benchmark target";
+    case "repeatCount":
+      return "repeat count";
+    default:
+      return fieldId;
+  }
+}
+
 function toDisplayError(error: unknown) {
   return error instanceof Error ? error.message : "Request failed.";
 }
@@ -171,7 +216,7 @@ function hasLaunchOptions(data: PortalLaunchViewResponse | null) {
     data &&
       data.benchmarks.length > 0 &&
       data.modelConfigs.length > 0 &&
-      data.runKinds.length > 0
+      getSupportedLaunchRunKinds(data).length > 0
   );
 }
 
@@ -397,11 +442,15 @@ export function PortalBenchmarkOpsSurface({
       return;
     }
 
+    const supportedRunKinds = getSupportedLaunchRunKinds(launchState.data);
     setLaunchSelection((current) => ({
       benchmarkVersionId:
         current.benchmarkVersionId || launchState.data?.benchmarks[0]?.benchmarkVersionId || "",
       modelConfigId: current.modelConfigId || launchState.data?.modelConfigs[0]?.modelConfigId || "",
-      runKind: current.runKind || launchState.data?.runKinds[0]?.id || "single_run"
+      runKind:
+        supportedRunKinds.find((item) => item.id === current.runKind)?.id ??
+        supportedRunKinds[0]?.id ??
+        "full_benchmark"
     }));
   }, [launchState.data]);
 
@@ -1246,6 +1295,20 @@ export function PortalLaunchSurface({
   const modelConfig = loadState.data?.modelConfigs.find(
     (item) => item.modelConfigId === selection.modelConfigId
   );
+  const supportedRunKinds = getSupportedLaunchRunKinds(loadState.data);
+  const unsupportedRunKinds = getUnsupportedLaunchRunKinds(loadState.data);
+  const selectedRunKind =
+    supportedRunKinds.find((item) => item.id === selection.runKind) ?? supportedRunKinds[0] ?? null;
+  const effectiveConcurrencyCap = selectedRunKind
+    ? getEffectiveLaunchConcurrencyCap(loadState.data, selectedRunKind.id)
+    : loadState.data?.governance.defaultPolicy.concurrency.maxConcurrentJobsPerRun ?? null;
+  const unsupportedRequiredFields = [
+    ...new Set(
+      unsupportedRunKinds.flatMap((item) =>
+        item.requiredFields.filter((fieldId) => !launchPreflightSupportedFieldIds.has(fieldId))
+      )
+    )
+  ].map(formatLaunchFieldLabel);
   const launchEvidenceHref = benchmark
     ? buildRunDetailHref(benchmark.lastSeenRunId)
     : buildPortalUrl("/runs");
@@ -1326,7 +1389,7 @@ export function PortalLaunchSurface({
                   }}
                   value={selection.runKind}
                 >
-                  {(loadState.data?.runKinds ?? []).map((item) => (
+                  {supportedRunKinds.map((item) => (
                     <option key={item.id} value={item.id}>
                       {formatRunKind(item.id)}
                     </option>
@@ -1334,6 +1397,17 @@ export function PortalLaunchSurface({
                 </select>
               </label>
             </div>
+            {unsupportedRunKinds.length > 0 ? (
+              <div className="portal-results-contract-card">
+                <p className="section-tag">Unavailable run shapes</p>
+                <h3>Additional run kinds stay out of this preflight until target inputs land.</h3>
+                <p>
+                  {unsupportedRunKinds.map((item) => formatRunKind(item.id)).join(", ")} still need{" "}
+                  {unsupportedRequiredFields.join(", ")}
+                  .
+                </p>
+              </div>
+            ) : null}
             {isCompactLayout ? (
               <PortalFreshnessCard
                 isRefreshing={loadState.isLoading}
@@ -1359,7 +1433,9 @@ export function PortalLaunchSurface({
                 <article className="portal-results-contract-card">
                   <p className="section-tag">Benchmark</p>
                   <h3>{benchmark.benchmarkLabel}</h3>
-                  <p>{benchmark.benchmarkItemCount} items across {benchmark.laneIds.join(", ")}.</p>
+                  <p>
+                    Observed in {benchmark.benchmarkItemCount} prior runs across {benchmark.laneIds.join(", ")}.
+                  </p>
                   <a className="portal-inline-link" href={buildRunDetailHref(benchmark.lastSeenRunId)}>
                     Open last seen run
                   </a>
@@ -1372,14 +1448,20 @@ export function PortalLaunchSurface({
                 </article>
                 <article className="portal-results-contract-card">
                   <p className="section-tag">Governance</p>
-                  <h3>{formatRunKind(selection.runKind)}</h3>
+                  <h3>{selectedRunKind ? formatRunKind(selectedRunKind.id) : formatRunKind(selection.runKind)}</h3>
                   <p>
-                    Max per run: {loadState.data?.governance.defaultPolicy.concurrency.maxConcurrentJobsPerRun}
+                    Max per run: {effectiveConcurrencyCap}
                     {" "}jobs
                   </p>
                   <p>
                     Budget cap: ${loadState.data?.governance.defaultPolicy.budget.maxEstimatedUsdPerRun}
                   </p>
+                  {selectedRunKind ? (
+                    <p>
+                      Required preflight fields:{" "}
+                      {selectedRunKind.requiredFields.map(formatLaunchFieldLabel).join(", ")}
+                    </p>
+                  ) : null}
                 </article>
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- keep `/portal/launch` truthful by only surfacing run kinds the current preflight can actually represent
- show the effective per-run-kind concurrency cap and the required preflight fields for the selected run kind
- relabel history-derived benchmark counts as observed prior runs and add regressions for unsupported-run-kind payloads

## Testing
- `bun test apps/web/src/routes/portal-benchmark-ops-surfaces.test.js apps/web/src/routes/portal-shell.test.js`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`

Closes #1018