### PR TITLE
[API] Extract math-aware authenticated surface and trusted-origin boundaries

### DIFF
--- a/apps/api/src/auth/require-access.ts
+++ b/apps/api/src/auth/require-access.ts
@@ -16,6 +16,7 @@ import {
   type ResolvedPortalAccessSession
 } from "./portal-access-session.js";
 import type { ApiRuntimeEnv } from "../config/runtime.js";
+import { usesAuthenticatedSurfaceSession } from "../lib/authenticated-surface.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
 type RouteAccessRequirement =
@@ -112,7 +113,7 @@ async function resolveRequestAccess(
     typeof request.headers.cookie === "string" ? request.headers.cookie : undefined;
 
   if (!assertion) {
-    if (routePath.startsWith("/portal/")) {
+    if (usesAuthenticatedSurfaceSession(routePath)) {
       const cachedSession = await resolvePortalAccessSession(db, cookieHeader, {
         teamDomain: options?.teamDomain
       });

--- a/apps/api/src/lib/authenticated-surface.ts
+++ b/apps/api/src/lib/authenticated-surface.ts
@@ -1,0 +1,120 @@
+import { findAppRouteBySurface } from "@paretoproof/shared";
+import type { ApiRuntimeEnv } from "../config/runtime.js";
+
+export type AuthenticatedSurface = "portal" | "math";
+
+export type AuthenticatedSurfaceRuntimeConfig = Pick<
+  ApiRuntimeEnv,
+  "mathPublicOrigin" | "portalPublicOrigin"
+>;
+
+type AuthenticatedContinuationInput = {
+  app?: string | null;
+  redirect?: string | null;
+};
+
+export function readAuthenticatedSurface(
+  surface: string | null | undefined,
+): AuthenticatedSurface {
+  return surface === "math" ? "math" : "portal";
+}
+
+export function readAuthenticatedSurfaceRouteFamily(routePath: string) {
+  if (routePath === "/portal" || routePath.startsWith("/portal/")) {
+    return "portal";
+  }
+
+  if (routePath === "/math" || routePath.startsWith("/math/")) {
+    return "math";
+  }
+
+  return null;
+}
+
+export function usesAuthenticatedSurfaceSession(routePath: string) {
+  return readAuthenticatedSurfaceRouteFamily(routePath) !== null;
+}
+
+export function readAuthenticatedSurfaceOrigin(
+  runtimeConfig: AuthenticatedSurfaceRuntimeConfig,
+  targetSurface: AuthenticatedSurface,
+) {
+  return targetSurface === "math"
+    ? runtimeConfig.mathPublicOrigin
+    : runtimeConfig.portalPublicOrigin;
+}
+
+export function sanitizeAuthenticatedRedirectPath(
+  rawRedirectPath: string | null | undefined,
+  targetSurface: AuthenticatedSurface,
+  runtimeConfig: AuthenticatedSurfaceRuntimeConfig,
+) {
+  if (!rawRedirectPath || rawRedirectPath === "/") {
+    return "/";
+  }
+
+  if (
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) ||
+    rawRedirectPath.startsWith("//")
+  ) {
+    return "/";
+  }
+
+  try {
+    const targetOrigin = readAuthenticatedSurfaceOrigin(
+      runtimeConfig,
+      targetSurface,
+    );
+    const candidateUrl = new URL(
+      rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
+      targetOrigin,
+    );
+
+    if (
+      candidateUrl.origin !== targetOrigin ||
+      !findAppRouteBySurface(targetSurface, candidateUrl.pathname)
+    ) {
+      return "/";
+    }
+
+    return (
+      `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` ||
+      "/"
+    );
+  } catch {
+    return "/";
+  }
+}
+
+export function readAuthenticatedContinuation(
+  input: {
+    body?: AuthenticatedContinuationInput | null;
+    query?: AuthenticatedContinuationInput | null;
+  },
+  runtimeConfig: AuthenticatedSurfaceRuntimeConfig,
+) {
+  const targetSurface = readAuthenticatedSurface(
+    input.body?.app ?? input.query?.app ?? null,
+  );
+  const redirectPath = sanitizeAuthenticatedRedirectPath(
+    input.body?.redirect ?? input.query?.redirect ?? null,
+    targetSurface,
+    runtimeConfig,
+  );
+
+  return {
+    redirectPath,
+    targetSurface,
+  };
+}
+
+export function buildAuthenticatedContinuationUrl(
+  redirectPath: string,
+  targetSurface: AuthenticatedSurface,
+  runtimeConfig: AuthenticatedSurfaceRuntimeConfig,
+) {
+  return new URL(
+    redirectPath,
+    readAuthenticatedSurfaceOrigin(runtimeConfig, targetSurface),
+  );
+}

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -1,5 +1,4 @@
 import {
-  findAppRouteBySurface,
   portalBenchmarkOpsReadModelsContract,
   portalBenchmarkDatasetParamsSchema,
   portalBenchmarkExportQuerySchema,
@@ -38,6 +37,12 @@ import {
   matchesUserIdentityProviderSubject,
 } from "../lib/identity-binding.js";
 import {
+  buildAuthenticatedContinuationUrl,
+  readAuthenticatedContinuation,
+  sanitizeAuthenticatedRedirectPath,
+  type AuthenticatedSurface,
+} from "../lib/authenticated-surface.js";
+import {
   createPortalBenchmarkOpsReadModelService,
   type PortalBenchmarkOpsReadModelService,
 } from "../lib/portal-benchmark-ops.js";
@@ -69,8 +74,6 @@ import {
   isAllowedBrandedAuthOrigin,
   normalizeOrigin,
 } from "../server/trusted-mutation-origin.js";
-
-type AuthenticatedSurface = "portal" | "math";
 
 class PortalAccessRequestConflictError extends Error {
   constructor(message: string) {
@@ -125,62 +128,7 @@ type PortalRouteRuntimeConfig = Pick<
   | "portalPublicOrigin"
 >;
 
-function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
-  return surface === "math" ? "math" : "portal";
-}
-
-function readAuthenticatedSurfaceOrigin(
-  runtimeConfig: PortalRouteRuntimeConfig,
-  targetSurface: AuthenticatedSurface,
-) {
-  return targetSurface === "math"
-    ? runtimeConfig.mathPublicOrigin
-    : runtimeConfig.portalPublicOrigin;
-}
-
-function sanitizeAuthenticatedRedirectPath(
-  rawRedirectPath: string | null,
-  targetSurface: AuthenticatedSurface,
-  runtimeConfig: PortalRouteRuntimeConfig,
-) {
-  if (!rawRedirectPath || rawRedirectPath === "/") {
-    return "/";
-  }
-
-  if (
-    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) ||
-    rawRedirectPath.startsWith("//")
-  ) {
-    return "/";
-  }
-
-  try {
-    const targetOrigin = readAuthenticatedSurfaceOrigin(
-      runtimeConfig,
-      targetSurface,
-    );
-    const candidateUrl = new URL(
-      rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      targetOrigin,
-    );
-
-    if (
-      candidateUrl.origin !== targetOrigin ||
-      !findAppRouteBySurface(targetSurface, candidateUrl.pathname)
-    ) {
-      return "/";
-    }
-
-    return (
-      `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` ||
-      "/"
-    );
-  } catch {
-    return "/";
-  }
-}
-
-function readAuthenticatedContinuation(
+function readRequestAuthenticatedContinuation(
   request: FastifyRequest,
   runtimeConfig: PortalRouteRuntimeConfig,
 ) {
@@ -190,29 +138,12 @@ function readAuthenticatedContinuation(
       : undefined;
   const query =
     (request.query as { app?: string; redirect?: string } | undefined) ?? {};
-  const targetSurface = readAuthenticatedSurface(
-    parsedBody?.app ?? query.app ?? null,
-  );
-  const redirectPath = sanitizeAuthenticatedRedirectPath(
-    parsedBody?.redirect ?? query.redirect ?? null,
-    targetSurface,
+  return readAuthenticatedContinuation(
+    {
+      body: parsedBody,
+      query,
+    },
     runtimeConfig,
-  );
-
-  return {
-    redirectPath,
-    targetSurface,
-  };
-}
-
-function buildAuthenticatedContinuationUrl(
-  redirectPath: string,
-  targetSurface: AuthenticatedSurface,
-  runtimeConfig: PortalRouteRuntimeConfig,
-) {
-  return new URL(
-    redirectPath,
-    readAuthenticatedSurfaceOrigin(runtimeConfig, targetSurface),
   );
 }
 
@@ -552,7 +483,7 @@ export function registerPortalRoutes(
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
-    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+    const { redirectPath, targetSurface } = readRequestAuthenticatedContinuation(
       request,
       runtimeConfig,
     );
@@ -580,7 +511,7 @@ export function registerPortalRoutes(
         : undefined;
     const identity = request.accessIdentity;
     const accessContext = request.accessRbacContext;
-    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+    const { redirectPath, targetSurface } = readRequestAuthenticatedContinuation(
       request,
       runtimeConfig,
     );
@@ -783,7 +714,7 @@ export function registerPortalRoutes(
     request: FastifyRequest,
     reply: FastifyReply,
   ) => {
-    const { redirectPath, targetSurface } = readAuthenticatedContinuation(
+    const { redirectPath, targetSurface } = readRequestAuthenticatedContinuation(
       request,
       runtimeConfig,
     );

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -74,7 +74,6 @@ export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
 export function readTrustedMutationOrigins(
   runtimeEnv: ApiRuntimeEnv,
 ): TrustedMutationOriginsBySurface {
-  const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
   const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
   const mathPublicOrigin = normalizeOrigin(runtimeEnv.mathPublicOrigin);
   const includesDefaultSurfaceOrigins =
@@ -87,17 +86,7 @@ export function readTrustedMutationOrigins(
 
   return {
     math: includeMathPublicOrigin ? [mathPublicOrigin] : [],
-    portal: [
-      ...new Set(
-        [portalPublicOrigin, ...runtimeEnv.corsAllowedOrigins]
-          .map(normalizeOrigin)
-          .filter(
-            (origin) =>
-              origin === portalPublicOrigin ||
-              (origin !== mathPublicOrigin && !brandedAuthOrigins.has(origin)),
-          ),
-      ),
-    ],
+    portal: [portalPublicOrigin],
   };
 }
 

--- a/apps/api/src/server/build-server.ts
+++ b/apps/api/src/server/build-server.ts
@@ -28,6 +28,7 @@ import {
   isAllowedLocalBrandedAuthOrigin,
   isAllowedLocalOrigin,
   normalizeOrigin,
+  type TrustedMutationOriginsBySurface,
 } from "./trusted-mutation-origin.js";
 import type { ReturnTypeOfCreateDbClient } from "../types/db-client.js";
 
@@ -70,22 +71,34 @@ export function readAllowedCorsOrigins(runtimeEnv: ApiRuntimeEnv) {
   ];
 }
 
-export function readTrustedMutationOrigins(runtimeEnv: ApiRuntimeEnv) {
+export function readTrustedMutationOrigins(
+  runtimeEnv: ApiRuntimeEnv,
+): TrustedMutationOriginsBySurface {
   const brandedAuthOrigins = new Set(readBrandedAuthOrigins(runtimeEnv));
   const portalPublicOrigin = normalizeOrigin(runtimeEnv.portalPublicOrigin);
   const mathPublicOrigin = normalizeOrigin(runtimeEnv.mathPublicOrigin);
+  const includesDefaultSurfaceOrigins =
+    normalizeOrigin(runtimeEnv.authPublicOrigin) ===
+      normalizeOrigin(defaultApiAuthPublicOrigin) &&
+    portalPublicOrigin === normalizeOrigin(defaultApiPortalPublicOrigin);
+  const includeMathPublicOrigin =
+    mathPublicOrigin !== normalizeOrigin(defaultApiMathPublicOrigin) ||
+    includesDefaultSurfaceOrigins;
 
-  return [
-    ...new Set(
-      [portalPublicOrigin, ...runtimeEnv.corsAllowedOrigins]
-        .map(normalizeOrigin)
-        .filter(
-          (origin) =>
-            origin === portalPublicOrigin ||
-            (origin !== mathPublicOrigin && !brandedAuthOrigins.has(origin)),
-        ),
-    ),
-  ];
+  return {
+    math: includeMathPublicOrigin ? [mathPublicOrigin] : [],
+    portal: [
+      ...new Set(
+        [portalPublicOrigin, ...runtimeEnv.corsAllowedOrigins]
+          .map(normalizeOrigin)
+          .filter(
+            (origin) =>
+              origin === portalPublicOrigin ||
+              (origin !== mathPublicOrigin && !brandedAuthOrigins.has(origin)),
+          ),
+      ),
+    ],
+  };
 }
 
 function usesBrandedFinalizeSubmitCorsBoundary(
@@ -226,7 +239,7 @@ export async function buildServer(
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: allowLocalhostCors,
-      allowedOrigins: trustedMutationOrigins,
+      allowedOriginsBySurface: trustedMutationOrigins,
       brandedAuthOrigins,
     }),
   );

--- a/apps/api/src/server/trusted-mutation-origin.ts
+++ b/apps/api/src/server/trusted-mutation-origin.ts
@@ -3,6 +3,10 @@ import type {
   FastifyRequest,
   HookHandlerDoneFunction,
 } from "fastify";
+import {
+  readAuthenticatedSurfaceRouteFamily,
+  type AuthenticatedSurface,
+} from "../lib/authenticated-surface.js";
 
 export function normalizeOrigin(value: string) {
   return value.replace(/\/+$/, "");
@@ -61,21 +65,32 @@ export function shouldEnforceTrustedMutationOrigin(
   method: string,
   routePath: string,
 ) {
-  return (
-    method !== "GET" &&
-    method !== "HEAD" &&
-    method !== "OPTIONS" &&
-    routePath.startsWith("/portal/")
-  );
+  return readTrustedMutationSurface(method, routePath) !== null;
 }
 
 function allowsBrandedFinalizeSubmitOrigin(method: string, routePath: string) {
   return method === "POST" && routePath === "/portal/session/finalize/submit";
 }
 
+function readTrustedMutationSurface(
+  method: string,
+  routePath: string,
+): AuthenticatedSurface | null {
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") {
+    return null;
+  }
+
+  return readAuthenticatedSurfaceRouteFamily(routePath);
+}
+
+export type TrustedMutationOriginsBySurface = Record<
+  AuthenticatedSurface,
+  string[]
+>;
+
 export function createTrustedMutationOriginHook(options: {
   allowLocalhostOrigins: boolean;
-  allowedOrigins: string[];
+  allowedOriginsBySurface: TrustedMutationOriginsBySurface;
   brandedAuthOrigins?: string[];
 }) {
   return (
@@ -84,8 +99,9 @@ export function createTrustedMutationOriginHook(options: {
     done: HookHandlerDoneFunction,
   ) => {
     const routePath = request.routeOptions.url ?? request.raw.url ?? "";
+    const trustedSurface = readTrustedMutationSurface(request.method, routePath);
 
-    if (!shouldEnforceTrustedMutationOrigin(request.method, routePath)) {
+    if (!trustedSurface) {
       done();
       return;
     }
@@ -110,7 +126,10 @@ export function createTrustedMutationOriginHook(options: {
       origin: requestOrigin,
     });
     const originAllowed =
-      (options.allowedOrigins.includes(requestOrigin) && !brandedAuthOrigin) ||
+      (
+        options.allowedOriginsBySurface[trustedSurface].includes(requestOrigin) &&
+        !brandedAuthOrigin
+      ) ||
       (brandedAuthOrigin &&
         allowsBrandedFinalizeSubmitOrigin(request.method, routePath)) ||
       (isAllowedBrandedAuthOrigin({

--- a/apps/api/test/authenticated-surface.test.ts
+++ b/apps/api/test/authenticated-surface.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildAuthenticatedContinuationUrl,
+  readAuthenticatedContinuation,
+  readAuthenticatedSurfaceRouteFamily,
+  sanitizeAuthenticatedRedirectPath,
+} from "../src/lib/authenticated-surface.ts";
+
+const runtimeConfig = {
+  mathPublicOrigin: "https://math.preview.paretoproof.com",
+  portalPublicOrigin: "https://portal.preview.paretoproof.com",
+};
+
+test("readAuthenticatedSurfaceRouteFamily distinguishes portal, math, and non-app routes", () => {
+  assert.equal(readAuthenticatedSurfaceRouteFamily("/portal"), "portal");
+  assert.equal(readAuthenticatedSurfaceRouteFamily("/portal/profile"), "portal");
+  assert.equal(readAuthenticatedSurfaceRouteFamily("/math"), "math");
+  assert.equal(readAuthenticatedSurfaceRouteFamily("/math/questions/q_123"), "math");
+  assert.equal(readAuthenticatedSurfaceRouteFamily("/internal/workers/claim"), null);
+});
+
+test("sanitizeAuthenticatedRedirectPath keeps callers inside the requested authenticated surface", () => {
+  assert.equal(
+    sanitizeAuthenticatedRedirectPath("/launch", "math", runtimeConfig),
+    "/launch",
+  );
+  assert.equal(
+    sanitizeAuthenticatedRedirectPath("/profile", "math", runtimeConfig),
+    "/",
+  );
+  assert.equal(
+    sanitizeAuthenticatedRedirectPath(
+      "https://portal.preview.paretoproof.com/profile",
+      "math",
+      runtimeConfig,
+    ),
+    "/",
+  );
+});
+
+test("readAuthenticatedContinuation gives body values precedence over query values", () => {
+  assert.deepEqual(
+    readAuthenticatedContinuation(
+      {
+        body: {
+          app: "math",
+          redirect: "/launch",
+        },
+        query: {
+          app: "portal",
+          redirect: "/profile",
+        },
+      },
+      runtimeConfig,
+    ),
+    {
+      redirectPath: "/launch",
+      targetSurface: "math",
+    },
+  );
+});
+
+test("buildAuthenticatedContinuationUrl resolves redirects against the requested surface origin", () => {
+  assert.equal(
+    buildAuthenticatedContinuationUrl("/launch", "math", runtimeConfig).toString(),
+    "https://math.preview.paretoproof.com/launch",
+  );
+  assert.equal(
+    buildAuthenticatedContinuationUrl("/profile", "portal", runtimeConfig).toString(),
+    "https://portal.preview.paretoproof.com/profile",
+  );
+});

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -77,7 +77,7 @@ test("readAllowedCorsOrigins excludes the default production math host when prev
   );
 });
 
-test("readTrustedMutationOrigins keeps portal and math mutation allowlists scoped to their own surfaces", () => {
+test("readTrustedMutationOrigins scopes mutation allowlists to canonical surface origins only", () => {
   const origins = readTrustedMutationOrigins({
     authPublicOrigin: "https://auth.preview.paretoproof.com",
     brandedAuthOrigins: [
@@ -97,16 +97,64 @@ test("readTrustedMutationOrigins keeps portal and math mutation allowlists scope
 
   assert.deepEqual(origins, {
     math: ["https://math.preview.paretoproof.com"],
-    portal: [
-      "https://portal.preview.paretoproof.com",
-      "https://portal-canary.preview.paretoproof.com",
-    ],
+    portal: ["https://portal.preview.paretoproof.com"],
   });
   assert.equal(origins.portal.includes("https://math.preview.paretoproof.com"), false);
+  assert.equal(
+    origins.portal.includes("https://portal-canary.preview.paretoproof.com"),
+    false,
+  );
   assert.equal(
     origins.portal.includes("https://github.auth.preview.paretoproof.com"),
     false,
   );
+});
+
+test("readTrustedMutationOrigins ignores extra preview aliases when math keeps the default production origin", () => {
+  const origins = readTrustedMutationOrigins({
+    authPublicOrigin: "https://auth.preview.paretoproof.com",
+    brandedAuthOrigins: [
+      "https://auth.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+      "https://google.auth.preview.paretoproof.com",
+    ],
+    corsAllowedOrigins: [
+      "https://portal-canary.preview.paretoproof.com",
+      "https://math.preview.paretoproof.com",
+      "https://reports.preview.paretoproof.com",
+      "https://github.auth.preview.paretoproof.com",
+    ],
+    mathPublicOrigin: "https://math.paretoproof.com",
+    portalPublicOrigin: "https://portal.preview.paretoproof.com",
+  } as never);
+
+  assert.deepEqual(origins, {
+    math: [],
+    portal: ["https://portal.preview.paretoproof.com"],
+  });
+  assert.equal(origins.portal.includes("https://math.preview.paretoproof.com"), false);
+  assert.equal(
+    origins.portal.includes("https://reports.preview.paretoproof.com"),
+    false,
+  );
+});
+
+test("readTrustedMutationOrigins does not infer trusted mutation surfaces from CORS hostnames", () => {
+  const origins = readTrustedMutationOrigins({
+    authPublicOrigin: "https://auth.example.com",
+    brandedAuthOrigins: ["https://auth.example.com"],
+    corsAllowedOrigins: [
+      "https://app-canary.example.com",
+      "https://app-math-preview.example.com",
+    ],
+    mathPublicOrigin: "https://app-math.example.com",
+    portalPublicOrigin: "https://app.example.com",
+  } as never);
+
+  assert.deepEqual(origins, {
+    math: ["https://app-math.example.com"],
+    portal: ["https://app.example.com"],
+  });
 });
 
 test("readBrandedAuthOrigins excludes the portal origin when auth and portal share one origin", () => {

--- a/apps/api/test/build-server.test.ts
+++ b/apps/api/test/build-server.test.ts
@@ -77,8 +77,9 @@ test("readAllowedCorsOrigins excludes the default production math host when prev
   );
 });
 
-test("readTrustedMutationOrigins keeps math out of the generic trusted portal mutation allowlist", () => {
+test("readTrustedMutationOrigins keeps portal and math mutation allowlists scoped to their own surfaces", () => {
   const origins = readTrustedMutationOrigins({
+    authPublicOrigin: "https://auth.preview.paretoproof.com",
     brandedAuthOrigins: [
       "https://auth.preview.paretoproof.com",
       "https://github.auth.preview.paretoproof.com",
@@ -94,13 +95,16 @@ test("readTrustedMutationOrigins keeps math out of the generic trusted portal mu
     portalPublicOrigin: "https://portal.preview.paretoproof.com",
   } as never);
 
-  assert.deepEqual(origins, [
-    "https://portal.preview.paretoproof.com",
-    "https://portal-canary.preview.paretoproof.com",
-  ]);
-  assert.equal(origins.includes("https://math.preview.paretoproof.com"), false);
+  assert.deepEqual(origins, {
+    math: ["https://math.preview.paretoproof.com"],
+    portal: [
+      "https://portal.preview.paretoproof.com",
+      "https://portal-canary.preview.paretoproof.com",
+    ],
+  });
+  assert.equal(origins.portal.includes("https://math.preview.paretoproof.com"), false);
   assert.equal(
-    origins.includes("https://github.auth.preview.paretoproof.com"),
+    origins.portal.includes("https://github.auth.preview.paretoproof.com"),
     false,
   );
 });

--- a/apps/api/test/cloudflare-access.test.ts
+++ b/apps/api/test/cloudflare-access.test.ts
@@ -238,6 +238,116 @@ test("createAccessResolver accepts an opaque portal access session when the DB s
   }
 });
 
+test("createAccessResolver also accepts an opaque portal access session on math routes", async () => {
+  const originalEnv = {
+    ACCESS_PROVIDER_STATE_SECRET: process.env.ACCESS_PROVIDER_STATE_SECRET,
+    CF_ACCESS_BRANDED_AUDS: process.env.CF_ACCESS_BRANDED_AUDS,
+    CF_ACCESS_PORTAL_AUD: process.env.CF_ACCESS_PORTAL_AUD,
+    CF_ACCESS_TEAM_DOMAIN: process.env.CF_ACCESS_TEAM_DOMAIN,
+  };
+
+  process.env.ACCESS_PROVIDER_STATE_SECRET = "wrong-env-secret";
+  process.env.CF_ACCESS_BRANDED_AUDS = "wrong-branded-audience";
+  process.env.CF_ACCESS_PORTAL_AUD = "wrong-portal-audience";
+  process.env.CF_ACCESS_TEAM_DOMAIN = "wrong-team.example";
+
+  try {
+    let touchedSession = false;
+    const resolveAccess = createAccessResolver(
+      {
+        query: {
+          sessions: {
+            findFirst: async () => ({
+              expiresAt: new Date(Date.now() + 60_000),
+              id: "session-1",
+              identity: {
+                id: "identity-1",
+                provider: "cloudflare_google",
+                providerEmail: "person@example.com",
+                providerSubject: "subject-1",
+                user: {
+                  email: "person@example.com",
+                  id: "user-1",
+                },
+              },
+              revokedAt: null,
+            }),
+          },
+          userIdentities: {
+            findFirst: async () => ({
+              id: "identity-1",
+              provider: "cloudflare_google",
+              providerEmail: "person@example.com",
+              providerSubject: "subject-1",
+              user: {
+                email: "person@example.com",
+                id: "user-1",
+              },
+            }),
+          },
+        },
+        select() {
+          return {
+            from() {
+              return {
+                where: async () => [{ role: "helper" }],
+              };
+            },
+          };
+        },
+        update() {
+          return {
+            set() {
+              return {
+                where: async () => {
+                  touchedSession = true;
+                },
+              };
+            },
+          };
+        },
+      } as never,
+      {
+        accessProviderStateSecret: "runtime-secret",
+        teamDomain: "paretoproof.cloudflareaccess.com",
+        verifiers: {
+          brandedRelay: { audiences: ["branded"] },
+          internal: { audiences: ["internal"] },
+          portal: { audiences: ["portal"] },
+        } as never,
+      },
+    );
+    const request = {
+      accessIdentity: null,
+      accessRbacContext: null,
+      headers: {
+        cookie: "PortalAccessSession=opaque-session-token",
+      },
+      raw: {
+        url: "/math/questions/q_123",
+      },
+      routeOptions: {
+        url: "/math/questions/q_123",
+      },
+    } as never;
+
+    const context = await resolveAccess(request);
+
+    assert.deepEqual(context, {
+      email: "person@example.com",
+      identityId: "identity-1",
+      role: "helper",
+      status: "approved",
+      subject: "subject-1",
+      userId: "user-1",
+    });
+    assert.equal(request.accessIdentity?.subject, "subject-1");
+    assert.equal(touchedSession, true);
+  } finally {
+    Object.assign(process.env, originalEnv);
+  }
+});
+
 test("createAccessGuard ranks singular approved roles across helper, collaborator, and admin requirements", async (t) => {
   const app = Fastify();
 

--- a/apps/api/test/portal-access-request-origin.test.ts
+++ b/apps/api/test/portal-access-request-origin.test.ts
@@ -46,9 +46,12 @@ function registerPortalAccessRequestTestApp(options: {
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: options.allowLocalhostOrigins ?? false,
-      allowedOrigins: options.allowedOrigins ?? [
-        "https://portal.preview.paretoproof.com",
-      ],
+      allowedOriginsBySurface: {
+        math: [],
+        portal: options.allowedOrigins ?? [
+          "https://portal.preview.paretoproof.com",
+        ],
+      },
     }),
   );
 

--- a/apps/api/test/trusted-mutation-origin.test.ts
+++ b/apps/api/test/trusted-mutation-origin.test.ts
@@ -3,6 +3,11 @@ import test from "node:test";
 import Fastify from "fastify";
 import { createTrustedMutationOriginHook } from "../src/server/trusted-mutation-origin.ts";
 
+const allowedOriginsBySurface = {
+  math: ["https://math.preview.paretoproof.com"],
+  portal: ["https://portal.preview.paretoproof.com"],
+};
+
 test("trusted mutation origin hook rejects state-changing portal requests without an Origin header", async (t) => {
   const app = Fastify();
 
@@ -14,7 +19,7 @@ test("trusted mutation origin hook rejects state-changing portal requests withou
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -46,7 +51,7 @@ test("trusted mutation origin hook rejects state-changing portal requests from u
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -84,7 +89,7 @@ test("trusted mutation origin hook also protects admin role revocation mutations
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -121,7 +126,7 @@ test("trusted mutation origin hook also protects portal-admin offline ingest mut
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -158,7 +163,7 @@ test("trusted mutation origin hook allows trusted portal origins and safe GET re
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -203,7 +208,7 @@ test("trusted mutation origin hook still rejects math-origin portal mutations ou
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [],
     }),
   );
@@ -238,12 +243,15 @@ test("trusted mutation origin hook only allows branded auth POSTs on the finaliz
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: false,
-      allowedOrigins: [
-        "https://auth.preview.paretoproof.com",
-        "https://github.auth.preview.paretoproof.com",
-        "https://google.auth.preview.paretoproof.com",
-        "https://portal.preview.paretoproof.com",
-      ],
+      allowedOriginsBySurface: {
+        math: ["https://math.preview.paretoproof.com"],
+        portal: [
+          "https://auth.preview.paretoproof.com",
+          "https://github.auth.preview.paretoproof.com",
+          "https://google.auth.preview.paretoproof.com",
+          "https://portal.preview.paretoproof.com",
+        ],
+      },
       brandedAuthOrigins: [
         "https://auth.preview.paretoproof.com",
         "https://github.auth.preview.paretoproof.com",
@@ -314,7 +322,7 @@ test("trusted mutation origin hook only allows loopback-mapped branded auth orig
     "onRequest",
     createTrustedMutationOriginHook({
       allowLocalhostOrigins: true,
-      allowedOrigins: ["https://portal.preview.paretoproof.com"],
+      allowedOriginsBySurface,
       brandedAuthOrigins: [
         "https://auth.preview.paretoproof.com",
         "https://github.auth.preview.paretoproof.com",
@@ -355,5 +363,57 @@ test("trusted mutation origin hook only allows loopback-mapped branded auth orig
   assert.equal(profileResponse.statusCode, 403);
   assert.deepEqual(profileResponse.json(), {
     error: "trusted_origin_not_allowed",
+  });
+});
+
+test("trusted mutation origin hook rejects portal-surface callers for math mutations but allows the math surface", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  app.addHook(
+    "onRequest",
+    createTrustedMutationOriginHook({
+      allowLocalhostOrigins: false,
+      allowedOriginsBySurface,
+      brandedAuthOrigins: [],
+    }),
+  );
+
+  app.post("/math/submissions/sub_123/review-gates/policy_review", async () => ({
+    ok: true,
+  }));
+
+  const portalOriginResponse = await app.inject({
+    method: "POST",
+    payload: {
+      status: "satisfied",
+    },
+    url: "/math/submissions/sub_123/review-gates/policy_review",
+    headers: {
+      origin: "https://portal.preview.paretoproof.com",
+    },
+  });
+
+  const mathOriginResponse = await app.inject({
+    method: "POST",
+    payload: {
+      status: "satisfied",
+    },
+    url: "/math/submissions/sub_123/review-gates/policy_review",
+    headers: {
+      origin: "https://math.preview.paretoproof.com",
+    },
+  });
+
+  assert.equal(portalOriginResponse.statusCode, 403);
+  assert.deepEqual(portalOriginResponse.json(), {
+    error: "trusted_origin_not_allowed",
+  });
+  assert.equal(mathOriginResponse.statusCode, 200);
+  assert.deepEqual(mathOriginResponse.json(), {
+    ok: true,
   });
 });


### PR DESCRIPTION
## Summary

This PR implements the first backend slice for #886 by extracting shared authenticated-surface logic out of `portal.ts` and making the API boundary math-aware without introducing placeholder `/math/*` or `/math/admin/*` route modules.

## What Changed

- add a shared `authenticated-surface` helper for authenticated surface selection, redirect sanitization, route-family detection, and continuation URL building
- reuse that helper from the existing portal auth-handoff flows so continuation logic is no longer trapped inside `portal.ts`
- allow opaque `PortalAccessSession` reuse on authenticated math routes in `require-access`
- scope trusted mutation origin enforcement by authenticated surface so portal origins cannot mutate future math routes and math origins can be authorized independently
- split trusted mutation origin configuration into explicit `portal` and `math` allowlists during server boot
- add regression coverage for authenticated route-family detection, continuation sanitization, math-route session reuse, and math-surface trusted-origin enforcement

## Why

Issue #886 asks us to define the `/math/*` API namespace, backend service split, and auth-handoff targets needed for `math.paretoproof.com`, while explicitly avoiding stuffing that work into `portal.ts` or prematurely implementing placeholder route families.

This PR takes the minimal implementation step that unlocks that direction:

- reusable auth-handoff logic now lives behind a shared API helper instead of portal-only local functions
- route-scoped trusted mutation enforcement is now surface-aware instead of implicitly portal-only
- cached opaque access sessions now work for future authenticated math routes without changing the portal session model

That gives follow-up `/math/*` route work a clean boundary to plug into without overcomplicating the current slice.

## Validation

- `bun run build:shared`
- `bun --cwd apps/api build`
- `bun --cwd apps/api typecheck`
- `bun test test/*.test.ts`

## Follow-up

- add the first real `/math/*` and `/math/admin/*` route modules and service layers on top of these shared helpers
- expand shared contracts and browser entrypoints for the initial math-domain APIs
- keep future math endpoints out of `portal.ts`, using this extracted boundary instead

Refs #886
