### PR TITLE
Improve portal auth handoff reuse

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js src/routes/public-header-layout.browser.test.js src/routes/public-navigation.browser.test.js",
+    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js src/routes/portal-bootstrap.browser.test.js src/routes/public-header-layout.browser.test.js src/routes/public-navigation.browser.test.js",
     "test:ui": "bun test src/lib/web-navigation.test.js src/routes/public-site.test.js && bun run test:layout",
     "test:functions": "bun test functions",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json",

--- a/apps/web/src/lib/approved-auth-handoff.test.js
+++ b/apps/web/src/lib/approved-auth-handoff.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildApprovedAuthHandoffCookieMutation,
+  buildApprovedAuthHandoffCookieValue,
+  buildClearApprovedAuthHandoffCookieMutation,
+  consumeApprovedAuthHandoffCookie,
+  readApprovedAuthHandoffCookie
+} from "./approved-auth-handoff.ts";
+
+describe("approved auth handoff cookies", () => {
+  it("round-trips a fresh portal handoff cookie", () => {
+    const cookieHeader = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "admin",
+        status: "approved",
+        surface: "portal"
+      },
+      10_000
+    );
+
+    expect(
+      readApprovedAuthHandoffCookie(cookieHeader, {
+        nowMs: 20_000,
+        surface: "portal"
+      })
+    ).toEqual({
+      role: "admin",
+      status: "approved",
+      surface: "portal"
+    });
+  });
+
+  it("ignores expired handoff cookies", () => {
+    const cookieHeader = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "collaborator",
+        status: "approved",
+        surface: "portal"
+      },
+      10_000
+    );
+
+    expect(
+      readApprovedAuthHandoffCookie(cookieHeader, {
+        nowMs: 50_001,
+        surface: "portal"
+      })
+    ).toBeNull();
+  });
+
+  it("ignores cookies meant for a different authenticated surface", () => {
+    const cookieHeader = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "admin",
+        status: "approved",
+        surface: "math"
+      },
+      10_000
+    );
+
+    expect(
+      readApprovedAuthHandoffCookie(cookieHeader, {
+        nowMs: 20_000,
+        surface: "portal"
+      })
+    ).toBeNull();
+  });
+
+  it("uses a shared paretoproof.com domain for hosted auth handoffs", () => {
+    expect(
+      buildApprovedAuthHandoffCookieMutation(
+        {
+          role: "admin",
+          status: "approved",
+          surface: "portal"
+        },
+        {
+          hostname: "auth.paretoproof.com",
+          protocol: "https:"
+        },
+        10_000
+      )
+    ).toContain("Domain=.paretoproof.com");
+  });
+
+  it("keeps local preview handoffs host-only", () => {
+    expect(
+      buildApprovedAuthHandoffCookieMutation(
+        {
+          role: "admin",
+          status: "approved",
+          surface: "portal"
+        },
+        {
+          hostname: "127.0.0.1",
+          protocol: "http:"
+        },
+        10_000
+      )
+    ).not.toContain("Domain=");
+  });
+
+  it("consumes and clears the cookie in one hop", () => {
+    const cookieStore = {
+      cookie: buildApprovedAuthHandoffCookieValue(
+        {
+          role: "helper",
+          status: "approved",
+          surface: "portal"
+        },
+        10_000
+      )
+    };
+
+    expect(
+      consumeApprovedAuthHandoffCookie({
+        documentLike: cookieStore,
+        locationLike: {
+          hostname: "portal.paretoproof.com",
+          protocol: "https:"
+        },
+        nowMs: 20_000,
+        surface: "portal"
+      })
+    ).toEqual({
+      role: "helper",
+      status: "approved",
+      surface: "portal"
+    });
+    expect(cookieStore.cookie).toBe(
+      buildClearApprovedAuthHandoffCookieMutation({
+        hostname: "portal.paretoproof.com",
+        protocol: "https:"
+      })
+    );
+  });
+});

