### PR TITLE
Prevent manual Pages deploys from publishing non-main code

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check deployment workflow Node runtimes
         run: node infra/scripts/check-deployment-workflow-node-runtime.mjs
 
+      - name: Test deployment workflow guard fixtures
+        run: node --test infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs
+
       - name: Check main-branch promotion gate docs
         run: node infra/scripts/check-main-branch-promotion-gate.mjs
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,7 +2,7 @@
 
 `apps/web` is the React and Vite frontend for the public site, auth entry, and authenticated portal UI.
 
-Cloudflare Pages is configured around this app through the local Wrangler config. The project name is `paretoproof-web`, the build output is `dist`, and deployments should build the workspace from the repository root before uploading the finished bundle to Pages.
+Cloudflare Pages is configured around this app through the local Wrangler config. The project name is `paretoproof-web`, the build output is `dist`, and deployments should build the workspace from the repository root before uploading the finished bundle to Pages. Repository-owned production uploads are sourced from `main`; branch builds are preview or local-only and must not be uploaded as the Pages `main` branch.
 
 Runtime env guidance:
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -38,6 +38,7 @@ A scoping issue is only complete when it produces a clear implementation path. I
 - the required pre-merge evidence source is the `Pull Request CI` workflow on the exact PR head that will merge
 - when a slice touches worker execution, image packaging, auth handoff, or runtime validation, reviewers should read the named smoke and boundary steps listed in [runtime.md](./runtime.md) instead of inferring health from unrelated UI, build, or typecheck steps
 - post-merge publish workflows may add release evidence such as image digests, but they do not replace the pre-merge PR smoke gate
+- manual production deploys must not bypass the main-branch promotion path; Pages production deploys are sourced from `main`, while rollback should use a Cloudflare Pages rollback or a revert/fix on `main`
 
 ## Status rule
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -16,6 +16,7 @@ This repo uses a small number of runtime rules.
 ## Deploy surfaces
 
 - Cloudflare Pages hosts the public site and auth-entry runtime.
+- Repository-owned Cloudflare Pages production deploys must be sourced from `main`; non-`main` web builds are preview or local-only and must not be uploaded as the Pages `main` branch.
 - Railway hosts the API.
 - Workers run locally or in hosted runtimes against the API control plane.
 - GHCR holds worker images.
@@ -63,6 +64,7 @@ Required kernel evidence comes from these named steps:
 
 After merge, treat the main-branch publish workflows as release evidence only:
 
+- `Deploy Pages` uploads the web bundle to Cloudflare Pages as branch `main` only from a `push` to `main`
 - `Publish Problem 9 Execution and Worker Images` records the pushed image digests in the `problem9-image-digests` artifact and step summary
 - `Publish Problem 9 Devbox Image` records the pushed image digest in the `problem9-devbox-image-digest` artifact and step summary
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,7 +9,7 @@ Current helper scripts:
 - `infra/scripts/check-runtime-env-examples.mjs`: fails CI when app `.env.example` files or README env pointers drift from the approved runtime-env contract shape.
 - `infra/scripts/check-harness-registry-seed.mjs`: fails CI when the harness registry seed manifest drifts from the approved image graph, hosted capability matrix, or root script wiring.
 - `infra/scripts/check-problem9-image-policy.mjs`: fails CI when the Problem 9 image manifest, publish workflows, root build scripts, or operator docs drift apart.
-- `infra/scripts/check-deployment-workflow-node-runtime.mjs`: fails CI when deployment workflows drift away from the approved Node 24-compatible action/runtime shape, replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step, and pins the active deployment workflows to Node-24-compatible action revisions.
+- `infra/scripts/check-deployment-workflow-node-runtime.mjs`: fails CI when deployment workflows drift away from the approved Node 24-compatible action/runtime shape, replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step, pins the active deployment workflows to Node-24-compatible action revisions, and enforces the main-only production source invariant for Cloudflare Pages deploys.
 - `infra/scripts/verify-problem9-image-toolchains.mjs`: runs toolchain checks against a built `problem9-execution` or `problem9-devbox` image, or against a filesystem export of one, and fails on Lean, Node, Bun, Codex CLI, or `lean-lsp-mcp` drift.
 - `infra/scripts/check-trusted-local-boundaries.mjs`: fails CI when repo ignore rules, worker Docker packaging, or trusted-local docs drift toward persisting Codex auth material in the repository or image build context.
 

