### PR TITLE
Add truthful portal overview visualizations

### DIFF
--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -368,12 +368,6 @@ describe("PortalShell live overview helpers", () => {
         count: 4,
         label: "Failed runs",
         note: "Terminal runs that ended in failure."
-      },
-      {
-        accent: "mint",
-        count: 5,
-        label: "Other recorded runs",
-        note: "Runs not included in the active, queued, or failed summary slices."
       }
     ]);
   });

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -178,6 +178,18 @@ describe("PortalShell overview ordering", () => {
     );
   });
 
+  it("keeps overview visuals in the compact overview order", async () => {
+    const { getCompactOverviewSectionOrder } = await loadPortalShellModule();
+
+    expect(getCompactOverviewSectionOrder()).toEqual([
+      "recentRuns",
+      "metrics",
+      "visuals",
+      "overviewLead",
+      "actions"
+    ]);
+  });
+
   it("keeps the wide admin overview metric strip before the action rail", async () => {
     const html = await renderPortalShell({
       email: "ada@paretoproof.local",
@@ -315,6 +327,99 @@ describe("PortalShell live overview helpers", () => {
       detail: "The synced backend has not produced any benchmark runs.",
       headline: "No runs recorded yet."
     });
+  });
+
+  it("builds run-posture segments from the overview summary without inventing extra states", async () => {
+    const { buildOverviewRunPostureSegments } = await loadPortalShellModule();
+
+    expect(
+      buildOverviewRunPostureSegments({
+        benchmarkHighlights: [],
+        generatedAt: "2026-04-17T08:00:00.000Z",
+        recentIncidents: [],
+        recentRuns: [],
+        summary: {
+          activeLeases: 2,
+          activeRuns: 3,
+          failedRuns: 4,
+          observedBenchmarkPackageCount: 2,
+          queuedJobs: 5,
+          queuedRuns: 2,
+          runningJobs: 4,
+          staleLeaseCount: 1,
+          totalRuns: 14
+        }
+      })
+    ).toEqual([
+      {
+        accent: "indigo",
+        count: 3,
+        label: "Active runs",
+        note: "Currently running or mid-flight."
+      },
+      {
+        accent: "amber",
+        count: 2,
+        label: "Queued runs",
+        note: "Accepted by the control plane but not started."
+      },
+      {
+        accent: "rose",
+        count: 4,
+        label: "Failed runs",
+        note: "Terminal runs that ended in failure."
+      },
+      {
+        accent: "mint",
+        count: 5,
+        label: "Other recorded runs",
+        note: "Runs not included in the active, queued, or failed summary slices."
+      }
+    ]);
+  });
+
+  it("builds benchmark-activity segments with a truthful non-terminal remainder", async () => {
+    const { buildOverviewBenchmarkVisualSegments } = await loadPortalShellModule();
+
+    expect(
+      buildOverviewBenchmarkVisualSegments({
+        attemptCount: 9,
+        benchmarkLabel: "Problem 9",
+        benchmarkPackageId: "problem9",
+        latestCompletedAt: "2026-04-17T08:00:00.000Z",
+        latestRunId: "PP-401",
+        modelConfigIds: ["gpt-5.4-pro"],
+        providerFamilies: ["openai"],
+        runCount: 8,
+        versions: ["2026.04"],
+        verdictCounts: {
+          fail: 2,
+          invalid_result: 1,
+          pass: 3
+        }
+      })
+    ).toEqual([
+      {
+        accent: "mint",
+        count: 3,
+        label: "Pass verdicts"
+      },
+      {
+        accent: "rose",
+        count: 2,
+        label: "Fail verdicts"
+      },
+      {
+        accent: "amber",
+        count: 1,
+        label: "Invalid-result verdicts"
+      },
+      {
+        accent: "indigo",
+        count: 2,
+        label: "Runs outside verdict counts"
+      }
+    ]);
   });
 });
 

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -45,6 +45,19 @@ type PortalOverviewMetricCopy = {
   value: string;
 };
 