--- a/apps/web/src/lib/approved-auth-handoff.ts
+++ b/apps/web/src/lib/approved-auth-handoff.ts
@@ -1,0 +1,213 @@
+import type { PortalRole } from "@paretoproof/shared";
+import type { AuthenticatedSurface } from "./surface";
+
+export type ApprovedAuthHandoff = {
+  role: PortalRole | null;
+  status: "approved";
+  surface: AuthenticatedSurface;
+};
+
+type ApprovedAuthHandoffRecord = ApprovedAuthHandoff & {
+  savedAtMs: number;
+  version: 1;
+};
+
+type LocationLike = Pick<Location, "hostname" | "protocol">;
+
+type CookieDocumentLike = {
+  cookie: string;
+};
+
+const approvedAuthHandoffCookieName = "paretoproof_approved_auth_handoff";
+const approvedAuthHandoffTtlMs = 30_000;
+
+function encodeApprovedAuthHandoff(
+  handoff: ApprovedAuthHandoff,
+  savedAtMs: number
+) {
+  const record: ApprovedAuthHandoffRecord = {
+    ...handoff,
+    savedAtMs,
+    version: 1
+  };
+
+  return encodeURIComponent(JSON.stringify(record));
+}
+
+function decodeApprovedAuthHandoff(
+  rawValue: string
+): ApprovedAuthHandoffRecord | null {
+  try {
+    const parsed = JSON.parse(decodeURIComponent(rawValue)) as Partial<ApprovedAuthHandoffRecord>;
+
+    if (
+      parsed.version !== 1 ||
+      parsed.status !== "approved" ||
+      (parsed.surface !== "portal" && parsed.surface !== "math") ||
+      (parsed.role !== null &&
+        parsed.role !== "admin" &&
+        parsed.role !== "collaborator" &&
+        parsed.role !== "helper") ||
+      typeof parsed.savedAtMs !== "number"
+    ) {
+      return null;
+    }
+
+    return parsed as ApprovedAuthHandoffRecord;
+  } catch {
+    return null;
+  }
+}
+
+function readCookieValue(cookieHeader: string, name: string) {
+  for (const segment of cookieHeader.split(";")) {
+    const [cookieName, ...valueParts] = segment.trim().split("=");
+
+    if (cookieName === name) {
+      return valueParts.join("=");
+    }
+  }
+
+  return null;
+}
+
+function resolveCookieDomain(locationLike: LocationLike) {
+  return locationLike.hostname.endsWith(".paretoproof.com") ||
+    locationLike.hostname === "paretoproof.com"
+    ? ".paretoproof.com"
+    : null;
+}
+
+export function buildApprovedAuthHandoffCookieValue(
+  handoff: ApprovedAuthHandoff,
+  savedAtMs = Date.now()
+) {
+  return `${approvedAuthHandoffCookieName}=${encodeApprovedAuthHandoff(
+    handoff,
+    savedAtMs
+  )}`;
+}
+
+export function buildApprovedAuthHandoffCookieMutation(
+  handoff: ApprovedAuthHandoff,
+  locationLike: LocationLike = window.location,
+  savedAtMs = Date.now()
+) {
+  const parts = [
+    buildApprovedAuthHandoffCookieValue(handoff, savedAtMs),
+    "Path=/",
+    `Max-Age=${Math.ceil(approvedAuthHandoffTtlMs / 1000)}`,
+    "SameSite=Lax"
+  ];
+  const cookieDomain = resolveCookieDomain(locationLike);
+
+  if (cookieDomain) {
+    parts.push(`Domain=${cookieDomain}`);
+  }
+
+  if (locationLike.protocol === "https:") {
+    parts.push("Secure");
+  }
+
+  return parts.join("; ");
+}
+
+export function buildClearApprovedAuthHandoffCookieMutation(
+  locationLike: LocationLike = window.location
+) {
+  const parts = [
+    `${approvedAuthHandoffCookieName}=`,
+    "Path=/",
+    "Max-Age=0",
+    "SameSite=Lax"
+  ];
+  const cookieDomain = resolveCookieDomain(locationLike);
+
+  if (cookieDomain) {
+    parts.push(`Domain=${cookieDomain}`);
+  }
+
+  if (locationLike.protocol === "https:") {
+    parts.push("Secure");
+  }
+
+  return parts.join("; ");
+}
+
+export function readApprovedAuthHandoffCookie(
+  cookieHeader: string,
+  options: {
+    nowMs?: number;
+    surface: AuthenticatedSurface;
+  }
+): ApprovedAuthHandoff | null {
+  const rawValue = readCookieValue(cookieHeader, approvedAuthHandoffCookieName);
+
+  if (!rawValue) {
+    return null;
+  }
+
+  const record = decodeApprovedAuthHandoff(rawValue);
+
+  if (!record || record.surface !== options.surface) {
+    return null;
+  }
+
+  if ((options.nowMs ?? Date.now()) - record.savedAtMs > approvedAuthHandoffTtlMs) {
+    return null;
+  }
+
+  return {
+    role: record.role,
+    status: "approved",
+    surface: record.surface
+  };
+}
+
+export function writeApprovedAuthHandoffCookie(
+  handoff: ApprovedAuthHandoff,
+  options?: {
+    documentLike?: CookieDocumentLike;
+    locationLike?: LocationLike;
+    savedAtMs?: number;
+  }
+) {
+  const documentLike = options?.documentLike ?? document;
+  documentLike.cookie = buildApprovedAuthHandoffCookieMutation(
+    handoff,
+    options?.locationLike ?? window.location,
+    options?.savedAtMs
+  );
+}
+
+export function clearApprovedAuthHandoffCookie(options?: {
+  documentLike?: CookieDocumentLike;
+  locationLike?: LocationLike;
+}) {
+  const documentLike = options?.documentLike ?? document;
+  documentLike.cookie = buildClearApprovedAuthHandoffCookieMutation(
+    options?.locationLike ?? window.location
+  );
+}
+
+export function consumeApprovedAuthHandoffCookie(
+  options: {
+    documentLike?: CookieDocumentLike;
+    locationLike?: LocationLike;
+    nowMs?: number;
+    surface: AuthenticatedSurface;
+  }
+) {
+  const documentLike = options.documentLike ?? document;
+  const handoff = readApprovedAuthHandoffCookie(documentLike.cookie, {
+    nowMs: options.nowMs,
+    surface: options.surface
+  });
+
+  clearApprovedAuthHandoffCookie({
+    documentLike,
+    locationLike: options.locationLike ?? window.location
+  });
+
+  return handoff;
+}

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   AuthEntry,
   buildLocalAuthEntryPreviewState,
