### PR TITLE
Fix portal sidebar navigation behavior

### DIFF
--- a/apps/web/src/routes/portal-bootstrap.browser.test.js
+++ b/apps/web/src/routes/portal-bootstrap.browser.test.js
@@ -107,7 +107,10 @@ async function assertApprovedHandoffTransition({
     await delay(1_000);
 
     const provisionalBody = await page.locator("body").innerText();
-    assert.match(provisionalBody, /Formal benchmark operations and contributor tooling\./);
+    assert.match(provisionalBody, /Portal landing summary for current run activity/);
+    assert.match(provisionalBody, /Requests/);
+    assert.match(provisionalBody, /Users/);
+    assert.doesNotMatch(provisionalBody, /Formal benchmark operations and contributor tooling\./);
     assert.doesNotMatch(provisionalBody, /Opening portal/);
 
     await page.waitForFunction(

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -87,6 +87,7 @@ describe("PortalShell overview ordering", () => {
     expect(html).toContain("portal-shell-compact-nav-closed");
     expect(html).toContain("portal-sidebar-hidden");
     expect(html).toContain("portal-topbar-nav-toggle");
+    expect(html).toContain("inert=\"\"");
     expect(html).toContain(">Menu<");
   });
 

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -57,6 +57,39 @@ afterEach(() => {
 });
 
 describe("PortalShell overview ordering", () => {
+  it("uses short sidebar labels and removes explanatory summaries from navigation", async () => {
+    const { getPortalSidebarLabel } = await loadPortalShellModule();
+
+    expect(getPortalSidebarLabel({ id: "overview" })).toBe("Overview");
+    expect(getPortalSidebarLabel({ id: "access_requests" })).toBe("Requests");
+
+    const html = await renderPortalShell({
+      email: "ada@paretoproof.local",
+      roles: ["admin"],
+      url: "http://127.0.0.1/?surface=portal&access=approved&roles=admin&email=ada%40paretoproof.local",
+      width: 1280
+    });
+
+    expect(html).toContain("Requests");
+    expect(html).not.toContain("Landing summary before deeper benchmark operations.");
+    expect(html).not.toContain("Admin-only contributor approval workspace.");
+  });
+
+  it("starts compact portal navigation as a closed drawer with a reachable menu toggle", async () => {
+    const html = await renderPortalShell({
+      email: "ada@paretoproof.local",
+      roles: ["admin"],
+      url: "http://127.0.0.1/?surface=portal&access=approved&roles=admin&email=ada%40paretoproof.local",
+      width: 390
+    });
+
+    expect(html).toContain("portal-shell-compact");
+    expect(html).toContain("portal-shell-compact-nav-closed");
+    expect(html).toContain("portal-sidebar-hidden");
+    expect(html).toContain("portal-topbar-nav-toggle");
+    expect(html).toContain(">Menu<");
+  });
+
   it("blocks overlapping overview polls until the active request settles", async () => {
     jest.useFakeTimers();
     setWindow("http://127.0.0.1/?surface=portal&access=approved", 1280);

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -926,6 +926,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       <aside
         aria-label="Portal navigation"
         aria-hidden={compactSidebarClosed ? true : undefined}
+        inert={compactSidebarClosed || undefined}
         className={`portal-sidebar${
           desktopSidebarCollapsed ? " portal-sidebar-collapsed" : ""
         }${

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -30,7 +30,6 @@ type PortalShellProps = {
 
 type PortalNavGroup = {
   id: "account" | "benchmark_ops" | "admin";
-  label: string;
   sections: PortalSectionDefinition[];
 };
 
@@ -98,6 +97,16 @@ const portalSectionIconById: Record<PortalSectionDefinition["id"], AppIconName> 
   workers: "server"
 };
 
+const portalSidebarLabelById: Record<PortalSectionDefinition["id"], string> = {
+  access_requests: "Requests",
+  launch: "Launch",
+  overview: "Overview",
+  profile: "Profile",
+  runs: "Runs",
+  users: "Users",
+  workers: "Workers"
+};
+
 
 const portalSectionBodyCopy: Record<PortalSectionDefinition["id"], string> = {
   access_requests:
@@ -151,20 +160,21 @@ function getPortalNavGroups(sections: PortalSectionDefinition[]): PortalNavGroup
   return [
     {
       id: "account" as const,
-      label: "Portal",
       sections: accountSections
     },
     {
       id: "benchmark_ops" as const,
-      label: "Benchmark Ops",
       sections: benchmarkOpsSections
     },
     {
       id: "admin" as const,
-      label: "Admin",
       sections: adminSections
     }
   ].filter((group) => group.sections.length > 0);
+}
+
+export function getPortalSidebarLabel(section: PortalSectionDefinition) {
+  return portalSidebarLabelById[section.id];
 }
 
 function resolveActiveSection(
@@ -440,12 +450,12 @@ export function buildOverviewBenchmarkVisualSegments(
 }
 
 export function PortalShell({ email, roles }: PortalShellProps) {
-  const [navigationCollapsed, setNavigationCollapsed] = useState(false);
+  const compactLayout = useCompactLayout();
+  const [navigationCollapsed, setNavigationCollapsed] = useState(() => compactLayout);
   const [overviewRefreshing, setOverviewRefreshing] = useState(false);
   const [overviewState, setOverviewState] = useState<PortalOverviewState>({
     status: "loading"
   });
-  const compactLayout = useCompactLayout();
   const approvedRoles = useMemo(() => coercePortalRoles(roles), [roles]);
   const sections = useMemo(
     () => getPortalSectionsForRoles(approvedRoles),
@@ -505,6 +515,11 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       })) ?? [],
     [overviewData]
   );
+  const compactSidebarClosed = compactLayout && navigationCollapsed;
+  const desktopSidebarCollapsed = !compactLayout && navigationCollapsed;
+  const navigationToggleLabel = compactSidebarClosed || desktopSidebarCollapsed
+    ? "Open navigation"
+    : "Close navigation";
 
   useEffect(() => {
     if (matchedPortalRoute || pathname === activeSectionHref || pathname.startsWith("/runs/")) {
@@ -532,6 +547,28 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       window.removeEventListener("popstate", handlePopState);
     };
   }, []);
+
+  useEffect(() => {
+    setNavigationCollapsed(compactLayout);
+  }, [compactLayout]);
+
+  useEffect(() => {
+    if (!compactLayout || compactSidebarClosed) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setNavigationCollapsed(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [compactLayout, compactSidebarClosed]);
 
   useEffect(() => {
     if (!overviewRouteActive) {
@@ -583,6 +620,10 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       pathname: nextPathname,
       search: mergedSearch
     });
+  }
+
+  function toggleNavigation() {
+    setNavigationCollapsed((collapsed) => !collapsed);
   }
 
   const overviewActionRail = (
@@ -857,7 +898,13 @@ export function PortalShell({ email, roles }: PortalShellProps) {
   return (
     <main
       className={`portal-shell${
-        navigationCollapsed ? " portal-shell-collapsed" : ""
+        desktopSidebarCollapsed ? " portal-shell-collapsed" : ""
+      }${
+        compactLayout ? " portal-shell-compact" : ""
+      }${
+        compactSidebarClosed ? " portal-shell-compact-nav-closed" : ""
+      }${
+        compactLayout && !compactSidebarClosed ? " portal-shell-compact-nav-open" : ""
       }${
         overviewRouteActive ? " portal-shell-overview-active" : ""
       }${
@@ -866,38 +913,53 @@ export function PortalShell({ email, roles }: PortalShellProps) {
         benchmarkOpsRouteActive ? " portal-shell-benchmark-ops-active" : ""
       }`}
     >
+      {compactLayout && !compactSidebarClosed ? (
+        <button
+          aria-label="Close navigation"
+          className="portal-sidebar-scrim"
+          onClick={() => {
+            setNavigationCollapsed(true);
+          }}
+          type="button"
+        />
+      ) : null}
       <aside
         aria-label="Portal navigation"
-        className={`portal-sidebar${navigationCollapsed ? " portal-sidebar-collapsed" : ""}`}
+        aria-hidden={compactSidebarClosed ? true : undefined}
+        className={`portal-sidebar${
+          desktopSidebarCollapsed ? " portal-sidebar-collapsed" : ""
+        }${
+          compactLayout ? " portal-sidebar-compact" : ""
+        }${
+          compactSidebarClosed ? " portal-sidebar-hidden" : ""
+        }`}
       >
         <div className="portal-sidebar-header">
           <div className="portal-brand-block">
             <span className="portal-brand-mark" aria-hidden="true">
               <AppIcon name="spark" />
             </span>
-            {!navigationCollapsed ? (
+            {!desktopSidebarCollapsed ? (
               <div>
                 <p className="eyebrow">Portal</p>
                 <h1>ParetoProof</h1>
-                <p className="portal-brand-copy">
-                  Formal benchmark operations and contributor tooling.
-                </p>
               </div>
             ) : null}
           </div>
           <button
-            aria-expanded={!navigationCollapsed}
+            aria-expanded={!compactSidebarClosed && !desktopSidebarCollapsed}
+            aria-label={navigationToggleLabel}
             className="sidebar-toggle"
-            onClick={() => {
-              setNavigationCollapsed((collapsed) => !collapsed);
-            }}
+            onClick={toggleNavigation}
             type="button"
           >
             <span className="sidebar-toggle-icon" aria-hidden="true">
-              <AppIcon name={navigationCollapsed ? "panel-right" : "panel-left"} />
+              <AppIcon
+                name={compactSidebarClosed || desktopSidebarCollapsed ? "panel-right" : "panel-left"}
+              />
             </span>
             <span className="sr-only">
-              {navigationCollapsed ? "Expand navigation" : "Collapse navigation"}
+              {navigationToggleLabel}
             </span>
           </button>
         </div>
@@ -905,28 +967,30 @@ export function PortalShell({ email, roles }: PortalShellProps) {
         <nav className="portal-nav">
           {navGroups.map((group) => (
             <div className="portal-nav-group" key={group.id}>
-              {!navigationCollapsed ? (
-                <p className="portal-nav-group-label">{group.label}</p>
-              ) : null}
               {group.sections.map((section) => {
                 const href = getSectionHref(section);
                 const isActive = activeSection?.id === section.id;
+                const sidebarLabel = getPortalSidebarLabel(section);
 
                 return (
                   <a
                     aria-current={isActive ? "page" : undefined}
                     className={`portal-nav-link${isActive ? " portal-nav-link-active" : ""}`}
                     href={href}
+                    onClick={() => {
+                      if (compactLayout) {
+                        setNavigationCollapsed(true);
+                      }
+                    }}
                     key={section.id}
-                    title={section.navLabel}
+                    title={sidebarLabel}
                   >
                     <span className="portal-nav-link-icon" aria-hidden="true">
                       <AppIcon name={portalSectionIconById[section.id]} />
                     </span>
-                    {!navigationCollapsed ? (
+                    {!desktopSidebarCollapsed ? (
                       <span className="portal-nav-copy">
-                        <span className="portal-nav-label">{section.navLabel}</span>
-                        <span className="portal-nav-summary">{section.summary}</span>
+                        <span className="portal-nav-label">{sidebarLabel}</span>
                       </span>
                     ) : null}
                   </a>
@@ -936,7 +1000,7 @@ export function PortalShell({ email, roles }: PortalShellProps) {
           ))}
         </nav>
 
-        {!navigationCollapsed ? (
+        {!desktopSidebarCollapsed ? (
           <div className="portal-sidebar-footer">
             <p className="portal-sidebar-footer-label">Signed in</p>
             <p className="portal-sidebar-footer-value">
@@ -949,6 +1013,22 @@ export function PortalShell({ email, roles }: PortalShellProps) {
       <section className="portal-main">
         <header className="portal-topbar">
           <div className="portal-topbar-left">
+            {compactLayout ? (
+              <button
+                aria-expanded={!compactSidebarClosed}
+                aria-label={navigationToggleLabel}
+                className="portal-topbar-nav-toggle"
+                onClick={toggleNavigation}
+                type="button"
+              >
+                <span className="portal-topbar-nav-toggle-icon" aria-hidden="true">
+                  <AppIcon
+                    name={compactSidebarClosed ? "panel-right" : "panel-left"}
+                  />
+                </span>
+                <span>Menu</span>
+              </button>
+            ) : null}
             <h1>{activeSection?.navLabel ?? "Portal"}</h1>
             <span className="portal-topbar-breadcrumb">
               {activeSection?.description ?? "Contributor and benchmark control surface."}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -327,8 +327,6 @@ a.button-secondary {
 .portal-request-meta,
 .portal-request-rationale,
 .portal-timeline-item p,
-.portal-nav-summary,
-.portal-brand-copy,
 .form-error,
 .auth-inline-status p:last-child {
   color: var(--ink-soft);
@@ -1100,6 +1098,7 @@ a.button-secondary {
   position: sticky;
   top: 10px;
   height: calc(100vh - 20px);
+  overflow-x: hidden;
   overflow-y: auto;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 14px;
@@ -1146,10 +1145,8 @@ a.button-secondary {
   letter-spacing: -0.04em;
 }
 
-.portal-brand-copy,
 .portal-sidebar-footer-label,
-.portal-sidebar-footer-value,
-.portal-nav-summary {
+.portal-sidebar-footer-value {
   color: var(--sidebar-text-muted);
 }
 
@@ -1179,7 +1176,7 @@ a.button-secondary {
 
 .portal-nav {
   display: grid;
-  gap: 4px;
+  gap: 8px;
 }
 
 .portal-nav-group {
@@ -1193,24 +1190,17 @@ a.button-secondary {
   border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.portal-nav-group-label {
-  margin: 0 10px 2px;
-  color: var(--sidebar-text-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .portal-nav-link {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
+  grid-template-columns: 34px minmax(0, 1fr);
   align-items: center;
-  gap: 12px;
-  padding: 12px 10px;
-  border-left: 1px solid transparent;
-  border-radius: 4px;
-  transition: background-color 160ms ease, border-color 160ms ease;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
 }
 
 .portal-nav-link:hover,
@@ -1219,13 +1209,12 @@ a.button-secondary {
 }
 
 .portal-nav-link-active {
-  background: rgba(255, 255, 255, 0.05);
-  border-left-color: var(--sidebar-accent);
+  background: rgba(99, 140, 255, 0.1);
 }
 
 .portal-nav-link-icon {
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.08);
   color: #fff;
@@ -1244,10 +1233,22 @@ a.button-secondary {
   font-weight: 700;
 }
 
+.portal-nav-label {
+  font-size: 0.92rem;
+  line-height: 1.2;
+}
+
 .portal-sidebar-footer {
   margin-top: auto;
   padding-top: 18px;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.portal-sidebar-footer-value {
+  display: block;
+  font-size: 0.92rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .portal-shell-collapsed {
@@ -1269,10 +1270,6 @@ a.button-secondary {
   display: none;
 }
 
-.portal-sidebar-collapsed .portal-nav-group-label {
-  display: none;
-}
-
 .portal-sidebar-collapsed .portal-nav-link {
   grid-template-columns: 1fr;
   justify-items: center;
@@ -1289,6 +1286,29 @@ a.button-secondary {
 .portal-nav-link-active {
   border-color: rgba(99, 140, 255, 0.22);
   background: rgba(99, 140, 255, 0.1);
+}
+
+.portal-sidebar-scrim,
+.portal-topbar-nav-toggle {
+  display: none;
+}
+
+.portal-topbar-nav-toggle {
+  align-items: center;
+  gap: 8px;
+  min-height: 2.4rem;
+  padding: 0.52rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.portal-topbar-nav-toggle-icon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
 }
 
 .portal-main {
@@ -2698,17 +2718,15 @@ a.button-secondary {
 
   .site-band-grid,
   .site-card-grid,
-  .portal-shell,
   .portal-grid,
-  .portal-nav,
   .portal-metric-strip {
     grid-template-columns: 1fr;
   }
 
   .portal-shell {
     padding: 10px;
-    display: flex;
-    flex-direction: column;
+    grid-template-columns: minmax(0, 1fr);
+    position: relative;
   }
 
   .portal-overview-benchmark-header,
@@ -2718,20 +2736,27 @@ a.button-secondary {
   }
 
   .portal-sidebar {
-    order: 1;
-    position: static;
-    top: auto;
-    height: auto;
-    overflow: visible;
-    padding: 14px 12px;
-    border-radius: 0;
-    min-height: auto;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: min(82vw, 18rem);
+    height: 100dvh;
+    min-height: 100dvh;
+    overflow-y: auto;
+    padding: 16px 12px 18px;
+    gap: 12px;
+    border-radius: 0 18px 18px 0;
+    z-index: 260;
+    box-shadow: 0 18px 38px rgba(16, 32, 61, 0.26);
+    transition:
+      transform 220ms ease,
+      opacity 220ms ease;
   }
 
-  .portal-brand-copy,
-  .portal-nav-summary,
-  .portal-sidebar-footer {
-    display: none;
+  .portal-sidebar-compact.portal-sidebar-hidden {
+    transform: translateX(calc(-100% - 16px));
+    opacity: 0;
+    pointer-events: none;
   }
 
   .portal-brand-block {
@@ -2743,27 +2768,37 @@ a.button-secondary {
   }
 
   .portal-nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: 8px;
   }
 
   .portal-nav-group {
-    display: contents;
+    display: grid;
+    gap: 8px;
   }
 
   .portal-nav-group + .portal-nav-group {
-    margin-top: 0;
-    padding-top: 0;
-    border-top: 0;
-  }
-
-  .portal-nav-group-label {
-    display: none;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
   }
 
   .portal-nav-link {
+    grid-template-columns: 32px minmax(0, 1fr);
+    justify-items: start;
     gap: 10px;
-    padding: 10px;
+    padding: 10px 12px;
+    text-align: left;
+  }
+
+  .portal-nav-label {
+    font-size: 0.9rem;
+    line-height: 1.2;
+  }
+
+  .portal-nav-link-icon {
+    width: 32px;
+    height: 32px;
   }
 
   .site-band + .site-band {
@@ -2782,9 +2817,35 @@ a.button-secondary {
   }
 
   .portal-main {
-    order: 2;
     padding: 16px 14px 18px;
-    border-radius: 0;
+    border-radius: 14px;
+  }
+
+  .portal-sidebar-collapsed .portal-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-sidebar-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    background: rgba(9, 19, 46, 0.4);
+    z-index: 250;
+  }
+
+  .portal-topbar {
+    gap: 10px;
+    align-items: flex-start;
+  }
+
+  .portal-topbar-left {
+    align-items: center;
+    gap: 10px;
+  }
+
+  .portal-topbar-nav-toggle {
+    display: inline-flex;
   }
 
   .portal-grid-admin-workspace .portal-admin-list-panel {
@@ -2943,7 +3004,8 @@ a.button-secondary {
   }
 
   .portal-sidebar {
-    padding: 10px 10px 12px;
+    width: min(86vw, 17rem);
+    padding: 14px 10px 14px;
     gap: 10px;
   }
 
@@ -2961,25 +3023,21 @@ a.button-secondary {
   }
 
   .portal-nav {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: 6px;
   }
 
   .portal-nav-link {
-    grid-template-columns: 1fr;
-    justify-items: center;
+    grid-template-columns: 30px minmax(0, 1fr);
+    justify-items: start;
     gap: 6px;
-    padding: 8px 6px;
-    text-align: center;
-  }
-
-  .portal-nav-summary {
-    display: none;
+    padding: 9px 10px;
+    text-align: left;
   }
 
   .portal-nav-label {
-    font-size: 0.72rem;
-    line-height: 1.1;
+    font-size: 0.84rem;
+    line-height: 1.16;
   }
 
   .portal-nav-link-icon {
@@ -2993,6 +3051,10 @@ a.button-secondary {
   }
 
   .portal-topbar {
+    gap: 8px;
+  }
+
+  .portal-topbar-left {
     gap: 8px;
   }
 
@@ -3016,7 +3078,7 @@ a.button-secondary {
   }
 
   .portal-sidebar-collapsed .portal-nav {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 
   .portal-results-panel-compact .portal-toolbar .button,
@@ -3679,17 +3741,18 @@ a.button-secondary {
   }
 
   .portal-shell-overview-active .portal-nav {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 5px;
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 
   .portal-shell-overview-active .portal-nav-link {
-    gap: 4px;
-    padding: 7px 4px;
+    grid-template-columns: 30px minmax(0, 1fr);
+    gap: 8px;
+    padding: 9px 10px;
   }
 
   .portal-shell-overview-active .portal-nav-label {
-    font-size: 0.66rem;
+    font-size: 0.84rem;
   }
 
   .portal-shell-overview-active .portal-main {
@@ -3750,17 +3813,18 @@ a.button-secondary {
   }
 
   .portal-shell-profile-active .portal-nav {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 5px;
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 
   .portal-shell-profile-active .portal-nav-link {
-    gap: 4px;
-    padding: 7px 4px;
+    grid-template-columns: 30px minmax(0, 1fr);
+    gap: 8px;
+    padding: 9px 10px;
   }
 
   .portal-shell-profile-active .portal-nav-label {
-    font-size: 0.66rem;
+    font-size: 0.84rem;
   }
 
   .portal-shell-profile-active .portal-main {
@@ -3792,17 +3856,18 @@ a.button-secondary {
   }
 
   .portal-shell-benchmark-ops-active .portal-nav {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 5px;
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 
   .portal-shell-benchmark-ops-active .portal-nav-link {
-    gap: 4px;
-    padding: 7px 4px;
+    grid-template-columns: 30px minmax(0, 1fr);
+    gap: 8px;
+    padding: 9px 10px;
   }
 
   .portal-shell-benchmark-ops-active .portal-nav-label {
-    font-size: 0.66rem;
+    font-size: 0.84rem;
   }
 
   .portal-shell-benchmark-ops-active .portal-main {


### PR DESCRIPTION
## Summary
- replace verbose sidebar entries with short one-word navigation labels
- make compact portal navigation a real open/close drawer instead of a tile grid
- keep the signed-in footer readable without horizontal overflow

## Verification
- bun test apps/web/src/routes/portal-shell.test.js
- node apps/web/node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json
- bun --cwd apps/web build
- browser QA with Playwright-served mocked portal data plus pywinauto zoom and OS-level screenshots for desktop, compact closed, compact open, and compact close

Closes #1109