### PR TITLE
Fix local auth to use real backend relay flow

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,5 +8,5 @@ Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline for browser env versus hosted auth-entry secrets
 - use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages auth-entry runtime checklists
-- the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production completion stays on `/api/access/finalize`, while local loopback-branded previews target the local API finalize-submit route directly when the local API is running with localhost origin exceptions enabled
+- the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production and loopback-branded local completion stay on `/api/access/finalize`, with the relay forwarding to the API finalize-submit boundary when the local API is running with localhost origin exceptions enabled
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/web/functions/_shared/access-finalize.test.ts
+++ b/apps/web/functions/_shared/access-finalize.test.ts
@@ -154,6 +154,72 @@ describe("handleAccessFinalize", () => {
     ]);
   });
 
+  it("relays loopback-branded finalize requests through the local API and accepts local surface redirects", async () => {
+    globalThis.fetch = async (input, init) => {
+      expect(input).toBe(
+        "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit"
+      );
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Headers).get("origin")).toBe(
+        "http://github.auth.paretoproof.com:4173"
+      );
+      expect((init?.headers as Headers).get("cookie")).toContain(
+        "CF_Authorization=session-cookie"
+      );
+      expect(init?.body).toBe(JSON.stringify({ app: "portal", redirect: "/profile" }));
+
+      return new Response(
+        JSON.stringify({
+          redirectTo: "http://portal.paretoproof.com:4173/profile"
+        }),
+        {
+          status: 200
+        }
+      );
+    };
+
+    const response = await handleAccessFinalize(
+      new Request("http://github.auth.paretoproof.com:4173/api/access/finalize?app=portal", {
+        body: new URLSearchParams({
+          app: "portal",
+          redirect: "/profile"
+        }),
+        headers: {
+          cookie: "CF_Authorization=session-cookie; PortalAccessProvider=signed",
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "http://github.auth.paretoproof.com:4173"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "http://portal.paretoproof.com:4173/profile"
+    );
+  });
+
+  it("redirects loopback-branded finalize retries back through the local auth entry", async () => {
+    const response = await handleAccessFinalize(
+      new Request("http://google.auth.paretoproof.com:4173/api/access/finalize?app=math", {
+        body: new URLSearchParams({
+          app: "math",
+          redirect: "/launch"
+        }),
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          origin: "http://google.auth.paretoproof.com:4173"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "http://auth.paretoproof.com:4173/?app=math&redirect=%2Flaunch&handoff=retry"
+    );
+  });
+
   it("preserves the finalized portal path when converting the response into a browser redirect", async () => {
     globalThis.fetch = async () =>
       new Response(

--- a/apps/web/functions/_shared/access-finalize.ts
+++ b/apps/web/functions/_shared/access-finalize.ts
@@ -1,10 +1,18 @@
 import { findAppRouteBySurface } from "@paretoproof/shared";
+import {
+  type AuthenticatedSurface,
+  isLocalDevelopmentLocation,
+  isLoopbackBrandedLocation,
+  paretoProofSurfaceHosts,
+  resolveAuthenticatedSurfaceOrigin,
+  resolveAuthStartOrigin
+} from "../../src/lib/local-development";
 
-const authOrigin = "https://auth.paretoproof.com";
-const portalOrigin = "https://portal.paretoproof.com";
-const mathOrigin = "https://math.paretoproof.com";
-
-type AuthenticatedSurface = "portal" | "math";
+const brandedFinalizeRelayHosts = new Set<string>([
+  paretoProofSurfaceHosts.auth,
+  paretoProofSurfaceHosts.githubAuth,
+  paretoProofSurfaceHosts.googleAuth
+]);
 
 function trimTrailingSlash(url: string) {
   return url.replace(/\/+$/, "");
@@ -26,27 +34,16 @@ function readCookieValue(cookieHeader: string | null, name: string) {
   return null;
 }
 
-const brandedHosts = new Set([
-  "paretoproof.com",
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com",
-  "math.paretoproof.com",
-  "portal.paretoproof.com"
-]);
-const brandedFinalizeRelayHosts = new Set([
-  "auth.paretoproof.com",
-  "github.auth.paretoproof.com",
-  "google.auth.paretoproof.com"
-]);
+function isTrustedFinalizeRelayUrl(url: URL) {
+  if (!brandedFinalizeRelayHosts.has(url.hostname)) {
+    return false;
+  }
 
-function isLocalHostname(hostname: string) {
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "::1" ||
-    hostname.endsWith(".localhost")
-  );
+  if (url.protocol === "https:") {
+    return true;
+  }
+
+  return isLoopbackBrandedLocation(url);
 }
 
 function readTrustedFinalizeRelayOrigin(request: Request) {
@@ -62,20 +59,7 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
     try {
       const refererUrl = new URL(refererHeader);
 
-      if (
-        refererUrl.protocol === "https:" &&
-        brandedFinalizeRelayHosts.has(refererUrl.hostname)
-      ) {
-        return refererUrl.origin;
-      }
-
-      if (
-        refererUrl.protocol === "http:" &&
-        (
-          brandedFinalizeRelayHosts.has(refererUrl.hostname) ||
-          isLocalHostname(refererUrl.hostname)
-        )
-      ) {
+      if (isTrustedFinalizeRelayUrl(refererUrl)) {
         return refererUrl.origin;
       }
     } catch {
@@ -88,20 +72,7 @@ function readTrustedFinalizeRelayOrigin(request: Request) {
   try {
     const originUrl = new URL(originHeader);
 
-    if (
-      originUrl.protocol === "https:" &&
-      brandedFinalizeRelayHosts.has(originUrl.hostname)
-    ) {
-      return originUrl.origin;
-    }
-
-    if (
-      originUrl.protocol === "http:" &&
-      (
-        brandedFinalizeRelayHosts.has(originUrl.hostname) ||
-        isLocalHostname(originUrl.hostname)
-      )
-    ) {
+    if (isTrustedFinalizeRelayUrl(originUrl)) {
       return originUrl.origin;
     }
   } catch {
@@ -115,13 +86,14 @@ function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface 
   return surface === "math" ? "math" : "portal";
 }
 
-function readSurfaceOrigin(surface: AuthenticatedSurface) {
-  return surface === "math" ? mathOrigin : portalOrigin;
+function readSurfaceOrigin(surface: AuthenticatedSurface, requestUrl: URL) {
+  return resolveAuthenticatedSurfaceOrigin(surface, requestUrl);
 }
 
 function sanitizeRedirectPath(
   rawRedirectPath: string | null,
-  targetSurface: AuthenticatedSurface
+  targetSurface: AuthenticatedSurface,
+  requestUrl: URL
 ) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
@@ -134,7 +106,7 @@ function sanitizeRedirectPath(
   try {
     const url = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      readSurfaceOrigin(targetSurface)
+      readSurfaceOrigin(targetSurface, requestUrl)
     );
 
     if (!findAppRouteBySurface(targetSurface, url.pathname)) {
@@ -149,9 +121,10 @@ function sanitizeRedirectPath(
 
 function buildAuthRetryUrl(
   redirectPath: string,
-  targetSurface: AuthenticatedSurface
+  targetSurface: AuthenticatedSurface,
+  requestUrl: URL
 ) {
-  const authUrl = new URL(authOrigin);
+  const authUrl = new URL(resolveAuthStartOrigin(requestUrl));
   authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
@@ -164,11 +137,7 @@ function buildAuthRetryUrl(
 }
 
 function resolveApiBaseUrl(requestUrl: URL) {
-  if (
-    requestUrl.protocol === "http:" &&
-    requestUrl.port !== "" &&
-    brandedHosts.has(requestUrl.hostname)
-  ) {
+  if (isLocalDevelopmentLocation(requestUrl)) {
     const localApiUrl = new URL(requestUrl.origin);
     localApiUrl.port = "3000";
     return trimTrailingSlash(localApiUrl.origin);
@@ -181,30 +150,25 @@ function resolveApiBaseUrl(requestUrl: URL) {
     return "https://api.paretoproof.com";
   }
 
-  const localApiUrl = new URL(requestUrl.origin);
-  localApiUrl.port = "3000";
-
-  if (isLocalHostname(requestUrl.hostname)) {
-    return trimTrailingSlash(localApiUrl.origin);
-  }
-
   return "https://api.paretoproof.com";
 }
 
 function buildAuthenticatedRedirectUrl(
   targetSurface: AuthenticatedSurface,
-  redirectPath: string
+  redirectPath: string,
+  requestUrl: URL
 ) {
-  return new URL(redirectPath, readSurfaceOrigin(targetSurface)).toString();
+  return new URL(redirectPath, readSurfaceOrigin(targetSurface, requestUrl)).toString();
 }
 
 function resolveAuthenticatedRedirectTarget(
   rawRedirectTarget: unknown,
   fallbackRedirectPath: string,
-  fallbackSurface: AuthenticatedSurface
+  fallbackSurface: AuthenticatedSurface,
+  requestUrl: URL
 ) {
   if (typeof rawRedirectTarget !== "string" || rawRedirectTarget.length === 0) {
-    return buildAuthenticatedRedirectUrl(fallbackSurface, fallbackRedirectPath);
+    return buildAuthenticatedRedirectUrl(fallbackSurface, fallbackRedirectPath, requestUrl);
   }
 
   let targetUrl: URL;
@@ -215,6 +179,8 @@ function resolveAuthenticatedRedirectTarget(
     return null;
   }
 
+  const portalOrigin = resolveAuthenticatedSurfaceOrigin("portal", requestUrl);
+  const mathOrigin = resolveAuthenticatedSurfaceOrigin("math", requestUrl);
   const targetSurface =
     targetUrl.origin === portalOrigin
       ? "portal"
@@ -265,7 +231,7 @@ async function readRedirectOptions(request: Request) {
 
   if (request.method !== "POST") {
     return {
-      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface, requestUrl),
       targetSurface: fallbackSurface
     };
   }
@@ -277,7 +243,7 @@ async function readRedirectOptions(request: Request) {
     !contentType.includes("multipart/form-data")
   ) {
     return {
-      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface),
+      redirectPath: sanitizeRedirectPath(fallbackRedirectPath, fallbackSurface, requestUrl),
       targetSurface: fallbackSurface
     };
   }
@@ -293,7 +259,8 @@ async function readRedirectOptions(request: Request) {
   return {
     redirectPath: sanitizeRedirectPath(
       typeof redirectValue === "string" ? redirectValue : fallbackRedirectPath,
-      targetSurface
+      targetSurface,
+      requestUrl
     ),
     targetSurface
   };
@@ -317,8 +284,8 @@ function buildRedirectResponse(targetUrl: string, responseHeaders?: Headers) {
 
 export async function handleAccessFinalize(request: Request) {
   const { redirectPath, targetSurface } = await readRedirectOptions(request);
-  const retryUrl = buildAuthRetryUrl(redirectPath, targetSurface);
   const requestUrl = new URL(request.url);
+  const retryUrl = buildAuthRetryUrl(redirectPath, targetSurface, requestUrl);
   const apiUrl = new URL("/portal/session/finalize/submit", resolveApiBaseUrl(requestUrl));
   const trustedOrigin = readTrustedFinalizeRelayOrigin(request);
 
@@ -382,7 +349,8 @@ export async function handleAccessFinalize(request: Request) {
   const redirectTarget = resolveAuthenticatedRedirectTarget(
     (responseBody as { redirectTo?: unknown }).redirectTo,
     redirectPath,
-    targetSurface
+    targetSurface,
+    requestUrl
   );
 
   if (!redirectTarget) {

--- a/apps/web/functions/_shared/access-start.test.ts
+++ b/apps/web/functions/_shared/access-start.test.ts
@@ -25,9 +25,13 @@ describe("handleAccessStart", () => {
     const setCookies = readSetCookies(response);
     expect(setCookies).toHaveLength(2);
     expect(setCookies[0]).toContain("PortalLinkIntent=");
+    expect(setCookies[0]).toContain("Domain=.paretoproof.com");
     expect(setCookies[0]).toContain("SameSite=Strict");
+    expect(setCookies[0]).toContain("Secure");
     expect(setCookies[1]).toContain("PortalAccessProvider=");
+    expect(setCookies[1]).toContain("Domain=.paretoproof.com");
     expect(setCookies[1]).toContain("SameSite=Strict");
+    expect(setCookies[1]).toContain("Secure");
   });
 
   it("starts GitHub profile linking without clearing the existing link intent and keeps provider state Strict", async () => {
@@ -66,6 +70,47 @@ describe("handleAccessStart", () => {
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
       "https://google.auth.paretoproof.com/?app=math&redirect=%2Fquestions%2Fproblem-9"
+    );
+  });
+
+  it("routes loopback-branded starts to the matching local provider host and emits non-Secure shared cookies", async () => {
+    const response = await handleAccessStart(
+      new Request(
+        "http://auth.paretoproof.com:4173/api/access/start/google?app=portal&redirect=/profile"
+      ),
+      {
+        ACCESS_PROVIDER_STATE_SECRET: "test-secret"
+      },
+      "google"
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://google.auth.paretoproof.com:4173/?app=portal&redirect=%2Fprofile"
+    );
+
+    const setCookies = readSetCookies(response);
+    expect(setCookies).toHaveLength(2);
+    expect(setCookies[0]).toContain("PortalLinkIntent=");
+    expect(setCookies[0]).toContain("Domain=.paretoproof.com");
+    expect(setCookies[0]).not.toContain("; Secure");
+    expect(setCookies[1]).toContain("PortalAccessProvider=");
+    expect(setCookies[1]).toContain("Domain=.paretoproof.com");
+    expect(setCookies[1]).not.toContain("; Secure");
+  });
+
+  it("keeps local start failures on the loopback-branded auth entry", async () => {
+    const response = await handleAccessStart(
+      new Request(
+        "http://auth.paretoproof.com:4173/api/access/start/github?app=portal&redirect=/profile"
+      ),
+      {},
+      "github"
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://auth.paretoproof.com:4173/?app=portal&redirect=%2Fprofile&handoff=failed"
     );
   });
 });

--- a/apps/web/functions/_shared/access-start.ts
+++ b/apps/web/functions/_shared/access-start.ts
@@ -1,8 +1,10 @@
 import { findAppRouteBySurface } from "@paretoproof/shared";
-
-const authOrigin = "https://auth.paretoproof.com";
-const portalOrigin = "https://portal.paretoproof.com";
-const mathOrigin = "https://math.paretoproof.com";
+import {
+  resolveAuthenticatedSurfaceOrigin,
+  resolveAuthRelayCookieOptions,
+  resolveAuthStartOrigin,
+  resolveProviderAuthOrigin
+} from "../../src/lib/local-development";
 
 type Provider = "github" | "google";
 type PersistedProvider = "cloudflare_github" | "cloudflare_google";
@@ -10,11 +12,6 @@ type AuthenticatedSurface = "portal" | "math";
 
 type AccessStartEnv = {
   ACCESS_PROVIDER_STATE_SECRET?: string;
-};
-
-const providerOrigins: Record<Provider, string> = {
-  github: "https://github.auth.paretoproof.com",
-  google: "https://google.auth.paretoproof.com"
 };
 
 const persistedProviders: Record<Provider, PersistedProvider> = {
@@ -26,13 +23,10 @@ function readAuthenticatedSurface(surface: string | null): AuthenticatedSurface 
   return surface === "math" ? "math" : "portal";
 }
 
-function readSurfaceOrigin(surface: AuthenticatedSurface) {
-  return surface === "math" ? mathOrigin : portalOrigin;
-}
-
 function sanitizeRedirectPath(
   rawRedirectPath: string | null,
-  targetSurface: AuthenticatedSurface
+  targetSurface: AuthenticatedSurface,
+  requestUrl: URL
 ) {
   if (!rawRedirectPath || rawRedirectPath === "/") {
     return "/";
@@ -45,7 +39,7 @@ function sanitizeRedirectPath(
   try {
     const url = new URL(
       rawRedirectPath.startsWith("/") ? rawRedirectPath : `/${rawRedirectPath}`,
-      readSurfaceOrigin(targetSurface)
+      resolveAuthenticatedSurfaceOrigin(targetSurface, requestUrl)
     );
 
     if (!findAppRouteBySurface(targetSurface, url.pathname)) {
@@ -78,7 +72,11 @@ async function signProviderHint(provider: PersistedProvider, secret: string) {
   return `${payload}.${toBase64Url(signature)}`;
 }
 
-async function buildProviderHintCookie(env: AccessStartEnv, provider: Provider) {
+async function buildProviderHintCookie(
+  env: AccessStartEnv,
+  provider: Provider,
+  requestUrl: URL
+) {
   const secret = env.ACCESS_PROVIDER_STATE_SECRET;
 
   if (!secret) {
@@ -86,35 +84,42 @@ async function buildProviderHintCookie(env: AccessStartEnv, provider: Provider) 
   }
 
   const value = await signProviderHint(persistedProviders[provider], secret);
+  const { cookieDomain, secure } = resolveAuthRelayCookieOptions(requestUrl);
 
   return [
     `PortalAccessProvider=${value}`,
-    "Domain=.paretoproof.com",
+    ...(cookieDomain ? [`Domain=${cookieDomain}`] : []),
     "Path=/",
     "SameSite=Strict",
     "Max-Age=600",
-    "Secure",
+    ...(secure ? ["Secure"] : []),
     "HttpOnly"
   ].join("; ");
 }
 
-function clearSignedAccessCookie(name: "PortalAccessProvider" | "PortalLinkIntent") {
+function clearSignedAccessCookie(
+  name: "PortalAccessProvider" | "PortalLinkIntent",
+  requestUrl: URL
+) {
+  const { cookieDomain, secure } = resolveAuthRelayCookieOptions(requestUrl);
+
   return [
     `${name}=`,
-    "Domain=.paretoproof.com",
+    ...(cookieDomain ? [`Domain=${cookieDomain}`] : []),
     "Path=/",
     "SameSite=Strict",
     "Max-Age=0",
-    "Secure",
+    ...(secure ? ["Secure"] : []),
     "HttpOnly"
   ].join("; ");
 }
 
 function buildAuthFailureUrl(
   redirectPath: string,
-  targetSurface: AuthenticatedSurface
+  targetSurface: AuthenticatedSurface,
+  requestUrl: URL
 ) {
-  const authUrl = new URL(authOrigin);
+  const authUrl = new URL(resolveAuthStartOrigin(requestUrl));
   authUrl.searchParams.set("app", targetSurface);
 
   if (redirectPath !== "/") {
@@ -135,13 +140,14 @@ export async function handleAccessStart(
   const targetSurface = readAuthenticatedSurface(requestUrl.searchParams.get("app"));
   const redirectPath = sanitizeRedirectPath(
     requestUrl.searchParams.get("redirect"),
-    targetSurface
+    targetSurface,
+    requestUrl
   );
 
   try {
     const flow = requestUrl.searchParams.get("flow") === "link" ? "link" : "sign_in";
-    const providerUrl = new URL("/", providerOrigins[provider]);
-    const providerHintCookie = await buildProviderHintCookie(env, provider);
+    const providerUrl = new URL("/", resolveProviderAuthOrigin(provider, requestUrl));
+    const providerHintCookie = await buildProviderHintCookie(env, provider, requestUrl);
 
     providerUrl.searchParams.set("app", targetSurface);
 
@@ -159,7 +165,7 @@ export async function handleAccessStart(
 
     // Regular sign-in should not inherit an abandoned profile-link cookie.
     if (flow !== "link") {
-      headers.append("set-cookie", clearSignedAccessCookie("PortalLinkIntent"));
+      headers.append("set-cookie", clearSignedAccessCookie("PortalLinkIntent", requestUrl));
     }
 
     headers.append("set-cookie", providerHintCookie);
@@ -173,7 +179,7 @@ export async function handleAccessStart(
 
     return new Response(null, {
       headers: {
-        location: buildAuthFailureUrl(redirectPath, targetSurface)
+        location: buildAuthFailureUrl(redirectPath, targetSurface, requestUrl)
       },
       status: 302
     });

--- a/apps/web/src/lib/local-development.ts
+++ b/apps/web/src/lib/local-development.ts
@@ -7,33 +7,175 @@ export const paretoProofBrandedHosts = [
   "portal.paretoproof.com"
 ] as const;
 
+export const paretoProofSurfaceHosts = {
+  auth: "auth.paretoproof.com",
+  githubAuth: "github.auth.paretoproof.com",
+  googleAuth: "google.auth.paretoproof.com",
+  math: "math.paretoproof.com",
+  portal: "portal.paretoproof.com",
+  public: "paretoproof.com"
+} as const;
+
+export const productionWebOrigins = {
+  auth: `https://${paretoProofSurfaceHosts.auth}`,
+  githubAuth: `https://${paretoProofSurfaceHosts.githubAuth}`,
+  googleAuth: `https://${paretoProofSurfaceHosts.googleAuth}`,
+  math: `https://${paretoProofSurfaceHosts.math}`,
+  portal: `https://${paretoProofSurfaceHosts.portal}`,
+  public: `https://${paretoProofSurfaceHosts.public}`
+} as const;
+
 type LocationLike = {
   hostname: string;
   port?: string;
   protocol?: string;
 };
 
+export type AccessProvider = "github" | "google";
+export type AuthenticatedSurface = "portal" | "math";
+
+export const syntheticLocalAuthParamKeys = [
+  "access",
+  "email",
+  "reason",
+  "role",
+  "roles"
+] as const;
+
+export function isLoopbackHostname(hostname: string) {
+  const normalizedHostname = hostname.toLowerCase();
+
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "127.0.0.1" ||
+    normalizedHostname === "::1" ||
+    normalizedHostname === "[::1]" ||
+    normalizedHostname.endsWith(".localhost")
+  );
+}
+
+export function isParetoProofBrandedHost(hostname: string) {
+  return paretoProofBrandedHosts.includes(
+    hostname.toLowerCase() as (typeof paretoProofBrandedHosts)[number]
+  );
+}
+
+export function isLoopbackBrandedLocation({
+  hostname,
+  port = "",
+  protocol = ""
+}: LocationLike) {
+  return protocol === "http:" && port !== "" && isParetoProofBrandedHost(hostname);
+}
+
 export function isLocalDevelopmentLocation({
   hostname,
   port = "",
   protocol = ""
 }: LocationLike) {
-  const normalizedHostname = hostname.toLowerCase();
-
-  if (
-    normalizedHostname === "localhost" ||
-    normalizedHostname === "127.0.0.1" ||
-    normalizedHostname === "::1" ||
-    normalizedHostname.endsWith(".localhost")
-  ) {
+  if (isLoopbackHostname(hostname)) {
     return true;
   }
 
-  return (
-    protocol === "http:" &&
-    port !== "" &&
-    paretoProofBrandedHosts.includes(
-      normalizedHostname as (typeof paretoProofBrandedHosts)[number]
-    )
-  );
+  return isLoopbackBrandedLocation({ hostname, port, protocol });
+}
+
+export function buildLoopbackBrandedOrigin(
+  hostname: string,
+  locationLike: Pick<LocationLike, "port" | "protocol">
+) {
+  const protocol = locationLike.protocol || "http:";
+  const port = locationLike.port ? `:${locationLike.port}` : "";
+
+  return `${protocol}//${hostname}${port}`;
+}
+
+export function resolveAuthStartOrigin(locationLike: LocationLike) {
+  if (isLocalDevelopmentLocation(locationLike)) {
+    return buildLoopbackBrandedOrigin(paretoProofSurfaceHosts.auth, locationLike);
+  }
+
+  return productionWebOrigins.auth;
+}
+
+export function resolveProviderAuthOrigin(
+  provider: AccessProvider,
+  locationLike: LocationLike
+) {
+  const host =
+    provider === "github"
+      ? paretoProofSurfaceHosts.githubAuth
+      : paretoProofSurfaceHosts.googleAuth;
+
+  if (isLocalDevelopmentLocation(locationLike)) {
+    return buildLoopbackBrandedOrigin(host, locationLike);
+  }
+
+  return provider === "github"
+    ? productionWebOrigins.githubAuth
+    : productionWebOrigins.googleAuth;
+}
+
+export function resolveAuthenticatedSurfaceOrigin(
+  surface: AuthenticatedSurface,
+  locationLike: LocationLike
+) {
+  const host =
+    surface === "math" ? paretoProofSurfaceHosts.math : paretoProofSurfaceHosts.portal;
+
+  if (isLocalDevelopmentLocation(locationLike)) {
+    return buildLoopbackBrandedOrigin(host, locationLike);
+  }
+
+  return surface === "math" ? productionWebOrigins.math : productionWebOrigins.portal;
+}
+
+export function resolvePublicOrigin(locationLike: LocationLike & { origin?: string }) {
+  if (!isLocalDevelopmentLocation(locationLike)) {
+    return locationLike.origin ?? productionWebOrigins.public;
+  }
+
+  if (isParetoProofBrandedHost(locationLike.hostname)) {
+    return buildLoopbackBrandedOrigin(paretoProofSurfaceHosts.public, locationLike);
+  }
+
+  return locationLike.origin ?? buildLoopbackBrandedOrigin(locationLike.hostname, locationLike);
+}
+
+export function resolveAuthRelayCookieOptions(locationLike: LocationLike) {
+  return {
+    cookieDomain: isParetoProofBrandedHost(locationLike.hostname)
+      ? ".paretoproof.com"
+      : null,
+    secure: locationLike.protocol === "https:"
+  };
+}
+
+export function stripSyntheticLocalAuthParams(
+  params: URLSearchParams,
+  options?: {
+    preserveRouteDeniedReason?: boolean;
+  }
+) {
+  const routeDeniedReason =
+    options?.preserveRouteDeniedReason && params.get("reason") === "insufficient_role"
+      ? "insufficient_role"
+      : null;
+
+  for (const key of syntheticLocalAuthParamKeys) {
+    params.delete(key);
+  }
+
+  if (routeDeniedReason) {
+    params.set("reason", routeDeniedReason);
+  }
+
+  return params;
+}
+
+export function buildSearchWithoutSyntheticLocalAuthParams(search = "") {
+  const params = stripSyntheticLocalAuthParams(new URLSearchParams(search));
+  const nextSearch = params.toString();
+
+  return nextSearch ? `?${nextSearch}` : "";
 }

--- a/apps/web/src/lib/portal-route-access.test.js
+++ b/apps/web/src/lib/portal-route-access.test.js
@@ -41,9 +41,9 @@ describe("resolvePortalRouteRedirect", () => {
 
     expect(redirect.pathname).toBe("/profile");
     expect(redirect.searchParams.get("surface")).toBe("portal");
-    expect(redirect.searchParams.get("access")).toBe("approved");
-    expect(redirect.searchParams.get("email")).toBe("lin@paretoproof.local");
-    expect(redirect.searchParams.get("roles")).toBe("helper");
+    expect(redirect.searchParams.has("access")).toBe(false);
+    expect(redirect.searchParams.has("email")).toBe(false);
+    expect(redirect.searchParams.has("roles")).toBe(false);
     expect(redirect.searchParams.has("reason")).toBe(false);
   });
 
@@ -65,8 +65,8 @@ describe("resolvePortalRouteRedirect", () => {
 
     expect(redirect.pathname).toBe("/pending");
     expect(redirect.searchParams.get("surface")).toBe("portal");
-    expect(redirect.searchParams.get("access")).toBe("pending");
-    expect(redirect.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(redirect.searchParams.has("access")).toBe(false);
+    expect(redirect.searchParams.has("email")).toBe(false);
     expect(redirect.searchParams.has("roles")).toBe(false);
   });
 
@@ -172,7 +172,7 @@ describe("resolvePortalRouteRedirect", () => {
 
     expect(redirect.pathname).toBe("/pending");
     expect(redirect.searchParams.get("surface")).toBe("portal");
-    expect(redirect.searchParams.get("access")).toBe("pending");
+    expect(redirect.searchParams.has("access")).toBe(false);
   });
 
   it("canonicalizes hosted pending math users onto the portal host even when the path already matches", () => {
@@ -212,6 +212,6 @@ describe("resolvePortalRouteRedirect", () => {
 
     expect(redirect.pathname).toBe("/");
     expect(redirect.searchParams.get("surface")).toBe("math");
-    expect(redirect.searchParams.get("access")).toBe("approved");
+    expect(redirect.searchParams.has("access")).toBe(false);
   });
 });

--- a/apps/web/src/lib/portal-route-access.ts
+++ b/apps/web/src/lib/portal-route-access.ts
@@ -7,6 +7,7 @@ import {
   buildPortalUrl,
   buildPublicUrl
 } from "./surface";
+import { stripSyntheticLocalAuthParams } from "./local-development";
 
 type PortalAccessStatus = "approved" | "denied" | "pending" | "unauthenticated";
 type AuthenticatedSurface = "portal" | "math";
@@ -110,7 +111,9 @@ function readRouteDeniedReason(
 }
 
 function normalizeSearch(search = "") {
-  const params = new URLSearchParams(search);
+  const params = stripSyntheticLocalAuthParams(new URLSearchParams(search), {
+    preserveRouteDeniedReason: true
+  });
   params.sort();
   const normalizedSearch = params.toString();
   return normalizedSearch ? `?${normalizedSearch}` : "";

--- a/apps/web/src/lib/surface.test.js
+++ b/apps/web/src/lib/surface.test.js
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   buildAccessFinalizeUrl,
+  buildAccessStartUrl,
   buildAuthGuidanceUrl,
   buildAuthUrl,
   buildMathUrl,
@@ -30,7 +31,7 @@ afterEach(() => {
 });
 
 describe("buildPortalUrl", () => {
-  it("drops stale denial reasons when building approved portal routes", () => {
+  it("strips synthetic approved access params when building local portal routes", () => {
     setWindowUrl(
       "http://localhost/denied?surface=portal&access=approved&role=helper&reason=insufficient_role&email=lin@paretoproof.local"
     );
@@ -39,13 +40,13 @@ describe("buildPortalUrl", () => {
 
     expect(portalUrl.pathname).toBe("/");
     expect(portalUrl.searchParams.get("surface")).toBe("portal");
-    expect(portalUrl.searchParams.get("access")).toBe("approved");
-    expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
-    expect(portalUrl.searchParams.get("role")).toBe("helper");
+    expect(portalUrl.searchParams.has("access")).toBe(false);
+    expect(portalUrl.searchParams.has("email")).toBe(false);
+    expect(portalUrl.searchParams.has("role")).toBe(false);
     expect(portalUrl.searchParams.has("reason")).toBe(false);
   });
 
-  it("keeps denied reasons on denied-flow targets", () => {
+  it("strips synthetic denied access params on denied-flow targets", () => {
     setWindowUrl(
       "http://localhost/denied?surface=portal&access=denied&reason=access_request_required&roles=helper&email=lin@paretoproof.local"
     );
@@ -54,13 +55,28 @@ describe("buildPortalUrl", () => {
 
     expect(portalUrl.pathname).toBe("/access-request");
     expect(portalUrl.searchParams.get("surface")).toBe("portal");
-    expect(portalUrl.searchParams.get("access")).toBe("denied");
-    expect(portalUrl.searchParams.get("email")).toBe("lin@paretoproof.local");
-    expect(portalUrl.searchParams.get("reason")).toBe("access_request_required");
+    expect(portalUrl.searchParams.has("access")).toBe(false);
+    expect(portalUrl.searchParams.has("email")).toBe(false);
+    expect(portalUrl.searchParams.has("reason")).toBe(false);
     expect(portalUrl.searchParams.has("roles")).toBe(false);
   });
 
-  it("drops stale approved roles when the current preview access is pending", () => {
+  it("keeps explicit insufficient-role route reasons while stripping synthetic access params", () => {
+    setWindowUrl(
+      "http://localhost/admin/users?surface=portal&access=approved&role=collaborator&email=ada@paretoproof.local"
+    );
+
+    const deniedUrl = new URL(buildPortalUrl("/denied?reason=insufficient_role"));
+
+    expect(deniedUrl.pathname).toBe("/denied");
+    expect(deniedUrl.searchParams.get("surface")).toBe("portal");
+    expect(deniedUrl.searchParams.get("reason")).toBe("insufficient_role");
+    expect(deniedUrl.searchParams.has("access")).toBe(false);
+    expect(deniedUrl.searchParams.has("email")).toBe(false);
+    expect(deniedUrl.searchParams.has("role")).toBe(false);
+  });
+
+  it("strips synthetic pending access params when building local portal routes", () => {
     setWindowUrl(
       "http://localhost/pending?surface=portal&access=pending&role=admin&email=ada@paretoproof.local"
     );
@@ -69,23 +85,25 @@ describe("buildPortalUrl", () => {
 
     expect(portalUrl.pathname).toBe("/");
     expect(portalUrl.searchParams.get("surface")).toBe("portal");
-    expect(portalUrl.searchParams.get("access")).toBe("pending");
-    expect(portalUrl.searchParams.get("email")).toBe("ada@paretoproof.local");
+    expect(portalUrl.searchParams.has("access")).toBe(false);
+    expect(portalUrl.searchParams.has("email")).toBe(false);
     expect(portalUrl.searchParams.has("role")).toBe(false);
   });
 
-  it("preserves the singular approved role preview on local portal redirects", () => {
+  it("strips singular approved role previews on local portal redirects", () => {
     setWindowUrl(
       "http://localhost/?surface=portal&access=approved&role=collaborator&email=ada@paretoproof.local"
     );
 
     const portalUrl = new URL(buildPortalUrl("/launch"));
 
-    expect(portalUrl.searchParams.get("role")).toBe("collaborator");
+    expect(portalUrl.searchParams.has("role")).toBe(false);
+    expect(portalUrl.searchParams.has("access")).toBe(false);
+    expect(portalUrl.searchParams.has("email")).toBe(false);
     expect(portalUrl.searchParams.has("roles")).toBe(false);
   });
 
-  it("uses the local API finalize endpoint on loopback-mapped branded auth hosts", () => {
+  it("uses the branded finalize relay endpoint on loopback-mapped branded auth hosts", () => {
     setWindowUrl("http://github.auth.paretoproof.com:4371/?surface=auth&app=math");
 
     expect(
@@ -93,7 +111,7 @@ describe("buildPortalUrl", () => {
         surface: "math"
       })
     ).toBe(
-      "http://github.auth.paretoproof.com:3000/portal/session/finalize/submit?app=math&redirect=%2Flaunch"
+      "http://github.auth.paretoproof.com:4371/api/access/finalize?app=math&redirect=%2Flaunch"
     );
   });
 
@@ -107,6 +125,25 @@ describe("buildPortalUrl", () => {
     ).toBe(
       "https://google.auth.paretoproof.com/api/access/finalize?app=portal&redirect=%2Fprofile"
     );
+  });
+
+  it("builds local provider starts through the loopback-branded auth relay without synthetic access params", () => {
+    setWindowUrl(
+      "http://127.0.0.1:4173/?surface=auth&access=approved&email=ada@paretoproof.local&role=admin"
+    );
+
+    const startUrl = new URL(
+      buildAccessStartUrl("github", "/runs/alpha", {
+        surface: "portal"
+      })
+    );
+
+    expect(startUrl.toString()).toBe(
+      "http://auth.paretoproof.com:4173/api/access/start/github?app=portal&redirect=%2Fruns%2Falpha"
+    );
+    expect(startUrl.searchParams.has("access")).toBe(false);
+    expect(startUrl.searchParams.has("email")).toBe(false);
+    expect(startUrl.searchParams.has("role")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/surface.ts
+++ b/apps/web/src/lib/surface.ts
@@ -1,24 +1,21 @@
 import { findAppRouteBySurface } from "@paretoproof/shared";
-import { getApiBaseUrl } from "./api-base-url";
-import { isLocalDevelopmentLocation } from "./local-development";
+import {
+  isLocalDevelopmentLocation,
+  paretoProofSurfaceHosts,
+  productionWebOrigins,
+  resolveAuthStartOrigin,
+  resolvePublicOrigin,
+  stripSyntheticLocalAuthParams
+} from "./local-development";
 
 export type WebSurface = "public" | "auth" | "portal" | "math";
 export type AuthenticatedSurface = "portal" | "math";
 export type AccessProvider = "github" | "google";
 
-const productionPublicOrigin = "https://paretoproof.com";
-const productionAuthOrigin = "https://auth.paretoproof.com";
-const productionPortalOrigin = "https://portal.paretoproof.com";
-const productionMathOrigin = "https://math.paretoproof.com";
-const localPortalStateParamKeys = ["access", "email"] as const;
 const authenticatedSurfaces = ["portal", "math"] as const;
-const productionProviderAuthOrigins: Record<AccessProvider, string> = {
-  github: "https://github.auth.paretoproof.com",
-  google: "https://google.auth.paretoproof.com"
-};
 const productionOriginByAuthenticatedSurface: Record<AuthenticatedSurface, string> = {
-  math: productionMathOrigin,
-  portal: productionPortalOrigin
+  math: productionWebOrigins.math,
+  portal: productionWebOrigins.portal
 };
 
 type OwnedAppSurface = "public_site" | AuthenticatedSurface;
@@ -52,23 +49,7 @@ function isLocalOrigin(hostname = window.location.hostname) {
 }
 
 function buildLocalPublicOrigin(locationLike = window.location) {
-  const { hostname, origin, port, protocol } = locationLike;
-
-  if (!isLocalDevelopmentLocation(locationLike)) {
-    return origin;
-  }
-
-  if (
-    hostname === "auth.paretoproof.com" ||
-    hostname === "github.auth.paretoproof.com" ||
-    hostname === "google.auth.paretoproof.com" ||
-    hostname === "portal.paretoproof.com" ||
-    hostname === "math.paretoproof.com"
-  ) {
-    return `${protocol}//paretoproof.com${port ? `:${port}` : ""}`;
-  }
-
-  return origin;
+  return resolvePublicOrigin(locationLike);
 }
 
 function isAuthenticatedSurface(surface: string | null): surface is AuthenticatedSurface {
@@ -108,18 +89,18 @@ export function resolveWebSurfaceFromUrl(
   const { hostname, search } = locationLike;
 
   if (
-    hostname === "auth.paretoproof.com" ||
-    hostname === "github.auth.paretoproof.com" ||
-    hostname === "google.auth.paretoproof.com"
+    hostname === paretoProofSurfaceHosts.auth ||
+    hostname === paretoProofSurfaceHosts.githubAuth ||
+    hostname === paretoProofSurfaceHosts.googleAuth
   ) {
     return "auth";
   }
 
-  if (hostname === "portal.paretoproof.com") {
+  if (hostname === paretoProofSurfaceHosts.portal) {
     return "portal";
   }
 
-  if (hostname === "math.paretoproof.com") {
+  if (hostname === paretoProofSurfaceHosts.math) {
     return "math";
   }
 
@@ -184,7 +165,7 @@ function tryResolveRelativeTarget(
 
 function mapOwnedSurfaceToOrigin(surface: OwnedAppSurface) {
   if (surface === "public_site") {
-    return productionPublicOrigin;
+    return productionWebOrigins.public;
   }
 
   return mapAuthenticatedSurfaceToOrigin(surface);
@@ -334,6 +315,9 @@ function buildLocalSurfaceUrl(
 
     surfaceUrl.searchParams.set("surface", surface);
     copyLocalPortalState(surfaceUrl);
+    stripSyntheticLocalAuthParams(surfaceUrl.searchParams, {
+      preserveRouteDeniedReason: true
+    });
     return surfaceUrl.toString();
   }
 
@@ -353,71 +337,24 @@ function buildLocalSurfaceUrl(
   return surfaceUrl.toString();
 }
 
-function shouldPreserveLocalPortalReason(
-  targetUrl: URL,
-  currentParams: URLSearchParams
-) {
-  if (currentParams.get("access") !== "denied") {
-    return false;
-  }
-
-  return targetUrl.pathname === "/access-request" || targetUrl.pathname === "/denied";
-}
-
-function shouldPreserveLocalPortalRoles(currentParams: URLSearchParams) {
-  return currentParams.get("access") === "approved";
-}
-
 export function copyLocalPortalState(targetUrl: URL, currentLocation = window.location) {
   if (!isLocalOrigin(currentLocation.hostname)) {
     return;
   }
 
   const currentParams = new URLSearchParams(currentLocation.search);
-
-  for (const key of localPortalStateParamKeys) {
-    if (targetUrl.searchParams.has(key)) {
-      continue;
-    }
-    const value = currentParams.get(key);
-
-    if (value) {
-      targetUrl.searchParams.set(key, value);
-    }
-  }
+  const surface = currentParams.get("surface");
 
   if (
-    !targetUrl.searchParams.has("role") &&
-    shouldPreserveLocalPortalRoles(currentParams)
+    !targetUrl.searchParams.has("surface") &&
+    (surface === "portal" || surface === "math")
   ) {
-    const role = currentParams.get("role");
-
-    if (role) {
-      targetUrl.searchParams.set("role", role);
-    }
+    targetUrl.searchParams.set("surface", surface);
   }
 
-  if (
-    !targetUrl.searchParams.has("roles") &&
-    shouldPreserveLocalPortalRoles(currentParams)
-  ) {
-    const roles = currentParams.get("roles");
-
-    if (roles) {
-      targetUrl.searchParams.set("roles", roles);
-    }
-  }
-
-  if (
-    !targetUrl.searchParams.has("reason") &&
-    shouldPreserveLocalPortalReason(targetUrl, currentParams)
-  ) {
-    const reason = currentParams.get("reason");
-
-    if (reason) {
-      targetUrl.searchParams.set("reason", reason);
-    }
-  }
+  stripSyntheticLocalAuthParams(targetUrl.searchParams, {
+    preserveRouteDeniedReason: true
+  });
 }
 
 export function buildAuthUrl(
@@ -446,7 +383,7 @@ export function buildAuthUrl(
     );
   }
 
-  const authUrl = new URL(productionAuthOrigin);
+  const authUrl = new URL(productionWebOrigins.auth);
   authUrl.searchParams.set("app", resolvedTarget.surface);
 
   if (resolvedTarget.targetPath !== "/") {
@@ -481,7 +418,7 @@ export function buildPublicUrl(targetPath = "/", hostname = window.location.host
     return new URL(normalizedTargetPath, buildLocalPublicOrigin()).toString();
   }
 
-  return new URL(normalizedTargetPath, productionPublicOrigin).toString();
+  return new URL(normalizedTargetPath, productionWebOrigins.public).toString();
 }
 
 export function buildPortalUrl(targetPath = "/", hostname = window.location.hostname) {
@@ -491,7 +428,7 @@ export function buildPortalUrl(targetPath = "/", hostname = window.location.host
     return buildLocalSurfaceUrl("portal", normalizedTargetPath, "portal");
   }
 
-  return new URL(normalizedTargetPath, productionPortalOrigin).toString();
+  return new URL(normalizedTargetPath, productionWebOrigins.portal).toString();
 }
 
 export function buildMathUrl(targetPath = "/", hostname = window.location.hostname) {
@@ -501,7 +438,7 @@ export function buildMathUrl(targetPath = "/", hostname = window.location.hostna
     return buildLocalSurfaceUrl("math", normalizedTargetPath, "math");
   }
 
-  return new URL(normalizedTargetPath, productionMathOrigin).toString();
+  return new URL(normalizedTargetPath, productionWebOrigins.math).toString();
 }
 
 export function buildAuthenticatedAppUrl(
@@ -547,34 +484,16 @@ export function buildAccessStartUrl(
       targetPath: "/"
     };
 
-  if (isLocalOrigin(hostname)) {
-    const localUrl = new URL(
-      buildAuthenticatedAppUrl(
-        resolvedTarget.targetPath,
-        {
-          surface: resolvedTarget.surface
-        },
-        hostname
-      )
-    );
-    const currentParams = new URLSearchParams(window.location.search);
-    const approvedRole =
-      currentParams.get("role") ??
-      (currentParams.get("roles") ?? "")
-        .split(",")
-        .map((role) => role.trim())
-        .find(Boolean) ??
-      "admin";
-
-    localUrl.searchParams.set("access", "approved");
-    localUrl.searchParams.set("email", currentParams.get("email") ?? "local@example.com");
-    localUrl.searchParams.set("role", approvedRole);
-    localUrl.searchParams.delete("roles");
-    localUrl.searchParams.delete("reason");
-    return localUrl.toString();
-  }
-
-  const authUrl = new URL(`/api/access/start/${provider}`, productionAuthOrigin);
+  const authUrl = new URL(
+    `/api/access/start/${provider}`,
+    isLocalOrigin(hostname)
+      ? resolveAuthStartOrigin({
+          hostname,
+          port: window.location.port,
+          protocol: window.location.protocol
+        })
+      : productionWebOrigins.auth
+  );
   authUrl.searchParams.set("app", resolvedTarget.surface);
 
   if (resolvedTarget.targetPath !== "/") {
@@ -606,17 +525,6 @@ export function buildAccessFinalizeUrl(
       targetPath: "/"
     };
 
-  if (isLocalOrigin(hostname)) {
-    const completionUrl = new URL("/portal/session/finalize/submit", getApiBaseUrl());
-    completionUrl.searchParams.set("app", resolvedTarget.surface);
-
-    if (resolvedTarget.targetPath !== "/") {
-      completionUrl.searchParams.set("redirect", resolvedTarget.targetPath);
-    }
-
-    return completionUrl.toString();
-  }
-
   const completionUrl = new URL("/api/access/finalize", window.location.origin);
   completionUrl.searchParams.set("app", resolvedTarget.surface);
 
@@ -630,11 +538,11 @@ export function buildAccessFinalizeUrl(
 export function resolveAccessProviderHost(
   hostname = window.location.hostname
 ): AccessProvider | null {
-  if (hostname === "github.auth.paretoproof.com") {
+  if (hostname === paretoProofSurfaceHosts.githubAuth) {
     return "github";
   }
 
-  if (hostname === "google.auth.paretoproof.com") {
+  if (hostname === paretoProofSurfaceHosts.googleAuth) {
     return "google";
   }
 
@@ -646,14 +554,8 @@ export function describeAuthenticatedSurface(surface: AuthenticatedSurface) {
 }
 
 export function getCurrentRelativeUrl(location = window.location) {
-  const params = new URLSearchParams(location.search);
-
+  const params = stripSyntheticLocalAuthParams(new URLSearchParams(location.search));
   params.delete("surface");
-  params.delete("access");
-  params.delete("email");
-  params.delete("role");
-  params.delete("roles");
-  params.delete("reason");
 
   const search = params.toString();
   const relativeUrl = `${location.pathname}${search ? `?${search}` : ""}${location.hash}`;

--- a/apps/web/src/routes/access-completion.tsx
+++ b/apps/web/src/routes/access-completion.tsx
@@ -4,8 +4,7 @@ import {
   buildAccessFinalizeUrl,
   buildAuthUrl,
   describeAuthenticatedSurface,
-  type AuthenticatedSurface,
-  isLocalHostname
+  type AuthenticatedSurface
 } from "../lib/surface";
 
 type AccessCompletionProps = {
@@ -28,18 +27,13 @@ export function AccessCompletion({
       surface: redirectSurface
     })
   );
-  const isLocal = isLocalHostname(window.location.hostname.toLowerCase());
   const destinationLabel = describeAuthenticatedSurface(redirectSurface);
 
   retryUrl.searchParams.set("handoff", "retry");
 
   useEffect(() => {
-    if (isLocal) {
-      return;
-    }
-
     finalizeFormRef.current?.requestSubmit();
-  }, [isLocal]);
+  }, []);
 
   const providerLabel = provider === "github" ? "GitHub" : "Google";
 

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   AuthEntry,
-  buildLocalAuthEntryPreviewState,
   resolveApprovedAuthEntryHandoff,
   resolveAuthEntryApprovedPortalTargetPath,
   resolveAuthEntrySessionCheckAction,
@@ -11,10 +10,6 @@ import {
 } from "./auth-entry.tsx";
 
 const originalWindow = globalThis.window;
-
-function countOccurrences(haystack, needle) {
-  return haystack.split(needle).length - 1;
-}
 
 afterEach(() => {
   if (originalWindow) {
@@ -254,83 +249,47 @@ describe("resolveAuthEntryApprovedPortalTargetPath", () => {
   });
 });
 
-describe("buildLocalAuthEntryPreviewState", () => {
-  it("builds a local sign-in preview with portal and access-request entry routes", () => {
-    globalThis.window = {
-      location: new URL("http://127.0.0.1/?surface=auth")
-    };
-
-    expect(buildLocalAuthEntryPreviewState("sign_in", "/runs/alpha", "portal")).toMatchObject({
-      actions: [
-        {
-          href: "http://127.0.0.1/runs/alpha?surface=portal",
-          title: "Open local portal preview"
-        },
-        {
-          href: "http://127.0.0.1/?surface=auth&app=portal&redirect=%2Faccess-request",
-          title: "Open local access-request preview"
-        }
-      ]
-    });
-  });
-
-  it("builds a local access-request preview with a direct portal route handoff", () => {
-    globalThis.window = {
-      location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
-    };
-
-    expect(
-      buildLocalAuthEntryPreviewState("access_request", "/access-request", "portal")
-    ).toMatchObject({
-      actions: [
-        {
-          href: "http://127.0.0.1/access-request?surface=portal",
-          title: "Open local access-request route"
-        },
-        {
-          href: "http://127.0.0.1/?surface=auth&app=portal",
-          title: "Open local sign-in guidance"
-        }
-      ]
-    });
-  });
-});
-
 describe("AuthEntry local rendering", () => {
-  it("renders truthful local sign-in guidance instead of provider sign-in CTAs", () => {
+  it("renders local sign-in provider CTAs backed by auth-start", () => {
     globalThis.window = {
-      location: new URL("http://127.0.0.1/?surface=auth")
+      location: new URL("http://127.0.0.1:4173/?surface=auth")
     };
 
     const html = renderToStaticMarkup(
       <AuthEntry redirectPath="/runs/alpha" redirectSurface="portal" />
     );
 
-    expect(html).toContain("Local development bypasses live provider sign-in.");
-    expect(html).toContain("Open local portal preview");
-    expect(html).toContain("Open local access-request preview");
-    expect(html).toContain("http://127.0.0.1/runs/alpha?surface=portal");
+    expect(html).toContain("Continue with GitHub");
+    expect(html).toContain("Continue with Google");
+    expect(html).toContain(
+      "http://auth.paretoproof.com:4173/api/access/start/github?app=portal&amp;redirect=%2Fruns%2Falpha"
+    );
+    expect(html).toContain(
+      "http://auth.paretoproof.com:4173/api/access/start/google?app=portal&amp;redirect=%2Fruns%2Falpha"
+    );
     expect(html).toContain("Back to local home");
-    expect(countOccurrences(html, "Open local portal preview")).toBe(1);
-    expect(html).not.toContain("Continue with GitHub");
-    expect(html).not.toContain("Continue with Google");
+    expect(html).not.toContain("Local development bypasses live provider sign-in.");
+    expect(html).not.toContain("Open local portal preview");
   });
 
-  it("renders truthful local access-request guidance instead of identity-verification promises", () => {
+  it("renders local access-request provider CTAs instead of preview-only actions", () => {
     globalThis.window = {
-      location: new URL("http://127.0.0.1/?surface=auth&redirect=%2Faccess-request")
+      location: new URL("http://127.0.0.1:4173/?surface=auth&redirect=%2Faccess-request")
     };
 
     const html = renderToStaticMarkup(
       <AuthEntry redirectPath="/access-request" redirectSurface="portal" />
     );
 
-    expect(html).toContain("Local development bypasses provider verification here.");
-    expect(html).toContain("Open local access-request route");
-    expect(html).toContain("Open local sign-in guidance");
+    expect(html).toContain("Use GitHub or Google to verify your identity.");
+    expect(html).toContain("Continue with GitHub");
+    expect(html).toContain("Continue with Google");
+    expect(html).toContain(
+      "http://auth.paretoproof.com:4173/api/access/start/github?app=portal&amp;redirect=%2Faccess-request"
+    );
     expect(html).toContain("Back to local home");
-    expect(countOccurrences(html, "Open local access-request route")).toBe(1);
-    expect(html).not.toContain("Use GitHub or Google to verify your identity.");
+    expect(html).not.toContain("Open local access-request route");
+    expect(html).not.toContain("Open local sign-in guidance");
   });
 });
 

--- a/apps/web/src/routes/auth-entry.tsx
+++ b/apps/web/src/routes/auth-entry.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AppIcon, type AppIconName } from "../components/app-icon";
+import { AppIcon } from "../components/app-icon";
 import { getApiBaseUrl } from "../lib/api-base-url";
 import {
   type ApprovedAuthHandoff,
@@ -38,27 +38,6 @@ type AuthEntrySessionCheckPayload = {
   } | null;
 };
 
-type AuthEntryAction = {
-  copy: string;
-  href: string;
-  icon: AppIconName;
-  title: string;
-};
-
-type AuthEntryLocalExperience = {
-  actions: AuthEntryAction[];
-  checks: string[];
-  footerCta?: {
-    href: string;
-    label: string;
-  };
-  footerText: string;
-  lead: string;
-  panelCopy: string;
-  panelTag: string;
-  panelTitle: string;
-};
-
 const signInChecks = [
   "We match this provider to your existing ParetoProof account whenever possible.",
   "If your account still needs approval, we will let you know clearly before portal entry.",
@@ -71,102 +50,12 @@ const accessRequestChecks = [
   "Approval is manual - requesting access is separate from approved sign-in."
 ];
 
-const localSignInChecks = [
-  "Local development bypasses live provider sign-in and uses this auth surface only for preview routing.",
-  "Open the destination preview when your local or configured API target is reachable.",
-  "Switch to the access-request entry preview to verify that path without a live identity handoff."
-];
-
-const localAccessRequestChecks = [
-  "Local development does not verify GitHub or Google identities before showing this entry.",
-  "Use the access-request route preview when your API target is reachable and you need to inspect request-state UX.",
-  "If the API is offline, the destination surface will tell you exactly which backend target is missing."
-];
-
 export function resolveAuthEntryMode(redirectPath: string) {
   return redirectPath === "/access-request" ? "access_request" : "sign_in";
 }
 
 export function resolveAuthEntryApprovedPortalTargetPath(redirectPath: string) {
   return redirectPath === "/access-request" ? "/" : redirectPath;
-}
-
-export function buildLocalAuthEntryPreviewState(
-  mode: ReturnType<typeof resolveAuthEntryMode>,
-  redirectPath: string,
-  redirectSurface: AuthenticatedSurface
-): AuthEntryLocalExperience {
-  if (mode === "access_request") {
-    return {
-      actions: [
-        {
-          copy:
-            "Continue into the access-request route preview once your local or configured API is reachable.",
-          href: buildPortalUrl("/access-request"),
-          icon: "key",
-          title: "Open local access-request route"
-        },
-        {
-          copy:
-            "Return to the standard local auth guidance without triggering any provider handoff.",
-          href: buildAuthUrl("/", undefined, {
-            surface: redirectSurface
-          }),
-          icon: "shield",
-          title: "Open local sign-in guidance"
-        }
-      ],
-      checks: localAccessRequestChecks,
-      footerText:
-        "Running locally - this entry explains the request path, but the actual portal route still needs a reachable API target.",
-      lead:
-        "Local development bypasses provider verification here. Use this entry to inspect request guidance, then open the access-request route preview against your API target.",
-      panelCopy:
-        "Choose which local preview path you want to inspect next.",
-      panelTag: "Local preview",
-      panelTitle: "Choose the next local access step"
-    };
-  }
-
-  return {
-    actions: [
-      {
-        copy:
-          redirectSurface === "math"
-            ? "Open the math workspace preview directly against your local or configured API target."
-            : "Open the contributor portal shell directly against your local or configured API target.",
-        href: buildAuthenticatedAppUrl(
-          resolveAuthEntryApprovedPortalTargetPath(redirectPath),
-          {
-            surface: redirectSurface
-          }
-        ),
-        icon: "grid",
-        title:
-          redirectSurface === "math"
-            ? "Open local math preview"
-            : "Open local portal preview"
-      },
-      {
-        copy:
-          "Switch to the access-request entry preview without triggering a live provider handoff.",
-        href: buildAuthUrl("/access-request", undefined, {
-          surface: "portal"
-        }),
-        icon: "key",
-        title: "Open local access-request preview"
-      }
-    ],
-    checks: localSignInChecks,
-    footerText:
-      "Running locally - live provider sign-in is disabled here, so use the preview routes above or return to the public site.",
-    lead:
-      "Local development bypasses live provider sign-in. Use this entry to move into the destination preview once your API target is reachable.",
-    panelCopy:
-      "Choose the local preview route you want to inspect next.",
-    panelTag: "Local preview",
-    panelTitle: "Choose a local preview"
-  };
 }
 
 export function buildAuthEntrySessionCheckRequestInit(signal: AbortSignal): RequestInit {
@@ -276,10 +165,6 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
   const portalAccessRequestUrl = useMemo(() => buildPortalUrl("/access-request"), []);
   const portalDeniedUrl = useMemo(() => buildPortalUrl("/denied"), []);
   const portalPendingUrl = useMemo(() => buildPortalUrl("/pending"), []);
-  const localExperience = useMemo(
-    () => (isLocal ? buildLocalAuthEntryPreviewState(mode, redirectPath, redirectSurface) : null),
-    [isLocal, mode, redirectPath, redirectSurface]
-  );
   const publicHomeLabel = isLocal ? "Back to local home" : "Back to paretoproof.com";
   const skipSessionCheck = shouldSkipAuthEntrySessionCheck();
   const [isCheckingSession, setIsCheckingSession] = useState(!isLocal && !skipSessionCheck);
@@ -287,11 +172,7 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
   const showFailedNotice = handoffMode === "failed";
   const showRetryNotice = handoffMode === "retry";
   const showAuxiliaryStatus = showFailedNotice || showRetryNotice || isCheckingSession;
-  const authChecks = localExperience
-    ? localExperience.checks
-    : mode === "access_request"
-      ? accessRequestChecks
-      : signInChecks;
+  const authChecks = mode === "access_request" ? accessRequestChecks : signInChecks;
 
   useEffect(() => {
     if (isLocal || skipSessionCheck) {
@@ -379,11 +260,9 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
               : "Sign in to your ParetoProof workspace."}
           </h1>
           <p className="auth-lead">
-            {localExperience
-              ? localExperience.lead
-              : mode === "access_request"
-                ? "Use GitHub or Google to verify your identity. After that, we will take you to the access request form."
-                : `Use GitHub or Google to continue. If you already have an active session, we will take you straight into the ${destinationLabel}.`}
+            {mode === "access_request"
+              ? "Use GitHub or Google to verify your identity. After that, we will take you to the access request form."
+              : `Use GitHub or Google to continue. If you already have an active session, we will take you straight into the ${destinationLabel}.`}
           </p>
           {showRetryNotice ? (
             <p className="auth-panel-copy">
@@ -405,70 +284,43 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
         <div className="auth-provider-layout">
           <section className="auth-provider-panel">
             <p className="section-tag">
-              {localExperience
-                ? localExperience.panelTag
-                : mode === "access_request"
-                  ? "Verify identity"
-                  : "Sign in"}
+              {mode === "access_request" ? "Verify identity" : "Sign in"}
             </p>
             <h2>
-              {localExperience
-                ? localExperience.panelTitle
-                : mode === "access_request"
-                  ? "Choose the identity you want reviewed"
-                  : "Choose a sign-in method"}
+              {mode === "access_request"
+                ? "Choose the identity you want reviewed"
+                : "Choose a sign-in method"}
             </h2>
             <p className="auth-panel-copy">
-              {localExperience
-                ? localExperience.panelCopy
-                : mode === "access_request"
-                  ? "Choose the provider you want linked to your access request."
-                  : "Choose the provider linked to your ParetoProof account."}
+              {mode === "access_request"
+                ? "Choose the provider you want linked to your access request."
+                : "Choose the provider linked to your ParetoProof account."}
             </p>
             <div className="auth-provider-list">
-              {localExperience ? (
-                localExperience.actions.map((action) => (
-                  <a className="auth-provider-button" href={action.href} key={action.title}>
-                    <span className="auth-provider-mark" aria-hidden="true">
-                      <AppIcon name={action.icon} />
-                    </span>
-                    <span>
-                      <strong>{action.title}</strong>
-                      <small>{action.copy}</small>
-                    </span>
-                    <span className="auth-provider-arrow" aria-hidden="true">
-                      <AppIcon name="arrow-right" />
-                    </span>
-                  </a>
-                ))
-              ) : (
-                <>
-                  <a className="auth-provider-button" href={githubStartUrl}>
-                    <span className="auth-provider-mark" aria-hidden="true">
-                      <AppIcon name="github" />
-                    </span>
-                    <span>
-                      <strong>Continue with GitHub</strong>
-                      <small>Best for contributors working from GitHub-linked repositories.</small>
-                    </span>
-                    <span className="auth-provider-arrow" aria-hidden="true">
-                      <AppIcon name="arrow-right" />
-                    </span>
-                  </a>
-                  <a className="auth-provider-button" href={googleStartUrl}>
-                    <span className="auth-provider-mark" aria-hidden="true">
-                      <AppIcon name="google" />
-                    </span>
-                    <span>
-                      <strong>Continue with Google</strong>
-                      <small>Use Google when your approved ParetoProof identity lives outside GitHub.</small>
-                    </span>
-                    <span className="auth-provider-arrow" aria-hidden="true">
-                      <AppIcon name="arrow-right" />
-                    </span>
-                  </a>
-                </>
-              )}
+              <a className="auth-provider-button" href={githubStartUrl}>
+                <span className="auth-provider-mark" aria-hidden="true">
+                  <AppIcon name="github" />
+                </span>
+                <span>
+                  <strong>Continue with GitHub</strong>
+                  <small>Best for contributors working from GitHub-linked repositories.</small>
+                </span>
+                <span className="auth-provider-arrow" aria-hidden="true">
+                  <AppIcon name="arrow-right" />
+                </span>
+              </a>
+              <a className="auth-provider-button" href={googleStartUrl}>
+                <span className="auth-provider-mark" aria-hidden="true">
+                  <AppIcon name="google" />
+                </span>
+                <span>
+                  <strong>Continue with Google</strong>
+                  <small>Use Google when your approved ParetoProof identity lives outside GitHub.</small>
+                </span>
+                <span className="auth-provider-arrow" aria-hidden="true">
+                  <AppIcon name="arrow-right" />
+                </span>
+              </a>
             </div>
           </section>
 
@@ -490,27 +342,18 @@ export function AuthEntry({ redirectPath, redirectSurface }: AuthEntryProps) {
 
         <div className="auth-card-footer">
           <p>
-            {localExperience
-              ? localExperience.footerText
-              : mode === "access_request"
-                ? "Already have an account? Use the sign-in entry instead."
-                : "New here? Request contributor access to get started."}
+            {mode === "access_request"
+              ? "Already have an account? Use the sign-in entry instead."
+              : "New here? Request contributor access to get started."}
           </p>
-          {!localExperience?.footerCta ? null : (
-            <a className="button" href={localExperience.footerCta.href}>
-              {localExperience.footerCta.label}
-            </a>
-          )}
-          {!localExperience ? (
-            <a
-              className="button"
-              href={mode === "access_request" ? approvedSignInUrl : accessRequestUrl}
-            >
-              {mode === "access_request"
-                ? "Approved contributor sign in"
-                : "Request collaborator access"}
-            </a>
-          ) : null}
+          <a
+            className="button"
+            href={mode === "access_request" ? approvedSignInUrl : accessRequestUrl}
+          >
+            {mode === "access_request"
+              ? "Approved contributor sign in"
+              : "Request collaborator access"}
+          </a>
           <a className="button button-secondary" href={buildPublicUrl("/")}>
             {publicHomeLabel}
           </a>

--- a/apps/web/src/routes/portal-bootstrap-state.ts
+++ b/apps/web/src/routes/portal-bootstrap-state.ts
@@ -1,3 +1,5 @@
+import { stripSyntheticLocalAuthParams } from "../lib/local-development";
+
 export type PortalAccessState =
   | { status: "loading" }
   | { status: "unauthenticated" }
@@ -19,20 +21,9 @@ export type PortalAccessState =
     };
 
 export function buildLocalPendingPortalUrl(currentSearch = window.location.search) {
-  const currentParams = new URLSearchParams(currentSearch);
-  const nextParams = new URLSearchParams(currentParams);
+  const nextParams = stripSyntheticLocalAuthParams(new URLSearchParams(currentSearch));
 
   nextParams.set("surface", "portal");
-  nextParams.set("access", "pending");
-  nextParams.delete("reason");
-  nextParams.delete("role");
-  nextParams.delete("roles");
-
-  const email = currentParams.get("email");
-
-  if (email) {
-    nextParams.set("email", email);
-  }
 
   const nextSearch = nextParams.toString();
   return `/pending${nextSearch ? `?${nextSearch}` : ""}`;

--- a/apps/web/src/routes/portal-bootstrap.browser.test.js
+++ b/apps/web/src/routes/portal-bootstrap.browser.test.js
@@ -242,7 +242,7 @@ test(
   async () => {
     for (const scenario of [
       {
-        expectedText: /Local preview needs auth context/,
+        expectedText: /Local session required/,
         expectedPathname: "/",
         name: "401",
         port: 4177,

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -38,18 +38,18 @@ afterEach(() => {
 });
 
 describe("portal bootstrap state", () => {
-  it("promotes the local access state to pending and clears denial-only params", () => {
+  it("builds a local pending URL without synthetic access state", () => {
     expect(
       buildLocalPendingPortalUrl(
         "?surface=portal&access=denied&reason=access_request_required&email=lin@paretoproof.local&roles=helper"
       )
-    ).toBe("/pending?surface=portal&access=pending&email=lin%40paretoproof.local");
+    ).toBe("/pending?surface=portal");
   });
 
-  it("preserves the local email when no denial reason is present", () => {
+  it("drops local email when no denial reason is present", () => {
     expect(
       buildLocalPendingPortalUrl("?surface=portal&access=denied&email=ada@paretoproof.local")
-    ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
+    ).toBe("/pending?surface=portal");
   });
 
   it("clears stale singular approved role previews when returning to pending", () => {
@@ -57,7 +57,7 @@ describe("portal bootstrap state", () => {
       buildLocalPendingPortalUrl(
         "?surface=portal&access=denied&email=ada@paretoproof.local&role=admin"
       )
-    ).toBe("/pending?surface=portal&access=pending&email=ada%40paretoproof.local");
+    ).toBe("/pending?surface=portal");
   });
 
   it("moves stale approved state into recovery loading after auth expiry", () => {
@@ -159,7 +159,7 @@ describe("mapPortalMutationErrorMessage", () => {
     ).toEqual({
       kind: "local_api_unavailable",
       message:
-        "This local portal preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
+        "This local portal route is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
       status: "error"
     });
   });
@@ -173,7 +173,7 @@ describe("mapPortalMutationErrorMessage", () => {
     ).toEqual({
       kind: "local_api_unavailable",
       message:
-        "This local portal preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
+        "This local portal route is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
       status: "error"
     });
   });
@@ -202,7 +202,7 @@ describe("mapPortalMutationErrorMessage", () => {
         {
           kind: "local_api_unavailable",
           message:
-            "This local portal preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
+            "This local portal route is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.",
           status: "error"
         },
         "/"
@@ -211,7 +211,7 @@ describe("mapPortalMutationErrorMessage", () => {
 
     expect(html).toContain("Local API unavailable");
     expect(html).toContain("Retry after starting API");
-    expect(html).toContain("Open local auth guidance");
+    expect(html).toContain("Start local sign-in");
     expect(html).toContain("http://127.0.0.1:3000");
   });
 
@@ -315,8 +315,8 @@ describe("mapPortalMutationErrorMessage", () => {
 
     const html = renderToStaticMarkup(renderLocalPortalUnauthenticatedCard("/"));
 
-    expect(html).toContain("Local preview needs auth context");
-    expect(html).toContain("Open local auth guidance");
+    expect(html).toContain("Local session required");
+    expect(html).toContain("Start local sign-in");
     expect(html).toContain("Back to local home");
     expect(html).not.toContain("Continue to sign in");
   });
@@ -479,9 +479,9 @@ describe("PortalBootstrap auth handoff", () => {
     const secondHtml = renderToStaticMarkup(<PortalBootstrap />);
 
     expect(firstHtml).not.toContain("Opening portal");
-    expect(firstHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(firstHtml).toContain("Portal landing summary");
     expect(firstHtml).toContain("Authenticated session");
-    expect(secondHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(secondHtml).toContain("Portal landing summary");
     expect(globalThis.document.cookie).toBe(handoffCookie);
   });
 

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -174,7 +174,7 @@ export function buildPortalBootstrapErrorState(
   if (isNetworkFetchFailure(error) && context.localApiFallback) {
     return {
       kind: "local_api_unavailable",
-      message: `This local portal preview is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.`,
+      message: `This local portal route is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.`,
       status: "error"
     };
   }
@@ -619,7 +619,7 @@ export function renderPortalBootstrapErrorCard(
               : buildPublicUrl("/"),
           label:
             state.kind === "local_api_unavailable"
-              ? "Open local auth guidance"
+              ? "Start local sign-in"
               : localPreviewMode
                 ? "Back to local home"
                 : "Back to paretoproof.com",
@@ -637,14 +637,14 @@ export function renderLocalPortalUnauthenticatedCard(
   return (
     <PortalStatusCard
       eyebrow={describeSurfaceLabel(surface)}
-      title="Local preview needs auth context"
-      body={`This localhost ${surface === "math" ? "math" : "portal"} route did not receive an authenticated access state from the API. Open the local auth guidance to choose the right preview path, or return to the public site.`}
+      title="Local session required"
+      body={`This localhost ${surface === "math" ? "math" : "portal"} route did not receive a backend-confirmed session from the API. Start local sign-in to complete the provider handoff, or return to the public site.`}
       actions={[
         {
           href: buildAuthUrl(currentRelativeUrl, undefined, {
             surface
           }),
-          label: "Open local auth guidance"
+          label: "Start local sign-in"
         },
         {
           href: buildPublicUrl("/"),

--- a/apps/web/src/routes/portal-shell.test.js
+++ b/apps/web/src/routes/portal-shell.test.js
@@ -185,10 +185,11 @@ describe("PortalShell overview ordering", () => {
     );
     const mergedUrl = new URL(`http://127.0.0.1/${mergedSearch}`);
 
-    expect(mergedUrl.searchParams.get("role")).toBe("collaborator");
     expect(mergedUrl.searchParams.get("tab")).toBe("history");
     expect(mergedUrl.searchParams.get("surface")).toBe("portal");
-    expect(mergedUrl.searchParams.get("access")).toBe("approved");
+    expect(mergedUrl.searchParams.has("access")).toBe(false);
+    expect(mergedUrl.searchParams.has("email")).toBe(false);
+    expect(mergedUrl.searchParams.has("role")).toBe(false);
   });
 
   it("puts compact admin recent-run evidence before the action rail", async () => {

--- a/apps/web/src/routes/portal-shell.tsx
+++ b/apps/web/src/routes/portal-shell.tsx
@@ -13,6 +13,7 @@ import {
 } from "@paretoproof/shared";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { AppIcon, type AppIconName } from "../components/app-icon";
+import { stripSyntheticLocalAuthParams } from "../lib/local-development";
 import { PortalFreshnessCard } from "../components/portal-freshness-card";
 import { fetchPortalOverview } from "../lib/portal-overview";
 import { findMatchedPortalRoute } from "../lib/portal-route-access";
@@ -63,12 +64,12 @@ const portalRoutePathById = new Map<PortalRouteId, string>(
     .map((entry) => [entry.id, entry.path] as [PortalRouteId, string])
 );
 
-const localPortalStateParamKeys = ["surface", "access", "email", "role", "roles", "reason"] as const;
+const localPortalStateParamKeys = ["surface"] as const;
 
 export function mergeLocalPortalSearchParams(currentSearch: string, nextSearch: string) {
   const preservedParams = new URLSearchParams();
   const currentParams = new URLSearchParams(currentSearch);
-  const nextParams = new URLSearchParams(nextSearch);
+  const nextParams = stripSyntheticLocalAuthParams(new URLSearchParams(nextSearch));
 
   for (const key of localPortalStateParamKeys) {
     const value = currentParams.get(key);

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -81,7 +81,7 @@ Use this mode for `bun run dev:api`, `bun run build:api`, and direct local serve
 - Notes:
   - `CF_ACCESS_INTERNAL_AUD` falls back to the portal audience when omitted
   - `CF_ACCESS_BRANDED_AUDS` is the comma-separated allowlist of branded provider-host Access audiences accepted only on the finalize-submit handoff boundary
-  - set `CORS_ALLOW_LOCALHOST=true` when you need loopback-mapped branded auth hosts such as `http://github.auth.paretoproof.com:<port>` or `http://google.auth.paretoproof.com:<port>` to post directly to the local API finalize-submit boundary during auth-flow previews
+  - set `CORS_ALLOW_LOCALHOST=true` when you need loopback-mapped branded auth hosts such as `http://github.auth.paretoproof.com:<port>` or `http://google.auth.paretoproof.com:<port>` to let the Pages finalize relay forward auth-flow previews to the local API finalize-submit boundary
   - `PORTAL_PUBLIC_ORIGIN` defaults to `https://portal.paretoproof.com`
   - `MATH_PUBLIC_ORIGIN` defaults to `https://math.paretoproof.com`
   - `AUTH_PUBLIC_ORIGIN` defaults to `https://auth.paretoproof.com`


### PR DESCRIPTION
## Summary

Fixes the local development auth path so it exercises the same backend-linked provider and finalize relay boundaries as hosted auth instead of synthesizing local `access=approved` state in browser URLs.

## Root Cause

The local auth entry and surface URL helpers still carried older preview behavior:

- local provider buttons could bypass the Pages provider-start handler by constructing approved portal URLs directly
- local finalize URLs could jump straight to the API finalize-submit route instead of using the Pages `/api/access/finalize` relay
- local navigation preserved synthetic auth query params such as `access`, `email`, `role`, `roles`, and denial `reason`

That made local development look successful even when the real provider-start, cookie handoff, and finalize-submit boundaries were not wired correctly.

## Changes

- Added shared local-development helpers for ParetoProof branded hosts, production origins, loopback-branded origins, relay cookie options, and synthetic auth query stripping.
- Updated auth entry rendering so local GitHub/Google actions use real `/api/access/start/{provider}` URLs on the loopback-branded auth host.
- Kept provider completion on `/api/access/finalize` and made the Pages finalize relay forward local loopback-branded requests to the local API finalize-submit boundary.
- Preserved shared `.paretoproof.com` cookies for loopback-branded local auth while omitting `Secure` on `http://*.paretoproof.com:<port>`.
- Removed local propagation of synthetic auth params while preserving real route guard state such as `reason=insufficient_role`.
- Updated portal fallback copy and runtime docs so local auth guidance describes backend-confirmed sessions rather than preview bypasses.
- Expanded unit and browser coverage for provider starts, finalize relay behavior, synthetic query stripping, local retry/failure routing, and provisional handoff revalidation.

## Validation

- `bun test $(rg --files src functions | rg '\.test\.(js|ts)$' | rg -v '\.browser\.test\.js$')` from `apps/web`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run test:layout` from `apps/web`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run typecheck`
- `PATH=/Users/vuductai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run build`
- `bun run check:bidi`
- `git diff --check`

Closes #1103.
