### PR TITLE
Route portal bootstrap and profile flows through shared contracts

### DIFF
--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -5,10 +5,13 @@ import {
   portalHarnessRegistryReadContract,
   portalAccessRecoveryInputSchema,
   portalAccessRequestInputSchema,
+  portalMeResponseSchema,
+  portalProfileContract,
   portalRunDetailParamsSchema,
   portalProfileLinkIntentInputSchema,
   portalProfileUpdateInputSchema,
   portalRunsListQuerySchema,
+  portalSessionFinalizeResponseSchema,
   type PortalBenchmarkDatasetResponse,
   type PortalProfile,
   type PortalProfileLinkIntent,
@@ -145,6 +148,13 @@ function readRequestAuthenticatedContinuation(
     },
     runtimeConfig,
   );
+}
+
+function buildPortalMeResponse(request: FastifyRequest) {
+  return portalMeResponseSchema.parse({
+    access: request.accessRbacContext,
+    identity: request.accessIdentity,
+  });
 }
 
 function clearSignedAccessCookie(
@@ -667,9 +677,9 @@ export function registerPortalRoutes(
       typeof request.headers.accept === "string" &&
       request.headers.accept.includes("application/json")
     ) {
-      return reply.send({
+      return reply.send(portalSessionFinalizeResponseSchema.parse({
         redirectTo: redirectUrl.toString(),
-      });
+      }));
     }
 
     reply.redirect(redirectUrl.toString());
@@ -786,6 +796,9 @@ export function registerPortalRoutes(
   app.get(
     "/portal/me",
     {
+      config: {
+        contract: portalProfileContract.meResponse,
+      },
       preHandler: [
         ...withAuthenticatedRateLimit(
           requireAccess("authenticated_access_identity"),
@@ -793,10 +806,7 @@ export function registerPortalRoutes(
       ],
     },
     async (request) => {
-      return {
-        identity: request.accessIdentity,
-        access: request.accessRbacContext,
-      };
+      return buildPortalMeResponse(request);
     },
   );
 
@@ -973,6 +983,9 @@ export function registerPortalRoutes(
   app.get(
     "/portal/profile",
     {
+      config: {
+        contract: portalProfileContract.readResponse,
+      },
       preHandler: [
         ...withAuthenticatedRateLimit(
           requireAccess("approved_helper_or_higher"),
@@ -988,13 +1001,13 @@ export function registerPortalRoutes(
         );
       }
 
-      return {
+      return portalProfileContract.readResponse.parse({
         profile: await loadPortalProfile(db, {
           fallbackEmail: normalizeOptionalEmail(identity.email),
           identityProvider: identity.provider,
           identitySubject: identity.subject,
         }),
-      };
+      });
     },
   );
 
@@ -1307,18 +1320,21 @@ export function registerPortalRoutes(
       })
       .where(eq(users.id, linkedIdentity.user.id));
 
-    return {
+    return portalProfileContract.updateResponse.parse({
       profile: await loadPortalProfile(db, {
         fallbackEmail: normalizeOptionalEmail(identity.email),
         identityProvider: identity.provider,
         identitySubject: identity.subject,
       }),
-    };
+    });
   };
 
   app.patch(
     "/portal/profile",
     {
+      config: {
+        contract: portalProfileContract.updateResponse,
+      },
       preHandler: [
         ...withAuthenticatedRateLimit(
           requireAccess("approved_helper_or_higher"),
@@ -1331,6 +1347,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/profile",
     {
+      config: {
+        contract: portalProfileContract.updateResponse,
+      },
       preHandler: [
         ...withAuthenticatedRateLimit(
           requireAccess("approved_helper_or_higher"),
@@ -1343,6 +1362,9 @@ export function registerPortalRoutes(
   app.post(
     "/portal/profile/link-intents",
     {
+      config: {
+        contract: portalProfileContract.createLinkIntentResponse,
+      },
       preHandler: [
         ...withAuthenticatedRateLimit(
           requireAccess("approved_helper_or_higher"),
@@ -1484,9 +1506,9 @@ export function registerPortalRoutes(
         }),
       );
 
-      return {
+      return portalProfileContract.createLinkIntentResponse.parse({
         intent: responseBody,
-      };
+      });
     },
   );
 

--- a/apps/api/test/portal-bootstrap-contract.test.ts
+++ b/apps/api/test/portal-bootstrap-contract.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { portalMeResponseSchema } from "@paretoproof/shared";
+import { registerPortalRoutes } from "../src/routes/portal.ts";
+
+function createAuthenticatedAccessGuard() {
+  return () =>
+    (
+      request: {
+        accessIdentity?: unknown;
+        accessRbacContext?: unknown;
+      },
+      _reply: unknown,
+      done: () => void,
+    ) => {
+      request.accessIdentity = {
+        email: "helper@example.com",
+        issuer: "https://paretoproof.cloudflareaccess.com",
+        provider: "cloudflare_github",
+        subject: "github|123",
+      };
+      request.accessRbacContext = {
+        email: "helper@example.com",
+        identityId: "identity-1",
+        role: "helper",
+        status: "approved",
+        subject: "github|123",
+        userId: "user-1",
+      };
+      done();
+    };
+}
+
+test("GET /portal/me returns the shared authenticated bootstrap contract", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createAuthenticatedAccessGuard() as never,
+    {
+      resolvePortalAccess: async () => null,
+    },
+  );
+
+  const response = await app.inject({
+    headers: {
+      accept: "application/json",
+    },
+    method: "GET",
+    url: "/portal/me",
+  });
+
+  assert.equal(response.statusCode, 200);
+
+  const responseBody = response.json();
+  const parsed = portalMeResponseSchema.safeParse(responseBody);
+
+  assert.equal(parsed.success, true);
+  assert.equal(responseBody.access.email, "helper@example.com");
+  assert.equal(responseBody.access.role, "helper");
+  assert.equal(responseBody.identity.provider, "cloudflare_github");
+});

--- a/apps/api/test/portal-session-finalize.test.ts
+++ b/apps/api/test/portal-session-finalize.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify from "fastify";
+import { portalSessionFinalizeResponseSchema } from "@paretoproof/shared";
 import { buildSignedAccessCookie } from "../src/auth/cloudflare-access.ts";
 import { createAccessGuard } from "../src/auth/require-access.ts";
 import { sessions } from "../src/db/schema.ts";
@@ -403,7 +404,9 @@ test("POST /portal/session/finalize/submit returns the JSON redirect payload for
   });
 
   assert.equal(response.statusCode, 200);
-  assert.deepEqual(response.json(), {
+  const responseBody = response.json();
+  assert.equal(portalSessionFinalizeResponseSchema.safeParse(responseBody).success, true);
+  assert.deepEqual(responseBody, {
     redirectTo: "https://portal.paretoproof.com/profile",
   });
   assert.equal(mutationAttempted, false);
@@ -482,7 +485,9 @@ test("POST /portal/session/finalize/submit returns a math-surface redirect for a
   });
 
   assert.equal(response.statusCode, 200);
-  assert.deepEqual(response.json(), {
+  const responseBody = response.json();
+  assert.equal(portalSessionFinalizeResponseSchema.safeParse(responseBody).success, true);
+  assert.deepEqual(responseBody, {
     redirectTo: "https://math.preview.paretoproof.com/launch",
   });
   assert.equal(mutationAttempted, false);

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -431,6 +431,38 @@ describe("handleAccessFinalize", () => {
     );
   });
 
+  it("redirects back to retry when the API finalize response does not match the shared contract", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          redirectTo: "/profile"
+        }),
+        {
+          status: 200
+        }
+      );
+
+    const response = await handleAccessFinalize(
+      new Request("https://github.auth.paretoproof.com/api/access/finalize?app=portal", {
+        body: new URLSearchParams({
+          app: "portal",
+          redirect: "/profile"
+        }),
+        headers: {
+          "cf-access-jwt-assertion": "assertion-malformed-contract",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "https://github.auth.paretoproof.com"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.paretoproof.com/?app=portal&redirect=%2Fprofile&handoff=retry"
+    );
+  });
+
   it("redirects back to retry without relaying when the browser Origin header is absent", async () => {
     globalThis.fetch = async (_input, init) => {
       expect((init?.headers as Headers).get("origin")).toBe(

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,4 +1,7 @@
-import { findAppRouteBySurface } from "@paretoproof/shared";
+import {
+  findAppRouteBySurface,
+  portalSessionFinalizeResponseSchema
+} from "@paretoproof/shared";
 
 const authOrigin = "https://auth.paretoproof.com";
 const portalOrigin = "https://portal.paretoproof.com";
@@ -379,8 +382,14 @@ export async function handleAccessFinalize(request: Request) {
     return buildRedirectResponse(retryUrl, finalizeResponse.headers);
   }
 
+  const parsedResponseBody = portalSessionFinalizeResponseSchema.safeParse(responseBody);
+
+  if (!parsedResponseBody.success) {
+    return buildRedirectResponse(retryUrl, finalizeResponse.headers);
+  }
+
   const redirectTarget = resolveAuthenticatedRedirectTarget(
-    (responseBody as { redirectTo?: unknown }).redirectTo,
+    parsedResponseBody.data.redirectTo,
     redirectPath,
     targetSurface
   );

--- a/apps/web/src/lib/api-fetch.test.js
+++ b/apps/web/src/lib/api-fetch.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ApiRateLimitError,
+  authenticatedAuthExpiredEventName,
   fetchApi,
   portalAuthExpiredEventName
 } from "./api-fetch.ts";
@@ -94,7 +95,7 @@ test("fetchApi throws ApiRateLimitError for non-idempotent requests after readin
   }
 });
 
-test("fetchApi emits a portal auth-expired event for 401 portal responses", async () => {
+test("fetchApi emits authenticated and legacy portal auth-expired events for 401 portal responses", async () => {
   const originalFetch = globalThis.fetch;
   const originalWindow = globalThis.window;
   const observedEvents = [];
@@ -124,14 +125,54 @@ test("fetchApi emits a portal auth-expired event for 401 portal responses", asyn
     const response = await fetchApi("https://api.paretoproof.com/portal/admin/access-requests");
 
     assert.equal(response.status, 401);
-    assert.deepEqual(observedEvents, [portalAuthExpiredEventName]);
+    assert.deepEqual(observedEvents, [
+      authenticatedAuthExpiredEventName,
+      portalAuthExpiredEventName
+    ]);
   } finally {
     globalThis.fetch = originalFetch;
     globalThis.window = originalWindow;
   }
 });
 
-test("fetchApi does not emit a portal auth-expired event for non-portal 401 responses", async () => {
+test("fetchApi emits the authenticated auth-expired event for 401 math responses", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = globalThis.window;
+  const observedEvents = [];
+
+  globalThis.window = {
+    dispatchEvent(event) {
+      observedEvents.push(event.type);
+      return true;
+    },
+    location: {
+      origin: "https://math.paretoproof.com"
+    },
+    setTimeout(callback) {
+      callback();
+      return 0;
+    }
+  };
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ error: "access_assertion_required" }), {
+      headers: {
+        "Content-Type": "application/json"
+      },
+      status: 401
+    });
+
+  try {
+    const response = await fetchApi("https://api.paretoproof.com/math/submissions");
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(observedEvents, [authenticatedAuthExpiredEventName]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.window = originalWindow;
+  }
+});
+
+test("fetchApi does not emit an authenticated auth-expired event for public 401 responses", async () => {
   const originalFetch = globalThis.fetch;
   const originalWindow = globalThis.window;
   const observedEvents = [];

--- a/apps/web/src/lib/api-fetch.ts
+++ b/apps/web/src/lib/api-fetch.ts
@@ -1,4 +1,5 @@
 const rateLimitBackoffByOrigin = new Map<string, number>();
+export const authenticatedAuthExpiredEventName = "paretoproof:authenticated-auth-expired";
 export const portalAuthExpiredEventName = "paretoproof:portal-auth-expired";
 
 export class ApiRateLimitError extends Error {
@@ -69,8 +70,12 @@ function shouldAutoRetry(init: RequestInit | undefined) {
   return method === "GET" || method === "HEAD";
 }
 
-function signalPortalAuthExpired(requestUrl: URL, response: Response) {
-  if (response.status !== 401 || !requestUrl.pathname.startsWith("/portal/")) {
+function isAuthenticatedSurfaceApiPath(pathname: string) {
+  return pathname.startsWith("/portal/") || pathname.startsWith("/math/");
+}
+
+function signalAuthenticatedAuthExpired(requestUrl: URL, response: Response) {
+  if (response.status !== 401 || !isAuthenticatedSurfaceApiPath(requestUrl.pathname)) {
     return;
   }
 
@@ -78,7 +83,11 @@ function signalPortalAuthExpired(requestUrl: URL, response: Response) {
     return;
   }
 
-  window.dispatchEvent(new Event(portalAuthExpiredEventName));
+  window.dispatchEvent(new Event(authenticatedAuthExpiredEventName));
+
+  if (requestUrl.pathname.startsWith("/portal/")) {
+    window.dispatchEvent(new Event(portalAuthExpiredEventName));
+  }
 }
 
 export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -98,7 +107,7 @@ export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Pr
     const response = await fetch(input, init);
 
     if (response.status !== 429) {
-      signalPortalAuthExpired(requestUrl, response);
+      signalAuthenticatedAuthExpired(requestUrl, response);
       return response;
     }
 

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   AuthEntry,
   buildLocalAuthEntryPreviewState,
+  parseAuthEntrySessionCheckPayload,
   resolveApprovedAuthEntryHandoff,
   resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
@@ -54,6 +55,45 @@ describe("shouldStayOnAuthEntryForProviderlessRecovery", () => {
   });
 });
 
+describe("parseAuthEntrySessionCheckPayload", () => {
+  it("accepts the shared portal bootstrap response contract", () => {
+    expect(
+      parseAuthEntrySessionCheckPayload({
+        access: {
+          email: "helper@example.com",
+          role: "helper",
+          status: "approved"
+        },
+        identity: {
+          provider: "cloudflare_google"
+        }
+      })
+    ).toEqual({
+      access: {
+        email: "helper@example.com",
+        role: "helper",
+        status: "approved"
+      },
+      identity: {
+        provider: "cloudflare_google"
+      }
+    });
+  });
+
+  it("returns null for malformed session-check payloads", () => {
+    expect(
+      parseAuthEntrySessionCheckPayload({
+        access: {
+          status: "approved"
+        },
+        identity: {
+          provider: "google"
+        }
+      })
+    ).toBeNull();
+  });
+});
+
 describe("shouldSkipAuthEntrySessionCheck", () => {
   it("skips automatic session reuse when guidance mode is requested explicitly", () => {
     expect(shouldSkipAuthEntrySessionCheck("?guidance=1")).toBe(true);
@@ -62,6 +102,19 @@ describe("shouldSkipAuthEntrySessionCheck", () => {
 });
 
 describe("resolveAuthEntrySessionCheckAction", () => {
+  it("stays on auth entry when a successful response does not match the shared contract", () => {
+    expect(
+      resolveAuthEntrySessionCheckAction(
+        {
+          ok: true,
+          status: 200,
+          type: "basic"
+        },
+        null
+      )
+    ).toBe("stay_on_auth_entry");
+  });
+
   it("stays on auth entry for providerless recovery responses", () => {
     expect(
       resolveAuthEntrySessionCheckAction(

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,3 +1,7 @@
+import {
+  portalMeResponseSchema,
+  type PortalMeResponse
+} from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import { AppIcon, type AppIconName } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
@@ -23,20 +27,7 @@ type AuthEntryProps = {
   redirectSurface: AuthenticatedSurface;
 };
 
-type AuthEntrySessionCheckPayload = {
-  access: {
-    role?: "admin" | "collaborator" | "helper" | null;
-    reason?:
-      | "access_request_required"
-      | "identity_recovery_required"
-      | "rejected_or_withdrawn"
-      | "unknown_identity";
-    status: "approved" | "pending" | "denied";
-  };
-  identity: {
-    provider: "cloudflare_one_time_pin" | "cloudflare_github" | "cloudflare_google" | null;
-  } | null;
-};
+type AuthEntrySessionCheckPayload = PortalMeResponse;
 
 type AuthEntryAction = {
   copy: string;
@@ -180,6 +171,14 @@ export function buildAuthEntrySessionCheckRequestInit(signal: AbortSignal): Requ
   };
 }
 
+export function parseAuthEntrySessionCheckPayload(
+  payload: unknown
+): AuthEntrySessionCheckPayload | null {
+  const parsed = portalMeResponseSchema.safeParse(payload);
+
+  return parsed.success ? parsed.data : null;
+}
+
 export function shouldStayOnAuthEntryForProviderlessRecovery(
   payload: AuthEntrySessionCheckPayload | null
 ) {
@@ -206,6 +205,10 @@ export function resolveAuthEntrySessionCheckAction(
   payload: AuthEntrySessionCheckPayload | null = null
 ): AuthEntrySessionCheckAction {
   if (response.ok) {
+    if (!payload) {
+      return "stay_on_auth_entry";
+    }
+
     if (shouldStayOnAuthEntryForProviderlessRecovery(payload)) {
       return "stay_on_auth_entry";
     }
@@ -222,7 +225,11 @@ export function resolveAuthEntrySessionCheckAction(
       return "redirect_denied";
     }
 
-    return "redirect_authenticated_app";
+    if (payload.access.status === "approved") {
+      return "redirect_authenticated_app";
+    }
+
+    return "stay_on_auth_entry";
   }
 
   if (response.type === "opaqueredirect" || response.status === 401) {
@@ -306,8 +313,9 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
           `${apiBaseUrl}/portal/me`,
           buildAuthEntrySessionCheckRequestInit(controller.signal)
         );
-        const payload =
-          response.ok ? ((await response.json()) as AuthEntrySessionCheckPayload) : null;
+        const payload = response.ok
+          ? parseAuthEntrySessionCheckPayload(await response.json())
+          : null;
         const action = resolveAuthEntrySessionCheckAction(response, payload);
 
         if (action !== "stay_on_auth_entry") {

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -131,6 +131,28 @@ describe("mapPortalMutationErrorMessage", () => {
     });
   });
 
+  it("rejects malformed /portal/me payloads before deriving portal state", async () => {
+    await expect(
+      fetchPortalBootstrapState("https://api.paretoproof.test", {
+        fetcher: async () => ({
+          json: async () => ({
+            access: {
+              email: "collab@paretoproof.local",
+              role: "collaborator",
+              status: "approved"
+            },
+            identity: {
+              provider: "github"
+            }
+          }),
+          ok: true,
+          status: 200,
+          type: "basic"
+        })
+      })
+    ).rejects.toThrow("Portal bootstrap response did not match the shared contract.");
+  });
+
   it("derives the local singleton role list from the approved portal role", () => {
     expect(derivePortalRoles("collaborator")).toEqual(["collaborator"]);
     expect(derivePortalRoles(null)).toEqual([]);
@@ -160,6 +182,21 @@ describe("mapPortalMutationErrorMessage", () => {
       kind: "local_api_unavailable",
       message:
         "This local portal preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
+      status: "error"
+    });
+  });
+
+  it("describes missing local API wiring in math workspace terms", () => {
+    expect(
+      buildPortalBootstrapErrorState(new Error("Failed to fetch"), {
+        apiBaseUrl: "http://127.0.0.1:3000",
+        localApiFallback: true,
+        surface: "math"
+      })
+    ).toEqual({
+      kind: "local_api_unavailable",
+      message:
+        "This local math workspace preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using math workspace routes.",
       status: "error"
     });
   });
@@ -479,9 +516,9 @@ describe("PortalBootstrap auth handoff", () => {
     const secondHtml = renderToStaticMarkup(<PortalBootstrap />);
 
     expect(firstHtml).not.toContain("Opening portal");
-    expect(firstHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(firstHtml).toContain("Portal landing summary for current run activity");
     expect(firstHtml).toContain("Authenticated session");
-    expect(secondHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(secondHtml).toContain("Portal landing summary for current run activity");
     expect(globalThis.document.cookie).toBe(handoffCookie);
   });
 

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -1,7 +1,8 @@
-import type {
-  PortalAccessRecoveryInput,
-  PortalAccessRequestInput,
-  PortalRole
+import {
+  portalMeResponseSchema,
+  type PortalMeResponse,
+  type PortalAccessRecoveryInput,
+  type PortalAccessRequestInput
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AppIcon } from "../components/app-icon";
@@ -10,7 +11,11 @@ import {
   clearApprovedAuthHandoffCookie,
   readApprovedAuthHandoffCookie
 } from "../lib/approved-auth-handoff";
-import { fetchApi, portalAuthExpiredEventName } from "../lib/api-fetch";
+import {
+  authenticatedAuthExpiredEventName,
+  fetchApi,
+  portalAuthExpiredEventName
+} from "../lib/api-fetch";
 import { createApiFormBody } from "../lib/api-form";
 import { isLocalDevelopmentLocation } from "../lib/local-development";
 import { resolveSurfaceRouteRedirect } from "../lib/portal-route-access";
@@ -32,22 +37,6 @@ import {
 } from "./portal-bootstrap-state";
 import { PortalShell } from "./portal-shell";
 
-type PortalMeResponse = {
-  access: {
-    email: string | null;
-    role?: PortalRole | null;
-    reason?:
-      | "access_request_required"
-      | "identity_recovery_required"
-      | "rejected_or_withdrawn"
-      | "unknown_identity";
-    status: "approved" | "pending" | "denied";
-  };
-  identity: {
-    provider: "cloudflare_one_time_pin" | "cloudflare_github" | "cloudflare_google" | null;
-  } | null;
-};
-
 type PortalMutationAction = "access_request" | "identity_recovery";
 
 type PortalMutationErrorPayload = {
@@ -62,6 +51,16 @@ type PortalBootstrapFetcher = (
 
 export function derivePortalRoles(role: string | null | undefined) {
   return role ? [role] : [];
+}
+
+export function parsePortalMeResponse(payload: unknown): PortalMeResponse {
+  const parsed = portalMeResponseSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new Error("Portal bootstrap response did not match the shared contract.");
+  }
+
+  return parsed.data;
 }
 
 export async function fetchPortalBootstrapState(
@@ -89,7 +88,7 @@ export async function fetchPortalBootstrapState(
     throw new Error(`Portal bootstrap failed with ${response.status}.`);
   }
 
-  const payload = (await response.json()) as PortalMeResponse;
+  const payload = parsePortalMeResponse(await response.json());
 
   if (shouldRestartPortalAuthForMissingProvider(payload)) {
     return { status: "unauthenticated" };
@@ -124,6 +123,7 @@ export async function recoverPortalStateAfterAuthExpiry(
     fetcher?: PortalBootstrapFetcher;
     localApiFallback?: boolean;
     signal?: AbortSignal;
+    surface?: AuthenticatedSurface;
   }
 ): Promise<PortalAccessState> {
   const reducedState = reducePortalStateAfterAuthExpiry(currentState);
@@ -137,7 +137,8 @@ export async function recoverPortalStateAfterAuthExpiry(
   } catch (error) {
     return buildPortalBootstrapErrorState(error, {
       apiBaseUrl,
-      localApiFallback: options?.localApiFallback ?? false
+      localApiFallback: options?.localApiFallback ?? false,
+      surface: options?.surface
     });
   }
 }
@@ -151,6 +152,7 @@ function readRouteDeniedReason(search = window.location.search) {
 type PortalBootstrapErrorContext = {
   apiBaseUrl: string;
   localApiFallback: boolean;
+  surface?: AuthenticatedSurface;
 };
 
 function isNetworkFetchFailure(error: unknown) {
@@ -171,10 +173,12 @@ export function buildPortalBootstrapErrorState(
   error: unknown,
   context: PortalBootstrapErrorContext
 ): Extract<PortalAccessState, { status: "error" }> {
+  const surface = context.surface ?? "portal";
+
   if (isNetworkFetchFailure(error) && context.localApiFallback) {
     return {
       kind: "local_api_unavailable",
-      message: `This local portal preview is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.`,
+      message: `This local ${describeSurfaceName(surface)} preview is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using ${describeSurfaceRouteScope(surface)}.`,
       status: "error"
     };
   }
@@ -182,8 +186,7 @@ export function buildPortalBootstrapErrorState(
   if (isNetworkFetchFailure(error)) {
     return {
       kind: "portal_unavailable",
-      message:
-        "The portal could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+      message: `The ${describeSurfaceName(surface)} could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.`,
       status: "error"
     };
   }
@@ -191,15 +194,14 @@ export function buildPortalBootstrapErrorState(
   if (error instanceof Error) {
     return {
       kind: "portal_unavailable",
-      message:
-        "The portal could not finish loading right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+      message: `The ${describeSurfaceName(surface)} could not finish loading right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.`,
       status: "error"
     };
   }
 
   return {
     kind: "portal_unavailable",
-    message: "The portal could not finish loading right now. Try again in a moment.",
+    message: `The ${describeSurfaceName(surface)} could not finish loading right now. Try again in a moment.`,
     status: "error"
   };
 }
@@ -249,6 +251,10 @@ function describeSurfaceLabel(surface: AuthenticatedSurface) {
 
 function describeSurfaceName(surface: AuthenticatedSurface) {
   return surface === "math" ? "math workspace" : "portal";
+}
+
+function describeSurfaceRouteScope(surface: AuthenticatedSurface) {
+  return surface === "math" ? "math workspace routes" : "portal routes";
 }
 
 type PortalBootstrapProps = {
@@ -368,7 +374,8 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
         setState(
           buildPortalBootstrapErrorState(error, {
             apiBaseUrl,
-            localApiFallback
+            localApiFallback,
+            surface
           })
         );
       }
@@ -394,7 +401,8 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
 
       void recoverPortalStateAfterAuthExpiry(currentState, apiBaseUrl, {
         localApiFallback,
-        signal: controller.signal
+        signal: controller.signal,
+        surface
       })
         .then((recoveredState) => {
           if (controller.signal.aborted || !active) {
@@ -408,14 +416,16 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
         });
     };
 
+    window.addEventListener(authenticatedAuthExpiredEventName, handlePortalAuthExpired);
     window.addEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
 
     return () => {
       active = false;
       controller.abort();
+      window.removeEventListener(authenticatedAuthExpiredEventName, handlePortalAuthExpired);
       window.removeEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
     };
-  }, [apiBaseUrl, localApiFallback]);
+  }, [apiBaseUrl, localApiFallback, surface]);
 
   useEffect(() => {
     if (state.status !== "unauthenticated" || localPreviewMode) {

--- a/apps/web/src/routes/portal-profile-panel.test.js
+++ b/apps/web/src/routes/portal-profile-panel.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { consumeLinkStatus } from "./portal-profile-panel.tsx";
+import {
+  consumeLinkStatus,
+  parsePortalProfileLinkIntentResponse,
+  parsePortalProfileResponse
+} from "./portal-profile-panel.tsx";
 
 describe("consumeLinkStatus", () => {
   it("returns the linked message and strips the link query param", () => {
@@ -51,5 +55,55 @@ describe("consumeLinkStatus", () => {
       nextUrl:
         "/profile?surface=portal&access=approved&roles=admin&email=ada@paretoproof.local"
     });
+  });
+});
+
+describe("portal profile response parsers", () => {
+  it("accepts shared profile response envelopes", () => {
+    expect(
+      parsePortalProfileResponse({
+        profile: {
+          createdAt: "2026-04-26T00:00:00.000Z",
+          displayName: "Ada",
+          email: "ada@example.com",
+          identities: [],
+          linkedUserId: "11111111-1111-4111-8111-111111111111",
+          updatedAt: "2026-04-26T00:00:00.000Z"
+        }
+      }).profile.email
+    ).toBe("ada@example.com");
+  });
+
+  it("rejects malformed profile response envelopes", () => {
+    expect(() =>
+      parsePortalProfileResponse({
+        item: {
+          email: "ada@example.com"
+        }
+      })
+    ).toThrow("Portal profile response did not match the shared contract.");
+  });
+
+  it("accepts shared profile link-intent envelopes", () => {
+    expect(
+      parsePortalProfileLinkIntentResponse({
+        intent: {
+          expiresAt: "2026-04-26T00:10:00.000Z",
+          provider: "cloudflare_github",
+          startUrl: "https://auth.paretoproof.com/api/access/start/github"
+        }
+      }).intent.provider
+    ).toBe("cloudflare_github");
+  });
+
+  it("rejects malformed profile link-intent envelopes", () => {
+    expect(() =>
+      parsePortalProfileLinkIntentResponse({
+        intent: {
+          provider: "github",
+          startUrl: "/api/access/start/github"
+        }
+      })
+    ).toThrow("Portal profile link-intent response did not match the shared contract.");
   });
 });

--- a/apps/web/src/routes/portal-profile-panel.tsx
+++ b/apps/web/src/routes/portal-profile-panel.tsx
@@ -1,11 +1,11 @@
 import type {
   PortalLinkableIdentityProvider,
-  PortalProfile,
-  PortalProfileLinkIntent,
-  PortalProfileUpdateInput
+  PortalProfile
 } from "@paretoproof/shared";
 import {
   portalProfileLinkIntentInputSchema,
+  portalProfileLinkIntentResponseSchema,
+  portalProfileResponseSchema,
   portalProfileUpdateInputSchema
 } from "@paretoproof/shared";
 import { useEffect, useMemo, useState, startTransition } from "react";
@@ -120,6 +120,26 @@ export function consumeLinkStatus(
   };
 }
 
+export function parsePortalProfileResponse(payload: unknown) {
+  const parsed = portalProfileResponseSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new Error("Portal profile response did not match the shared contract.");
+  }
+
+  return parsed.data;
+}
+
+export function parsePortalProfileLinkIntentResponse(payload: unknown) {
+  const parsed = portalProfileLinkIntentResponseSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new Error("Portal profile link-intent response did not match the shared contract.");
+  }
+
+  return parsed.data;
+}
+
 export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
   const [profile, setProfile] = useState<PortalProfile | null>(null);
   const [displayNameInput, setDisplayNameInput] = useState("");
@@ -178,9 +198,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
           throw new Error(`Profile load failed with ${response.status}.`);
         }
 
-        const payload = (await response.json()) as {
-          profile: PortalProfile;
-        };
+        const payload = parsePortalProfileResponse(await response.json());
 
         if (!cancelled) {
           setDisplayNameInput(payload.profile.displayName ?? "");
@@ -240,9 +258,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         throw new Error(`Link preparation failed with ${response.status}.`);
       }
 
-      const payload = (await response.json()) as {
-        intent: PortalProfileLinkIntent;
-      };
+      const payload = parsePortalProfileLinkIntentResponse(await response.json());
 
       window.location.assign(payload.intent.startUrl);
     } catch (error) {
@@ -285,9 +301,7 @@ export function PortalProfilePanel({ email }: PortalProfilePanelProps) {
         throw new Error(`Profile save failed with ${response.status}.`);
       }
 
-      const payload = (await response.json()) as {
-        profile: PortalProfile;
-      };
+      const payload = parsePortalProfileResponse(await response.json());
 
       setDisplayNameInput(payload.profile.displayName ?? "");
       setLastUpdatedAt(new Date().toISOString());

--- a/packages/shared/src/contracts/api-call-boundary.ts
+++ b/packages/shared/src/contracts/api-call-boundary.ts
@@ -10,12 +10,12 @@ export const apiCallBoundaryCatalog = [
       "Health checks need to work without Access so Railway and external uptime probes can reach the API."
   },
   {
-    credential: "cloudflare_access_jwt",
+    credential: "cloudflare_access_jwt_or_session",
     endpointId: "portal.me.read",
     mode: "browser_direct",
-    origin: "portal_browser",
+    origin: "authenticated_browser",
     rationale:
-      "The portal shell needs the caller identity immediately after Access login, so the browser calls the protected route directly."
+      "Portal and math bootstrap flows need the caller identity immediately after Access login, and the API can also trust the DB-backed session established by the protected finalize handoff."
   },
   {
     credential: "none",
@@ -42,28 +42,28 @@ export const apiCallBoundaryCatalog = [
       "The branded auth handoff can arrive through a top-level GET navigation on the finalize-submit route, which either completes the session or redirects the browser back to the retry relay."
   },
   {
-    credential: "cloudflare_access_jwt",
+    credential: "cloudflare_access_jwt_or_session",
     endpointId: "portal.session.complete.submit",
     mode: "browser_navigation",
-    origin: "portal_browser",
+    origin: "authenticated_browser",
     rationale:
-      "Legacy same-site completion forms still POST to the complete alias, so the authenticated browser must retain an explicit contract for that handoff route."
+      "Legacy same-site completion forms can serve portal or math handoffs, so the authenticated browser must retain an explicit contract that accepts the Access assertion or existing session."
   },
   {
-    credential: "cloudflare_access_jwt",
+    credential: "cloudflare_access_jwt_or_session",
     endpointId: "portal.session.finalize.submit",
     mode: "browser_navigation",
-    origin: "portal_browser",
+    origin: "authenticated_browser",
     rationale:
-      "Legacy finalize POSTs stay on the same authenticated browser boundary as the canonical submit route while preserving redirect-bearing handoff semantics."
+      "Legacy finalize POSTs stay on the authenticated browser boundary shared by portal and math while preserving redirect-bearing handoff semantics."
   },
   {
-    credential: "cloudflare_access_jwt",
+    credential: "cloudflare_access_jwt_or_session",
     endpointId: "portal.session.complete",
     mode: "browser_navigation",
-    origin: "portal_browser",
+    origin: "authenticated_browser",
     rationale:
-      "Custom auth buttons finish on a protected API handoff route through a same-site form POST so Cloudflare Access can establish the API audience without leaving a mutating GET finalize path."
+      "Custom auth buttons finish on a protected API handoff route through a same-site form POST so Cloudflare Access can establish the API audience for either authenticated browser surface."
   },
   {
     credential: "cloudflare_access_jwt",

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -11,11 +11,12 @@ export const apiEndpointCatalog = [
   },
   {
     access: "authenticated_access_identity",
-    audience: "portal",
+    audience: "authenticated_surface",
     id: "portal.me.read",
     method: "GET",
     path: "/portal/me",
-    purpose: "Return the caller's resolved identity, role summary, and approval state."
+    purpose:
+      "Return the caller's resolved identity, role summary, and approval state for portal or math bootstrap."
   },
   {
     access: "anonymous",
@@ -46,30 +47,30 @@ export const apiEndpointCatalog = [
   },
   {
     access: "authenticated_access_identity",
-    audience: "portal",
+    audience: "authenticated_surface",
     id: "portal.session.complete.submit",
     method: "POST",
     path: "/portal/session/complete",
     purpose:
-      "Finish the Cloudflare Access login handoff on the legacy complete POST alias without requiring the caller to switch away from the authenticated browser surface."
+      "Finish a portal or math Cloudflare Access login handoff on the legacy complete POST alias without requiring the caller to switch away from the authenticated browser surface."
   },
   {
     access: "authenticated_access_identity",
-    audience: "portal",
+    audience: "authenticated_surface",
     id: "portal.session.finalize.submit",
     method: "POST",
     path: "/portal/session/finalize",
     purpose:
-      "Finish the Cloudflare Access login handoff on the legacy finalize POST alias while preserving the same redirect-bearing session semantics as the canonical submit route."
+      "Finish a portal or math Cloudflare Access login handoff on the legacy finalize POST alias while preserving the same redirect-bearing session semantics as the canonical submit route."
   },
   {
     access: "authenticated_access_identity",
-    audience: "portal",
+    audience: "authenticated_surface",
     id: "portal.session.complete",
     method: "POST",
     path: "/portal/session/finalize/submit",
     purpose:
-      "Finish the Cloudflare Access login handoff with a first-party POST on the API audience and return the browser to the static portal host."
+      "Finish a portal or math Cloudflare Access login handoff with a first-party POST on the API audience and return the browser to the requested authenticated surface."
   },
   {
     access: "authenticated_access_identity",

--- a/packages/shared/src/contracts/api-schema-catalog.ts
+++ b/packages/shared/src/contracts/api-schema-catalog.ts
@@ -56,9 +56,11 @@ import {
   problem9OfflineIngestResponseSchema
 } from "../schemas/problem9-offline-ingest.js";
 import {
+  portalMeResponseSchema,
   portalProfileLinkIntentInputSchema,
   portalProfileLinkIntentResponseSchema,
   portalProfileResponseSchema,
+  portalSessionFinalizeResponseSchema,
   portalSessionRedirectInputSchema,
   portalSessionRedirectRequestBodySchema,
   portalProfileUpdateInputSchema
@@ -92,7 +94,7 @@ export const apiEndpointSchemaCatalog = {
     requestBody: null,
     requestParams: null,
     requestQuery: null,
-    responseBody: null
+    responseBody: portalMeResponseSchema
   },
   "portal.session.retry.complete": {
     requestBody: null,
@@ -116,19 +118,19 @@ export const apiEndpointSchemaCatalog = {
     requestBody: portalSessionRedirectRequestBodySchema,
     requestParams: null,
     requestQuery: portalSessionRedirectInputSchema,
-    responseBody: null
+    responseBody: portalSessionFinalizeResponseSchema
   },
   "portal.session.finalize.submit": {
     requestBody: portalSessionRedirectRequestBodySchema,
     requestParams: null,
     requestQuery: portalSessionRedirectInputSchema,
-    responseBody: null
+    responseBody: portalSessionFinalizeResponseSchema
   },
   "portal.session.complete": {
     requestBody: portalSessionRedirectRequestBodySchema,
     requestParams: null,
     requestQuery: portalSessionRedirectInputSchema,
-    responseBody: null
+    responseBody: portalSessionFinalizeResponseSchema
   },
   "portal.access-request.create": {
     requestBody: portalAccessRequestInputSchema,

--- a/packages/shared/src/contracts/profile.ts
+++ b/packages/shared/src/contracts/profile.ts
@@ -1,14 +1,23 @@
 import {
+  portalMeResponseSchema,
   portalProfileLinkIntentInputSchema,
+  portalProfileLinkIntentResponseSchema,
   portalProfileLinkIntentSchema,
+  portalProfileResponseSchema,
   portalProfileSchema,
+  portalSessionFinalizeResponseSchema,
   portalProfileUpdateInputSchema
 } from "../schemas/profile.js";
 
 export const portalProfileContract = {
   createLinkIntentInput: portalProfileLinkIntentInputSchema,
+  createLinkIntentResponse: portalProfileLinkIntentResponseSchema,
   createLinkIntentOutput: portalProfileLinkIntentSchema,
+  meResponse: portalMeResponseSchema,
   readOutput: portalProfileSchema,
+  readResponse: portalProfileResponseSchema,
+  sessionFinalizeResponse: portalSessionFinalizeResponseSchema,
   updateInput: portalProfileUpdateInputSchema,
-  updateOutput: portalProfileSchema
+  updateOutput: portalProfileSchema,
+  updateResponse: portalProfileResponseSchema
 };

--- a/packages/shared/src/schemas/profile.test.js
+++ b/packages/shared/src/schemas/profile.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import {
+  portalMeResponseSchema,
+  portalProfileLinkIntentResponseSchema,
+  portalProfileResponseSchema,
+  portalSessionFinalizeResponseSchema
+} from "./profile.js";
+
+describe("portal profile and bootstrap response schemas", () => {
+  it("accepts approved bootstrap responses with provider and RBAC details", () => {
+    const parsed = portalMeResponseSchema.safeParse({
+      access: {
+        email: "helper@example.com",
+        role: "helper",
+        status: "approved",
+        userId: "usr_123"
+      },
+      identity: {
+        provider: "cloudflare_github",
+        subject: "github|123"
+      }
+    });
+
+    expect(parsed.success).toBeTrue();
+
+    if (!parsed.success) {
+      return;
+    }
+
+    expect(parsed.data.access.role).toBe("helper");
+    expect(parsed.data.access.userId).toBe("usr_123");
+    expect(parsed.data.identity?.provider).toBe("cloudflare_github");
+  });
+
+  it("accepts providerless recovery bootstrap responses", () => {
+    expect(
+      portalMeResponseSchema.safeParse({
+        access: {
+          email: "helper@example.com",
+          reason: "identity_recovery_required",
+          status: "denied"
+        },
+        identity: {
+          provider: null
+        }
+      }).success
+    ).toBeTrue();
+  });
+
+  it("rejects malformed bootstrap envelopes", () => {
+    expect(
+      portalMeResponseSchema.safeParse({
+        access: {
+          email: "helper@example.com",
+          status: "approved"
+        },
+        identity: {
+          provider: "github"
+        }
+      }).success
+    ).toBeFalse();
+
+    expect(
+      portalMeResponseSchema.safeParse({
+        access: {
+          email: "helper@example.com",
+          state: "approved"
+        },
+        identity: null
+      }).success
+    ).toBeFalse();
+
+    expect(
+      portalMeResponseSchema.safeParse({
+        access: {
+          email: "helper@example.com",
+          status: "approved"
+        },
+        identity: {
+          provider: "cloudflare_github"
+        }
+      }).success
+    ).toBeFalse();
+
+    expect(
+      portalMeResponseSchema.safeParse({
+        access: {
+          email: "helper@example.com",
+          status: "denied"
+        },
+        identity: null
+      }).success
+    ).toBeFalse();
+  });
+
+  it("models session finalize redirects as absolute URLs", () => {
+    expect(
+      portalSessionFinalizeResponseSchema.safeParse({
+        redirectTo: "https://portal.paretoproof.com/profile"
+      }).success
+    ).toBeTrue();
+
+    expect(
+      portalSessionFinalizeResponseSchema.safeParse({
+        redirectTo: "/profile"
+      }).success
+    ).toBeFalse();
+  });
+
+  it("models profile and link-intent response envelopes", () => {
+    expect(
+      portalProfileResponseSchema.safeParse({
+        profile: {
+          createdAt: "2026-04-26T00:00:00.000Z",
+          displayName: "Ada",
+          email: "ada@example.com",
+          identities: [],
+          linkedUserId: "11111111-1111-4111-8111-111111111111",
+          updatedAt: "2026-04-26T00:00:00.000Z"
+        }
+      }).success
+    ).toBeTrue();
+
+    expect(
+      portalProfileLinkIntentResponseSchema.safeParse({
+        intent: {
+          expiresAt: "2026-04-26T00:10:00.000Z",
+          provider: "cloudflare_google",
+          startUrl: "https://auth.paretoproof.com/api/access/start/google"
+        }
+      }).success
+    ).toBeTrue();
+  });
+});

--- a/packages/shared/src/schemas/profile.ts
+++ b/packages/shared/src/schemas/profile.ts
@@ -19,6 +19,17 @@ export const portalLinkableIdentityProviderSchema = z.enum([
   "cloudflare_github"
 ]);
 
+export const portalRoleSchema = z.enum(["admin", "collaborator", "helper"]);
+
+export const portalAccessStatusSchema = z.enum(["approved", "pending", "denied"]);
+
+export const portalAccessDeniedReasonSchema = z.enum([
+  "access_request_required",
+  "identity_recovery_required",
+  "rejected_or_withdrawn",
+  "unknown_identity"
+]);
+
 export const portalProfileIdentitySchema = z.object({
   createdAt: z.string(),
   current: z.boolean(),
@@ -39,6 +50,34 @@ export const portalProfileSchema = z.object({
 
 export const portalProfileResponseSchema = z.object({
   profile: portalProfileSchema
+});
+
+const portalApprovedAccessResponseSchema = z.object({
+  email: z.string().email(),
+  role: portalRoleSchema,
+  status: z.literal("approved")
+}).passthrough();
+
+const portalPendingAccessResponseSchema = z.object({
+  email: z.string().email().nullable(),
+  status: z.literal("pending")
+}).passthrough();
+
+const portalDeniedAccessResponseSchema = z.object({
+  email: z.string().email().nullable(),
+  reason: portalAccessDeniedReasonSchema,
+  status: z.literal("denied")
+}).passthrough();
+
+export const portalMeResponseSchema = z.object({
+  access: z.discriminatedUnion("status", [
+    portalApprovedAccessResponseSchema,
+    portalPendingAccessResponseSchema,
+    portalDeniedAccessResponseSchema
+  ]),
+  identity: z.object({
+    provider: portalIdentityProviderSchema.nullable()
+  }).passthrough().nullable()
 });
 
 export const portalProfileUpdateInputSchema = z.object({
@@ -62,6 +101,10 @@ export const portalSessionRedirectInputSchema = z.object({
 
 export const portalSessionRedirectRequestBodySchema = portalSessionRedirectInputSchema.optional();
 
+export const portalSessionFinalizeResponseSchema = z.object({
+  redirectTo: z.string().url()
+});
+
 export const portalProfileLinkIntentSchema = z.object({
   expiresAt: z.string(),
   provider: portalLinkableIdentityProviderSchema,
@@ -71,4 +114,3 @@ export const portalProfileLinkIntentSchema = z.object({
 export const portalProfileLinkIntentResponseSchema = z.object({
   intent: portalProfileLinkIntentSchema
 });
-

--- a/packages/shared/src/types/api-call-boundary.ts
+++ b/packages/shared/src/types/api-call-boundary.ts
@@ -9,12 +9,14 @@ export type ApiCallBoundaryMode =
 export type ApiCallCredential =
   | "none"
   | "cloudflare_access_jwt"
+  | "cloudflare_access_jwt_or_session"
   | "cloudflare_service_token"
   | "worker_bootstrap_token"
   | "worker_job_token";
 
 export type ApiCallOrigin =
   | "public_browser"
+  | "authenticated_browser"
   | "portal_browser"
   | "portal_server"
   | "worker_service"

--- a/packages/shared/src/types/api-catalog.ts
+++ b/packages/shared/src/types/api-catalog.ts
@@ -1,4 +1,4 @@
-export type ApiAudience = "public" | "portal" | "internal";
+export type ApiAudience = "public" | "authenticated_surface" | "portal" | "internal";
 
 export type ApiAccessLevel =
   | "anonymous"

--- a/packages/shared/src/types/profile.ts
+++ b/packages/shared/src/types/profile.ts
@@ -1,3 +1,5 @@
+import type { PortalRole } from "./portal-navigation.js";
+
 export type PortalIdentityProvider =
   | "cloudflare_google"
   | "cloudflare_github"
@@ -6,6 +8,30 @@ export type PortalIdentityProvider =
 export type PortalLinkableIdentityProvider =
   | "cloudflare_google"
   | "cloudflare_github";
+
+export type PortalAccessStatus = "approved" | "pending" | "denied";
+
+export type PortalAccessDeniedReason =
+  | "access_request_required"
+  | "identity_recovery_required"
+  | "rejected_or_withdrawn"
+  | "unknown_identity";
+
+export type PortalMeAccess =
+  | {
+      email: string;
+      role: PortalRole;
+      status: "approved";
+    }
+  | {
+      email: string | null;
+      status: "pending";
+    }
+  | {
+      email: string | null;
+      reason: PortalAccessDeniedReason;
+      status: "denied";
+    };
 
 export type PortalProfileIdentity = {
   createdAt: string;
@@ -38,8 +64,19 @@ export type PortalSessionRedirectInput = {
   redirect?: string | null;
 };
 
+export type PortalMeResponse = {
+  access: PortalMeAccess;
+  identity: {
+    provider: PortalIdentityProvider | null;
+  } | null;
+};
+
 export type PortalProfileLinkIntent = {
   expiresAt: string;
   provider: PortalLinkableIdentityProvider;
   startUrl: string;
+};
+
+export type PortalSessionFinalizeResponse = {
+  redirectTo: string;
 };

--- a/packages/shared/test/api-contract-parity.test.js
+++ b/packages/shared/test/api-contract-parity.test.js
@@ -31,11 +31,33 @@ describe("shared api catalog parity", () => {
     );
   });
 
+  it("covers shared authenticated portal and math bootstrap boundaries explicitly", () => {
+    expect(apiCallBoundaryCatalog).toContainEqual(
+      expect.objectContaining({
+        credential: "cloudflare_access_jwt_or_session",
+        endpointId: "portal.me.read",
+        mode: "browser_direct",
+        origin: "authenticated_browser"
+      })
+    );
+
+    expect(apiCallBoundaryCatalog).toContainEqual(
+      expect.objectContaining({
+        credential: "cloudflare_access_jwt_or_session",
+        endpointId: "portal.session.finalize.submit",
+        mode: "browser_navigation",
+        origin: "authenticated_browser"
+      })
+    );
+  });
+
   it("exposes non-null schemas for representative catalogued endpoints", () => {
     expect(apiEndpointSchemaContract["health.read"].responseBodySchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.me.read"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.access-request.create"].requestBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.access-request.read"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.profile.read"].responseBodySchema).not.toBeNull();
+    expect(apiEndpointSchemaContract["portal.session.finalize.submit"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.benchmarks.list"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.benchmark-dataset.read"].paramsSchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.profile.link-intent.create"].responseBodySchema).not.toBeNull();
@@ -53,12 +75,10 @@ describe("shared api catalog parity", () => {
       ]);
     }
 
-    expect(apiEndpointSchemaContract["portal.me.read"]).toEqual({
-      paramsSchema: null,
-      querySchema: null,
-      requestBodySchema: null,
-      responseBodySchema: null
-    });
+    expect(apiEndpointSchemaContract["portal.me.read"].paramsSchema).toBeNull();
+    expect(apiEndpointSchemaContract["portal.me.read"].querySchema).toBeNull();
+    expect(apiEndpointSchemaContract["portal.me.read"].requestBodySchema).toBeNull();
+    expect(apiEndpointSchemaContract["portal.me.read"].responseBodySchema).not.toBeNull();
 
     expect(apiEndpointSchemaContract["portal.benchmark-export.read"].paramsSchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.benchmark-export.read"].querySchema).not.toBeNull();

--- a/packages/shared/test/api-schema-catalog.test.js
+++ b/packages/shared/test/api-schema-catalog.test.js
@@ -10,9 +10,11 @@ import {
   portalBenchmarkDatasetResponseSchema,
   portalBenchmarkExportQuerySchema,
   portalBenchmarksListResponseSchema,
+  portalMeResponseSchema,
   portalRunDetailParamsSchema,
   portalAccessRequestSummaryResponseSchema,
   portalProfileResponseSchema,
+  portalSessionFinalizeResponseSchema,
   portalSessionRedirectInputSchema,
   portalSessionRedirectRequestBodySchema,
   workerJobParamsSchema,
@@ -43,6 +45,13 @@ describe("shared api schema catalog", () => {
       responseBody: portalProfileResponseSchema
     });
 
+    expect(apiEndpointSchemaCatalog["portal.me.read"]).toEqual({
+      requestBody: null,
+      requestParams: null,
+      requestQuery: null,
+      responseBody: portalMeResponseSchema
+    });
+
     expect(apiEndpointSchemaCatalog["portal.session.retry.complete"]).toEqual({
       requestBody: null,
       requestParams: null,
@@ -68,21 +77,21 @@ describe("shared api schema catalog", () => {
       requestBody: portalSessionRedirectRequestBodySchema,
       requestParams: null,
       requestQuery: portalSessionRedirectInputSchema,
-      responseBody: null
+      responseBody: portalSessionFinalizeResponseSchema
     });
 
     expect(apiEndpointSchemaCatalog["portal.session.finalize.submit"]).toEqual({
       requestBody: portalSessionRedirectRequestBodySchema,
       requestParams: null,
       requestQuery: portalSessionRedirectInputSchema,
-      responseBody: null
+      responseBody: portalSessionFinalizeResponseSchema
     });
 
     expect(apiEndpointSchemaCatalog["portal.session.complete"]).toEqual({
       requestBody: portalSessionRedirectRequestBodySchema,
       requestParams: null,
       requestQuery: portalSessionRedirectInputSchema,
-      responseBody: null
+      responseBody: portalSessionFinalizeResponseSchema
     });
 
     expect(apiEndpointSchemaCatalog["portal.benchmarks.list"].responseBody).toBe(
@@ -132,12 +141,8 @@ describe("shared api schema catalog", () => {
   });
 
   it("makes intentionally unmodeled endpoint responses explicit", () => {
-    expect(apiEndpointSchemaCatalog["portal.me.read"].responseBody).toBeNull();
     expect(apiEndpointSchemaCatalog["portal.session.retry.complete"].responseBody).toBeNull();
     expect(apiEndpointSchemaCatalog["portal.session.retry.finalize"].responseBody).toBeNull();
     expect(apiEndpointSchemaCatalog["portal.session.finalize.read"].responseBody).toBeNull();
-    expect(apiEndpointSchemaCatalog["portal.session.complete.submit"].responseBody).toBeNull();
-    expect(apiEndpointSchemaCatalog["portal.session.finalize.submit"].responseBody).toBeNull();
-    expect(apiEndpointSchemaCatalog["portal.session.complete"].responseBody).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Resolves Tomodovodoo/ParetoProof#1017.

This PR routes the portal bootstrap, session finalize, and profile response paths through shared contracts instead of local response casts. It also updates the API catalog and call-boundary metadata so the shared portal/math authenticated surface is represented explicitly.

## What changed

- Added shared response schemas and public types for `/portal/me`, session finalize JSON redirects, profile reads/updates, and profile link intents.
- Registered those schemas in the shared API schema catalog and profile contract surface.
- Updated API route handlers to attach contract metadata and parse the responses they emit.
- Updated web bootstrap, auth-entry, profile-panel, API fetch, and Cloudflare finalize relay code to parse shared contracts before deriving UI state or redirects.
- Added a shared authenticated auth-expiry event while preserving the legacy portal event for compatibility.
- Tightened the `/portal/me` access payload to a discriminated shared contract: approved responses require a role, denied responses require a reason, and pending responses stay minimal.

## Why

The bootstrap/profile flows were relying on route-local TypeScript casts and portal-specific metadata even though the same session and handoff mechanics now serve both portal and math authenticated surfaces. That made the contract easy to drift and left malformed responses able to drive redirects or UI state.

## Validation

- `bun run build:shared`
- `bun run typecheck:shared`
- `bun run typecheck:web`
- `bun run typecheck:api`
- `bun --cwd packages/shared test`
- `bun test test/*.test.js` in `packages/shared`
- `bun test src/routes/portal-bootstrap.test.js src/routes/auth-entry.test.js src/routes/portal-profile-panel.test.js src/lib/api-fetch.test.js functions/_shared/access-finalize.test.ts` in `apps/web`
- `bun test test/portal-session-finalize.test.ts test/portal-bootstrap-contract.test.ts` in `apps/api`
- `bun run build:api`
- `bunx --bun vite build` in `apps/web`
- `bun run check:bidi`
- `git diff --check`
