### PR TITLE
Add API-owned worker-ops freshness metadata

### DIFF
--- a/apps/api/src/lib/portal-benchmark-ops.ts
+++ b/apps/api/src/lib/portal-benchmark-ops.ts
@@ -28,6 +28,7 @@ import {
   type PortalRunsListQuery,
   type PortalRunsListResponse,
   type PortalWorkerIncident,
+  type PortalWorkerOpsFreshness,
   type PortalWorkerLeaseSummary,
   type PortalWorkersViewResponse
 } from "@paretoproof/shared";
@@ -100,6 +101,8 @@ function getRunLifecycleBucket(runState: RunRow["state"]): PortalRunsLifecycleBu
 const terminalRunStates = ["succeeded", "failed", "cancelled"] as const;
 const terminalJobStates = ["completed", "failed", "cancelled"] as const;
 const terminalAttemptStates = ["succeeded", "failed", "cancelled"] as const;
+const portalWorkerOpsRecommendedPollAfterSeconds = 15;
+const portalWorkerOpsStaleAfterSeconds = 60;
 
 function isTerminalRunState(
   state: RunRow["state"]
@@ -132,6 +135,46 @@ function compareByLeaseExpiryDesc(
   right: WorkerJobLeaseRow
 ) {
   return right.leaseExpiresAt.getTime() - left.leaseExpiresAt.getTime();
+}
+
+function getLatestTimestamp(values: Array<Date | null | undefined>) {
+  return values.reduce<Date | null>((latest, value) => {
+    if (!value) {
+      return latest;
+    }
+
+    if (!latest || value.getTime() > latest.getTime()) {
+      return value;
+    }
+
+    return latest;
+  }, null);
+}
+
+function buildPortalWorkerOpsFreshness(options: {
+  degradationReason?: string | null;
+  generatedAt: Date;
+  observedAtValues: Array<Date | null | undefined>;
+}): PortalWorkerOpsFreshness {
+  const observedThrough = getLatestTimestamp(options.observedAtValues);
+  const degradationReason = options.degradationReason ?? null;
+  const freshnessStatus =
+    degradationReason !== null
+      ? "degraded"
+      : observedThrough &&
+          options.generatedAt.getTime() - observedThrough.getTime() >
+            portalWorkerOpsStaleAfterSeconds * 1000
+        ? "stale"
+        : "live";
+
+  return {
+    degradationReason,
+    freshnessStatus,
+    generatedAt: options.generatedAt.toISOString(),
+    observedThrough: toIso(observedThrough),
+    recommendedPollAfterSeconds: portalWorkerOpsRecommendedPollAfterSeconds,
+    staleAfterSeconds: portalWorkerOpsStaleAfterSeconds
+  };
 }
 
 function compareNullableTimestampDescNullsLast(
@@ -461,6 +504,7 @@ function buildTimeline(options: {
 }
 
 export const portalBenchmarkOpsReadModelTestUtils = {
+  buildPortalWorkerOpsFreshness,
   buildWorkerPoolSummaries,
   readRegisteredWorkerPoolsForEnvironment,
   buildOverviewBenchmarkHighlightsQuery,
@@ -1612,7 +1656,8 @@ export function createPortalBenchmarkOpsReadModelService(
           .select({
             completedAt: runs.completedAt,
             primaryFailureFamily: runs.primaryFailureFamily,
-            sourceRunId: runs.sourceRunId
+            sourceRunId: runs.sourceRunId,
+            updatedAt: runs.updatedAt
           })
           .from(runs)
           .where(eq(runs.state, "failed"))
@@ -1620,7 +1665,8 @@ export function createPortalBenchmarkOpsReadModelService(
           .limit(20),
         db
           .select({
-            sourceRunId: runs.sourceRunId
+            sourceRunId: runs.sourceRunId,
+            updatedAt: runs.updatedAt
           })
           .from(runs)
           .where(eq(runs.state, "queued"))
@@ -1713,10 +1759,22 @@ export function createPortalBenchmarkOpsReadModelService(
           });
         }
       }
+      const freshness = buildPortalWorkerOpsFreshness({
+        generatedAt: now,
+        observedAtValues: [
+          ...leaseRows.flatMap((leaseRow) => [leaseRow.updatedAt, leaseRow.lastHeartbeatAt]),
+          ...runRows.map((runRow) => runRow.updatedAt),
+          ...jobRows.map((jobRow) => jobRow.updatedAt),
+          ...attemptRows.map((attemptRow) => attemptRow.updatedAt),
+          ...recentFailedRuns.flatMap((runRow) => [runRow.updatedAt, runRow.completedAt]),
+          ...queuedRunRows.map((runRow) => runRow.updatedAt)
+        ]
+      });
 
       return {
         activeLeases,
-        generatedAt: now.toISOString(),
+        freshness,
+        generatedAt: freshness.generatedAt,
         incidents,
         queueSummary: {
           activeRuns,

--- a/apps/api/src/routes/portal.ts
+++ b/apps/api/src/routes/portal.ts
@@ -1251,6 +1251,21 @@ export function registerPortalRoutes(
     async () => portalBenchmarkOpsReadModels.getWorkersView(),
   );
 
+  app.get(
+    "/portal/worker-ops/overview",
+    {
+      config: {
+        contract: portalBenchmarkOpsReadModelsContract.workersViewResponse,
+      },
+      preHandler: [
+        ...withAuthenticatedRateLimit(
+          requireAccess("approved_collaborator_or_higher"),
+        ),
+      ],
+    },
+    async () => portalBenchmarkOpsReadModels.getWorkersView(),
+  );
+
   const handlePortalProfileUpdate = async (
     request: FastifyRequest,
     reply: FastifyReply,

--- a/apps/api/test/portal-benchmark-ops.test.ts
+++ b/apps/api/test/portal-benchmark-ops.test.ts
@@ -445,6 +445,14 @@ function buildLaunchViewResponse(): PortalLaunchViewResponse {
 function buildWorkersViewResponse(): PortalWorkersViewResponse {
   return {
     activeLeases: [],
+    freshness: {
+      degradationReason: null,
+      freshnessStatus: "live",
+      generatedAt: "2026-03-13T20:00:00.000Z",
+      observedThrough: "2026-03-13T19:59:30.000Z",
+      recommendedPollAfterSeconds: 15,
+      staleAfterSeconds: 60
+    },
     generatedAt: "2026-03-13T20:00:00.000Z",
     incidents: [],
     queueSummary: {
@@ -948,6 +956,33 @@ test("portal worker-pool registry selection filters the catalog by deployment en
       workerRuntime: "modal"
     }
   ]);
+});
+
+test("portal worker-ops freshness is stale only when control-plane observations are old", () => {
+  const live = portalBenchmarkOpsReadModelTestUtils.buildPortalWorkerOpsFreshness({
+    generatedAt: new Date("2026-04-26T18:00:00.000Z"),
+    observedAtValues: [new Date("2026-04-26T17:59:30.000Z")]
+  });
+  const stale = portalBenchmarkOpsReadModelTestUtils.buildPortalWorkerOpsFreshness({
+    generatedAt: new Date("2026-04-26T18:00:00.000Z"),
+    observedAtValues: [new Date("2026-04-26T17:58:00.000Z")]
+  });
+  const empty = portalBenchmarkOpsReadModelTestUtils.buildPortalWorkerOpsFreshness({
+    generatedAt: new Date("2026-04-26T18:00:00.000Z"),
+    observedAtValues: []
+  });
+  const degraded = portalBenchmarkOpsReadModelTestUtils.buildPortalWorkerOpsFreshness({
+    degradationReason: "worker_ops_partial_snapshot",
+    generatedAt: new Date("2026-04-26T18:00:00.000Z"),
+    observedAtValues: [new Date("2026-04-26T17:59:30.000Z")]
+  });
+
+  assert.equal(live.freshnessStatus, "live");
+  assert.equal(stale.freshnessStatus, "stale");
+  assert.equal(empty.freshnessStatus, "live");
+  assert.equal(empty.observedThrough, null);
+  assert.equal(degraded.freshnessStatus, "degraded");
+  assert.equal(degraded.degradationReason, "worker_ops_partial_snapshot");
 });
 
 test("portal overview benchmark highlight query counts verdicts per run instead of per attempt row", () => {
@@ -1518,6 +1553,38 @@ test("GET /portal/workers returns the worker posture view for collaborators", as
     response.json()
   );
   assert.equal(payload.queueSummary.queuedJobs, 1);
+  assert.equal(payload.freshness.freshnessStatus, "live");
+  assert.equal(payload.generatedAt, payload.freshness.generatedAt);
+});
+
+test("GET /portal/worker-ops/overview mirrors the worker posture compatibility view", async (t) => {
+  const app = Fastify();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  registerPortalRoutes(
+    app,
+    {} as never,
+    createRequireAccessStub(["collaborator"]) as never,
+    {
+      portalBenchmarkOpsReadModels: createReadModelService(),
+      resolvePortalAccess: createResolvePortalAccessStub(["collaborator"]) as never
+    }
+  );
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/portal/worker-ops/overview"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = portalBenchmarkOpsReadModelsContract.workersViewResponse.parse(
+    response.json()
+  );
+  assert.equal(payload.queueSummary.queuedJobs, 1);
+  assert.equal(payload.freshness.recommendedPollAfterSeconds, 15);
 });
 
 test("portal benchmark ops normalization helpers keep canonical lifecycle wording aligned", () => {

--- a/apps/web/src/components/portal-freshness-card.tsx
+++ b/apps/web/src/components/portal-freshness-card.tsx
@@ -1,7 +1,12 @@
-import { getPortalLiveViewFreshness, type PortalRouteId } from "@paretoproof/shared";
+import {
+  getPortalLiveViewFreshness,
+  type PortalRouteId,
+  type PortalWorkerOpsFreshness
+} from "@paretoproof/shared";
 import { useEffect, useMemo, useState } from "react";
 import {
   describePortalFreshness,
+  formatTimestamp,
   getPortalFreshnessState,
   getPortalFreshnessStateLabel
 } from "../lib/portal-freshness";
@@ -11,13 +16,46 @@ type PortalFreshnessCardProps = {
   lastUpdatedAt: string | null;
   onRefresh?: () => void;
   routeId: PortalRouteId;
+  workerOpsFreshness?: PortalWorkerOpsFreshness | null;
 };
+
+function getWorkerOpsFreshnessLabel(freshness: PortalWorkerOpsFreshness) {
+  switch (freshness.freshnessStatus) {
+    case "live":
+      return "Live";
+    case "stale":
+      return "Stale";
+    case "degraded":
+      return "Degraded";
+    default:
+      return "Live";
+  }
+}
+
+function getWorkerOpsFreshnessClassName(freshness: PortalWorkerOpsFreshness) {
+  return freshness.freshnessStatus === "live" ? "fresh" : freshness.freshnessStatus;
+}
+
+function describeWorkerOpsFreshness(freshness: PortalWorkerOpsFreshness) {
+  const observedCopy = freshness.observedThrough
+    ? `Observed through ${formatTimestamp(freshness.observedThrough)}.`
+    : "No worker observations are visible yet.";
+  const statusCopy =
+    freshness.freshnessStatus === "degraded"
+      ? `Snapshot is degraded: ${freshness.degradationReason}.`
+      : freshness.freshnessStatus === "stale"
+        ? "The API marked this worker snapshot stale."
+        : "The API marked this worker snapshot live.";
+
+  return `${statusCopy} ${observedCopy} Generated ${formatTimestamp(freshness.generatedAt)}. Recommended refresh: ${freshness.recommendedPollAfterSeconds}s; stale after ${freshness.staleAfterSeconds}s.`;
+}
 
 export function PortalFreshnessCard({
   isRefreshing = false,
   lastUpdatedAt,
   onRefresh,
-  routeId
+  routeId,
+  workerOpsFreshness = null
 }: PortalFreshnessCardProps) {
   const policy = useMemo(() => getPortalLiveViewFreshness(routeId), [routeId]);
   const [clockNow, setClockNow] = useState(() => Date.now());
@@ -39,6 +77,12 @@ export function PortalFreshnessCard({
   }, [lastUpdatedAt, policy]);
 
   const freshnessState = getPortalFreshnessState(policy, lastUpdatedAt, clockNow);
+  const badgeLabel = workerOpsFreshness
+    ? getWorkerOpsFreshnessLabel(workerOpsFreshness)
+    : getPortalFreshnessStateLabel(freshnessState);
+  const badgeClassName = workerOpsFreshness
+    ? getWorkerOpsFreshnessClassName(workerOpsFreshness)
+    : freshnessState;
 
   return (
     <section className="portal-freshness-card">
@@ -46,14 +90,16 @@ export function PortalFreshnessCard({
         <p className="eyebrow">Refresh behavior</p>
         <h3>{policy?.title ?? "Refresh on demand"}</h3>
         <p className="portal-panel-muted">
-          {describePortalFreshness(policy, lastUpdatedAt, clockNow)}
+          {workerOpsFreshness
+            ? describeWorkerOpsFreshness(workerOpsFreshness)
+            : describePortalFreshness(policy, lastUpdatedAt, clockNow)}
         </p>
       </div>
       <div className="portal-freshness-actions">
         <span
-          className={`portal-action-badge portal-freshness-badge portal-freshness-${freshnessState}`}
+          className={`portal-action-badge portal-freshness-badge portal-freshness-${badgeClassName}`}
         >
-          {getPortalFreshnessStateLabel(freshnessState)}
+          {badgeLabel}
         </span>
         {onRefresh ? (
           <button

--- a/apps/web/src/lib/portal-benchmark-ops.test.js
+++ b/apps/web/src/lib/portal-benchmark-ops.test.js
@@ -462,6 +462,14 @@ describe("portal benchmark ops fetchers", () => {
       return new Response(
         JSON.stringify({
           activeLeases: [],
+          freshness: {
+            degradationReason: null,
+            freshnessStatus: "live",
+            generatedAt: "2026-04-17T03:30:00.000Z",
+            observedThrough: null,
+            recommendedPollAfterSeconds: 15,
+            staleAfterSeconds: 60
+          },
           generatedAt: "2026-04-17T03:30:00.000Z",
           incidents: [],
           queueSummary: {

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.test.js
@@ -167,10 +167,23 @@ function createLaunchLoadState() {
   };
 }
 
+function createWorkerOpsFreshness(overrides = {}) {
+  return {
+    degradationReason: null,
+    freshnessStatus: "live",
+    generatedAt: "2026-04-17T04:00:00.000Z",
+    observedThrough: "2026-04-17T03:59:45.000Z",
+    recommendedPollAfterSeconds: 15,
+    staleAfterSeconds: 60,
+    ...overrides
+  };
+}
+
 function createWorkersLoadState() {
   return {
     data: {
       activeLeases: [],
+      freshness: createWorkerOpsFreshness(),
       generatedAt: "2026-04-17T04:00:00.000Z",
       incidents: [],
       queueSummary: {
@@ -377,5 +390,49 @@ describe("portal benchmark ops route targets", () => {
     expect(html).toContain("modal / no workers seen yet");
     expect(html).toContain("modal / worker.v1");
     expect(html).toContain("Open PP-318");
+  });
+
+  it("renders API-owned stale worker freshness without hiding current worker rows", () => {
+    setWindow("http://127.0.0.1/workers?surface=portal&access=approved", 1280);
+    const loadState = createWorkersLoadState();
+    loadState.data.freshness = createWorkerOpsFreshness({
+      freshnessStatus: "stale",
+      observedThrough: "2026-04-17T03:57:45.000Z"
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(PortalWorkersSurface, {
+        activeRouteId: "portal.workers",
+        loadState,
+        onRefresh: async () => {}
+      })
+    );
+
+    expect(html).toContain("Worker snapshot is stale");
+    expect(html).toContain("Stale");
+    expect(html).toContain("modal / worker.v1");
+    expect(html).toContain("Open PP-318");
+  });
+
+  it("renders degraded worker freshness with the API reason", () => {
+    setWindow("http://127.0.0.1/workers?surface=portal&access=approved", 1280);
+    const loadState = createWorkersLoadState();
+    loadState.data.freshness = createWorkerOpsFreshness({
+      degradationReason: "worker read model lagged behind the queue",
+      freshnessStatus: "degraded",
+      observedThrough: null
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(PortalWorkersSurface, {
+        activeRouteId: "portal.workers",
+        loadState,
+        onRefresh: async () => {}
+      })
+    );
+
+    expect(html).toContain("Worker snapshot is degraded");
+    expect(html).toContain("worker read model lagged behind the queue");
+    expect(html).toContain("Degraded");
   });
 });

--- a/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
+++ b/apps/web/src/routes/portal-benchmark-ops-surfaces.tsx
@@ -9,6 +9,7 @@ import {
   type PortalRunDetailResponse,
   type PortalRunsListQuery,
   type PortalRunsListResponse,
+  type PortalWorkerOpsFreshness,
   type PortalWorkersViewResponse,
   type RunKind
 } from "@paretoproof/shared";
@@ -1510,17 +1511,19 @@ export function PortalWorkersSurface({
   onRefresh
 }: SurfaceProps<PortalWorkersViewResponse>) {
   const data = loadState.data;
+  const workerOpsFreshness = data?.freshness ?? null;
   const awaitingFirstLoad = isAwaitingFirstLoad(loadState);
   const isCompactLayout = useCompactLayout(480);
   const compactEvidenceCards = buildWorkersCompactEvidenceCards(data);
   const freshnessCard = (
     <PortalFreshnessCard
       isRefreshing={loadState.isLoading}
-      lastUpdatedAt={loadState.lastUpdatedAt}
+      lastUpdatedAt={workerOpsFreshness?.generatedAt ?? loadState.lastUpdatedAt}
       onRefresh={() => {
         void onRefresh();
       }}
       routeId={activeRouteId}
+      workerOpsFreshness={workerOpsFreshness}
     />
   );
 
@@ -1538,7 +1541,7 @@ export function PortalWorkersSurface({
         <div className="portal-panel-header">
           <div>
             {!isCompactLayout ? <p className="section-tag">Worker operations</p> : null}
-            <h2>Workers tracks queue pressure, lease health, and incident anchors.</h2>
+            <h2>Workers gives the current fleet overview, pool posture, and recovery signals.</h2>
           </div>
           <a className="button button-secondary" href={buildPortalUrl("/runs")}>
             Jump to runs
@@ -1568,6 +1571,7 @@ export function PortalWorkersSurface({
                 </div>
               </article>
             ) : null}
+            <PortalWorkerOpsFreshnessBanner freshness={data.freshness} />
             <div className="portal-summary-grid">
               <article className="portal-summary-card">
                 <span>Queued jobs</span>
@@ -1585,33 +1589,45 @@ export function PortalWorkersSurface({
                 <small>{data.queueSummary.cancelRequestedJobs} cancel requested</small>
               </article>
               <article className="portal-summary-card">
-                <span>Generated</span>
-                <strong>{formatTimestamp(data.generatedAt)}</strong>
-                <small>Current read model snapshot</small>
+                <span>Observed through</span>
+                <strong>
+                  {data.freshness.observedThrough
+                    ? formatTimestamp(data.freshness.observedThrough)
+                    : "No observations"}
+                </strong>
+                <small>API-owned worker freshness</small>
               </article>
             </div>
             {isCompactLayout ? freshnessCard : null}
             {data.workerPools.length ? (
-              <div className="portal-results-contract-grid">
-                {data.workerPools.map((pool) => (
-                  <article
-                    className="portal-results-contract-card"
-                    key={`${pool.workerPool}:${pool.workerRuntime}:${pool.workerVersion ?? "unseen"}`}
-                  >
-                    <p className="section-tag">Worker pool</p>
-                    <h3>{pool.workerPool}</h3>
-                    <p>{pool.workerRuntime} / {pool.workerVersion ?? "no workers seen yet"}</p>
-                    <p>
-                      Active leases: {pool.activeLeaseCount} / stale leases: {pool.staleLeaseCount}
-                    </p>
-                    {pool.activeRunIds.length ? (
-                      <a className="portal-inline-link" href={buildRunDetailHref(pool.activeRunIds[0])}>
-                        Open {pool.activeRunIds[0]}
-                      </a>
-                    ) : null}
-                  </article>
-                ))}
-              </div>
+              <article className="portal-panel-table-flat">
+                <div className="portal-panel-header">
+                  <div>
+                    <p className="section-tag">Pool posture</p>
+                    <h2>Worker pools stay bounded to fields the API exposes today.</h2>
+                  </div>
+                </div>
+                <div className="portal-results-contract-grid">
+                  {data.workerPools.map((pool) => (
+                    <article
+                      className="portal-results-contract-card"
+                      key={`${pool.workerPool}:${pool.workerRuntime}:${pool.workerVersion ?? "unseen"}`}
+                    >
+                      <p className="section-tag">Worker pool</p>
+                      <h3>{pool.workerPool}</h3>
+                      <p>{pool.workerRuntime} / {pool.workerVersion ?? "no workers seen yet"}</p>
+                      <p>
+                        Active leases: {pool.activeLeaseCount} / stale leases: {pool.staleLeaseCount}
+                      </p>
+                      {pool.activeRunIds.length ? (
+                        <a className="portal-inline-link" href={buildRunDetailHref(pool.activeRunIds[0])}>
+                          Open {pool.activeRunIds[0]}
+                        </a>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              </article>
             ) : (
               <PortalEmptyState
                 description="Refresh the worker operations view to reload current pool and lease posture."
@@ -1622,7 +1638,7 @@ export function PortalWorkersSurface({
               <div className="portal-panel-header">
                 <div>
                   <p className="section-tag">Incidents</p>
-                  <h2>Operational incidents stay tied to concrete runs.</h2>
+                  <h2>Active incidents route operators to concrete runs.</h2>
                 </div>
               </div>
               {data.incidents.length ? (
@@ -1670,8 +1686,8 @@ export function PortalWorkersSurface({
       </article>
 
       <aside className="portal-surface-rail">
-        <p className="section-tag">Active leases</p>
-        <h2>Lease posture stays tied to run evidence.</h2>
+        <p className="section-tag">Stale leases and active runs</p>
+        <h2>Lease posture stays tied to run evidence until worker-ops detail routes land.</h2>
         {(data?.activeLeases ?? []).length ? (
           <div className="portal-action-list">
             {(data?.activeLeases ?? []).map((lease) => (
@@ -1757,6 +1773,38 @@ function buildWorkersCompactEvidenceCards(data: PortalWorkersViewResponse | null
   );
 
   return cards;
+}
+
+function PortalWorkerOpsFreshnessBanner({
+  freshness
+}: {
+  freshness: PortalWorkerOpsFreshness;
+}) {
+  if (freshness.freshnessStatus === "live") {
+    return null;
+  }
+
+  if (freshness.freshnessStatus === "degraded") {
+    return (
+      <article className="portal-feedback-card portal-feedback-error">
+        <strong>Worker snapshot is degraded</strong>
+        <p>
+          The API returned a partial worker-operations snapshot: {freshness.degradationReason}.
+        </p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="portal-feedback-card">
+      <strong>Worker snapshot is stale</strong>
+      <p>
+        The API last observed worker data through{" "}
+        {freshness.observedThrough ? formatTimestamp(freshness.observedThrough) : "an unknown time"}.
+        Keep existing rows visible, but confirm current posture before taking operator action.
+      </p>
+    </article>
+  );
 }
 
 function PortalErrorState({ error }: { error: string }) {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1687,6 +1687,12 @@ a.button-secondary {
   background: rgba(185, 117, 20, 0.1);
 }
 
+.portal-freshness-degraded {
+  color: var(--rose);
+  border-color: rgba(176, 52, 71, 0.22);
+  background: rgba(176, 52, 71, 0.1);
+}
+
 .portal-section-notes {
   padding-top: 14px;
   border-top: 1px solid var(--line);

--- a/packages/shared/src/contracts/api-call-boundary.ts
+++ b/packages/shared/src/contracts/api-call-boundary.ts
@@ -171,6 +171,14 @@ export const apiCallBoundaryCatalog = [
   },
   {
     credential: "cloudflare_access_jwt",
+    endpointId: "portal.worker-ops.overview.read",
+    mode: "browser_direct",
+    origin: "portal_browser",
+    rationale:
+      "The worker-ops compatibility overview is a browser-facing portal read model with API-owned freshness metadata and no control-plane mutations."
+  },
+  {
+    credential: "cloudflare_access_jwt",
     endpointId: "portal.profile.update",
     mode: "browser_direct",
     origin: "portal_browser",

--- a/packages/shared/src/contracts/api-catalog.ts
+++ b/packages/shared/src/contracts/api-catalog.ts
@@ -186,6 +186,15 @@ export const apiEndpointCatalog = [
       "Return the bounded worker-operations overview for queue pressure, active leases, and derived operational incidents."
   },
   {
+    access: "approved_collaborator_or_higher",
+    audience: "portal",
+    id: "portal.worker-ops.overview.read",
+    method: "GET",
+    path: "/portal/worker-ops/overview",
+    purpose:
+      "Return the private worker-ops compatibility overview with API-owned freshness metadata."
+  },
+  {
     access: "authenticated_access_identity",
     audience: "portal",
     id: "portal.profile.update",

--- a/packages/shared/src/contracts/api-schema-catalog.ts
+++ b/packages/shared/src/contracts/api-schema-catalog.ts
@@ -208,6 +208,12 @@ export const apiEndpointSchemaCatalog = {
     requestQuery: null,
     responseBody: portalWorkersViewResponseSchema
   },
+  "portal.worker-ops.overview.read": {
+    requestBody: null,
+    requestParams: null,
+    requestQuery: null,
+    responseBody: portalWorkersViewResponseSchema
+  },
   "portal.profile.update": {
     requestBody: portalProfileUpdateInputSchema,
     requestParams: null,

--- a/packages/shared/src/schemas/portal-benchmark-ops.ts
+++ b/packages/shared/src/schemas/portal-benchmark-ops.ts
@@ -416,20 +416,65 @@ export const portalWorkerPoolSummarySchema = z.object({
   workerVersion: z.string().nullable()
 });
 
-export const portalWorkersViewResponseSchema = z.object({
-  activeLeases: z.array(portalWorkerLeaseSummarySchema),
-  generatedAt: timestampSchema,
-  incidents: z.array(portalWorkerIncidentSchema),
-  queueSummary: z.object({
-    activeRuns: z.number().int().nonnegative(),
-    cancelRequestedJobs: z.number().int().nonnegative(),
-    claimedJobs: z.number().int().nonnegative(),
-    queuedJobs: z.number().int().nonnegative(),
-    queuedRuns: z.number().int().nonnegative(),
-    runningJobs: z.number().int().nonnegative()
-  }),
-  workerPools: z.array(portalWorkerPoolSummarySchema)
-});
+export const portalWorkerOpsFreshnessStatusSchema = z.enum([
+  "live",
+  "stale",
+  "degraded"
+]);
+
+export const portalWorkerOpsFreshnessSchema = z
+  .object({
+    degradationReason: z.string().min(1).nullable(),
+    freshnessStatus: portalWorkerOpsFreshnessStatusSchema,
+    generatedAt: timestampSchema,
+    observedThrough: timestampSchema.nullable(),
+    recommendedPollAfterSeconds: z.number().int().positive(),
+    staleAfterSeconds: z.number().int().positive()
+  })
+  .superRefine((value, context) => {
+    if (value.freshnessStatus === "degraded" && !value.degradationReason) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "degraded worker-ops freshness requires a degradation reason",
+        path: ["degradationReason"]
+      });
+      return;
+    }
+
+    if (value.freshnessStatus !== "degraded" && value.degradationReason !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "non-degraded worker-ops freshness must not include a degradation reason",
+        path: ["degradationReason"]
+      });
+    }
+  });
+
+export const portalWorkersViewResponseSchema = z
+  .object({
+    activeLeases: z.array(portalWorkerLeaseSummarySchema),
+    freshness: portalWorkerOpsFreshnessSchema,
+    generatedAt: timestampSchema,
+    incidents: z.array(portalWorkerIncidentSchema),
+    queueSummary: z.object({
+      activeRuns: z.number().int().nonnegative(),
+      cancelRequestedJobs: z.number().int().nonnegative(),
+      claimedJobs: z.number().int().nonnegative(),
+      queuedJobs: z.number().int().nonnegative(),
+      queuedRuns: z.number().int().nonnegative(),
+      runningJobs: z.number().int().nonnegative()
+    }),
+    workerPools: z.array(portalWorkerPoolSummarySchema)
+  })
+  .superRefine((value, context) => {
+    if (value.generatedAt !== value.freshness.generatedAt) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "worker-ops snapshot generatedAt must match freshness.generatedAt",
+        path: ["freshness", "generatedAt"]
+      });
+    }
+  });
 
 export const portalOverviewResponseSchema = z.object({
   benchmarkHighlights: z.array(portalBenchmarkListItemSchema),

--- a/packages/shared/src/types/portal-benchmark-ops.ts
+++ b/packages/shared/src/types/portal-benchmark-ops.ts
@@ -385,8 +385,20 @@ export type PortalWorkerPoolSummary = {
   workerVersion: string | null;
 };
 
+export type PortalWorkerOpsFreshnessStatus = "live" | "stale" | "degraded";
+
+export type PortalWorkerOpsFreshness = {
+  degradationReason: string | null;
+  freshnessStatus: PortalWorkerOpsFreshnessStatus;
+  generatedAt: string;
+  observedThrough: string | null;
+  recommendedPollAfterSeconds: number;
+  staleAfterSeconds: number;
+};
+
 export type PortalWorkersViewResponse = {
   activeLeases: PortalWorkerLeaseSummary[];
+  freshness: PortalWorkerOpsFreshness;
   generatedAt: string;
   incidents: PortalWorkerIncident[];
   queueSummary: {

--- a/packages/shared/test/api-contract-parity.test.js
+++ b/packages/shared/test/api-contract-parity.test.js
@@ -31,6 +31,17 @@ describe("shared api catalog parity", () => {
     );
   });
 
+  it("covers the worker-ops compatibility overview as a browser-facing read model", () => {
+    expect(apiCallBoundaryCatalog).toContainEqual(
+      expect.objectContaining({
+        credential: "cloudflare_access_jwt",
+        endpointId: "portal.worker-ops.overview.read",
+        mode: "browser_direct",
+        origin: "portal_browser"
+      })
+    );
+  });
+
   it("exposes non-null schemas for representative catalogued endpoints", () => {
     expect(apiEndpointSchemaContract["health.read"].responseBodySchema).not.toBeNull();
     expect(apiEndpointSchemaContract["portal.access-request.create"].requestBodySchema).not.toBeNull();

--- a/packages/shared/test/api-schema-catalog.test.js
+++ b/packages/shared/test/api-schema-catalog.test.js
@@ -13,6 +13,7 @@ import {
   portalRunDetailParamsSchema,
   portalAccessRequestSummaryResponseSchema,
   portalProfileResponseSchema,
+  portalWorkersViewResponseSchema,
   portalSessionRedirectInputSchema,
   portalSessionRedirectRequestBodySchema,
   workerJobParamsSchema,
@@ -110,6 +111,17 @@ describe("shared api schema catalog", () => {
     expect(apiEndpointSchemaCatalog["portal.run-detail.read"].requestParams).toBe(
       portalRunDetailParamsSchema
     );
+
+    expect(apiEndpointSchemaCatalog["portal.workers.read"].responseBody).toBe(
+      portalWorkersViewResponseSchema
+    );
+
+    expect(apiEndpointSchemaCatalog["portal.worker-ops.overview.read"]).toEqual({
+      requestBody: null,
+      requestParams: null,
+      requestQuery: null,
+      responseBody: portalWorkersViewResponseSchema
+    });
 
     expect(apiEndpointSchemaCatalog["admin.access-request.detail"].requestParams).toBe(
       portalAdminAccessRequestParamsSchema

--- a/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
+++ b/packages/shared/test/portal-benchmark-ops-lifecycle-contract.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
   portalBenchmarkDatasetResponseSchema,
+  portalWorkerOpsFreshnessSchema,
+  portalWorkersViewResponseSchema,
   portalRunAttemptSummarySchema,
   portalRunJobSummarySchema,
   portalRunListItemSchema,
@@ -43,6 +45,80 @@ const baseRunItem = {
 };
 
 describe("portal benchmark-ops lifecycle contracts", () => {
+  it("requires explicit API-owned worker freshness for workers responses", () => {
+    const baseWorkersResponse = {
+      activeLeases: [],
+      freshness: {
+        degradationReason: null,
+        freshnessStatus: "live",
+        generatedAt: "2026-04-26T18:00:00.000Z",
+        observedThrough: null,
+        recommendedPollAfterSeconds: 15,
+        staleAfterSeconds: 60
+      },
+      generatedAt: "2026-04-26T18:00:00.000Z",
+      incidents: [],
+      queueSummary: {
+        activeRuns: 0,
+        cancelRequestedJobs: 0,
+        claimedJobs: 0,
+        queuedJobs: 0,
+        queuedRuns: 0,
+        runningJobs: 0
+      },
+      workerPools: []
+    };
+    const parsed = portalWorkersViewResponseSchema.parse(baseWorkersResponse);
+
+    expect(parsed.freshness.freshnessStatus).toBe("live");
+    expect(parsed.freshness.observedThrough).toBeNull();
+
+    expect(
+      portalWorkersViewResponseSchema.safeParse({
+        ...baseWorkersResponse,
+        freshness: {
+          ...baseWorkersResponse.freshness,
+          generatedAt: "2026-04-26T18:00:01.000Z"
+        }
+      }).success
+    ).toBe(false);
+  });
+
+  it("keeps worker degraded-state reasons explicit and absent from live states", () => {
+    expect(
+      portalWorkerOpsFreshnessSchema.parse({
+        degradationReason: "worker_ops_partial_snapshot",
+        freshnessStatus: "degraded",
+        generatedAt: "2026-04-26T18:00:00.000Z",
+        observedThrough: "2026-04-26T17:59:00.000Z",
+        recommendedPollAfterSeconds: 15,
+        staleAfterSeconds: 60
+      }).degradationReason
+    ).toBe("worker_ops_partial_snapshot");
+
+    expect(
+      portalWorkerOpsFreshnessSchema.safeParse({
+        degradationReason: null,
+        freshnessStatus: "degraded",
+        generatedAt: "2026-04-26T18:00:00.000Z",
+        observedThrough: "2026-04-26T17:59:00.000Z",
+        recommendedPollAfterSeconds: 15,
+        staleAfterSeconds: 60
+      }).success
+    ).toBe(false);
+
+    expect(
+      portalWorkerOpsFreshnessSchema.safeParse({
+        degradationReason: "not_allowed_for_live",
+        freshnessStatus: "live",
+        generatedAt: "2026-04-26T18:00:00.000Z",
+        observedThrough: "2026-04-26T17:59:00.000Z",
+        recommendedPollAfterSeconds: 15,
+        staleAfterSeconds: 60
+      }).success
+    ).toBe(false);
+  });
+
   it("accepts non-terminal runs with null terminal-only fields", () => {
     const parsed = portalRunListItemSchema.parse({
       ...baseRunItem,


### PR DESCRIPTION
## Problem

Issue #1019 calls out drift between the portal worker-ops UI, local web fixtures, freshness behavior, and the shared/API runtime contracts. The worker view previously treated browser fetch time as the freshness source, while the API response did not expose explicit freshness metadata and the worker-ops information architecture had no dedicated compatibility endpoint in the shared catalogs.

## Approach

- Add a shared `PortalWorkerOpsFreshness` contract with `live`, `stale`, and `degraded` states, including schema validation for degraded-state reasons and `generatedAt` consistency.
- Have the API compute worker-ops freshness from actual control-plane observation timestamps and return it with the existing workers read model.
- Add `/portal/worker-ops/overview` as a collaborator-gated compatibility route using the same bounded worker posture response contract.
- Register the new endpoint in the API endpoint, schema, and call-boundary catalogs so generated/shared contract parity stays intact.
- Update the web worker surface and freshness card to render API-owned worker freshness, preserve real worker rows when snapshots are stale, and surface degraded snapshots with the API-provided reason.
- Refresh web/API/shared fixtures and regression coverage for the new contract and UI states.

## Validation

- `bun --cwd packages/shared build`
- `bun --cwd packages/shared typecheck`
- `bun test src/**/*.test.js test/*.test.js` from `packages/shared`
- `PATH=... bun --cwd apps/api test`
- `bun --cwd apps/api typecheck`
- `bun --cwd apps/api build`
- `bun --cwd apps/web typecheck`
- `bun test src/lib/portal-benchmark-ops.test.js src/routes/portal-benchmark-ops-surfaces.test.js` from `apps/web`
- `PATH=... bun --cwd apps/web build`
- `PATH=... bun --cwd apps/web test:ui`
- `bun run check:bidi`
- `git diff --check`

Fixes #1019.