--- a/infra/scripts/check-deployment-workflow-node-runtime.mjs
+++ b/infra/scripts/check-deployment-workflow-node-runtime.mjs
@@ -3,32 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDirectory, "..", "..");
-
-function readText(relativePath) {
-  return readFileSync(path.join(repoRoot, relativePath), "utf8");
-}
-
-function fail(message) {
-  console.error(`Deployment workflow Node runtime check failed: ${message}`);
-  process.exit(1);
-}
-
-function assertIncludes(contents, snippets, file) {
-  for (const snippet of snippets) {
-    if (!contents.includes(snippet)) {
-      fail(`${file} is missing required snippet "${snippet}"`);
-    }
-  }
-}
-
-function assertExcludes(contents, snippets, file) {
-  for (const snippet of snippets) {
-    if (contents.includes(snippet)) {
-      fail(`${file} still includes forbidden snippet "${snippet}"`);
-    }
-  }
-}
+const defaultRepoRoot = path.resolve(scriptDirectory, "..", "..");
 
 const deployPagesWorkflowPath = ".github/workflows/deploy-pages.yml";
 const publishWorkerWorkflowPath = ".github/workflows/publish-worker-image.yml";
@@ -37,74 +12,282 @@ const pullRequestCiWorkflowPath = ".github/workflows/pull-request-ci.yml";
 const infraReadmePath = "infra/README.md";
 const packageJsonPath = "package.json";
 
-const deployPagesWorkflow = readText(deployPagesWorkflowPath);
-const publishWorkerWorkflow = readText(publishWorkerWorkflowPath);
-const publishDevboxWorkflow = readText(publishDevboxWorkflowPath);
-const pullRequestCiWorkflow = readText(pullRequestCiWorkflowPath);
-const infraReadme = readText(infraReadmePath);
-const packageJson = JSON.parse(readText(packageJsonPath));
+export class DeploymentWorkflowPolicyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "DeploymentWorkflowPolicyError";
+  }
+}
 
-assertIncludes(
-  deployPagesWorkflow,
-  [
-    "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
-    "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
-    "working-directory: apps/web",
-    "bunx wrangler pages deploy dist",
-    "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
-    "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
-  ],
-  deployPagesWorkflowPath
-);
-assertExcludes(
-  deployPagesWorkflow,
-  ["cloudflare/wrangler-action@", "actions/checkout@v4"],
-  deployPagesWorkflowPath
-);
+function readText(relativePath, repoRoot = defaultRepoRoot) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
 