+  resolveApprovedAuthEntryHandoff,
   resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
   shouldSkipAuthEntrySessionCheck,
@@ -183,6 +184,63 @@ describe("resolveAuthEntrySessionCheckAction", () => {
         }
       )
     ).toBe("redirect_denied");
+  });
+});
+
+describe("resolveApprovedAuthEntryHandoff", () => {
+  it("builds a portal handoff only for approved authenticated redirects", () => {
+    expect(
+      resolveApprovedAuthEntryHandoff(
+        "redirect_authenticated_app",
+        {
+          access: {
+            role: "admin",
+            status: "approved"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        },
+        "portal"
+      )
+    ).toEqual({
+      role: "admin",
+      status: "approved",
+      surface: "portal"
+    });
+  });
+
+  it("does not build a handoff for pending or denied states", () => {
+    expect(
+      resolveApprovedAuthEntryHandoff(
+        "redirect_pending",
+        {
+          access: {
+            status: "pending"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        },
+        "portal"
+      )
+    ).toBeNull();
+
+    expect(
+      resolveApprovedAuthEntryHandoff(
+        "redirect_denied",
+        {
+          access: {
+            reason: "rejected_or_withdrawn",
+            status: "denied"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        },
+        "portal"
+      )
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import {
+  type ApprovedAuthHandoff,
+  writeApprovedAuthHandoffCookie
+} from "../lib/approved-auth-handoff";
 import { fetchApi } from "../lib/api-fetch";
 import {
   buildAccessRequestUrl,
@@ -21,6 +25,7 @@ type AuthEntryProps = {
 
 type AuthEntrySessionCheckPayload = {
   access: {
+    role?: "admin" | "collaborator" | "helper" | null;
     reason?:
       | "access_request_required"
       | "identity_recovery_required"
@@ -227,6 +232,22 @@ export function resolveAuthEntrySessionCheckAction(
   return "stay_on_auth_entry";
 }
 
+export function resolveApprovedAuthEntryHandoff(
+  action: AuthEntrySessionCheckAction,
+  payload: AuthEntrySessionCheckPayload | null,
+  redirectSurface: AuthenticatedSurface
+): ApprovedAuthHandoff | null {
+  if (action !== "redirect_authenticated_app" || payload?.access.status !== "approved") {
+    return null;
+  }
+
+  return {
+    role: payload.access.role ?? null,
+    status: "approved",
+    surface: redirectSurface
+  };
+}
+
 export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
   const mode = resolveAuthEntryMode(redirectPath);
   const githubStartUrl = buildAccessStartUrl("github", redirectPath, {
@@ -290,6 +311,11 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
         const action = resolveAuthEntrySessionCheckAction(response, payload);
 
         if (action !== "stay_on_auth_entry") {
+          const approvedHandoff = resolveApprovedAuthEntryHandoff(
+            action,
+            payload,
+            redirectSurface
+          );
           const redirectTarget =
             action === "redirect_access_request"
               ? portalAccessRequestUrl
@@ -298,6 +324,10 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
                 : action === "redirect_pending"
                   ? portalPendingUrl
                   : destinationUrl;
+
+          if (approvedHandoff) {
+            writeApprovedAuthHandoffCookie(approvedHandoff);
+          }
 
           window.location.replace(redirectTarget);
           return;
@@ -325,6 +355,7 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
     portalAccessRequestUrl,
     portalDeniedUrl,
     portalPendingUrl,
+    redirectSurface,
     skipSessionCheck
   ]);
 

--- a/apps/web/src/routes/portal-bootstrap.browser.test.js
+++ b/apps/web/src/routes/portal-bootstrap.browser.test.js
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const webRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+async function waitForServer(url, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+
+    await delay(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function stopServer(processHandle) {
+  if (!processHandle || processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+  await delay(500);
+
+  if (processHandle.exitCode === null && process.platform === "win32") {
+    await new Promise((resolve) => {
+      const killer = spawn("taskkill", ["/pid", String(processHandle.pid), "/f", "/t"], {
+        stdio: "ignore"
+      });
+      killer.on("close", resolve);
+      killer.on("error", resolve);
+    });
+  }
+}
+
+function startServer(port) {
+  return process.platform === "win32"
+    ? spawn(
+        process.env.ComSpec || "cmd.exe",
+        ["/d", "/s", "/c", `bun run dev --host 127.0.0.1 --port ${port}`],
+        {
+          cwd: webRoot,
+          stdio: "ignore"
+        }
+      )
+    : spawn("bun", ["run", "dev", "--host", "127.0.0.1", "--port", String(port)], {
+        cwd: webRoot,
+        stdio: "ignore"
+      });
+}
+
+async function assertApprovedHandoffTransition({
+  expectedText,
+  expectedPathname,
+  port,
+  revalidationResponse
+}) {
+  const testServerUrl = `http://127.0.0.1:${port}`;
+  const server = startServer(port);
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    await waitForServer(`${testServerUrl}/?surface=portal`);
+
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 1100 }
+    });
+    await context.addCookies([
+      {
+        name: "paretoproof_approved_auth_handoff",
+        value: encodeURIComponent(
+          JSON.stringify({
+            role: "admin",
+            savedAtMs: Date.now(),
+            status: "approved",
+            surface: "portal",
+            version: 1
+          })
+        ),
+        url: `${testServerUrl}/`
+      }
+    ]);
+
+    const page = await context.newPage();
+
+    await page.route("http://127.0.0.1:3000/portal/me", async (route) => {
+      await delay(1_500);
+      await route.fulfill({
+        status: revalidationResponse.status,
+        contentType: "application/json",
+        body: revalidationResponse.body
+      });
+    });
+
+    await page.goto(`${testServerUrl}/?surface=portal`, { waitUntil: "domcontentloaded" });
+    await delay(1_000);
+
+    const provisionalBody = await page.locator("body").innerText();
+    assert.match(provisionalBody, /Formal benchmark operations and contributor tooling\./);
+    assert.doesNotMatch(provisionalBody, /Opening portal/);
+
+    await page.waitForFunction(
+      ({ expected, expectedPathname }) =>
+        window.location.pathname === expectedPathname &&
+        document.body.innerText.includes(expected),
+      {
+        expected: expectedText.source.replace(/\\/g, ""),
+        expectedPathname
+      },
+      { timeout: 10_000 }
+    );
+
+    const recoveredBody = await page.locator("body").innerText();
+    assert.match(recoveredBody, expectedText);
+    assert.doesNotMatch(recoveredBody, /Formal benchmark operations and contributor tooling\./);
+
+    await context.close();
+  } finally {
+    await browser.close();
+    await stopServer(server);
+  }
+}
+
+test(
+  "portal bootstrap replaces a provisional approved handoff when /portal/me revalidation disagrees",
+  { timeout: 120_000 },
+  async () => {
+    for (const scenario of [
+      {
+        expectedText: /Local preview needs auth context/,
+        expectedPathname: "/",
+        name: "401",
+        port: 4177,
+        revalidationResponse: {
+          body: JSON.stringify({ error: "access_assertion_required" }),
+          status: 401
+        }
+      },
+      {
+        expectedText: /Approval pending/,
+        expectedPathname: "/pending",
+        name: "pending",
+        port: 4179,
+        revalidationResponse: {
+          body: JSON.stringify({
+            access: {
+              email: "reviewer@paretoproof.test",
+              status: "pending"
+            },
+            identity: {
+              provider: "cloudflare_google"
+            }
+          }),
+          status: 200
+        }
+      },
+      {
+        expectedText: /Access denied/,
+        expectedPathname: "/denied",
+        name: "denied",
+        port: 4180,
+        revalidationResponse: {
+          body: JSON.stringify({
+            access: {
+              email: "reviewer@paretoproof.test",
+              reason: "rejected_or_withdrawn",
+              status: "denied"
+            },
+            identity: {
+              provider: "cloudflare_google"
+            }
+          }),
+          status: 200
+        }
+      }
+    ]) {
+      await assertApprovedHandoffTransition({
+        expectedText: scenario.expectedText,
+        expectedPathname: scenario.expectedPathname,
+        port: scenario.port,
+        revalidationResponse: scenario.revalidationResponse
+      });
+    }
+  }
+);

--- a/apps/web/src/routes/portal-bootstrap.browser.test.js
+++ b/apps/web/src/routes/portal-bootstrap.browser.test.js
@@ -132,6 +132,107 @@ async function assertApprovedHandoffTransition({
   }
 }
 
+async function assertRestrictedRouteHandoffRevalidation({
+  port,
+  provisionalRole,
+  revalidatedRole
+}) {
+  const testServerUrl = `http://127.0.0.1:${port}`;
+  const server = startServer(port);
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    await waitForServer(`${testServerUrl}/admin/users?surface=portal`);
+
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 1100 }
+    });
+    await context.addCookies([
+      {
+        name: "paretoproof_approved_auth_handoff",
+        value: encodeURIComponent(
+          JSON.stringify({
+            role: provisionalRole,
+            savedAtMs: Date.now(),
+            status: "approved",
+            surface: "portal",
+            version: 1
+          })
+        ),
+        url: `${testServerUrl}/`
+      }
+    ]);
+
+    const page = await context.newPage();
+
+    await page.route("http://127.0.0.1:3000/portal/me", async (route) => {
+      await delay(1_500);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          access: {
+            email: "reviewer@paretoproof.test",
+            role: revalidatedRole,
+            status: "approved"
+          },
+          identity: {
+            provider: "cloudflare_google"
+          }
+        })
+      });
+    });
+
+    await page.route("http://127.0.0.1:3000/portal/admin/users", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            {
+              accessPosture: "approved",
+              activeRole: revalidatedRole,
+              displayName: "Ada",
+              email: "ada@example.com",
+              lastReviewedRequestStatus: null,
+              linkedIdentityProviders: ["cloudflare_google"],
+              pendingRequest: null,
+              userId: "11111111-1111-4111-8111-111111111111"
+            }
+          ]
+        })
+      });
+    });
+
+    await page.goto(`${testServerUrl}/admin/users?surface=portal`, {
+      waitUntil: "domcontentloaded"
+    });
+    await delay(1_000);
+
+    assert.equal(new URL(page.url()).pathname, "/admin/users");
+    assert.doesNotMatch(await page.locator("body").innerText(), /Access denied/);
+
+    await page.waitForFunction(
+      () =>
+        window.location.pathname === "/admin/users" &&
+        document.body.innerText.includes("reviewer@paretoproof.test") &&
+        document.body.innerText.includes("ADMIN USERS"),
+      { timeout: 10_000 }
+    );
+
+    const settledBody = await page.locator("body").innerText();
+    assert.equal(new URL(page.url()).pathname, "/admin/users");
+    assert.match(settledBody, /reviewer@paretoproof\.test/);
+    assert.match(settledBody, /ADMIN USERS/);
+    assert.doesNotMatch(settledBody, /Access denied/);
+
+    await context.close();
+  } finally {
+    await browser.close();
+    await stopServer(server);
+  }
+}
+
 test(
   "portal bootstrap replaces a provisional approved handoff when /portal/me revalidation disagrees",
   { timeout: 120_000 },
@@ -192,5 +293,17 @@ test(
         revalidationResponse: scenario.revalidationResponse
       });
     }