+type PortalOverviewRunPostureSegment = {
+  accent: "amber" | "indigo" | "mint" | "rose";
+  count: number;
+  label: string;
+  note: string;
+};
+
+type PortalOverviewBenchmarkVisualSegment = {
+  accent: "amber" | "indigo" | "mint" | "rose";
+  count: number;
+  label: string;
+};
+
 const portalRoutePathById = new Map<PortalRouteId, string>(
   appRouteAccessMatrix
     .filter((entry) => entry.surface === "portal")
@@ -259,7 +272,7 @@ export function describePortalOverviewRecentRunsFallback(
 }
 
 export function getCompactOverviewSectionOrder() {
-  return ["recentRuns", "metrics", "overviewLead", "actions"] as const;
+  return ["recentRuns", "metrics", "visuals", "overviewLead", "actions"] as const;
 }
 
 export function createPortalOverviewPollController() {
@@ -364,6 +377,82 @@ export function startPortalOverviewPolling({
   };
 }
 
+export function buildOverviewRunPostureSegments(
+  overviewData: PortalOverviewResponse | null
+): PortalOverviewRunPostureSegment[] {
+  if (!overviewData) {
+    return [];
+  }
+
+  const otherTerminalRuns = Math.max(
+    overviewData.summary.totalRuns -
+      overviewData.summary.activeRuns -
+      overviewData.summary.queuedRuns -
+      overviewData.summary.failedRuns,
+    0
+  );
+
+  return [
+    {
+      accent: "indigo",
+      count: overviewData.summary.activeRuns,
+      label: "Active runs",
+      note: "Currently running or mid-flight."
+    },
+    {
+      accent: "amber",
+      count: overviewData.summary.queuedRuns,
+      label: "Queued runs",
+      note: "Accepted by the control plane but not started."
+    },
+    {
+      accent: "rose",
+      count: overviewData.summary.failedRuns,
+      label: "Failed runs",
+      note: "Terminal runs that ended in failure."
+    },
+    {
+      accent: "mint",
+      count: otherTerminalRuns,
+      label: "Other recorded runs",
+      note: "Runs not included in the active, queued, or failed summary slices."
+    }
+  ];
+}
+
+export function buildOverviewBenchmarkVisualSegments(
+  benchmark: PortalOverviewResponse["benchmarkHighlights"][number]
+): PortalOverviewBenchmarkVisualSegment[] {
+  const terminalVerdictCount =
+    benchmark.verdictCounts.pass +
+    benchmark.verdictCounts.fail +
+    benchmark.verdictCounts.invalid_result;
+  const inFlightCount = Math.max(benchmark.runCount - terminalVerdictCount, 0);
+
+  return [
+    {
+      accent: "mint",
+      count: benchmark.verdictCounts.pass,
+      label: "Pass verdicts"
+    },
+    {
+      accent: "rose",
+      count: benchmark.verdictCounts.fail,
+      label: "Fail verdicts"
+    },
+    {
+      accent: "amber",
+      count: benchmark.verdictCounts.invalid_result,
+      label: "Invalid-result verdicts"
+    },
+    {
+      accent: "indigo",
+      count: inFlightCount,
+      label: "Runs outside verdict counts"
+    }
+  ];
+}
+
 export function PortalShell({ email, roles }: PortalShellProps) {
   const [navigationCollapsed, setNavigationCollapsed] = useState(false);
   const [overviewRefreshing, setOverviewRefreshing] = useState(false);
@@ -412,7 +501,20 @@ export function PortalShell({ email, roles }: PortalShellProps) {
     [activeRouteId]
   );
   const overviewData = overviewState.status === "ready" ? overviewState.data : null;
+  const overviewTotalRuns = overviewData?.summary.totalRuns ?? 0;
   const overviewMetricsCopy = useMemo(() => buildOverviewMetricsCopy(overviewData), [overviewData]);
+  const overviewRunPostureSegments = useMemo(
+    () => buildOverviewRunPostureSegments(overviewData),
+    [overviewData]
+  );
+  const overviewBenchmarkVisuals = useMemo(
+    () =>
+      overviewData?.benchmarkHighlights.slice(0, 3).map((benchmark) => ({
+        benchmark,
+        segments: buildOverviewBenchmarkVisualSegments(benchmark)
+      })) ?? [],
+    [overviewData]
+  );
 
   useEffect(() => {
     if (matchedPortalRoute || pathname === activeSectionHref || pathname.startsWith("/runs/")) {
@@ -532,6 +634,127 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       </article>
 
       {!compactLayout ? overviewActionRail : null}
+    </section>
+  );
+  const overviewVisualSection = (
+    <section className="portal-overview-grid portal-overview-visual-grid">
+      <article className="portal-panel portal-overview-visual-panel">
+        <div className="portal-panel-header">
+          <h2>Run posture</h2>
+          <span className="role-chip role-chip-tonal">
+            {overviewData ? `${overviewTotalRuns} total` : "Waiting for backend"}
+          </span>
+        </div>
+        <p className="portal-panel-muted">
+          Visual summary of the current overview payload. The slices below use only the landing
+          summary counts already returned by <code>/portal/overview</code>.
+        </p>
+        {overviewState.status === "error" ? (
+          <p className="portal-panel-muted">{overviewState.message}</p>
+        ) : overviewState.status === "loading" ? (
+          <p className="portal-panel-muted">Loading run posture from the backend.</p>
+        ) : overviewTotalRuns === 0 ? (
+          <p className="portal-panel-muted">
+            No runs are recorded yet, so there is no run-state distribution to visualize.
+          </p>
+        ) : (
+          <div className="portal-overview-visual-stack">
+            <div className="portal-overview-track" aria-hidden="true">
+              {overviewRunPostureSegments.map((segment) => (
+                <span
+                  className={`portal-overview-track-segment portal-overview-track-${segment.accent}`}
+                  key={segment.label}
+                  style={{
+                    width: `${(segment.count / Math.max(overviewTotalRuns, 1)) * 100}%`
+                  }}
+                />
+              ))}
+            </div>
+            <div className="portal-overview-visual-list" role="list" aria-label="Run posture">
+              {overviewRunPostureSegments.map((segment) => (
+                <article className="portal-overview-visual-row" key={segment.label} role="listitem">
+                  <div className="portal-overview-visual-label">
+                    <span
+                      aria-hidden="true"
+                      className={`portal-overview-swatch portal-overview-swatch-${segment.accent}`}
+                    />
+                    <div>
+                      <strong>{segment.label}</strong>
+                      <p>{segment.note}</p>
+                    </div>
+                  </div>
+                  <strong className="portal-overview-visual-value">{segment.count}</strong>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+      </article>
+
+      <article className="portal-panel portal-overview-visual-panel">
+        <div className="portal-panel-header">
+          <h2>Benchmark activity</h2>
+          <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+            Open runs
+          </a>
+        </div>
+        <p className="portal-panel-muted">
+          Top benchmark packages from the overview payload, with run counts and verdict posture.
+        </p>
+        {overviewState.status === "error" ? (
+          <p className="portal-panel-muted">{overviewState.message}</p>
+        ) : overviewState.status === "loading" ? (
+          <p className="portal-panel-muted">Loading benchmark activity from the backend.</p>
+        ) : overviewBenchmarkVisuals.length === 0 ? (
+          <p className="portal-panel-muted">
+            The backend has not observed benchmark activity yet, so there is nothing to compare.
+          </p>
+        ) : (
+          <div className="portal-overview-benchmark-visuals" role="list" aria-label="Benchmark activity">
+            {overviewBenchmarkVisuals.map(({ benchmark, segments }) => (
+              <article
+                className="portal-overview-benchmark-card"
+                key={`${benchmark.benchmarkPackageId}:${benchmark.latestRunId ?? "none"}`}
+                role="listitem"
+              >
+                <div className="portal-overview-benchmark-header">
+                  <div>
+                    <strong>{benchmark.benchmarkLabel}</strong>
+                    <p>{benchmark.benchmarkPackageId}</p>
+                  </div>
+                  <span className="role-chip role-chip-tonal">{benchmark.runCount} run(s)</span>
+                </div>
+                <div className="portal-overview-track" aria-hidden="true">
+                  {segments.map((segment) => (
+                    <span
+                      className={`portal-overview-track-segment portal-overview-track-${segment.accent}`}
+                      key={segment.label}
+                      style={{
+                        width: `${(segment.count / Math.max(benchmark.runCount, 1)) * 100}%`
+                      }}
+                    />
+                  ))}
+                </div>
+                <div className="portal-overview-benchmark-metadata">
+                  <span>Latest completion {formatPortalOverviewTimestamp(benchmark.latestCompletedAt)}</span>
+                  <span>{benchmark.versions.join(", ")}</span>
+                </div>
+                <div className="portal-overview-benchmark-segment-list">
+                  {segments.map((segment) => (
+                    <span className="portal-overview-benchmark-segment" key={segment.label}>
+                      <span
+                        aria-hidden="true"
+                        className={`portal-overview-swatch portal-overview-swatch-${segment.accent}`}
+                      />
+                      {segment.label}: {segment.count}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </article>
     </section>
   );
   const overviewRecentRunsFallback = describePortalOverviewRecentRunsFallback(overviewState);
@@ -758,7 +981,8 @@ export function PortalShell({ email, roles }: PortalShellProps) {
                     actions: overviewActionRail,
                     metrics: overviewMetricStrip,
                     overviewLead: overviewLeadSection,
-                    recentRuns: overviewRecentRunsSection
+                    recentRuns: overviewRecentRunsSection,
+                    visuals: overviewVisualSection
                   };
 
                   return <Fragment key={sectionId}>{sections[sectionId]}</Fragment>;
@@ -766,6 +990,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
               : (
                   <>
                     {overviewMetricStrip}
+                    {overviewVisualSection}
                     {overviewLeadSection}
                     {overviewRecentRunsSection}
                   </>

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -384,14 +384,6 @@ export function buildOverviewRunPostureSegments(
     return [];
   }
 
-  const otherTerminalRuns = Math.max(
-    overviewData.summary.totalRuns -
-      overviewData.summary.activeRuns -
-      overviewData.summary.queuedRuns -
-      overviewData.summary.failedRuns,
-    0
-  );
-
   return [
     {
       accent: "indigo",
@@ -410,12 +402,6 @@ export function buildOverviewRunPostureSegments(
       count: overviewData.summary.failedRuns,
       label: "Failed runs",
       note: "Terminal runs that ended in failure."
-    },
-    {
-      accent: "mint",
-      count: otherTerminalRuns,
-      label: "Other recorded runs",
-      note: "Runs not included in the active, queued, or failed summary slices."
     }
   ];
 }
@@ -506,6 +492,10 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   const overviewRunPostureSegments = useMemo(
     () => buildOverviewRunPostureSegments(overviewData),
     [overviewData]
+  );
+  const overviewRunPostureScale = useMemo(
+    () => Math.max(...overviewRunPostureSegments.map((segment) => segment.count), 1),
+    [overviewRunPostureSegments]
   );
   const overviewBenchmarkVisuals = useMemo(
     () =>
@@ -646,8 +636,10 @@ export function PortalShell({ email, roles }: PortalShellProps) {
           </span>
         </div>
         <p className="portal-panel-muted">
-          Visual summary of the current overview payload. The slices below use only the landing
-          summary counts already returned by <code>/portal/overview</code>.
+          Visual summary of the current overview payload. This chart only visualizes the explicit
+          active, queued, and failed counts already returned by <code>/portal/overview</code>; the
+          total badge stays separate because the remainder is not broken out by the landing
+          summary.
         </p>
         {overviewState.status === "error" ? (
           <p className="portal-panel-muted">{overviewState.message}</p>
@@ -659,28 +651,27 @@ export function PortalShell({ email, roles }: PortalShellProps) {
           </p>
         ) : (
           <div className="portal-overview-visual-stack">
-            <div className="portal-overview-track" aria-hidden="true">
-              {overviewRunPostureSegments.map((segment) => (
-                <span
-                  className={`portal-overview-track-segment portal-overview-track-${segment.accent}`}
-                  key={segment.label}
-                  style={{
-                    width: `${(segment.count / Math.max(overviewTotalRuns, 1)) * 100}%`
-                  }}
-                />
-              ))}
-            </div>
             <div className="portal-overview-visual-list" role="list" aria-label="Run posture">
               {overviewRunPostureSegments.map((segment) => (
                 <article className="portal-overview-visual-row" key={segment.label} role="listitem">
-                  <div className="portal-overview-visual-label">
-                    <span
-                      aria-hidden="true"
-                      className={`portal-overview-swatch portal-overview-swatch-${segment.accent}`}
-                    />
-                    <div>
-                      <strong>{segment.label}</strong>
-                      <p>{segment.note}</p>
+                  <div className="portal-overview-visual-row-main">
+                    <div className="portal-overview-visual-label">
+                      <span
+                        aria-hidden="true"
+                        className={`portal-overview-swatch portal-overview-swatch-${segment.accent}`}
+                      />
+                      <div>
+                        <strong>{segment.label}</strong>
+                        <p>{segment.note}</p>
+                      </div>
+                    </div>
+                    <div className="portal-overview-track" aria-hidden="true">
+                      <span
+                        className={`portal-overview-track-segment portal-overview-track-${segment.accent}`}
+                        style={{
+                          width: `${(segment.count / overviewRunPostureScale) * 100}%`
+                        }}
+                      />
                     </div>
                   </div>
                   <strong className="portal-overview-visual-value">{segment.count}</strong>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1556,6 +1556,13 @@ a.button-secondary {
   gap: 10px;
 }
 
+.portal-overview-visual-row-main {
+  display: grid;
+  flex: 1 1 auto;
+  gap: 10px;
+  min-width: 0;
+}
+
 .portal-overview-visual-label strong,
 .portal-overview-benchmark-header strong {
   display: block;

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1420,6 +1420,10 @@ a.button-secondary {
   grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.92fr);
 }
 
+.portal-overview-visual-grid {
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+}
+
 .portal-grid-profile-compact .portal-panel {
   gap: 8px;
   padding-top: 8px;
@@ -1487,6 +1491,126 @@ a.button-secondary {
   border-radius: 0;
   padding: 14px 0 0;
   background: transparent;
+}
+
+.portal-overview-visual-panel {
+  gap: 14px;
+  padding-top: 14px;
+}
+
+.portal-overview-visual-stack,
+.portal-overview-benchmark-visuals {
+  display: grid;
+  gap: 12px;
+}
+
+.portal-overview-track {
+  display: flex;
+  min-height: 12px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(17, 42, 103, 0.05);
+}
+
+.portal-overview-track-segment {
+  min-width: 0;
+}
+
+.portal-overview-track-mint,
+.portal-overview-swatch-mint {
+  background: rgba(14, 139, 115, 0.82);
+}
+
+.portal-overview-track-amber,
+.portal-overview-swatch-amber {
+  background: rgba(185, 117, 20, 0.82);
+}
+
+.portal-overview-track-rose,
+.portal-overview-swatch-rose {
+  background: rgba(168, 71, 94, 0.84);
+}
+
+.portal-overview-track-indigo,
+.portal-overview-swatch-indigo {
+  background: rgba(79, 70, 229, 0.82);
+}
+
+.portal-overview-visual-list {
+  display: grid;
+  gap: 10px;
+}
+
+.portal-overview-visual-row,
+.portal-overview-benchmark-header,
+.portal-overview-benchmark-metadata {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.portal-overview-visual-label {
+  display: flex;
+  gap: 10px;
+}
+
+.portal-overview-visual-label strong,
+.portal-overview-benchmark-header strong {
+  display: block;
+  font-weight: 700;
+}
+
+.portal-overview-visual-label p,
+.portal-overview-benchmark-header p,
+.portal-overview-benchmark-metadata,
+.portal-overview-benchmark-segment {
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+
+.portal-overview-visual-value {
+  font-size: 1.2rem;
+  letter-spacing: -0.03em;
+}
+
+.portal-overview-swatch {
+  display: inline-flex;
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  margin-top: 0.38rem;
+  border-radius: 999px;
+}
+
+.portal-overview-benchmark-card {
+  display: grid;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.portal-overview-benchmark-card:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.portal-overview-benchmark-metadata {
+  font-size: 0.84rem;
+}
+
+.portal-overview-benchmark-segment-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.portal-overview-benchmark-segment {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.84rem;
 }
 
 .portal-freshness-card {
@@ -2501,6 +2625,10 @@ a.button-secondary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .portal-overview-visual-grid {
+    grid-template-columns: 1fr;
+  }
+
   .portal-admin-layout,
   .portal-admin-detail-columns,
   .portal-admin-summary-grid,
@@ -2573,6 +2701,12 @@ a.button-secondary {
   .portal-shell {
     padding: 10px;
     display: flex;
+    flex-direction: column;
+  }
+
+  .portal-overview-benchmark-header,
+  .portal-overview-benchmark-metadata,
+  .portal-overview-visual-row {
     flex-direction: column;
   }
 
@@ -2988,6 +3122,10 @@ a.button-secondary {
   .portal-overview-actions-compact .portal-action-copy,
   .portal-overview-actions-compact .portal-action-hint {
     display: none;
+  }
+
+  .portal-overview-benchmark-segment-list {
+    gap: 6px 8px;
   }
 
   .portal-launch-quick-actions {


### PR DESCRIPTION
## Summary
- add payload-backed portal overview visual summaries for run posture and benchmark activity
- keep the new visuals truthful to the current `/portal/overview` contract without implying unsupported lifecycle precision
- add focused overview helper coverage and compact-order coverage for the new sections

## Testing
- `bun run build:shared`
- `bun test apps/web/src/routes/portal-shell.test.js`
- `bun --cwd apps/web typecheck`
- `bun --cwd apps/web build`
- browser QA on desktop and compact overview layouts with mocked `/portal/me` and `/portal/overview`

Closes #802