-for (const [file, contents] of [
-  [publishWorkerWorkflowPath, publishWorkerWorkflow],
-  [publishDevboxWorkflowPath, publishDevboxWorkflow]
-]) {
+function policyError(message) {
+  return new DeploymentWorkflowPolicyError(message);
+}
+
+function assertCondition(condition, message) {
+  if (!condition) {
+    throw policyError(message);
+  }
+}
+
+function assertIncludes(contents, snippets, file) {
+  for (const snippet of snippets) {
+    assertCondition(
+      contents.includes(snippet),
+      `${file} is missing required snippet "${snippet}"`
+    );
+  }
+}
+
+function assertExcludes(contents, snippets, file) {
+  for (const snippet of snippets) {
+    assertCondition(
+      !contents.includes(snippet),
+      `${file} still includes forbidden snippet "${snippet}"`
+    );
+  }
+}
+
+function splitLines(contents) {
+  return contents.split(/\r?\n/u);
+}
+
+function indentation(line) {
+  const match = line.match(/^ */u);
+  return match ? match[0].length : 0;
+}
+
+function getBlockLines(lines, key, indent, file) {
+  const header = `${key}:`;
+  const startIndex = lines.findIndex(
+    (line) => indentation(line) === indent && line.trim() === header
+  );
+
+  assertCondition(
+    startIndex !== -1,
+    `${file} is missing ${" ".repeat(indent)}${header}`
+  );
+
+  const blockLines = [];
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (line.trim() !== "" && indentation(line) <= indent) {
+      break;
+    }
+
+    blockLines.push(line);
+  }
+
+  return blockLines;
+}
+
+function assertBlockLine(blockLines, indent, text, file) {
+  assertCondition(
+    blockLines.some((line) => indentation(line) === indent && line.trim() === text),
+    `${file} is missing ${" ".repeat(indent)}${text}`
+  );
+}
+
+function readIndentedList(blockLines, key, keyIndent, itemIndent, file) {
+  const startIndex = blockLines.findIndex(
+    (line) => indentation(line) === keyIndent && line.trim() === `${key}:`
+  );
+
+  assertCondition(
+    startIndex !== -1,
+    `${file} is missing ${" ".repeat(keyIndent)}${key}:`
+  );
+
+  const values = [];
+
+  for (let index = startIndex + 1; index < blockLines.length; index += 1) {
+    const line = blockLines[index];
+
+    if (line.trim() !== "" && indentation(line) <= keyIndent) {
+      break;
+    }
+
+    if (indentation(line) === itemIndent && line.trim().startsWith("- ")) {
+      values.push(line.trim().slice(2).trim());
+    }
+  }
+
+  assertCondition(values.length > 0, `${file} ${key} must contain at least one value`);
+  return values;
+}
+
+export function assertNoUnguardedPagesWorkflowDispatch(
+  contents,
+  file = deployPagesWorkflowPath
+) {
+  assertCondition(
+    !/^\s*workflow_dispatch\s*:/mu.test(contents),
+    `${file} must not expose workflow_dispatch while deploying with --branch=main`
+  );
+}
+
+export function assertPagesPushTriggerIsMainOnly(contents, file = deployPagesWorkflowPath) {
+  const lines = splitLines(contents);
+  const onBlock = getBlockLines(lines, "on", 0, file);
+  const pushBlock = getBlockLines(onBlock, "push", 2, file);
+  const branches = readIndentedList(pushBlock, "branches", 4, 6, file);
+
+  assertCondition(
+    branches.length === 1 && branches[0] === "main",
+    `${file} push trigger must be restricted to main only`
+  );
+}
+
+export function assertPagesDeployJobPolicy(contents, file = deployPagesWorkflowPath) {
+  const lines = splitLines(contents);
+  const permissionsBlock = getBlockLines(lines, "permissions", 0, file);
+  const jobsBlock = getBlockLines(lines, "jobs", 0, file);
+  const deployBlock = getBlockLines(jobsBlock, "deploy", 2, file);
+  const concurrencyBlock = getBlockLines(deployBlock, "concurrency", 4, file);
+
+  assertBlockLine(permissionsBlock, 2, "contents: read", file);
+  assertBlockLine(deployBlock, 4, "environment: production", file);
+  assertBlockLine(concurrencyBlock, 6, "group: pages-production-deploy", file);
+}
+
+export function assertDeployStepStillUsesApprovedWranglerShape(
+  contents,
+  file = deployPagesWorkflowPath
+) {
   assertIncludes(
     contents,
     [
       "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
       "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
-      "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0",
-      "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0",
-      "docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0",
-      "docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0",
-      "actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0"
+      "working-directory: apps/web",
+      "bunx wrangler pages deploy dist",
+      "--project-name=paretoproof-web",
+      "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+      "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
     ],
     file
   );
+
+  assertExcludes(
+    contents,
+    ["cloudflare/wrangler-action@", "actions/checkout@v4"],
+    file
+  );
+
+  const branchFlags = Array.from(
+    contents.matchAll(/--branch=([^\s]+)/gu),
+    (match) => match[1]
+  );
+
+  assertCondition(
+    branchFlags.length === 1 && branchFlags[0] === "main",
+    `${file} must deploy exactly one Cloudflare Pages branch, main`
+  );
 }
 
-assertIncludes(
-  pullRequestCiWorkflow,
-  [
-    "Check deployment workflow Node runtimes",
-    "node infra/scripts/check-deployment-workflow-node-runtime.mjs"
-  ],
-  pullRequestCiWorkflowPath
-);
+export function assertPagesDeployWorkflowPolicy(contents, file = deployPagesWorkflowPath) {
+  assertNoUnguardedPagesWorkflowDispatch(contents, file);
+  assertPagesPushTriggerIsMainOnly(contents, file);
+  assertPagesDeployJobPolicy(contents, file);
+  assertDeployStepStillUsesApprovedWranglerShape(contents, file);
+}
 