+  }
+);
+
+test(
+  "portal bootstrap does not preemptively redirect restricted routes before approved role revalidation",
+  { timeout: 60_000 },
+  async () => {
+    await assertRestrictedRouteHandoffRevalidation({
+      port: 4181,
+      provisionalRole: "collaborator",
+      revalidatedRole: "admin"
+    });
   }
 );

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -12,6 +12,7 @@ import {
   derivePortalRoles,
   mapPortalMutationErrorMessage,
   recoverPortalStateAfterAuthExpiry,
+  resolvePortalBootstrapRouteRedirect,
   renderPortalDeniedCard,
   renderPortalPendingCard,
   renderLocalPortalUnauthenticatedCard,
@@ -482,5 +483,54 @@ describe("PortalBootstrap auth handoff", () => {
     expect(firstHtml).toContain("Authenticated session");
     expect(secondHtml).toContain("Formal benchmark operations and contributor tooling.");
     expect(globalThis.document.cookie).toBe(handoffCookie);
+  });
+
+  it("defers insufficient-role redirects while an approved handoff is still provisional", () => {
+    globalThis.window = {
+      location: new URL(
+        "http://127.0.0.1/admin/users?surface=portal&access=approved&role=collaborator"
+      )
+    };
+
+    expect(
+      resolvePortalBootstrapRouteRedirect({
+        allowApprovedRouteRedirects: false,
+        pathname: "/admin/users",
+        routeDeniedReason: null,
+        search: "?surface=portal&access=approved&role=collaborator",
+        state: {
+          email: null,
+          role: "collaborator",
+          status: "approved"
+        },
+        surface: "portal"
+      })
+    ).toBeNull();
+  });
+
+  it("restores insufficient-role redirects after bootstrap revalidation", () => {
+    globalThis.window = {
+      location: new URL(
+        "http://127.0.0.1/admin/users?surface=portal&access=approved&role=collaborator"
+      )
+    };
+
+    const redirectTarget = resolvePortalBootstrapRouteRedirect({
+      pathname: "/admin/users",
+      routeDeniedReason: null,
+      search: "?surface=portal&access=approved&role=collaborator",
+      state: {
+        email: null,
+        role: "collaborator",
+        status: "approved"
+      },
+      surface: "portal"
+    });
+
+    expect(redirectTarget).not.toBeNull();
+    const redirectUrl = new URL(redirectTarget);
+
+    expect(redirectUrl.pathname).toBe("/denied");
+    expect(redirectUrl.searchParams.get("reason")).toBe("insufficient_role");
   });
 });

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { buildApprovedAuthHandoffCookieValue } from "../lib/approved-auth-handoff.ts";
 import {
   buildLocalPendingPortalUrl,
   reducePortalStateAfterAuthExpiry
 } from "./portal-bootstrap-state.ts";
 import {
+  PortalBootstrap,
   buildPortalBootstrapErrorState,
   fetchPortalBootstrapState,
   derivePortalRoles,
@@ -18,14 +20,20 @@ import {
 } from "./portal-bootstrap.tsx";
 
 const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
 
 afterEach(() => {
   if (originalWindow) {
     globalThis.window = originalWindow;
-    return;
+  } else {
+    delete globalThis.window;
   }
 
-  delete globalThis.window;
+  if (originalDocument) {
+    globalThis.document = originalDocument;
+  } else {
+    delete globalThis.document;
+  }
 });
 
 describe("portal bootstrap state", () => {
@@ -445,5 +453,34 @@ describe("recoverPortalStateAfterAuthExpiry", () => {
       status: "loading"
     });
     expect(fetchCalled).toBe(false);
+  });
+});
+
+describe("PortalBootstrap auth handoff", () => {
+  it("renders the portal shell immediately when a fresh approved handoff is present", () => {
+    const handoffCookie = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "admin",
+        status: "approved",
+        surface: "portal"
+      },
+      Date.now()
+    );
+
+    globalThis.window = {
+      location: new URL("https://portal.paretoproof.com/")
+    };
+    globalThis.document = {
+      cookie: handoffCookie
+    };
+
+    const firstHtml = renderToStaticMarkup(<PortalBootstrap />);
+    const secondHtml = renderToStaticMarkup(<PortalBootstrap />);
+
+    expect(firstHtml).not.toContain("Opening portal");
+    expect(firstHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(firstHtml).toContain("Authenticated session");
+    expect(secondHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(globalThis.document.cookie).toBe(handoffCookie);
   });
 });

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -6,6 +6,10 @@ import type {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
+import {
+  clearApprovedAuthHandoffCookie,
+  readApprovedAuthHandoffCookie
+} from "../lib/approved-auth-handoff";
 import { fetchApi, portalAuthExpiredEventName } from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { isLocalDevelopmentLocation } from "../lib/local-development";
@@ -252,9 +256,22 @@ type PortalBootstrapProps = {
 };
 
 export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
-  const [state, setState] = useState<PortalAccessState>({ status: "loading" });
-  const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
-  const localPreviewMode = useMemo(() => isLocalDevelopmentLocation(window.location), []);
+  const initialLocalPreviewMode = isLocalDevelopmentLocation(window.location);
+  const initialApiBaseUrl = getApiBaseUrl();
+  const initialApprovedHandoff = readApprovedAuthHandoffCookie(document.cookie, {
+    surface
+  });
+  const [state, setState] = useState<PortalAccessState>(
+    initialApprovedHandoff
+      ? {
+          email: null,
+          role: initialApprovedHandoff.role,
+          status: "approved"
+        }
+      : { status: "loading" }
+  );
+  const apiBaseUrl = useMemo(() => initialApiBaseUrl, []);
+  const localPreviewMode = useMemo(() => initialLocalPreviewMode, []);
   const localApiFallback = useMemo(() => isUsingImplicitLocalPortalApi(), []);
   const currentRelativeUrl = useMemo(() => getCurrentRelativeUrl(), []);
   const recoveryInFlightRef = useRef(false);
@@ -288,16 +305,24 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
   }, [state]);
 
   useEffect(() => {
+    if (!initialApprovedHandoff) {
+      return;
+    }
+
+    clearApprovedAuthHandoffCookie();
+  }, [initialApprovedHandoff]);
+
+  useEffect(() => {
     const controller = new AbortController();
     let active = true;
 
     async function loadAccessState() {
       try {
-        setState(
-          await fetchPortalBootstrapState(apiBaseUrl, {
-            signal: controller.signal
-          })
-        );
+        const nextState = await fetchPortalBootstrapState(apiBaseUrl, {
+          signal: controller.signal
+        });
+
+        setState(nextState);
       } catch (error) {
         if (controller.signal.aborted || !active) {
           return;
@@ -426,8 +451,8 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
     return (
       <PortalStatusCard
         eyebrow={surfaceLabel}
-        title="Checking access"
-        body={`Resolving your Cloudflare Access identity and ${describeSurfaceName(surface)} approval state.`}
+        title={`Opening ${describeSurfaceName(surface)}`}
+        body={`Checking your current sign-in and ${describeSurfaceName(surface)} approval state before loading the workspace.`}
       />
     );
   }

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -255,6 +255,48 @@ type PortalBootstrapProps = {
   surface?: AuthenticatedSurface;
 };
 
+type PortalBootstrapRouteRedirectInput = {
+  allowApprovedRouteRedirects?: boolean;
+  pathname: string;
+  routeDeniedReason: ReturnType<typeof readRouteDeniedReason>;
+  search: string;
+  state: PortalAccessState;
+  surface: AuthenticatedSurface;
+};
+
+export function resolvePortalBootstrapRouteRedirect({
+  allowApprovedRouteRedirects = true,
+  pathname,
+  routeDeniedReason,
+  search,
+  state,
+  surface
+}: PortalBootstrapRouteRedirectInput) {
+  if (
+    state.status === "loading" ||
+    state.status === "error" ||
+    state.status === "unauthenticated"
+  ) {
+    return null;
+  }
+
+  if (state.status === "approved" && !allowApprovedRouteRedirects) {
+    return null;
+  }
+
+  return resolveSurfaceRouteRedirect({
+    pathname,
+    reason:
+      state.status === "denied"
+        ? state.reason
+        : routeDeniedReason ?? undefined,
+    roles: state.status === "approved" ? derivePortalRoles(state.role) : [],
+    search,
+    status: state.status,
+    surface
+  });
+}
+
 export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
   const initialLocalPreviewMode = isLocalDevelopmentLocation(window.location);
   const initialApiBaseUrl = getApiBaseUrl();
@@ -270,6 +312,9 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
         }
       : { status: "loading" }
   );
+  const [hasRevalidatedSessionState, setHasRevalidatedSessionState] = useState(
+    !initialApprovedHandoff
+  );
   const apiBaseUrl = useMemo(() => initialApiBaseUrl, []);
   const localPreviewMode = useMemo(() => initialLocalPreviewMode, []);
   const localApiFallback = useMemo(() => isUsingImplicitLocalPortalApi(), []);
@@ -279,26 +324,16 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
   const surfaceLabel = describeSurfaceLabel(surface);
   const routeDeniedReason = readRouteDeniedReason();
   const routeRedirectTarget = useMemo(() => {
-    if (
-      state.status === "loading" ||
-      state.status === "error" ||
-      state.status === "unauthenticated"
-    ) {
-      return null;
-    }
-
-    return resolveSurfaceRouteRedirect({
+    return resolvePortalBootstrapRouteRedirect({
+      allowApprovedRouteRedirects:
+        state.status !== "approved" || hasRevalidatedSessionState,
       pathname: window.location.pathname,
-      reason:
-        state.status === "denied"
-          ? state.reason
-          : routeDeniedReason ?? undefined,
-      roles: state.status === "approved" ? derivePortalRoles(state.role) : [],
+      routeDeniedReason,
       search: window.location.search,
-      status: state.status,
+      state,
       surface
     });
-  }, [routeDeniedReason, state, surface]);
+  }, [hasRevalidatedSessionState, routeDeniedReason, state, surface]);
 
   useEffect(() => {
     stateRef.current = state;
@@ -322,12 +357,14 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
           signal: controller.signal
         });
 
+        setHasRevalidatedSessionState(true);
         setState(nextState);
       } catch (error) {
         if (controller.signal.aborted || !active) {
           return;
         }
 
+        setHasRevalidatedSessionState(true);
         setState(
           buildPortalBootstrapErrorState(error, {
             apiBaseUrl,


### PR DESCRIPTION
Closes #804.

## Summary
- add a short-lived cross-origin-safe approved auth handoff cookie between auth entry and portal bootstrap
- render the portal shell optimistically for fresh approved handoffs while `/portal/me` revalidates in the background
- add browser coverage for disagreeing `/portal/me` outcomes so the provisional approved shell falls back cleanly

## Verification
- `bun test apps/web/src/lib/approved-auth-handoff.test.js apps/web/src/routes/auth-entry.test.js apps/web/src/routes/portal-bootstrap.test.js`
- `bun --cwd apps/web typecheck`
- `bun run build`
- `bun --cwd apps/web test:layout`