### PR TITLE
Fix web auth surface routing contracts

### DIFF
--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -495,6 +495,110 @@ describe("handleAccessFinalize", () => {
     expect(fetchCalled).toBe(false);
   });
 
+  it("rejects branded http finalize relay origins unless they include an explicit local port", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(null, { status: 200 });
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("http://github.auth.paretoproof.com/api/access/finalize?app=portal", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-plain-http",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "http://github.auth.paretoproof.com"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
+    );
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("relays loopback-mapped branded http finalize origins through the local API port", async () => {
+    globalThis.fetch = async (input, init) => {
+      expect(input).toBe(
+        "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit"
+      );
+      expect((init?.headers as Headers).get("origin")).toBe(
+        "http://github.auth.paretoproof.com:4173"
+      );
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "https://portal.paretoproof.com/profile"
+        }),
+        {
+          status: 200
+        }
+      );
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("http://github.auth.paretoproof.com:4173/api/access/finalize?app=portal", {
+        body: new URLSearchParams({
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-local-http",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "http://github.auth.paretoproof.com:4173"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://portal.paretoproof.com/profile");
+  });
+
+  it("rejects finalized redirects to auth, public, or wrong-surface routes", async () => {
+    const unsafeRedirects = [
+      "https://auth.paretoproof.com/",
+      "https://paretoproof.com/project",
+      "https://math.paretoproof.com/profile"
+    ];
+
+    for (const redirectTo of unsafeRedirects) {
+      globalThis.fetch = async () =>
+        new Response(
+          JSON.stringify({
+            redirectTo
+          }),
+          {
+            status: 200
+          }
+        );
+
+      const response = await handleAccessFinalize(
+        new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
+          body: new URLSearchParams({
+            redirect: "/profile"
+          }),
+          headers: {
+            "cf-access-jwt-assertion": "assertion-unsafe-redirect",
+            "content-type": "application/x-www-form-urlencoded",
+            origin: "https://github.auth.paretoproof.com"
+          },
+          method: "POST"
+        })
+      );
+
+      expect(response.status).toBe(303);
+      expect(response.headers.get("location")).toBe(
+        "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
+      );
+    }
+  });
+
   it("redirects back to retry without relaying when both Origin and Referer are absent", async () => {
     let fetchCalled = false;
     globalThis.fetch = async () => {

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,10 +1,13 @@
-import { findAppRouteBySurface } from "@paretoproof/shared";
-
-const authOrigin = "https://auth.paretoproof.com";
-const portalOrigin = "https://portal.paretoproof.com";
-const mathOrigin = "https://math.paretoproof.com";
-
-type AuthenticatedSurface = "portal" | "math";
+import {
+  type AuthenticatedSurface,
+  isLocalDevelopmentLocation,
+  isParetoProofBrandedHost,
+  isTrustedFinalizeRelayLocation,
+  productionAuthOrigin,
+  readAuthenticatedSurface,
+  resolveFinalizedAuthenticatedRedirectTarget,
+  sanitizeAuthenticatedRedirectTarget
+} from "@paretoproof/shared";
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
@@ -26,29 +29,6 @@ function readCookieValue(cookieHeader: string | null, name: string) {
   return null;
 }
 
-const brandedHosts = new Set([
-  "paretoproof.com",
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com",
-  "math.paretoproof.com",
-  "portal.paretoproof.com"
-]);
-const brandedFinalizeRelayHosts = new Set([
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com"
-]);
-
-function isLocalHostname(hostname: string) {
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1" ||
-    hostname.endsWith(".localhost")
-  );
-}
-
 function readTrustedFinalizeRelayOrigin(request: Request) {
   const originHeader = request.headers.get("origin");
 
@@ -62,20 +42,7 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
     try {
       const refererUrl = new URL(refererHeader);
 
-      if (
-        refererUrl.protocol === "https:" &&
-        brandedFinalizeRelayHosts.has(refererUrl.hostname)
-      ) {
-        return refererUrl.origin;
-      }
-
-      if (
-        refererUrl.protocol === "http:" &&
-        (
-          brandedFinalizeRelayHosts.has(refererUrl.hostname) ||
-          isLocalHostname(refererUrl.hostname)
-        )
-      ) {
+      if (isTrustedFinalizeRelayLocation(refererUrl)) {
         return refererUrl.origin;
       }
     } catch {
@@ -88,20 +55,7 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
   try {
     const originUrl = new URL(originHeader);
 
-    if (
-      originUrl.protocol === "https:" &&
-      brandedFinalizeRelayHosts.has(originUrl.hostname)
-    ) {
-      return originUrl.origin;
-    }
-
-    if (
-      originUrl.protocol === "http:" &&
-      (
-        brandedFinalizeRelayHosts.has(originUrl.hostname) ||
-        isLocalHostname(originUrl.hostname)
-      )
-    ) {
+    if (isTrustedFinalizeRelayLocation(originUrl)) {
       return originUrl.origin;
     }
   } catch {
@@ -111,47 +65,11 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
   return null;
 }
 
-function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
-  return surface === "math" ? "math" : "portal";
-}
-
-function readSurfaceOrigin(surface: AuthenticatedSurface) {
-  return surface === "math" ? mathOrigin : portalOrigin;
-}
-
-function sanitizeRedirectPath(
-  rawRedirectPath: string | null,
-  targetSurface: AuthenticatedSurface
-) {
-  if (!rawRedirectPath || rawRedirectPath === "/") {
-    return "/";
-  }
-
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) || rawRedirectPath.startsWith("//")) {
-    return "/";
-  }
-
-  try {
-    const url = new URL(
-      rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      readSurfaceOrigin(targetSurface)
-    );
-
-    if (!findAppRouteBySurface(targetSurface, url.pathname)) {
-      return "/";
-    }
-
-    return `${url.pathname}${url.search}${url.hash}` || "/";
-  } catch {
-    return "/";
-  }
-}
-
 function buildAuthRetryUrl(
   redirectPath: string,
   targetSurface: AuthenticatedSurface
 ) {
-  const authUrl = new URL(authOrigin);
+  const authUrl = new URL(productionAuthOrigin);
   authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
@@ -165,9 +83,8 @@ function buildAuthRetryUrl(
 
 function resolveApiBaseUrl(requestUrl: URL) {
   if (
-    requestUrl.protocol === "http:" &&
-    requestUrl.port !== "" &&
-    brandedHosts.has(requestUrl.hostname)
+    isLocalDevelopmentLocation(requestUrl) &&
+    isParetoProofBrandedHost(requestUrl.hostname)
   ) {
     const localApiUrl = new URL(requestUrl.origin);
     localApiUrl.port = "3000";
@@ -184,49 +101,11 @@ function resolveApiBaseUrl(requestUrl: URL) {
   const localApiUrl = new URL(requestUrl.origin);
   localApiUrl.port = "3000";
 
-  if (isLocalHostname(requestUrl.hostname)) {
+  if (isLocalDevelopmentLocation(requestUrl)) {
     return trimTrailingSlash(localApiUrl.origin);
   }
 
   return "https://api.paretoproof.com";
-}
-
-function buildAuthenticatedRedirectUrl(
-  targetSurface: AuthenticatedSurface,
-  redirectPath: string
-) {
-  return new URL(redirectPath, readSurfaceOrigin(targetSurface)).toString();
-}
-
-function resolveAuthenticatedRedirectTarget(
-  rawRedirectTarget: unknown,
-  fallbackRedirectPath: string,
-  fallbackSurface: AuthenticatedSurface
-) {
-  if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
-    return buildAuthenticatedRedirectUrl(fallbackSurface, fallbackRedirectPath);
-  }
-
-  let targetUrl: URL;
-
-  try {
-    targetUrl = new URL(rawRedirectTarget);
-  } catch {
-    return null;
-  }
-
-  const targetSurface =
-    targetUrl.origin === portalOrigin
-      ? "portal"
-      : targetUrl.origin === mathOrigin
-        ? "math"
-        : null;
-
-  if (!targetSurface || !findAppRouteBySurface(targetSurface, targetUrl.pathname)) {
-    return null;
-  }
-
-  return targetUrl.toString();
 }
 
 function splitCombinedSetCookieHeader(cookieHeader: string) {
@@ -265,7 +144,10 @@ async function readRedirectOptions(request: Request) {
 
   if (request.method !== "POST") {
     return {
-      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      redirectPath: sanitizeAuthenticatedRedirectTarget(fallbackRedirectPath, {
+        allowAbsolute: false,
+        surface: fallbackSurface
+      }),
       targetSurface: fallbackSurface
     };
   }
@@ -277,7 +159,10 @@ async function readRedirectOptions(request: Request) {
     !contentType.includes("multipart/form-data")
   ) {
     return {
-      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      redirectPath: sanitizeAuthenticatedRedirectTarget(fallbackRedirectPath, {
+        allowAbsolute: false,
+        surface: fallbackSurface
+      }),
       targetSurface: fallbackSurface
     };
   }
@@ -291,9 +176,12 @@ async function readRedirectOptions(request: Request) {
       : fallbackSurface;
 
   return {
-    redirectPath: sanitizeRedirectPath(
+    redirectPath: sanitizeAuthenticatedRedirectTarget(
       typeof redirectValue === "string" ? redirectValue : fallbackRedirectPath,
-      targetSurface
+      {
+        allowAbsolute: false,
+        surface: targetSurface
+      }
     ),
     targetSurface
   };
@@ -379,10 +267,12 @@ export async function handleAccessFinalize(request: Request) {
     return buildRedirectResponse(retryUrl, finalizeResponse.headers);
   }
 
-  const redirectTarget = resolveAuthenticatedRedirectTarget(
+  const redirectTarget = resolveFinalizedAuthenticatedRedirectTarget(
     (responseBody as { redirectTo?: unknown }).redirectTo,
-    redirectPath,
-    targetSurface
+    {
+      fallbackRedirectPath: redirectPath,
+      fallbackSurface: targetSurface
+    }
   );
 
   if (!redirectTarget) {

--- a/apps/web/functions/_shared/access-start.test.ts
+++ b/apps/web/functions/_shared/access-start.test.ts
@@ -68,4 +68,48 @@ describe("handleAccessStart", () => {
       "https://google.auth.paretoproof.com/?app=math&redirect=%2Fquestions%2Fproblem-9"
     );
   });
+
+  it("drops absolute, public, and wrong-surface redirect inputs before provider handoff", async () => {
+    const redirectInputs = [
+      "https://portal.paretoproof.com/profile",
+      "//portal.paretoproof.com/profile",
+      "javascript:alert(1)",
+      "/project",
+      "/benchmarks"
+    ];
+
+    for (const redirectInput of redirectInputs) {
+      const response = await handleAccessStart(
+        new Request(
+          `https://auth.paretoproof.com/api/access/start/github?app=portal&redirect=${encodeURIComponent(
+            redirectInput
+          )}`
+        ),
+        {
+          ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+        },
+        "github"
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe(
+        "https://github.auth.paretoproof.com/?app=portal"
+      );
+    }
+
+    const mathResponse = await handleAccessStart(
+      new Request(
+        "https://auth.paretoproof.com/api/access/start/google?app=math&redirect=/profile"
+      ),
+      {
+        ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+      },
+      "google"
+    );
+
+    expect(mathResponse.status).toBe(302);
+    expect(mathResponse.headers.get("location")).toBe(
+      "https://google.auth.paretoproof.com/?app=math"
+    );
+  });
 });

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -1,62 +1,22 @@
-import { findAppRouteBySurface } from "@paretoproof/shared";
+import {
+  type AccessProvider as Provider,
+  type AuthenticatedSurface,
+  productionAuthOrigin,
+  productionProviderAuthOrigins,
+  readAuthenticatedSurface,
+  sanitizeAuthenticatedRedirectTarget
+} from "@paretoproof/shared";
 
-const authOrigin = "https://auth.paretoproof.com";
-const portalOrigin = "https://portal.paretoproof.com";
-const mathOrigin = "https://math.paretoproof.com";
-
-type Provider = "github" | "google";
 type PersistedProvider = "cloudflare_github" | "cloudflare_google";
-type AuthenticatedSurface = "portal" | "math";
 
 type AccessStartEnv = {
   ACCESS_PROVIDER_STATE_SECRET?: string;
-};
-
-const providerOrigins: Record<Provider, string> = {
-  github: "https://github.auth.paretoproof.com",
-  google: "https://google.auth.paretoproof.com"
 };
 
 const persistedProviders: Record<Provider, PersistedProvider> = {
   github: "cloudflare_github",
   google: "cloudflare_google"
 };
-
-function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
-  return surface === "math" ? "math" : "portal";
-}
-
-function readSurfaceOrigin(surface: AuthenticatedSurface) {
-  return surface === "math" ? mathOrigin : portalOrigin;
-}
-
-function sanitizeRedirectPath(
-  rawRedirectPath: string | null,
-  targetSurface: AuthenticatedSurface
-) {
-  if (!rawRedirectPath || rawRedirectPath === "/") {
-    return "/";
-  }
-
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawRedirectPath) || rawRedirectPath.startsWith("//")) {
-    return "/";
-  }
-
-  try {
-    const url = new URL(
-      rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      readSurfaceOrigin(targetSurface)
-    );
-
-    if (!findAppRouteBySurface(targetSurface, url.pathname)) {
-      return "/";
-    }
-
-    return `${url.pathname}${url.search}${url.hash}` || "/";
-  } catch {
-    return "/";
-  }
-}
 
 function toBase64Url(bytes: ArrayBuffer) {
   const encoded = btoa(String.fromCharCode(...new Uint8Array(bytes)));
@@ -114,7 +74,7 @@ function buildAuthFailureUrl(
   redirectPath: string,
   targetSurface: AuthenticatedSurface
 ) {
-  const authUrl = new URL(authOrigin);
+  const authUrl = new URL(productionAuthOrigin);
   authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
@@ -133,14 +93,17 @@ export async function handleAccessStart(
 ) {
   const requestUrl = new URL(request.url);
   const targetSurface = readAuthenticatedSurface(requestUrl.searchParams.get("app"));
-  const redirectPath = sanitizeRedirectPath(
+  const redirectPath = sanitizeAuthenticatedRedirectTarget(
     requestUrl.searchParams.get("redirect"),
-    targetSurface
+    {
+      allowAbsolute: false,
+      surface: targetSurface
+    }
   );
 
   try {
     const flow = requestUrl.searchParams.get("flow") === "link" ? "link" : "sign_in";
-    const providerUrl = new URL("/", providerOrigins[provider]);
+    const providerUrl = new URL("/", productionProviderAuthOrigins[provider]);
     const providerHintCookie = await buildProviderHintCookie(env, provider);
 
     providerUrl.searchParams.set("app", targetSurface);

--- a/apps/web/src/lib/api-base-url.ts
+++ b/apps/web/src/lib/api-base-url.ts
@@ -1,22 +1,44 @@
+import type { WebLocationLike } from "@paretoproof/shared";
 import { isLocalDevelopmentLocation } from "./local-development";
-import { readWebRuntimeEnv } from "./runtime-env";
+import { readWebRuntimeEnv, type WebRuntimeEnv } from "./runtime-env";
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
 }
 
-export function getApiBaseUrl() {
-  const configuredBaseUrl = readWebRuntimeEnv().apiBaseUrl;
+type ApiBaseUrlOptions = {
+  locationLike?: WebLocationLike;
+  runtimeEnv?: WebRuntimeEnv;
+};
+
+function buildOriginFromLocationLike(locationLike: WebLocationLike) {
+  if (locationLike.origin) {
+    return locationLike.origin;
+  }
+
+  const protocol = locationLike.protocol || "http:";
+  const port = locationLike.port ? `:${locationLike.port}` : "";
+
+  return `${protocol}//${locationLike.hostname}${port}`;
+}
+
+export function getApiBaseUrl(options: ApiBaseUrlOptions = {}) {
+  const configuredBaseUrl = (options.runtimeEnv ?? readWebRuntimeEnv()).apiBaseUrl;
 
   if (configuredBaseUrl) {
     return trimTrailingSlash(configuredBaseUrl);
   }
 
-  if (!isLocalDevelopmentLocation(window.location) && window.location.hostname.endsWith("paretoproof.com")) {
+  const locationLike = options.locationLike ?? window.location;
+
+  if (
+    !isLocalDevelopmentLocation(locationLike) &&
+    locationLike.hostname.endsWith("paretoproof.com")
+  ) {
     return "https://api.paretoproof.com";
   }
 
-  const localApiUrl = new URL(window.location.origin);
+  const localApiUrl = new URL(buildOriginFromLocationLike(locationLike));
   localApiUrl.port = "3000";
 
   return trimTrailingSlash(localApiUrl.origin);

--- a/apps/web/src/lib/local-development.ts
+++ b/apps/web/src/lib/local-development.ts
@@ -1,39 +1,4 @@
-export const paretoProofBrandedHosts = [
-  "paretoproof.com",
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com",
-  "math.paretoproof.com",
-  "portal.paretoproof.com"
-] as const;
-
-type LocationLike = {
-  hostname: string;
-  port?: string;
-  protocol?: string;
-};
-
-export function isLocalDevelopmentLocation({
-  hostname,
-  port = "",
-  protocol = ""
-}: LocationLike) {
-  const normalizedHostname = hostname.toLowerCase();
-
-  if (
-    normalizedHostname === "localhost" ||
-    normalizedHostname === "127.0.0.1" ||
-    normalizedHostname === "::1" ||
-    normalizedHostname.endsWith(".localhost")
-  ) {
-    return true;
-  }
-
-  return (
-    protocol === "http:" &&
-    port !== "" &&
-    paretoProofBrandedHosts.includes(
-      normalizedHostname as (typeof paretoProofBrandedHosts)[number]
-    )
-  );
-}
+export {
+  isLocalDevelopmentLocation,
+  paretoProofBrandedHosts
+} from "@paretoproof/shared";

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   buildAccessFinalizeUrl,
+  buildAccessStartUrl,
   buildAuthGuidanceUrl,
   buildAuthUrl,
+  buildLocalAuthPreviewUrl,
   buildMathUrl,
   buildPortalUrl,
   buildPublicUrl,
@@ -107,6 +109,94 @@ describe("buildPortalUrl", () => {
     ).toBe(
       "https://google.auth.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fprofile"
     );
+  });
+
+  it("keeps provider start URLs hosted even when the current browser host is local", () => {
+    setWindowUrl(
+      "http://127.0.0.1/?surface=auth&email=ada%40paretoproof.local&role=admin"
+    );
+
+    const startUrl = new URL(
+      buildAccessStartUrl("github", "/runs/alpha", {
+        surface: "portal"
+      })
+    );
+
+    expect(startUrl.origin).toBe("https://auth.paretoproof.com");
+    expect(startUrl.pathname).toBe("/api/access/start/github");
+    expect(startUrl.searchParams.get("app")).toBe("portal");
+    expect(startUrl.searchParams.get("redirect")).toBe("/runs/alpha");
+    expect(startUrl.searchParams.has("access")).toBe(false);
+    expect(startUrl.searchParams.has("email")).toBe(false);
+    expect(startUrl.searchParams.has("role")).toBe(false);
+  });
+
+  it("builds hosted provider start URLs without an ambient browser window when inputs are explicit", () => {
+    delete globalThis.window;
+
+    expect(
+      buildAccessStartUrl(
+        "google",
+        "/launch",
+        {
+          surface: "math"
+        },
+        "auth.paretoproof.com"
+      )
+    ).toBe(
+      "https://auth.paretoproof.com/api/access/start/google?app=math&redirect=%2Flaunch"
+    );
+  });
+
+  it("builds least-privilege local auth previews only through the explicit preview helper", () => {
+    setWindowUrl("http://127.0.0.1/?surface=auth");
+
+    const previewUrl = new URL(
+      buildLocalAuthPreviewUrl("/runs/alpha", {
+        surface: "portal"
+      })
+    );
+
+    expect(previewUrl.origin).toBe("http://127.0.0.1");
+    expect(previewUrl.pathname).toBe("/runs/alpha");
+    expect(previewUrl.searchParams.get("surface")).toBe("portal");
+    expect(previewUrl.searchParams.get("access")).toBe("approved");
+    expect(previewUrl.searchParams.get("email")).toBe("local@example.com");
+    expect(previewUrl.searchParams.get("role")).toBe("helper");
+    expect(previewUrl.searchParams.has("roles")).toBe(false);
+  });
+
+  it("preserves explicit local preview identity state without widening default privileges", () => {
+    setWindowUrl(
+      "http://localhost/?surface=auth&email=ada%40paretoproof.local&role=admin&roles=helper&reason=stale"
+    );
+
+    const previewUrl = new URL(
+      buildLocalAuthPreviewUrl("/profile", {
+        surface: "portal"
+      })
+    );
+
+    expect(previewUrl.searchParams.get("access")).toBe("approved");
+    expect(previewUrl.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(previewUrl.searchParams.get("role")).toBe("admin");
+    expect(previewUrl.searchParams.has("roles")).toBe(false);
+    expect(previewUrl.searchParams.has("reason")).toBe(false);
+  });
+
+  it("does not attach local preview access state on hosted auth surfaces", () => {
+    setWindowUrl("https://auth.paretoproof.com/?app=portal&redirect=%2Fruns%2Falpha");
+
+    const previewUrl = new URL(
+      buildLocalAuthPreviewUrl("/runs/alpha", {
+        surface: "portal"
+      })
+    );
+
+    expect(previewUrl.toString()).toBe("https://portal.paretoproof.com/runs/alpha");
+    expect(previewUrl.searchParams.has("access")).toBe(false);
+    expect(previewUrl.searchParams.has("email")).toBe(false);
+    expect(previewUrl.searchParams.has("role")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -1,61 +1,72 @@
-import { findAppRouteBySurface } from "@paretoproof/shared";
+import {
+  type AccessProvider,
+  type AuthenticatedSurface,
+  type WebLocationLike,
+  type WebSurface,
+  isAuthenticatedSurface,
+  isLocalDevelopmentLocation,
+  productionAuthOrigin,
+  productionMathOrigin,
+  productionPortalOrigin,
+  productionPublicOrigin,
+  resolveAccessProviderFromHost,
+  resolveAuthenticatedRouteTarget,
+  resolveWebSurfaceFromLocation,
+  sanitizeMathTargetPath,
+  sanitizePortalTargetPath,
+  sanitizePublicTargetPath
+} from "@paretoproof/shared";
 import { getApiBaseUrl } from "./api-base-url";
-import { isLocalDevelopmentLocation } from "./local-development";
 
-export type WebSurface = "public" | "auth" | "portal" | "math";
-export type AuthenticatedSurface = "portal" | "math";
-export type AccessProvider = "github" | "google";
+export type { AccessProvider, AuthenticatedSurface, WebSurface };
 
-const productionPublicOrigin = "https://paretoproof.com";
-const productionAuthOrigin = "https://auth.paretoproof.com";
-const productionPortalOrigin = "https://portal.paretoproof.com";
-const productionMathOrigin = "https://math.paretoproof.com";
 const localPortalStateParamKeys = ["access", "email"] as const;
-const authenticatedSurfaces = ["portal", "math"] as const;
-const productionProviderAuthOrigins: Record<AccessProvider, string> = {
-  github: "https://github.auth.paretoproof.com",
-  google: "https://google.auth.paretoproof.com"
-};
-const productionOriginByAuthenticatedSurface: Record<AuthenticatedSurface, string> = {
-  math: productionMathOrigin,
-  portal: productionPortalOrigin
-};
 
-type OwnedAppSurface = "public_site" | AuthenticatedSurface;
-type ResolvedOwnedTarget<TSurface extends OwnedAppSurface = OwnedAppSurface> = {
-  surface: TSurface;
-  targetPath: string;
-};
+function readBrowserLocation() {
+  return window.location;
+}
 
-function readLocalSurfaceOverride(search = window.location.search) {
-  const params = new URLSearchParams(search);
-  const surface = params.get("surface");
+function readOptionalBrowserLocation() {
+  return typeof window === "undefined" ? null : window.location;
+}
 
-  return surface === "public" ||
-    surface === "auth" ||
-    surface === "portal" ||
-    surface === "math"
-    ? surface
-    : null;
+function toLocationLike(locationLike: WebLocationLike | Location): WebLocationLike {
+  return {
+    hash: locationLike.hash ?? "",
+    hostname: locationLike.hostname,
+    origin: locationLike.origin,
+    pathname: locationLike.pathname ?? "/",
+    port: locationLike.port ?? "",
+    protocol: locationLike.protocol ?? "",
+    search: locationLike.search ?? ""
+  };
 }
 
 export function isLocalHostname(hostname: string) {
   return isLocalDevelopmentLocation({
-    hostname,
-    port: window.location.port,
-    protocol: window.location.protocol
+    hostname
   });
 }
 
-function isLocalOrigin(hostname = window.location.hostname) {
+function isLocalOrigin(
+  hostname = readBrowserLocation().hostname,
+  currentLocation = readOptionalBrowserLocation()
+) {
+  if (currentLocation && hostname === currentLocation.hostname) {
+    return isLocalDevelopmentLocation(toLocationLike(currentLocation));
+  }
+
   return isLocalHostname(hostname);
 }
 
-function buildLocalPublicOrigin(locationLike = window.location) {
-  const { hostname, origin, port, protocol } = locationLike;
+function buildLocalPublicOrigin(
+  locationLike: WebLocationLike | Location = readBrowserLocation()
+) {
+  const currentLocation = toLocationLike(locationLike);
+  const { hostname, origin, port, protocol } = currentLocation;
 
-  if (!isLocalDevelopmentLocation(locationLike)) {
-    return origin;
+  if (!origin || !isLocalDevelopmentLocation(currentLocation)) {
+    return origin ?? productionPublicOrigin;
   }
 
   if (
@@ -71,18 +82,6 @@ function buildLocalPublicOrigin(locationLike = window.location) {
   return origin;
 }
 
-function isAuthenticatedSurface(surface: string | null): surface is AuthenticatedSurface {
-  return surface === "portal" || surface === "math";
-}
-
-function mapAuthenticatedSurfaceToOrigin(surface: AuthenticatedSurface) {
-  return productionOriginByAuthenticatedSurface[surface];
-}
-
-function mapAuthenticatedSurfaceToLabel(surface: AuthenticatedSurface) {
-  return surface === "math" ? "math workspace" : "portal";
-}
-
 function mapWebSurfaceToAuthenticatedSurface(
   surface: WebSurface
 ): AuthenticatedSurface | null {
@@ -93,219 +92,56 @@ function mapWebSurfaceToAuthenticatedSurface(
   return null;
 }
 
-function readAuthenticatedSurfaceParam(search = window.location.search) {
+function mapAuthenticatedSurfaceToLabel(surface: AuthenticatedSurface) {
+  return surface === "math" ? "math workspace" : "portal";
+}
+
+function readAuthenticatedSurfaceParam(search = readBrowserLocation().search) {
   const surface = new URLSearchParams(search).get("app");
   return isAuthenticatedSurface(surface) ? surface : null;
 }
 
-function resolvePreferredAuthenticatedSurface(hostname = window.location.hostname) {
+function resolvePreferredAuthenticatedSurface(hostname = readBrowserLocation().hostname) {
   return mapWebSurfaceToAuthenticatedSurface(resolveWebSurface(hostname)) ?? "portal";
 }
 
 export function resolveWebSurfaceFromUrl(
-  locationLike: Pick<Location, "hostname" | "search"> | URL = window.location
+  locationLike: WebLocationLike | Location = readBrowserLocation()
 ): WebSurface {
-  const { hostname, search } = locationLike;
-
-  if (
-    hostname === "auth.paretoproof.com" ||
-    hostname === "github.auth.paretoproof.com" ||
-    hostname === "google.auth.paretoproof.com"
-  ) {
-    return "auth";
-  }
-
-  if (hostname === "portal.paretoproof.com") {
-    return "portal";
-  }
-
-  if (hostname === "math.paretoproof.com") {
-    return "math";
-  }
-
-  if (isLocalHostname(hostname)) {
-    return readLocalSurfaceOverride(search) ?? "public";
-  }
-
-  return "public";
+  return resolveWebSurfaceFromLocation(toLocationLike(locationLike));
 }
 
-export function resolveWebSurface(hostname = window.location.hostname): WebSurface {
-  if (hostname === window.location.hostname) {
-    return resolveWebSurfaceFromUrl(window.location);
+export function resolveWebSurface(hostname = readBrowserLocation().hostname): WebSurface {
+  const currentLocation = readOptionalBrowserLocation();
+
+  if (currentLocation && hostname === currentLocation.hostname) {
+    return resolveWebSurfaceFromUrl(currentLocation);
   }
 
-  return resolveWebSurfaceFromUrl({
+  return resolveWebSurfaceFromLocation({
     hostname,
     search: ""
   });
 }
 
-function normalizeTargetPath(targetPath: string) {
-  if (!targetPath || targetPath === "/") {
-    return "/";
-  }
-
-  return targetPath.startsWith("/") ? targetPath : `/${targetPath}`;
-}
-
-function tryResolveRelativeTarget(
-  targetPath: string,
-  allowedSurfaces: OwnedAppSurface[],
-  preferredSurface: OwnedAppSurface
-): ResolvedOwnedTarget | null {
-  try {
-    const candidateUrl = new URL(
-      normalizeTargetPath(targetPath),
-      mapOwnedSurfaceToOrigin(preferredSurface)
-    );
-    const matchingSurface =
-      allowedSurfaces.find(
-        (surface) =>
-          surface === preferredSurface &&
-          findAppRouteBySurface(surface, candidateUrl.pathname)
-      ) ??
-      allowedSurfaces.find((surface) =>
-        findAppRouteBySurface(surface, candidateUrl.pathname)
-      );
-
-    if (!matchingSurface) {
-      return null;
-    }
-
-    return {
-      surface: matchingSurface,
-      targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
-    };
-  } catch {
-    return null;
-  }
-}
-
-function mapOwnedSurfaceToOrigin(surface: OwnedAppSurface) {
-  if (surface === "public_site") {
-    return productionPublicOrigin;
-  }
-
-  return mapAuthenticatedSurfaceToOrigin(surface);
-}
-
-function tryResolveAbsoluteTarget(
-  targetPath: string,
-  allowedSurfaces: OwnedAppSurface[]
-): ResolvedOwnedTarget | null {
-  let candidateUrl: URL;
-
-  try {
-    candidateUrl = new URL(targetPath);
-  } catch {
-    return null;
-  }
-
-  const matchingSurface = allowedSurfaces.find((surface) => {
-    if (candidateUrl.origin !== mapOwnedSurfaceToOrigin(surface)) {
-      return false;
-    }
-
-    return findAppRouteBySurface(surface, candidateUrl.pathname);
-  });
-
-  if (!matchingSurface) {
-    return null;
-  }
-
-  return {
-    surface: matchingSurface,
-    targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
-  };
-}
-
-function resolveOwnedTarget(
-  targetPath: string,
-  options: {
-    allowedSurfaces: OwnedAppSurface[];
-    preferredSurface: OwnedAppSurface;
-  }
-): ResolvedOwnedTarget | null {
-  if (!targetPath || targetPath === "/") {
-    return {
-      surface: options.preferredSurface,
-      targetPath: "/"
-    };
-  }
-
-  if (
-    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetPath) ||
-    targetPath.startsWith("//")
-  ) {
-    return tryResolveAbsoluteTarget(targetPath, options.allowedSurfaces);
-  }
-
-  return tryResolveRelativeTarget(
-    targetPath,
-    options.allowedSurfaces,
-    options.preferredSurface
-  );
-}
-
-function resolveAuthenticatedTarget(
-  targetPath: string,
-  options?: {
-    preferredSurface?: AuthenticatedSurface;
-    surface?: AuthenticatedSurface | null;
-  }
-) {
-  const preferredSurface =
-    options?.surface ?? options?.preferredSurface ?? "portal";
-  const allowedSurfaces = options?.surface
-    ? [options.surface]
-    : [...authenticatedSurfaces];
-
-  return resolveOwnedTarget(targetPath, {
-    allowedSurfaces,
-    preferredSurface
-  }) as ResolvedOwnedTarget<AuthenticatedSurface> | null;
-}
-
-function sanitizeSurfaceTargetPath(surface: OwnedAppSurface, targetPath: string) {
-  return (
-    resolveOwnedTarget(targetPath, {
-      allowedSurfaces: [surface],
-      preferredSurface: surface
-    })?.targetPath ?? "/"
-  );
-}
-
-function sanitizePortalTargetPath(targetPath: string) {
-  return sanitizeSurfaceTargetPath("portal", targetPath);
-}
-
-function sanitizePublicTargetPath(targetPath: string) {
-  return sanitizeSurfaceTargetPath("public_site", targetPath);
-}
-
-function sanitizeMathTargetPath(targetPath: string) {
-  return sanitizeSurfaceTargetPath("math", targetPath);
-}
-
-export function readAuthenticatedRedirectTarget(search = window.location.search) {
+export function readAuthenticatedRedirectTarget(search = readBrowserLocation().search) {
   const params = new URLSearchParams(search);
   const targetSurface = readAuthenticatedSurfaceParam(search);
 
   return (
-    resolveAuthenticatedTarget(params.get("redirect") ?? "/", {
+    resolveAuthenticatedRouteTarget(params.get("redirect") ?? "/", {
       preferredSurface: targetSurface ?? "portal",
       surface: targetSurface
     })?.targetPath ?? "/"
   );
 }
 
-export function readAuthenticatedRedirectSurface(search = window.location.search) {
+export function readAuthenticatedRedirectSurface(search = readBrowserLocation().search) {
   const params = new URLSearchParams(search);
   const explicitSurface = readAuthenticatedSurfaceParam(search);
 
   return (
-    resolveAuthenticatedTarget(params.get("redirect") ?? "/", {
+    resolveAuthenticatedRouteTarget(params.get("redirect") ?? "/", {
       preferredSurface: explicitSurface ?? "portal",
       surface: explicitSurface
     })?.surface ??
@@ -314,7 +150,7 @@ export function readAuthenticatedRedirectSurface(search = window.location.search
   );
 }
 
-export function readPortalRedirectTarget(search = window.location.search) {
+export function readPortalRedirectTarget(search = readBrowserLocation().search) {
   return readAuthenticatedRedirectTarget(search);
 }
 
@@ -322,8 +158,11 @@ function buildLocalSurfaceUrl(
   surface: Exclude<WebSurface, "public">,
   targetPath: string,
   authenticatedSurface: AuthenticatedSurface,
-  origin = window.location.origin
+  currentLocation: WebLocationLike | Location = readBrowserLocation()
 ) {
+  const currentLocationLike = toLocationLike(currentLocation);
+  const origin = currentLocationLike.origin ?? productionPublicOrigin;
+
   if (surface === "portal" || surface === "math") {
     const surfaceUrl = new URL(
       surface === "portal"
@@ -333,7 +172,7 @@ function buildLocalSurfaceUrl(
     );
 
     surfaceUrl.searchParams.set("surface", surface);
-    copyLocalPortalState(surfaceUrl);
+    copyLocalPortalState(surfaceUrl, currentLocationLike);
     return surfaceUrl.toString();
   }
 
@@ -368,12 +207,17 @@ function shouldPreserveLocalPortalRoles(currentParams: URLSearchParams) {
   return currentParams.get("access") === "approved";
 }
 
-export function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
-  if (!isLocalOrigin(currentLocation.hostname)) {
+export function copyLocalPortalState(
+  targetUrl: URL,
+  currentLocation: WebLocationLike | Location = readBrowserLocation()
+) {
+  const currentLocationLike = toLocationLike(currentLocation);
+
+  if (!isLocalDevelopmentLocation(currentLocationLike)) {
     return;
   }
 
-  const currentParams = new URLSearchParams(currentLocation.search);
+  const currentParams = new URLSearchParams(currentLocationLike.search ?? "");
 
   for (const key of localPortalStateParamKeys) {
     if (targetUrl.searchParams.has(key)) {
@@ -422,15 +266,16 @@ export function copyLocalPortalState(targetUrl: URL, currentLocation = window.lo
 
 export function buildAuthUrl(
   targetPath = "/",
-  hostname = window.location.hostname,
+  hostname = readBrowserLocation().hostname,
   options?: {
     surface?: AuthenticatedSurface;
   }
 ) {
+  const currentLocation = readOptionalBrowserLocation();
   const preferredSurface =
     options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
   const resolvedTarget =
-    resolveAuthenticatedTarget(targetPath, {
+    resolveAuthenticatedRouteTarget(targetPath, {
       preferredSurface,
       surface: options?.surface
     }) ?? {
@@ -438,11 +283,12 @@ export function buildAuthUrl(
       targetPath: "/"
     };
 
-  if (isLocalOrigin(hostname)) {
+  if (currentLocation && isLocalOrigin(hostname, currentLocation)) {
     return buildLocalSurfaceUrl(
       "auth",
       resolvedTarget.targetPath,
-      resolvedTarget.surface
+      resolvedTarget.surface,
+      currentLocation
     );
   }
 
@@ -458,7 +304,7 @@ export function buildAuthUrl(
 
 export function buildAuthGuidanceUrl(
   targetPath = "/",
-  hostname = window.location.hostname,
+  hostname = readBrowserLocation().hostname,
   options?: {
     surface?: AuthenticatedSurface;
   }
@@ -468,37 +314,43 @@ export function buildAuthGuidanceUrl(
   return authUrl.toString();
 }
 
-export function buildAccessRequestUrl(hostname = window.location.hostname) {
+export function buildAccessRequestUrl(hostname = readBrowserLocation().hostname) {
   return buildAuthUrl("/access-request", hostname, {
     surface: "portal"
   });
 }
 
-export function buildPublicUrl(targetPath = "/", hostname = window.location.hostname) {
+export function buildPublicUrl(targetPath = "/", hostname = readBrowserLocation().hostname) {
+  const currentLocation = readOptionalBrowserLocation();
   const normalizedTargetPath = sanitizePublicTargetPath(targetPath);
 
-  if (isLocalOrigin(hostname)) {
-    return new URL(normalizedTargetPath, buildLocalPublicOrigin()).toString();
+  if (currentLocation && isLocalOrigin(hostname, currentLocation)) {
+    return new URL(
+      normalizedTargetPath,
+      buildLocalPublicOrigin(currentLocation)
+    ).toString();
   }
 
   return new URL(normalizedTargetPath, productionPublicOrigin).toString();
 }
 
-export function buildPortalUrl(targetPath = "/", hostname = window.location.hostname) {
+export function buildPortalUrl(targetPath = "/", hostname = readBrowserLocation().hostname) {
+  const currentLocation = readOptionalBrowserLocation();
   const normalizedTargetPath = sanitizePortalTargetPath(targetPath);
 
-  if (isLocalOrigin(hostname)) {
-    return buildLocalSurfaceUrl("portal", normalizedTargetPath, "portal");
+  if (currentLocation && isLocalOrigin(hostname, currentLocation)) {
+    return buildLocalSurfaceUrl("portal", normalizedTargetPath, "portal", currentLocation);
   }
 
   return new URL(normalizedTargetPath, productionPortalOrigin).toString();
 }
 
-export function buildMathUrl(targetPath = "/", hostname = window.location.hostname) {
+export function buildMathUrl(targetPath = "/", hostname = readBrowserLocation().hostname) {
+  const currentLocation = readOptionalBrowserLocation();
   const normalizedTargetPath = sanitizeMathTargetPath(targetPath);
 
-  if (isLocalOrigin(hostname)) {
-    return buildLocalSurfaceUrl("math", normalizedTargetPath, "math");
+  if (currentLocation && isLocalOrigin(hostname, currentLocation)) {
+    return buildLocalSurfaceUrl("math", normalizedTargetPath, "math", currentLocation);
   }
 
   return new URL(normalizedTargetPath, productionMathOrigin).toString();
@@ -509,12 +361,12 @@ export function buildAuthenticatedAppUrl(
   options?: {
     surface?: AuthenticatedSurface;
   },
-  hostname = window.location.hostname
+  hostname = readBrowserLocation().hostname
 ) {
   const preferredSurface =
     options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
   const resolvedTarget =
-    resolveAuthenticatedTarget(targetPath, {
+    resolveAuthenticatedRouteTarget(targetPath, {
       preferredSurface,
       surface: options?.surface
     }) ?? {
@@ -534,45 +386,18 @@ export function buildAccessStartUrl(
     flow?: "sign_in" | "link";
     surface?: AuthenticatedSurface;
   },
-  hostname = window.location.hostname
+  hostname = readBrowserLocation().hostname
 ) {
   const preferredSurface =
     options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
   const resolvedTarget =
-    resolveAuthenticatedTarget(targetPath, {
+    resolveAuthenticatedRouteTarget(targetPath, {
       preferredSurface,
       surface: options?.surface
     }) ?? {
       surface: preferredSurface,
       targetPath: "/"
     };
-
-  if (isLocalOrigin(hostname)) {
-    const localUrl = new URL(
-      buildAuthenticatedAppUrl(
-        resolvedTarget.targetPath,
-        {
-          surface: resolvedTarget.surface
-        },
-        hostname
-      )
-    );
-    const currentParams = new URLSearchParams(window.location.search);
-    const approvedRole =
-      currentParams.get("role") ??
-      (currentParams.get("roles") ?? "")
-        .split(",")
-        .map((role) => role.trim())
-        .find(Boolean) ??
-      "admin";
-
-    localUrl.searchParams.set("access", "approved");
-    localUrl.searchParams.set("email", currentParams.get("email") ?? "local@example.com");
-    localUrl.searchParams.set("role", approvedRole);
-    localUrl.searchParams.delete("roles");
-    localUrl.searchParams.delete("reason");
-    return localUrl.toString();
-  }
 
   const authUrl = new URL(`/api/access/start/${provider}`, productionAuthOrigin);
   authUrl.searchParams.set("app", resolvedTarget.surface);
@@ -588,17 +413,67 @@ export function buildAccessStartUrl(
   return authUrl.toString();
 }
 
+export function buildLocalAuthPreviewUrl(
+  targetPath = "/",
+  options?: {
+    surface?: AuthenticatedSurface;
+  },
+  hostname = readBrowserLocation().hostname
+) {
+  const currentLocation = readOptionalBrowserLocation();
+
+  if (!currentLocation || !isLocalOrigin(hostname, currentLocation)) {
+    return buildAuthenticatedAppUrl(targetPath, options, hostname);
+  }
+
+  const preferredSurface =
+    options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
+  const resolvedTarget =
+    resolveAuthenticatedRouteTarget(targetPath, {
+      preferredSurface,
+      surface: options?.surface
+    }) ?? {
+      surface: preferredSurface,
+      targetPath: "/"
+    };
+  const localUrl = new URL(
+    buildAuthenticatedAppUrl(
+      resolvedTarget.targetPath,
+      {
+        surface: resolvedTarget.surface
+      },
+      hostname
+    )
+  );
+  const currentParams = new URLSearchParams(currentLocation.search);
+  const approvedRole =
+    currentParams.get("role") ??
+    (currentParams.get("roles") ?? "")
+      .split(",")
+      .map((role) => role.trim())
+      .find(Boolean) ??
+    "helper";
+
+  localUrl.searchParams.set("access", "approved");
+  localUrl.searchParams.set("email", currentParams.get("email") ?? "local@example.com");
+  localUrl.searchParams.set("role", approvedRole);
+  localUrl.searchParams.delete("roles");
+  localUrl.searchParams.delete("reason");
+  return localUrl.toString();
+}
+
 export function buildAccessFinalizeUrl(
   targetPath = "/",
   options?: {
     surface?: AuthenticatedSurface;
   },
-  hostname = window.location.hostname
+  hostname = readBrowserLocation().hostname
 ) {
+  const currentLocation = readOptionalBrowserLocation();
   const preferredSurface =
     options?.surface ?? resolvePreferredAuthenticatedSurface(hostname);
   const resolvedTarget =
-    resolveAuthenticatedTarget(targetPath, {
+    resolveAuthenticatedRouteTarget(targetPath, {
       preferredSurface,
       surface: options?.surface
     }) ?? {
@@ -606,8 +481,13 @@ export function buildAccessFinalizeUrl(
       targetPath: "/"
     };
 
-  if (isLocalOrigin(hostname)) {
-    const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
+  if (currentLocation && isLocalOrigin(hostname, currentLocation)) {
+    const completionUrl = new URL(
+      "/portal/session/finalize/submit",
+      getApiBaseUrl({
+        locationLike: currentLocation
+      })
+    );
     completionUrl.searchParams.set("app", resolvedTarget.surface);
 
     if (resolvedTarget.targetPath !== "/") {
@@ -617,7 +497,10 @@ export function buildAccessFinalizeUrl(
     return completionUrl.toString();
   }
 
-  const completionUrl = new URL("/api/access/finalize", window.location.origin);
+  const completionUrl = new URL(
+    "/api/access/finalize",
+    currentLocation?.origin ?? productionAuthOrigin
+  );
   completionUrl.searchParams.set("app", resolvedTarget.surface);
 
   if (resolvedTarget.targetPath !== "/") {
@@ -628,24 +511,16 @@ export function buildAccessFinalizeUrl(
 }
 
 export function resolveAccessProviderHost(
-  hostname = window.location.hostname
+  hostname = readBrowserLocation().hostname
 ): AccessProvider | null {
-  if (hostname === "github.auth.paretoproof.com") {
-    return "github";
-  }
-
-  if (hostname === "google.auth.paretoproof.com") {
-    return "google";
-  }
-
-  return null;
+  return resolveAccessProviderFromHost(hostname);
 }
 
 export function describeAuthenticatedSurface(surface: AuthenticatedSurface) {
   return mapAuthenticatedSurfaceToLabel(surface);
 }
 
-export function getCurrentRelativeUrl(location = window.location) {
+export function getCurrentRelativeUrl(location = readBrowserLocation()) {
   const params = new URLSearchParams(location.search);
 
   params.delete("surface");

--- a/apps/web/src/routes/access-completion.tsx
+++ b/apps/web/src/routes/access-completion.tsx
@@ -4,9 +4,9 @@ import {
   buildAccessFinalizeUrl,
   buildAuthUrl,
   describeAuthenticatedSurface,
-  type AuthenticatedSurface,
-  isLocalHostname
+  type AuthenticatedSurface
 } from "../lib/surface";
+import { isLocalDevelopmentLocation } from "../lib/local-development";
 
 type AccessCompletionProps = {
   provider: "github" | "google";
@@ -28,7 +28,7 @@ export function AccessCompletion({
       surface: redirectSurface
     })
   );
-  const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
+  const isLocal = isLocalDevelopmentLocation(window.location);
   const destinationLabel = describeAuthenticatedSurface(redirectSurface);
 
   retryUrl.searchParams.set("handoff", "retry");

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -260,10 +260,16 @@ describe("buildLocalAuthEntryPreviewState", () => {
       location: new URL("http://127.0.0.1/?surface=auth")
     };
 
-    expect(buildLocalAuthEntryPreviewState("sign_in", "/runs/alpha", "portal")).toMatchObject({
+    const previewState = buildLocalAuthEntryPreviewState(
+      "sign_in",
+      "/runs/alpha",
+      "portal"
+    );
+    const portalPreviewUrl = new URL(previewState.actions[0].href);
+
+    expect(previewState).toMatchObject({
       actions: [
         {
-          href: "http://127.0.0.1/runs/alpha?surface=portal",
           title: "Open local portal preview"
         },
         {
@@ -272,6 +278,12 @@ describe("buildLocalAuthEntryPreviewState", () => {
         }
       ]
     });
+    expect(portalPreviewUrl.origin).toBe("http://127.0.0.1");
+    expect(portalPreviewUrl.pathname).toBe("/runs/alpha");
+    expect(portalPreviewUrl.searchParams.get("surface")).toBe("portal");
+    expect(portalPreviewUrl.searchParams.get("access")).toBe("approved");
+    expect(portalPreviewUrl.searchParams.get("email")).toBe("local@example.com");
+    expect(portalPreviewUrl.searchParams.get("role")).toBe("helper");
   });
 
   it("builds a local access-request preview with a direct portal route handoff", () => {
@@ -310,10 +322,15 @@ describe("AuthEntry local rendering", () => {
     expect(html).toContain("Open local portal preview");
     expect(html).toContain("Open local access-request preview");
     expect(html).toContain("http://127.0.0.1/runs/alpha?surface=portal");
+    expect(html).toContain("access=approved");
+    expect(html).toContain("email=local%40example.com");
+    expect(html).toContain("role=helper");
     expect(html).toContain("Back to local home");
     expect(countOccurrences(html, "Open local portal preview")).toBe(1);
     expect(html).not.toContain("Continue with GitHub");
     expect(html).not.toContain("Continue with Google");
+    expect(html).not.toContain("/api/access/start/github");
+    expect(html).not.toContain("/api/access/start/google");
   });
 
   it("renders truthful local access-request guidance instead of identity-verification promises", () => {

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -11,12 +11,13 @@ import {
   buildAccessStartUrl,
   buildAuthenticatedAppUrl,
   buildAuthUrl,
+  buildLocalAuthPreviewUrl,
   buildPortalUrl,
   buildPublicUrl,
   describeAuthenticatedSurface,
-  type AuthenticatedSurface,
-  isLocalHostname
+  type AuthenticatedSurface
 } from "../lib/surface";
+import { isLocalDevelopmentLocation } from "../lib/local-development";
 
 type AuthEntryProps = {
   redirectPath: string;
@@ -135,7 +136,7 @@ export function buildLocalAuthEntryPreviewState(
           redirectSurface === "math"
             ? "Open the math workspace preview directly against your local or configured API target."
             : "Open the contributor portal shell directly against your local or configured API target.",
-        href: buildAuthenticatedAppUrl(
+        href: buildLocalAuthPreviewUrl(
           resolveAuthEntryApprovedPortalTargetPath(redirectPath),
           {
             surface: redirectSurface
@@ -250,17 +251,21 @@ export function resolveApprovedAuthEntryHandoff(
 
 export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
   const mode = resolveAuthEntryMode(redirectPath);
-  const githubStartUrl = buildAccessStartUrl("github", redirectPath, {
-    surface: redirectSurface
-  });
-  const googleStartUrl = buildAccessStartUrl("google", redirectPath, {
-    surface: redirectSurface
-  });
   const approvedSignInUrl = buildAuthUrl("/", undefined, {
     surface: "portal"
   });
   const accessRequestUrl = buildAccessRequestUrl();
-  const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
+  const isLocal = isLocalDevelopmentLocation(window.location);
+  const providerStartUrls = isLocal
+    ? null
+    : {
+        github: buildAccessStartUrl("github", redirectPath, {
+          surface: redirectSurface
+        }),
+        google: buildAccessStartUrl("google", redirectPath, {
+          surface: redirectSurface
+        })
+      };
   const apiBaseUrl = useMemo(() => getApiBaseUrl(), []);
   const destinationUrl = useMemo(
     () =>
@@ -292,6 +297,10 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
     : mode === "access_request"
       ? accessRequestChecks
       : signInChecks;
+  const hostedProviderStartUrls = providerStartUrls ?? {
+    github: "#",
+    google: "#"
+  };
 
   useEffect(() => {
     if (isLocal || skipSessionCheck) {
@@ -443,7 +452,7 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
                 ))
               ) : (
                 <>
-                  <a className="auth-provider-button" href={githubStartUrl}>
+                  <a className="auth-provider-button" href={hostedProviderStartUrls.github}>
                     <span className="auth-provider-mark" aria-hidden="true">
                       <AppIcon name="github" />
                     </span>
@@ -455,7 +464,7 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
                       <AppIcon name="arrow-right" />
                     </span>
                   </a>
-                  <a className="auth-provider-button" href={googleStartUrl}>
+                  <a className="auth-provider-button" href={hostedProviderStartUrls.google}>
                     <span className="auth-provider-mark" aria-hidden="true">
                       <AppIcon name="google" />
                     </span>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { paretoProofBrandedHosts } from "./src/lib/local-development";
+import { paretoProofBrandedHosts } from "../../packages/shared/src/contracts/web-surface-hosts";
 
 export const paretoProofDevAllowedHosts = [...paretoProofBrandedHosts];
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "bunx tsc -p tsconfig.json",
-    "test": "bun run build && bun test src/**/*.test.js test/**/*.test.js",
+    "test": "bun run build && bun test src/**/*.test.js test/*.test.js test/**/*.test.js",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/shared/src/contracts/web-surface-hosts.ts
+++ b/packages/shared/src/contracts/web-surface-hosts.ts
@@ -1,0 +1,26 @@
+export type AccessProvider = "github" | "google";
+
+export const productionPublicOrigin = "https://paretoproof.com";
+export const productionAuthOrigin = "https://auth.paretoproof.com";
+export const productionPortalOrigin = "https://portal.paretoproof.com";
+export const productionMathOrigin = "https://math.paretoproof.com";
+
+export const paretoProofBrandedHosts = [
+  "paretoproof.com",
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com",
+  "math.paretoproof.com",
+  "portal.paretoproof.com"
+] as const;
+
+export const brandedFinalizeRelayHosts = [
+  "auth.paretoproof.com",
+  "github.auth.paretoproof.com",
+  "google.auth.paretoproof.com"
+] as const;
+
+export const productionProviderAuthOrigins: Record<AccessProvider, string> = {
+  github: "https://github.auth.paretoproof.com",
+  google: "https://google.auth.paretoproof.com"
+};

--- a/packages/shared/src/contracts/web-surface-routing.ts
+++ b/packages/shared/src/contracts/web-surface-routing.ts
@@ -1,0 +1,415 @@
+import { findAppRouteBySurface } from "./route-access.js";
+import type { AppSurface } from "../types/route-access.js";
+import {
+  brandedFinalizeRelayHosts,
+  paretoProofBrandedHosts,
+  productionAuthOrigin,
+  productionMathOrigin,
+  productionPortalOrigin,
+  productionPublicOrigin
+} from "./web-surface-hosts.js";
+import type { AccessProvider } from "./web-surface-hosts.js";
+export {
+  brandedFinalizeRelayHosts,
+  paretoProofBrandedHosts,
+  productionAuthOrigin,
+  productionMathOrigin,
+  productionPortalOrigin,
+  productionProviderAuthOrigins,
+  productionPublicOrigin
+} from "./web-surface-hosts.js";
+export type { AccessProvider } from "./web-surface-hosts.js";
+
+export type WebSurface = "public" | "auth" | "portal" | "math";
+export type AuthenticatedSurface = "portal" | "math";
+export type OwnedAppSurface = AppSurface;
+
+export type WebLocationLike = {
+  hash?: string;
+  hostname: string;
+  origin?: string;
+  pathname?: string;
+  port?: string;
+  protocol?: string;
+  search?: string;
+};
+
+export type ResolvedOwnedRouteTarget<
+  TSurface extends OwnedAppSurface = OwnedAppSurface
+> = {
+  surface: TSurface;
+  targetPath: string;
+};
+
+const authenticatedSurfaces = ["portal", "math"] as const;
+const productionOriginByAuthenticatedSurface: Record<AuthenticatedSurface, string> = {
+  math: productionMathOrigin,
+  portal: productionPortalOrigin
+};
+
+function normalizeHostname(hostname: string) {
+  return hostname.toLowerCase();
+}
+
+export function isLoopbackHostname(hostname: string) {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "127.0.0.1" ||
+    normalizedHostname === "::1" ||
+    normalizedHostname.endsWith(".localhost")
+  );
+}
+
+export function isParetoProofBrandedHost(hostname: string) {
+  return paretoProofBrandedHosts.includes(
+    normalizeHostname(hostname) as (typeof paretoProofBrandedHosts)[number]
+  );
+}
+
+export function isBrandedFinalizeRelayHost(hostname: string) {
+  return brandedFinalizeRelayHosts.includes(
+    normalizeHostname(hostname) as (typeof brandedFinalizeRelayHosts)[number]
+  );
+}
+
+export function isLocalDevelopmentLocation({
+  hostname,
+  port = "",
+  protocol = ""
+}: WebLocationLike) {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  if (isLoopbackHostname(normalizedHostname)) {
+    return true;
+  }
+
+  return (
+    protocol === "http:" &&
+    port !== "" &&
+    isParetoProofBrandedHost(normalizedHostname)
+  );
+}
+
+export function isTrustedFinalizeRelayLocation({
+  hostname,
+  port = "",
+  protocol = ""
+}: WebLocationLike) {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  if (protocol === "https:" && isBrandedFinalizeRelayHost(normalizedHostname)) {
+    return true;
+  }
+
+  if (protocol !== "http:") {
+    return false;
+  }
+
+  if (isLoopbackHostname(normalizedHostname)) {
+    return true;
+  }
+
+  return port !== "" && isBrandedFinalizeRelayHost(normalizedHostname);
+}
+
+function readLocalSurfaceOverride(search = ""): WebSurface | null {
+  const params = new URLSearchParams(search);
+  const surface = params.get("surface");
+
+  return surface === "public" ||
+    surface === "auth" ||
+    surface === "portal" ||
+    surface === "math"
+    ? surface
+    : null;
+}
+
+export function isAuthenticatedSurface(
+  surface: string | null
+): surface is AuthenticatedSurface {
+  return surface === "portal" || surface === "math";
+}
+
+export function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface {
+  return surface === "math" ? "math" : "portal";
+}
+
+export function resolveWebSurfaceFromLocation(locationLike: WebLocationLike): WebSurface {
+  const hostname = normalizeHostname(locationLike.hostname);
+
+  if (
+    hostname === "auth.paretoproof.com" ||
+    hostname === "github.auth.paretoproof.com" ||
+    hostname === "google.auth.paretoproof.com"
+  ) {
+    return "auth";
+  }
+
+  if (hostname === "portal.paretoproof.com") {
+    return "portal";
+  }
+
+  if (hostname === "math.paretoproof.com") {
+    return "math";
+  }
+
+  if (isLocalDevelopmentLocation(locationLike)) {
+    return readLocalSurfaceOverride(locationLike.search) ?? "public";
+  }
+
+  return "public";
+}
+
+export function resolveAccessProviderFromHost(hostname: string): AccessProvider | null {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  if (normalizedHostname === "github.auth.paretoproof.com") {
+    return "github";
+  }
+
+  if (normalizedHostname === "google.auth.paretoproof.com") {
+    return "google";
+  }
+
+  return null;
+}
+
+export function mapAuthenticatedSurfaceToOrigin(surface: AuthenticatedSurface) {
+  return productionOriginByAuthenticatedSurface[surface];
+}
+
+export function mapOwnedSurfaceToOrigin(surface: OwnedAppSurface) {
+  if (surface === "public_site") {
+    return productionPublicOrigin;
+  }
+
+  return mapAuthenticatedSurfaceToOrigin(surface);
+}
+
+function normalizeTargetPath(targetPath: string) {
+  if (!targetPath || targetPath === "/") {
+    return "/";
+  }
+
+  return targetPath.startsWith("/") ? targetPath : `/${targetPath}`;
+}
+
+function hasUrlScheme(targetPath: string) {
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(targetPath);
+}
+
+function tryResolveAbsoluteTarget<TSurface extends OwnedAppSurface>(
+  targetPath: string,
+  allowedSurfaces: readonly TSurface[]
+): ResolvedOwnedRouteTarget<TSurface> | null {
+  if (targetPath.startsWith("//")) {
+    return null;
+  }
+
+  let candidateUrl: URL;
+
+  try {
+    candidateUrl = new URL(targetPath);
+  } catch {
+    return null;
+  }
+
+  const matchingSurface = allowedSurfaces.find((surface) => {
+    if (candidateUrl.origin !== mapOwnedSurfaceToOrigin(surface)) {
+      return false;
+    }
+
+    return findAppRouteBySurface(surface, candidateUrl.pathname);
+  });
+
+  if (!matchingSurface) {
+    return null;
+  }
+
+  return {
+    surface: matchingSurface,
+    targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
+  };
+}
+
+function tryResolveRelativeTarget<TSurface extends OwnedAppSurface>(
+  targetPath: string,
+  allowedSurfaces: readonly TSurface[],
+  preferredSurface: TSurface
+): ResolvedOwnedRouteTarget<TSurface> | null {
+  try {
+    const candidateUrl = new URL(
+      normalizeTargetPath(targetPath),
+      mapOwnedSurfaceToOrigin(preferredSurface)
+    );
+    const matchingSurface =
+      allowedSurfaces.find(
+        (surface) =>
+          surface === preferredSurface &&
+          findAppRouteBySurface(surface, candidateUrl.pathname)
+      ) ??
+      allowedSurfaces.find((surface) =>
+        findAppRouteBySurface(surface, candidateUrl.pathname)
+      );
+
+    if (!matchingSurface) {
+      return null;
+    }
+
+    return {
+      surface: matchingSurface,
+      targetPath: `${candidateUrl.pathname}${candidateUrl.search}${candidateUrl.hash}` || "/"
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveOwnedRouteTarget<TSurface extends OwnedAppSurface>(
+  targetPath: string | null | undefined,
+  options: {
+    allowAbsolute?: boolean;
+    allowedSurfaces: readonly TSurface[];
+    preferredSurface: TSurface;
+  }
+): ResolvedOwnedRouteTarget<TSurface> | null {
+  if (!targetPath || targetPath === "/") {
+    return {
+      surface: options.preferredSurface,
+      targetPath: "/"
+    };
+  }
+
+  if (hasUrlScheme(targetPath) || targetPath.startsWith("//")) {
+    if (options.allowAbsolute === false) {
+      return null;
+    }
+
+    return tryResolveAbsoluteTarget(targetPath, options.allowedSurfaces);
+  }
+
+  return tryResolveRelativeTarget(
+    targetPath,
+    options.allowedSurfaces,
+    options.preferredSurface
+  );
+}
+
+export function resolveAuthenticatedRouteTarget(
+  targetPath: string | null | undefined,
+  options?: {
+    allowAbsolute?: boolean;
+    preferredSurface?: AuthenticatedSurface;
+    surface?: AuthenticatedSurface | null;
+  }
+) {
+  const preferredSurface =
+    options?.surface ?? options?.preferredSurface ?? "portal";
+  const allowedSurfaces = options?.surface
+    ? [options.surface]
+    : [...authenticatedSurfaces];
+
+  return resolveOwnedRouteTarget(targetPath, {
+    allowAbsolute: options?.allowAbsolute,
+    allowedSurfaces,
+    preferredSurface
+  });
+}
+
+export function sanitizeSurfaceTargetPath(
+  surface: OwnedAppSurface,
+  targetPath: string | null | undefined,
+  options?: {
+    allowAbsolute?: boolean;
+  }
+) {
+  return (
+    resolveOwnedRouteTarget(targetPath, {
+      allowAbsolute: options?.allowAbsolute,
+      allowedSurfaces: [surface],
+      preferredSurface: surface
+    })?.targetPath ?? "/"
+  );
+}
+
+export function sanitizePublicTargetPath(targetPath: string | null | undefined) {
+  return sanitizeSurfaceTargetPath("public_site", targetPath);
+}
+
+export function sanitizePortalTargetPath(targetPath: string | null | undefined) {
+  return sanitizeSurfaceTargetPath("portal", targetPath);
+}
+
+export function sanitizeMathTargetPath(targetPath: string | null | undefined) {
+  return sanitizeSurfaceTargetPath("math", targetPath);
+}
+
+export function sanitizeAuthenticatedRedirectTarget(
+  targetPath: string | null | undefined,
+  options?: {
+    allowAbsolute?: boolean;
+    preferredSurface?: AuthenticatedSurface;
+    surface?: AuthenticatedSurface | null;
+  }
+) {
+  return (
+    resolveAuthenticatedRouteTarget(targetPath, {
+      allowAbsolute: options?.allowAbsolute,
+      preferredSurface: options?.preferredSurface,
+      surface: options?.surface
+    })?.targetPath ?? "/"
+  );
+}
+
+export function buildAuthenticatedRedirectUrl(
+  targetSurface: AuthenticatedSurface,
+  redirectPath: string
+) {
+  return new URL(redirectPath, mapAuthenticatedSurfaceToOrigin(targetSurface)).toString();
+}
+
+export function resolveFinalizedAuthenticatedRedirectTarget(
+  rawRedirectTarget: unknown,
+  options: {
+    fallbackRedirectPath: string;
+    fallbackSurface: AuthenticatedSurface;
+  }
+) {
+  if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
+    const fallbackRedirectPath = sanitizeAuthenticatedRedirectTarget(
+      options.fallbackRedirectPath,
+      {
+        allowAbsolute: false,
+        surface: options.fallbackSurface
+      }
+    );
+
+    return buildAuthenticatedRedirectUrl(
+      options.fallbackSurface,
+      fallbackRedirectPath
+    );
+  }
+
+  let targetUrl: URL;
+
+  try {
+    targetUrl = new URL(rawRedirectTarget);
+  } catch {
+    return null;
+  }
+
+  const targetSurface =
+    targetUrl.origin === productionPortalOrigin
+      ? "portal"
+      : targetUrl.origin === productionMathOrigin
+        ? "math"
+        : null;
+
+  if (!targetSurface || !findAppRouteBySurface(targetSurface, targetUrl.pathname)) {
+    return null;
+  }
+
+  return targetUrl.toString();
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,6 +20,7 @@ export * from "./contracts/health.js";
 export * from "./contracts/harness-registry.js";
 export * from "./contracts/portal-navigation.js";
 export * from "./contracts/math-lean-submission.js";
+export * from "./contracts/web-surface-routing.js";
 export * from "./schemas/audit-event.js";
 export * from "./schemas/api-call-boundary.js";
 export * from "./schemas/access-request.js";

--- a/packages/shared/test/web-surface-routing.test.js
+++ b/packages/shared/test/web-surface-routing.test.js
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isLocalDevelopmentLocation,
+  isTrustedFinalizeRelayLocation,
+  resolveAccessProviderFromHost,
+  resolveAuthenticatedRouteTarget,
+  resolveFinalizedAuthenticatedRedirectTarget,
+  resolveWebSurfaceFromLocation,
+  sanitizeAuthenticatedRedirectTarget
+} from "../dist/index.js";
+
+describe("web surface routing policy", () => {
+  it("classifies hosted and local development surfaces without browser globals", () => {
+    expect(resolveWebSurfaceFromLocation({ hostname: "paretoproof.com" })).toBe("public");
+    expect(resolveWebSurfaceFromLocation({ hostname: "auth.paretoproof.com" })).toBe("auth");
+    expect(resolveWebSurfaceFromLocation({ hostname: "portal.paretoproof.com" })).toBe("portal");
+    expect(resolveWebSurfaceFromLocation({ hostname: "math.paretoproof.com" })).toBe("math");
+    expect(
+      resolveWebSurfaceFromLocation({
+        hostname: "paretoproof.com",
+        port: "4173",
+        protocol: "http:",
+        search: "?surface=math"
+      })
+    ).toBe("math");
+  });
+
+  it("recognizes provider auth hosts separately from the shared auth entry", () => {
+    expect(resolveAccessProviderFromHost("github.auth.paretoproof.com")).toBe("github");
+    expect(resolveAccessProviderFromHost("google.auth.paretoproof.com")).toBe("google");
+    expect(resolveAccessProviderFromHost("auth.paretoproof.com")).toBeNull();
+    expect(resolveAccessProviderFromHost("paretoproof.com")).toBeNull();
+  });
+
+  it("requires explicit local development signals for branded http hosts", () => {
+    expect(
+      isLocalDevelopmentLocation({
+        hostname: "localhost",
+        protocol: "http:"
+      })
+    ).toBe(true);
+    expect(
+      isLocalDevelopmentLocation({
+        hostname: "auth.paretoproof.com",
+        port: "4173",
+        protocol: "http:"
+      })
+    ).toBe(true);
+    expect(
+      isLocalDevelopmentLocation({
+        hostname: "auth.paretoproof.com",
+        protocol: "http:"
+      })
+    ).toBe(false);
+    expect(
+      isLocalDevelopmentLocation({
+        hostname: "auth.paretoproof.com",
+        protocol: "https:"
+      })
+    ).toBe(false);
+  });
+
+  it("accepts only trusted hosted or local finalize relay locations", () => {
+    expect(
+      isTrustedFinalizeRelayLocation({
+        hostname: "github.auth.paretoproof.com",
+        protocol: "https:"
+      })
+    ).toBe(true);
+    expect(
+      isTrustedFinalizeRelayLocation({
+        hostname: "github.auth.paretoproof.com",
+        port: "4173",
+        protocol: "http:"
+      })
+    ).toBe(true);
+    expect(
+      isTrustedFinalizeRelayLocation({
+        hostname: "localhost",
+        protocol: "http:"
+      })
+    ).toBe(true);
+    expect(
+      isTrustedFinalizeRelayLocation({
+        hostname: "github.auth.paretoproof.com",
+        protocol: "http:"
+      })
+    ).toBe(false);
+    expect(
+      isTrustedFinalizeRelayLocation({
+        hostname: "portal.paretoproof.com",
+        protocol: "https:"
+      })
+    ).toBe(false);
+  });
+
+  it("normalizes authenticated route targets by owned surface", () => {
+    expect(
+      resolveAuthenticatedRouteTarget("/questions/problem-9?tab=review#proof", {
+        surface: "math"
+      })
+    ).toEqual({
+      surface: "math",
+      targetPath: "/questions/problem-9?tab=review#proof"
+    });
+    expect(
+      resolveAuthenticatedRouteTarget("https://portal.paretoproof.com/profile", {
+        allowAbsolute: true
+      })
+    ).toEqual({
+      surface: "portal",
+      targetPath: "/profile"
+    });
+    expect(
+      resolveAuthenticatedRouteTarget("/project", {
+        surface: "portal"
+      })
+    ).toBeNull();
+    expect(
+      resolveAuthenticatedRouteTarget("/profile", {
+        surface: "math"
+      })
+    ).toBeNull();
+  });
+
+  it("sanitizes request-supplied redirects without allowing absolute handoffs", () => {
+    expect(
+      sanitizeAuthenticatedRedirectTarget("/profile?tab=identity#linked", {
+        allowAbsolute: false,
+        surface: "portal"
+      })
+    ).toBe("/profile?tab=identity#linked");
+    expect(
+      sanitizeAuthenticatedRedirectTarget("https://portal.paretoproof.com/profile", {
+        allowAbsolute: false,
+        surface: "portal"
+      })
+    ).toBe("/");
+    expect(
+      sanitizeAuthenticatedRedirectTarget("//portal.paretoproof.com/profile", {
+        allowAbsolute: false,
+        surface: "portal"
+      })
+    ).toBe("/");
+    expect(
+      sanitizeAuthenticatedRedirectTarget("javascript:alert(1)", {
+        allowAbsolute: false,
+        surface: "portal"
+      })
+    ).toBe("/");
+    expect(
+      sanitizeAuthenticatedRedirectTarget("/project", {
+        allowAbsolute: false,
+        surface: "portal"
+      })
+    ).toBe("/");
+  });
+
+  it("accepts only finalized redirects to owned authenticated hosts and routes", () => {
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget(
+        "https://portal.paretoproof.com/profile?tab=identity#linked",
+        {
+          fallbackRedirectPath: "/",
+          fallbackSurface: "portal"
+        }
+      )
+    ).toBe("https://portal.paretoproof.com/profile?tab=identity#linked");
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget(undefined, {
+        fallbackRedirectPath: "/launch",
+        fallbackSurface: "math"
+      })
+    ).toBe("https://math.paretoproof.com/launch");
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget(undefined, {
+        fallbackRedirectPath: "/profile",
+        fallbackSurface: "math"
+      })
+    ).toBe("https://math.paretoproof.com/");
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget("https://auth.paretoproof.com/", {
+        fallbackRedirectPath: "/profile",
+        fallbackSurface: "portal"
+      })
+    ).toBeNull();
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget("https://paretoproof.com/project", {
+        fallbackRedirectPath: "/profile",
+        fallbackSurface: "portal"
+      })
+    ).toBeNull();
+    expect(
+      resolveFinalizedAuthenticatedRedirectTarget("https://math.paretoproof.com/profile", {
+        fallbackRedirectPath: "/launch",
+        fallbackSurface: "math"
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Tomodovodoo/ParetoProof#1016.

This PR removes the remaining web/auth routing drift by moving public/auth/portal/math host, surface, and redirect policy into a shared pure contract, then wiring the browser helpers and Cloudflare Pages auth functions through that contract.

## Root Cause

The web auth surface had several mostly-correct but duplicated implementations of the same policy:

- browser URL helpers owned one route-normalization path
- `access-start` and `access-finalize` owned separate redirect sanitizers
- local preview behavior lived inside a provider-start helper, making local approved-preview links look too much like real hosted auth starts
- trusted finalize relay handling accepted broader `http:` branded origins than local development should allow

That duplication made the issue reproducible as a runtime-contract gap even though many individual paths already had partial protections.

## Changes

- Added shared web surface contracts for production origins, branded hosts, local development detection, trusted finalize relay detection, provider-host resolution, authenticated redirect normalization, and finalized redirect validation.
- Reworked `apps/web/src/lib/surface.ts` into a thin browser adapter over the shared policy while preserving existing public helper names.
- Split local approved auth preview into `buildLocalAuthPreviewUrl`, with least-privilege `helper` as the default role.
- Kept `buildAccessStartUrl` hosted-only so local auth entry pages no longer silently produce direct approved destination URLs from provider-start helpers.
- Rewired `access-start` and `access-finalize` to use the shared route-ownership and redirect validation helpers.
- Tightened finalize relay trust so branded `http:` origins require an explicit local-development port, while hosted branded relays remain `https:`.
- Added regression coverage for local preview containment, redirect rejection, finalized redirect acceptance, trusted relay origins, and shared public/auth/portal/math surface ownership.
- Updated the shared package test script so top-level `packages/shared/test/*.test.js` contract tests are run by `bun --cwd packages/shared test`.

## Validation

- `bun --cwd packages/shared test`
- `bun --cwd apps/web test:functions`
- `bun test apps/web/src/lib/surface.test.js apps/web/src/routes/auth-entry.test.js apps/web/src/lib/local-development.test.js`
- `bun --cwd packages/shared typecheck`
- `bun --cwd apps/web typecheck`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun --cwd apps/web build`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun --cwd apps/web test:ui`
- `bun run check:bidi`
- `git diff --check`

Note: the local system `node` is `v16.13.2`, so Vite/Playwright commands were run with the bundled Node runtime first in `PATH`.