-assertIncludes(
-  infraReadme,
-  [
-    "check-deployment-workflow-node-runtime.mjs",
-    "replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step",
-    "pins the active deployment workflows to Node-24-compatible action revisions"
-  ],
-  infraReadmePath
-);
-
-if (
-  packageJson.scripts?.["check:deployment-workflow-node-runtime"] !==
-  "node infra/scripts/check-deployment-workflow-node-runtime.mjs"
+export function validateDeploymentWorkflowNodeRuntimePolicy(
+  repoRoot = defaultRepoRoot
 ) {
-  fail(`${packageJsonPath} is missing script check:deployment-workflow-node-runtime`);
+  const deployPagesWorkflow = readText(deployPagesWorkflowPath, repoRoot);
+  const publishWorkerWorkflow = readText(publishWorkerWorkflowPath, repoRoot);
+  const publishDevboxWorkflow = readText(publishDevboxWorkflowPath, repoRoot);
+  const pullRequestCiWorkflow = readText(pullRequestCiWorkflowPath, repoRoot);
+  const infraReadme = readText(infraReadmePath, repoRoot);
+  const packageJson = JSON.parse(readText(packageJsonPath, repoRoot));
+
+  assertPagesDeployWorkflowPolicy(deployPagesWorkflow, deployPagesWorkflowPath);
+
+  for (const [file, contents] of [
+    [publishWorkerWorkflowPath, publishWorkerWorkflow],
+    [publishDevboxWorkflowPath, publishDevboxWorkflow]
+  ]) {
+    assertIncludes(
+      contents,
+      [
+        "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+        "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
+        "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0",
+        "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0",
+        "docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0",
+        "docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0",
+        "actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0"
+      ],
+      file
+    );
+  }
+
+  assertIncludes(
+    pullRequestCiWorkflow,
+    [
+      "Check deployment workflow Node runtimes",
+      "node infra/scripts/check-deployment-workflow-node-runtime.mjs",
+      "Test deployment workflow guard fixtures",
+      "node --test infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs"
+    ],
+    pullRequestCiWorkflowPath
+  );
+
+  assertIncludes(
+    infraReadme,
+    [
+      "check-deployment-workflow-node-runtime.mjs",
+      "replaces the Node-20-only Wrangler JavaScript action with a local `bunx wrangler` deploy step",
+      "pins the active deployment workflows to Node-24-compatible action revisions",
+      "enforces the main-only production source invariant for Cloudflare Pages deploys"
+    ],
+    infraReadmePath
+  );
+
+  if (
+    packageJson.scripts?.["check:deployment-workflow-node-runtime"] !==
+    "node infra/scripts/check-deployment-workflow-node-runtime.mjs"
+  ) {
+    throw policyError(`${packageJsonPath} is missing script check:deployment-workflow-node-runtime`);
+  }
 }
 
-console.log("Deployment workflows are pinned to the approved Node 24-compatible action/runtime shape.");
+function resolveCliRepoRoot(argv) {
+  const repoRootIndex = argv.indexOf("--repo-root");
+
+  if (repoRootIndex === -1) {
+    return defaultRepoRoot;
+  }
+
+  const repoRoot = argv[repoRootIndex + 1];
+
+  if (!repoRoot) {
+    throw policyError("--repo-root requires a path argument");
+  }
+
+  return path.resolve(repoRoot);
+}
+
+export function runCli(
+  argv = process.argv.slice(2),
+  io = { log: console.log, error: console.error }
+) {
+  try {
+    validateDeploymentWorkflowNodeRuntimePolicy(resolveCliRepoRoot(argv));
+    io.log("Deployment workflows satisfy the approved runtime and Pages production source policy.");
+    return 0;
+  } catch (error) {
+    io.error(`Deployment workflow Node runtime check failed: ${error.message}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(runCli());
+}

--- a/infra/scripts/fixtures/deployment-workflows/deploy-pages-manual-unsafe.yml
+++ b/infra/scripts/fixtures/deployment-workflows/deploy-pages-manual-unsafe.yml
@@ -11,6 +11,7 @@ on:
       - "bun.lock"
       - "tsconfig.base.json"
       - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,20 +30,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.10
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build shared package
-        run: bun run build:shared
-
-      - name: Build web app
-        run: bun run build:web
 
       - name: Deploy to Cloudflare Pages
         working-directory: apps/web

--- a/infra/scripts/fixtures/deployment-workflows/deploy-pages-safe.yml
+++ b/infra/scripts/fixtures/deployment-workflows/deploy-pages-safe.yml
@@ -30,20 +30,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.10
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build shared package
-        run: bun run build:shared
-
-      - name: Build web app
-        run: bun run build:web
-
       - name: Deploy to Cloudflare Pages
         working-directory: apps/web
         env:

--- a/infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs
+++ b/infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  DeploymentWorkflowPolicyError,
+  assertPagesDeployWorkflowPolicy,
+  runCli,
+  validateDeploymentWorkflowNodeRuntimePolicy
+} from "../check-deployment-workflow-node-runtime.mjs";
+
+const repoRoot = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+const fixturesRoot = resolve(
+  fileURLToPath(new URL("../fixtures/deployment-workflows", import.meta.url))
+);
+
+function readFixture(name) {
+  return readFileSync(resolve(fixturesRoot, name), "utf8");
+}
+
+function assertPolicyFailure(contents, expectedMessage) {
+  assert.throws(
+    () => assertPagesDeployWorkflowPolicy(contents, "fixture.yml"),
+    (error) => {
+      assert.equal(error instanceof DeploymentWorkflowPolicyError, true);
+      assert.match(error.message, expectedMessage);
+      return true;
+    }
+  );
+}
+
+test("checked-in deployment workflows satisfy the runtime and Pages source policy", () => {
+  assert.doesNotThrow(() => validateDeploymentWorkflowNodeRuntimePolicy(repoRoot));
+});
+
+test("safe Pages deployment fixture passes the policy guard", () => {
+  assert.doesNotThrow(() =>
+    assertPagesDeployWorkflowPolicy(readFixture("deploy-pages-safe.yml"), "safe.yml")
+  );
+});
+
+test("unguarded manual Pages dispatch cannot publish as main", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-manual-unsafe.yml"),
+    /must not expose workflow_dispatch while deploying with --branch=main/u
+  );
+});
+
+test("Pages deploy workflow must only push from main", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-safe.yml").replace("- main", ["- main", "      - staging"].join("\n")),
+    /push trigger must be restricted to main only/u
+  );
+});
+
+test("Pages deploy workflow must keep the production environment", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-safe.yml").replace("environment: production", "environment: staging"),
+    /environment: production/u
+  );
+});
+
+test("Pages deploy workflow must explicitly deploy the Cloudflare Pages main branch", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-safe.yml").replace("--branch=main", "--branch=preview"),
+    /must deploy exactly one Cloudflare Pages branch, main/u
+  );
+});
+
+test("Pages deploy workflow must keep Cloudflare credentials secret-backed", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-safe.yml").replace(
+      "CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}",
+      "CLOUDFLARE_API_TOKEN: unsafe-inline-token"
+    ),
+    /CLOUDFLARE_API_TOKEN/u
+  );
+});
+
+test("Pages deploy workflow must keep the checkout action pinned", () => {
+  assertPolicyFailure(
+    readFixture("deploy-pages-safe.yml").replace(
+      "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0",
+      "actions/checkout@v4"
+    ),
+    /actions\/checkout/u
+  );
+});
+
+test("Pages deploy workflow must not reintroduce the Wrangler JavaScript action", () => {
+  assertPolicyFailure(
+    `${readFixture("deploy-pages-safe.yml")}\n      - uses: cloudflare/wrangler-action@v3\n`,
+    /cloudflare\/wrangler-action@/u
+  );
+});
+
+test("CLI wrapper returns a failure code and useful error text for invalid repo roots", () => {
+  const messages = [];
+  const status = runCli(["--repo-root", "/path/that/does/not/exist"], {
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message)
+  });
+
+  assert.equal(status, 1);
+  assert.match(messages.join("\n"), /Deployment workflow Node runtime check failed:/u);
+});


### PR DESCRIPTION
## Summary

- Remove the manual `workflow_dispatch` trigger from the production Pages deploy workflow so repository-owned Pages uploads only run from `push` to `main`.
- Add explicit read-only workflow permissions and extend the deployment workflow guard to enforce the main-only Pages source invariant.
- Add fixture-backed regression tests for the previous unsafe manual dispatch shape and nearby deploy-policy drift.
- Update operator docs to describe that production Pages deploys must be sourced from `main`.

## Root Cause

The Pages deploy workflow could be manually dispatched from a selected non-main ref while still running `wrangler pages deploy dist --branch=main`. That made it possible for repository-owned automation to publish non-main code to the production Pages branch label.

## Changes

- `.github/workflows/deploy-pages.yml`: removes `workflow_dispatch` and adds `permissions: contents: read`.
- `infra/scripts/check-deployment-workflow-node-runtime.mjs`: exports testable policy assertions and rejects unguarded Pages manual dispatch when the deploy command targets `--branch=main`.
- `infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs`: covers the unsafe manual-dispatch workflow and adjacent deployment guard regressions.
- `infra/scripts/fixtures/deployment-workflows/*`: adds safe and unsafe workflow fixtures for the new regression tests.
- `infra/README.md`, `docs/runtime.md`, `docs/project-management.md`, and `apps/web/README.md`: document the enforced production deploy source rule.

## Validation

- `/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs`
- `bun test infra/scripts/test/check-deployment-workflow-node-runtime.test.mjs`
- `node infra/scripts/check-deployment-workflow-node-runtime.mjs`
- `node infra/scripts/check-main-branch-promotion-gate.mjs`
- `node infra/scripts/check-problem9-image-policy.mjs`
- `/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node infra/scripts/check-runtime-env-examples.mjs`
- `bun run check:bidi`
- `git diff --check`

## Notes

Local `/usr/local/bin/node` is v16.13.2 and does not support `node --test`; the focused test suite passed with the bundled modern Node runtime listed above. The existing PR CI path already invokes the Node test runner.

Closes #1020
