### PR TITLE
Implement authenticated math web shell

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,12 +1,13 @@
 # Web App
 
-`apps/web` is the React and Vite frontend for the public site, auth entry, and authenticated portal UI.
+`apps/web` is the React and Vite frontend for the public site, auth entry, authenticated portal UI, and authenticated math shell.
 
 Cloudflare Pages is configured around this app through the local Wrangler config. The project name is `paretoproof-web`, the build output is `dist`, and deployments should build the workspace from the repository root before uploading the finished bundle to Pages.
 
 Runtime env guidance:
 
 - use [docs/runtime.md](../../docs/runtime.md) as the runtime baseline for browser env versus hosted auth-entry secrets
-- use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages auth-entry runtime checklists
+- use [docs/runtime-env-mode-checklists.md](../../docs/runtime-env-mode-checklists.md) for the concrete local browser and Pages runtime checklists
 - the Pages auth-entry runtime owns the provider-start handlers and branded finalize relay; production completion stays on `/api/access/finalize`, while local loopback-branded previews target the local API finalize-submit route directly when the local API is running with localhost origin exceptions enabled
+- the same Pages bundle serves `math.paretoproof.com`; keep the math shell authenticated, noindexed, and backed by `/portal/me` until dedicated math APIs land
 - use [`.env.example`](./.env.example) only as the local browser-build example

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js src/routes/portal-bootstrap.browser.test.js src/routes/public-header-layout.browser.test.js src/routes/public-navigation.browser.test.js",
+    "test:layout": "node --test src/routes/portal-access-request-layout.browser.test.js src/routes/portal-bootstrap.browser.test.js src/routes/math-shell.browser.test.js src/routes/public-header-layout.browser.test.js src/routes/public-navigation.browser.test.js",
     "test:ui": "bun test src/lib/web-navigation.test.js src/routes/public-site.test.js && bun run test:layout",
     "test:functions": "bun test functions",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json",

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,2 +1,5 @@
 https://portal.paretoproof.com/*
   X-Robots-Tag: noindex, nofollow, noarchive
+
+https://math.paretoproof.com/*
+  X-Robots-Tag: noindex, nofollow, noarchive

--- a/apps/web/src/lib/approved-auth-handoff.test.js
+++ b/apps/web/src/lib/approved-auth-handoff.test.js
@@ -30,6 +30,28 @@ describe("approved auth handoff cookies", () => {
     });
   });
 
+  it("round-trips a fresh math handoff cookie", () => {
+    const cookieHeader = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "helper",
+        status: "approved",
+        surface: "math"
+      },
+      10_000
+    );
+
+    expect(
+      readApprovedAuthHandoffCookie(cookieHeader, {
+        nowMs: 20_000,
+        surface: "math"
+      })
+    ).toEqual({
+      role: "helper",
+      status: "approved",
+      surface: "math"
+    });
+  });
+
   it("ignores expired handoff cookies", () => {
     const cookieHeader = buildApprovedAuthHandoffCookieValue(
       {
@@ -62,6 +84,24 @@ describe("approved auth handoff cookies", () => {
       readApprovedAuthHandoffCookie(cookieHeader, {
         nowMs: 20_000,
         surface: "portal"
+      })
+    ).toBeNull();
+  });
+
+  it("ignores portal cookies while entering the math surface", () => {
+    const cookieHeader = buildApprovedAuthHandoffCookieValue(
+      {
+        role: "admin",
+        status: "approved",
+        surface: "portal"
+      },
+      10_000
+    );
+
+    expect(
+      readApprovedAuthHandoffCookie(cookieHeader, {
+        nowMs: 20_000,
+        surface: "math"
       })
     ).toBeNull();
   });

--- a/apps/web/src/routes/auth-entry.test.js
+++ b/apps/web/src/routes/auth-entry.test.js
@@ -210,6 +210,28 @@ describe("resolveApprovedAuthEntryHandoff", () => {
     });
   });
 
+  it("preserves math as the destination surface in approved handoffs", () => {
+    expect(
+      resolveApprovedAuthEntryHandoff(
+        "redirect_authenticated_app",
+        {
+          access: {
+            role: "helper",
+            status: "approved"
+          },
+          identity: {
+            provider: "cloudflare_github"
+          }
+        },
+        "math"
+      )
+    ).toEqual({
+      role: "helper",
+      status: "approved",
+      surface: "math"
+    });
+  });
+
   it("does not build a handoff for pending or denied states", () => {
     expect(
       resolveApprovedAuthEntryHandoff(
@@ -294,6 +316,28 @@ describe("buildLocalAuthEntryPreviewState", () => {
       ]
     });
   });
+
+  it("builds a local math preview from auth guidance without changing the target route", () => {
+    globalThis.window = {
+      location: new URL(
+        "http://127.0.0.1/?surface=auth&app=math&redirect=%2Fquestions%2Fproblem-9"
+      )
+    };
+
+    expect(buildLocalAuthEntryPreviewState("sign_in", "/questions/problem-9", "math"))
+      .toMatchObject({
+        actions: [
+          {
+            href: "http://127.0.0.1/questions/problem-9?surface=math",
+            title: "Open local math preview"
+          },
+          {
+            href: "http://127.0.0.1/?surface=auth&app=portal&redirect=%2Faccess-request",
+            title: "Open local access-request preview"
+          }
+        ]
+      });
+  });
 });
 
 describe("AuthEntry local rendering", () => {
@@ -331,6 +375,22 @@ describe("AuthEntry local rendering", () => {
     expect(html).toContain("Back to local home");
     expect(countOccurrences(html, "Open local access-request route")).toBe(1);
     expect(html).not.toContain("Use GitHub or Google to verify your identity.");
+  });
+
+  it("renders local math guidance with a math-surface destination link", () => {
+    globalThis.window = {
+      location: new URL(
+        "http://127.0.0.1/?surface=auth&app=math&redirect=%2Fquestions%2Fproblem-9"
+      )
+    };
+
+    const html = renderToStaticMarkup(
+      <AuthEntry redirectPath="/questions/problem-9" redirectSurface="math" />
+    );
+
+    expect(html).toContain("Open local math preview");
+    expect(html).toContain("http://127.0.0.1/questions/problem-9?surface=math");
+    expect(html).not.toContain("Open local portal preview");
   });
 });
 

--- a/apps/web/src/routes/math-shell.browser.test.js
+++ b/apps/web/src/routes/math-shell.browser.test.js
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const webRoot = fileURLToPath(new URL("../..", import.meta.url));
+const viteCli = fileURLToPath(
+  new URL("../../node_modules/vite/bin/vite.js", import.meta.url)
+);
+
+async function waitForServer(url, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+
+    await delay(250);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function stopServer(processHandle) {
+  if (!processHandle || processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+  await delay(500);
+}
+
+function startServer(port) {
+  return process.platform === "win32"
+    ? spawn(
+        process.env.ComSpec || "cmd.exe",
+        [
+          "/d",
+          "/s",
+          "/c",
+          `"${process.execPath}" "${viteCli}" --host 127.0.0.1 --port ${port}`
+        ],
+        {
+          cwd: webRoot,
+          stdio: "ignore"
+        }
+      )
+    : spawn(process.execPath, [viteCli, "--host", "127.0.0.1", "--port", String(port)], {
+        cwd: webRoot,
+        stdio: "ignore"
+      });
+}
+
+async function withMathServer(port, callback) {
+  const testServerUrl = `http://127.0.0.1:${port}`;
+  const server = startServer(port);
+  let browser = null;
+
+  try {
+    await waitForServer(`${testServerUrl}/questions/problem-9?surface=math`);
+    browser = await chromium.launch({ headless: true });
+    await callback({
+      browser,
+      testServerUrl
+    });
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    await stopServer(server);
+  }
+}
+
+test(
+  "math shell renders immediately from an approved math handoff and survives revalidation",
+  { timeout: 60_000 },
+  async () => {
+    await withMathServer(4186, async ({ browser, testServerUrl }) => {
+      const context = await browser.newContext({
+        viewport: { width: 1360, height: 900 }
+      });
+      await context.addCookies([
+        {
+          name: "paretoproof_approved_auth_handoff",
+          value: encodeURIComponent(
+            JSON.stringify({
+              role: "helper",
+              savedAtMs: Date.now(),
+              status: "approved",
+              surface: "math",
+              version: 1
+            })
+          ),
+          url: `${testServerUrl}/`
+        }
+      ]);
+
+      const page = await context.newPage();
+
+      await page.route("http://127.0.0.1:3000/portal/me", async (route) => {
+        await delay(1_200);
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            access: {
+              email: "reviewer@paretoproof.test",
+              role: "helper",
+              status: "approved"
+            },
+            identity: {
+              provider: "cloudflare_google"
+            }
+          })
+        });
+      });
+
+      await page.goto(`${testServerUrl}/questions/problem-9?surface=math`, {
+        waitUntil: "domcontentloaded"
+      });
+      await delay(400);
+
+      assert.equal(new URL(page.url()).pathname, "/questions/problem-9");
+
+      const provisionalBody = await page.locator("body").innerText();
+      assert.match(provisionalBody, /Math question workflow/);
+      assert.match(provisionalBody, /Questions/);
+      assert.match(provisionalBody, /Submissions/);
+      assert.doesNotMatch(provisionalBody, /Opening math workspace/);
+      assert.doesNotMatch(provisionalBody, /Workers/);
+
+      await page.waitForFunction(
+        () =>
+          window.location.pathname === "/questions/problem-9" &&
+          document.body.innerText.includes("reviewer@paretoproof.test"),
+        { timeout: 10_000 }
+      );
+
+      const settledBody = await page.locator("body").innerText();
+      assert.match(settledBody, /reviewer@paretoproof\.test/);
+      assert.match(settledBody, /helper/);
+      assert.doesNotMatch(settledBody, /Workers/);
+
+      await context.close();
+    });
+  }
+);
+
+test(
+  "math shell local unauthenticated entry routes back through math auth guidance",
+  { timeout: 60_000 },
+  async () => {
+    await withMathServer(4187, async ({ browser, testServerUrl }) => {
+      const context = await browser.newContext({
+        viewport: { width: 390, height: 844 }
+      });
+      const page = await context.newPage();
+
+      await page.route("http://127.0.0.1:3000/portal/me", async (route) => {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "access_assertion_required" })
+        });
+      });
+
+      await page.goto(`${testServerUrl}/questions/problem-9?surface=math`, {
+        waitUntil: "domcontentloaded"
+      });
+
+      await page.waitForFunction(
+        () => document.body.innerText.includes("Local preview needs auth context"),
+        { timeout: 10_000 }
+      );
+
+      const body = await page.locator("body").innerText();
+      assert.match(body, /localhost math route/);
+
+      const authHref = await page
+        .locator("a", { hasText: "Open local auth guidance" })
+        .getAttribute("href");
+      assert.equal(
+        authHref,
+        `${testServerUrl}/?surface=auth&app=math&redirect=%2Fquestions%2Fproblem-9`
+      );
+
+      await context.close();
+    });
+  }
+);
+
+test(
+  "math pending users are routed to the existing portal pending state",
+  { timeout: 60_000 },
+  async () => {
+    await withMathServer(4188, async ({ browser, testServerUrl }) => {
+      const context = await browser.newContext({
+        viewport: { width: 1024, height: 768 }
+      });
+      const page = await context.newPage();
+
+      await page.route("http://127.0.0.1:3000/portal/me", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            access: {
+              email: "pending@paretoproof.test",
+              status: "pending"
+            },
+            identity: {
+              provider: "cloudflare_google"
+            }
+          })
+        });
+      });
+
+      await page.goto(`${testServerUrl}/launch?surface=math`, {
+        waitUntil: "domcontentloaded"
+      });
+
+      await page.waitForFunction(
+        () =>
+          window.location.pathname === "/pending" &&
+          new URLSearchParams(window.location.search).get("surface") === "portal" &&
+          document.body.innerText.includes("Approval pending"),
+        { timeout: 10_000 }
+      );
+
+      const body = await page.locator("body").innerText();
+      assert.match(body, /Approval pending/);
+      assert.doesNotMatch(body, /Math launch entry/);
+
+      await context.close();
+    });
+  }
+);

--- a/apps/web/src/routes/math-shell.test.js
+++ b/apps/web/src/routes/math-shell.test.js
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describeMathPath, MathShell } from "./math-shell.tsx";
+
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalWindow) {
+    globalThis.window = originalWindow;
+    return;
+  }
+
+  delete globalThis.window;
+});
+
+describe("describeMathPath", () => {
+  it("describes question detail continuation as math-owned workflow state", () => {
+    expect(describeMathPath("/questions/problem-9")).toMatchObject({
+      eyebrow: "Question workflow",
+      title: "Math question workflow"
+    });
+  });
+
+  it("falls back to the math workspace for unknown math paths", () => {
+    expect(describeMathPath("/profile")).toMatchObject({
+      eyebrow: "Workspace",
+      title: "Math workspace"
+    });
+  });
+});
+
+describe("MathShell", () => {
+  it("renders top-level math navigation without portal admin routes", () => {
+    globalThis.window = {
+      location: new URL(
+        "http://127.0.0.1/questions/problem-9?surface=math&access=approved&role=helper"
+      )
+    };
+
+    const html = renderToStaticMarkup(
+      <MathShell
+        email="reviewer@paretoproof.local"
+        pathname="/questions/problem-9"
+        roles={["helper"]}
+      />
+    );
+
+    expect(html).toContain("Math question workflow");
+    expect(html).toContain("Question-specific continuation for problem-9");
+    expect(html).toContain("Signed in as reviewer@paretoproof.local");
+    expect(html).toContain("helper");
+    expect(html).toContain('href="http://127.0.0.1/questions?surface=math');
+    expect(html).toContain('href="http://127.0.0.1/submissions?surface=math');
+    expect(html).toContain('href="http://127.0.0.1/reviews?surface=math');
+    expect(html).toContain('href="http://127.0.0.1/launch?surface=math');
+    expect(html).toContain('aria-current="page"');
+    expect(html).not.toContain('math-shell-nav-label">Workers');
+    expect(html).not.toContain('math-shell-nav-label">Runs');
+    expect(html).not.toContain('math-shell-nav-label">Admin');
+  });
+
+  it("keeps portal links explicit and outside the math navigation", () => {
+    globalThis.window = {
+      location: new URL("https://math.paretoproof.com/submissions")
+    };
+
+    const html = renderToStaticMarkup(
+      <MathShell email={null} pathname="/submissions" roles={[]} />
+    );
+
+    expect(html).toContain("Structured submission workflow belongs on the math surface");
+    expect(html).toContain('href="https://math.paretoproof.com/submissions"');
+    expect(html).toContain('href="https://portal.paretoproof.com/profile"');
+    expect(html).toContain('href="https://portal.paretoproof.com/runs"');
+    expect(html).toContain("Portal handoff");
+  });
+});

--- a/apps/web/src/routes/math-shell.tsx
+++ b/apps/web/src/routes/math-shell.tsx
@@ -1,4 +1,6 @@
-import { AppIcon } from "../components/app-icon";
+import { findAppRouteBySurface } from "@paretoproof/shared";
+
+import { AppIcon, type AppIconName } from "../components/app-icon";
 import { buildMathUrl, buildPortalUrl } from "../lib/surface";
 
 type MathShellProps = {
@@ -7,43 +9,108 @@ type MathShellProps = {
   roles: string[];
 };
 
-function describeMathPath(pathname: string) {
-  if (pathname === "/launch") {
+type MathNavItem = {
+  icon: AppIconName;
+  label: string;
+  path: string;
+  routeIds: string[];
+};
+
+const mathNavItems: MathNavItem[] = [
+  {
+    icon: "grid",
+    label: "Home",
+    path: "/",
+    routeIds: ["math.home"]
+  },
+  {
+    icon: "compass",
+    label: "Questions",
+    path: "/questions",
+    routeIds: ["math.questions", "math.question-detail"]
+  },
+  {
+    icon: "flask",
+    label: "Submissions",
+    path: "/submissions",
+    routeIds: ["math.submissions"]
+  },
+  {
+    icon: "users",
+    label: "Reviews",
+    path: "/reviews",
+    routeIds: ["math.reviews"]
+  },
+  {
+    icon: "play",
+    label: "Launch",
+    path: "/launch",
+    routeIds: ["math.launch"]
+  }
+];
+
+function readQuestionId(pathname: string) {
+  const [, basePath, questionId] = pathname.split("/");
+
+  if (basePath !== "questions" || !questionId) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(questionId);
+  } catch {
+    return questionId;
+  }
+}
+
+export function describeMathPath(pathname: string) {
+  const route = findAppRouteBySurface("math", pathname);
+
+  if (route?.id === "math.launch") {
     return {
       body:
         "Question-centric launch now resolves onto the dedicated math surface. Execution evidence, worker posture, and admin controls still stay in the portal until later math product slices land.",
+      eyebrow: "Launch",
       title: "Math launch entry"
     };
   }
 
-  if (pathname.startsWith("/questions/")) {
+  if (route?.id === "math.question-detail") {
+    const questionId = readQuestionId(pathname);
+
     return {
       body:
-        "Question-specific continuation now lands on the math host instead of collapsing back into the portal. Deeper question objects and review state land in later scopes.",
+        questionId === null
+          ? "Question-specific continuation now lands on the math host instead of collapsing back into the portal. Deeper question objects and review state land in later scopes."
+          : `Question-specific continuation for ${questionId} now lands on the math host instead of collapsing back into the portal. Deeper question objects and review state land in later scopes.`,
+      eyebrow: "Question workflow",
       title: "Math question workflow"
     };
   }
 
-  if (pathname === "/questions") {
+  if (route?.id === "math.questions") {
     return {
       body:
         "The dedicated math workflow now has its own authenticated surface. Question catalog, submission, and review objects still arrive in later child scopes.",
+      eyebrow: "Catalog",
       title: "Math question catalog"
     };
   }
 
-  if (pathname === "/submissions") {
+  if (route?.id === "math.submissions") {
     return {
       body:
         "Structured submission workflow belongs on the math surface, while profile, access, and operational evidence stay in the portal.",
+      eyebrow: "Submission workflow",
       title: "Math submissions"
     };
   }
 
-  if (pathname === "/reviews") {
+  if (route?.id === "math.reviews") {
     return {
       body:
         "Reviewer continuation now preserves the math host boundary. Durable review objects and actions remain follow-on work after this routing slice.",
+      eyebrow: "Review workflow",
       title: "Math reviews"
     };
   }
@@ -51,40 +118,110 @@ function describeMathPath(pathname: string) {
   return {
     body:
       "The dedicated math surface is now a real authenticated destination instead of collapsing back into the portal. Later issues will fill in the question, submission, and review workflows that belong here.",
+    eyebrow: "Workspace",
     title: "Math workspace"
   };
 }
 
+function getActiveMathPath(pathname: string) {
+  const route = findAppRouteBySurface("math", pathname);
+  const matchingItem = mathNavItems.find((item) => route && item.routeIds.includes(route.id));
+
+  return matchingItem?.path ?? "/";
+}
+
 export function MathShell({ email, pathname, roles }: MathShellProps) {
   const descriptor = describeMathPath(pathname);
+  const activePath = getActiveMathPath(pathname);
   const roleLabel = roles[0] ?? "approved contributor";
+  const signedInLabel = email ? `Signed in as ${email}` : "Signed in";
 
   return (
-    <main className="auth-shell">
-      <section className="auth-card auth-card-polished auth-status-card">
-        <p className="eyebrow">
-          <span className="inline-icon" aria-hidden="true">
-            <AppIcon name="shield" />
-          </span>
-          ParetoProof math
-        </p>
-        <h1>{descriptor.title}</h1>
-        <p>{descriptor.body}</p>
-        <p>
-          Signed in
-          {email ? ` as ${email}` : ""} with {roleLabel} access.
-        </p>
-        <div className="auth-card-footer">
-          <a className="button" href={buildMathUrl("/")}>
-            Math home
-          </a>
-          <a className="button button-secondary" href={buildPortalUrl("/profile")}>
-            Open portal profile
-          </a>
-          <a className="button button-secondary" href={buildPortalUrl("/runs")}>
-            Open run evidence
-          </a>
+    <main className="math-shell">
+      <header className="math-shell-header">
+        <div className="math-shell-brand">
+          <p className="eyebrow">
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="shield" />
+            </span>
+            ParetoProof math
+          </p>
+          <h1>Math workspace</h1>
         </div>
+        <div className="math-shell-identity" aria-label="Current account">
+          <span>{signedInLabel}</span>
+          <strong>{roleLabel}</strong>
+        </div>
+      </header>
+
+      <nav className="math-shell-nav" aria-label="Math workspace">
+        {mathNavItems.map((item) => {
+          const isActive = item.path === activePath;
+
+          return (
+            <a
+              key={item.path}
+              className="math-shell-nav-link"
+              href={buildMathUrl(item.path)}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <span className="inline-icon" aria-hidden="true">
+                <AppIcon name={item.icon} />
+              </span>
+              <span className="math-shell-nav-label">{item.label}</span>
+            </a>
+          );
+        })}
+      </nav>
+
+      <section className="math-shell-content" aria-labelledby="math-shell-heading">
+        <article className="math-shell-panel">
+          <p className="section-tag">{descriptor.eyebrow}</p>
+          <h2 id="math-shell-heading">{descriptor.title}</h2>
+          <p>{descriptor.body}</p>
+
+          <div className="math-shell-status-list" aria-label="Surface boundaries">
+            <div>
+              <span>Current route</span>
+              <strong>{pathname}</strong>
+            </div>
+            <div>
+              <span>Authenticated surface</span>
+              <strong>math.paretoproof.com</strong>
+            </div>
+            <div>
+              <span>Portal handoff</span>
+              <strong>profile and evidence links</strong>
+            </div>
+          </div>
+
+          <div className="math-shell-actions">
+            <a className="button" href={buildMathUrl(pathname)}>
+              Stay on math surface
+            </a>
+            <a className="button button-secondary" href={buildPortalUrl("/profile")}>
+              Open portal profile
+            </a>
+            <a className="button button-secondary" href={buildPortalUrl("/runs")}>
+              Open run evidence
+            </a>
+          </div>
+        </article>
+
+        <aside className="math-shell-side-panel" aria-label="Math surface scope">
+          <p className="section-tag">Scope</p>
+          <h2>Question work lives here</h2>
+          <p>
+            The shell keeps math continuation on the math host while later slices add durable
+            question, submission, and review data.
+          </p>
+          <a className="math-shell-side-link" href={buildPortalUrl("/")}>
+            Portal home
+            <span className="inline-icon" aria-hidden="true">
+              <AppIcon name="arrow-right" />
+            </span>
+          </a>
+        </aside>
       </section>
     </main>
   );

--- a/apps/web/src/routes/portal-bootstrap.test.js
+++ b/apps/web/src/routes/portal-bootstrap.test.js
@@ -164,6 +164,21 @@ describe("mapPortalMutationErrorMessage", () => {
     });
   });
 
+  it("describes missing local API wiring explicitly for localhost math previews", () => {
+    expect(
+      buildPortalBootstrapErrorState(new Error("Failed to fetch"), {
+        apiBaseUrl: "http://127.0.0.1:3000",
+        localApiFallback: true,
+        surface: "math"
+      })
+    ).toEqual({
+      kind: "local_api_unavailable",
+      message:
+        "This local math workspace preview is targeting http://127.0.0.1:3000, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using math routes.",
+      status: "error"
+    });
+  });
+
   it("treats alternate browser network-failure strings as local API availability errors", () => {
     expect(
       buildPortalBootstrapErrorState(new Error("Load failed"), {
@@ -318,6 +333,22 @@ describe("mapPortalMutationErrorMessage", () => {
     expect(html).toContain("Local preview needs auth context");
     expect(html).toContain("Open local auth guidance");
     expect(html).toContain("Back to local home");
+    expect(html).not.toContain("Continue to sign in");
+  });
+
+  it("renders localhost math unauthenticated bootstrap with math auth guidance", () => {
+    globalThis.window = {
+      location: new URL("http://127.0.0.1/questions/problem-9?surface=math")
+    };
+
+    const html = renderToStaticMarkup(
+      renderLocalPortalUnauthenticatedCard("/questions/problem-9", "math")
+    );
+
+    expect(html).toContain("localhost math route");
+    expect(html).toContain(
+      "http://127.0.0.1/?surface=auth&amp;app=math&amp;redirect=%2Fquestions%2Fproblem-9"
+    );
     expect(html).not.toContain("Continue to sign in");
   });
 });
@@ -479,9 +510,9 @@ describe("PortalBootstrap auth handoff", () => {
     const secondHtml = renderToStaticMarkup(<PortalBootstrap />);
 
     expect(firstHtml).not.toContain("Opening portal");
-    expect(firstHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(firstHtml).toContain("Portal landing summary for current run activity");
     expect(firstHtml).toContain("Authenticated session");
-    expect(secondHtml).toContain("Formal benchmark operations and contributor tooling.");
+    expect(secondHtml).toContain("Portal landing summary for current run activity");
     expect(globalThis.document.cookie).toBe(handoffCookie);
   });
 

--- a/apps/web/src/routes/portal-bootstrap.tsx
+++ b/apps/web/src/routes/portal-bootstrap.tsx
@@ -124,6 +124,7 @@ export async function recoverPortalStateAfterAuthExpiry(
     fetcher?: PortalBootstrapFetcher;
     localApiFallback?: boolean;
     signal?: AbortSignal;
+    surface?: AuthenticatedSurface;
   }
 ): Promise<PortalAccessState> {
   const reducedState = reducePortalStateAfterAuthExpiry(currentState);
@@ -137,7 +138,8 @@ export async function recoverPortalStateAfterAuthExpiry(
   } catch (error) {
     return buildPortalBootstrapErrorState(error, {
       apiBaseUrl,
-      localApiFallback: options?.localApiFallback ?? false
+      localApiFallback: options?.localApiFallback ?? false,
+      surface: options?.surface
     });
   }
 }
@@ -151,6 +153,7 @@ function readRouteDeniedReason(search = window.location.search) {
 type PortalBootstrapErrorContext = {
   apiBaseUrl: string;
   localApiFallback: boolean;
+  surface?: AuthenticatedSurface;
 };
 
 function isNetworkFetchFailure(error: unknown) {
@@ -171,10 +174,14 @@ export function buildPortalBootstrapErrorState(
   error: unknown,
   context: PortalBootstrapErrorContext
 ): Extract<PortalAccessState, { status: "error" }> {
+  const surface = context.surface ?? "portal";
+  const surfaceName = surface === "math" ? "math workspace" : "portal";
+  const routeName = surface === "math" ? "math routes" : "portal routes";
+
   if (isNetworkFetchFailure(error) && context.localApiFallback) {
     return {
       kind: "local_api_unavailable",
-      message: `This local portal preview is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using portal routes.`,
+      message: `This local ${surfaceName} preview is targeting ${context.apiBaseUrl}, but no API responded. Start the local API there or set VITE_API_BASE_URL to a reachable backend before using ${routeName}.`,
       status: "error"
     };
   }
@@ -182,8 +189,7 @@ export function buildPortalBootstrapErrorState(
   if (isNetworkFetchFailure(error)) {
     return {
       kind: "portal_unavailable",
-      message:
-        "The portal could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+      message: `The ${surfaceName} could not reach the API right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.`,
       status: "error"
     };
   }
@@ -191,15 +197,14 @@ export function buildPortalBootstrapErrorState(
   if (error instanceof Error) {
     return {
       kind: "portal_unavailable",
-      message:
-        "The portal could not finish loading right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.",
+      message: `The ${surfaceName} could not finish loading right now. Try again in a moment. If the handoff still feels stuck, restart from the auth entry.`,
       status: "error"
     };
   }
 
   return {
     kind: "portal_unavailable",
-    message: "The portal could not finish loading right now. Try again in a moment.",
+    message: `The ${surfaceName} could not finish loading right now. Try again in a moment.`,
     status: "error"
   };
 }
@@ -368,7 +373,8 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
         setState(
           buildPortalBootstrapErrorState(error, {
             apiBaseUrl,
-            localApiFallback
+            localApiFallback,
+            surface
           })
         );
       }
@@ -394,7 +400,8 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
 
       void recoverPortalStateAfterAuthExpiry(currentState, apiBaseUrl, {
         localApiFallback,
-        signal: controller.signal
+        signal: controller.signal,
+        surface
       })
         .then((recoveredState) => {
           if (controller.signal.aborted || !active) {
@@ -415,7 +422,7 @@ export function PortalBootstrap({ surface = "portal" }: PortalBootstrapProps) {
       controller.abort();
       window.removeEventListener(portalAuthExpiredEventName, handlePortalAuthExpired);
     };
-  }, [apiBaseUrl, localApiFallback]);
+  }, [apiBaseUrl, localApiFallback, surface]);
 
   useEffect(() => {
     if (state.status !== "unauthenticated" || localPreviewMode) {

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1085,6 +1085,178 @@ a.button-secondary {
   color: var(--rose);
 }
 
+.math-shell {
+  width: min(1480px, calc(100% - 48px));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 22px 0 28px;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+
+.math-shell-header,
+.math-shell-nav,
+.math-shell-panel,
+.math-shell-side-panel {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--paper-elevated);
+  box-shadow:
+    0 1px 3px rgba(16, 42, 103, 0.05),
+    0 14px 36px rgba(16, 42, 103, 0.06);
+}
+
+.math-shell-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 20px;
+}
+
+.math-shell-brand {
+  display: grid;
+  gap: 8px;
+}
+
+.math-shell-brand h1 {
+  font-size: 2.35rem;
+  line-height: 1.05;
+}
+
+.math-shell-identity {
+  min-width: min(100%, 280px);
+  display: grid;
+  gap: 5px;
+  justify-items: end;
+  color: var(--ink-soft);
+  font-size: 0.92rem;
+  line-height: 1.35;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.math-shell-identity strong {
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.math-shell-nav {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+}
+
+.math-shell-nav-link {
+  min-height: 48px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--ink-soft);
+  font-weight: 800;
+  line-height: 1.2;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.math-shell-nav-link:hover,
+.math-shell-nav-link:focus-visible {
+  border-color: var(--line);
+  background: var(--teal-soft);
+  color: var(--ink);
+}
+
+.math-shell-nav-link[aria-current="page"] {
+  border-color: var(--teal-border);
+  background: linear-gradient(180deg, rgba(8, 145, 178, 0.12), rgba(255, 255, 255, 0.72));
+  color: var(--navy);
+}
+
+.math-shell-nav-label {
+  overflow-wrap: anywhere;
+}
+
+.math-shell-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  gap: 14px;
+  align-items: start;
+}
+
+.math-shell-panel,
+.math-shell-side-panel {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+}
+
+.math-shell-panel h2,
+.math-shell-side-panel h2 {
+  font-size: 1.75rem;
+  line-height: 1.12;
+}
+
+.math-shell-panel p:not(.section-tag),
+.math-shell-side-panel p:not(.section-tag) {
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
+.math-shell-status-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.math-shell-status-list div {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.math-shell-status-list div + div {
+  border-left: 1px solid var(--line);
+}
+
+.math-shell-status-list span {
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.math-shell-status-list strong {
+  overflow-wrap: anywhere;
+  line-height: 1.3;
+}
+
+.math-shell-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.math-shell-side-link {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 8px;
+  color: var(--indigo);
+  font-weight: 800;
+}
+
 .portal-shell {
   min-height: 100vh;
   padding: 10px;
@@ -2627,6 +2799,7 @@ a.button-secondary {
 @media (max-width: 1220px) {
   .site-hero,
   .auth-provider-layout,
+  .math-shell-content,
   .portal-overview-grid,
   .portal-overview-grid-secondary,
   .portal-workspace-grid,
@@ -2687,7 +2860,8 @@ a.button-secondary {
 
 @media (max-width: 900px) {
   .site-shell,
-  .auth-shell {
+  .auth-shell,
+  .math-shell {
     width: min(100%, calc(100% - 24px));
     padding: 12px 0;
   }
@@ -2727,6 +2901,38 @@ a.button-secondary {
     padding: 10px;
     grid-template-columns: minmax(0, 1fr);
     position: relative;
+  }
+
+  .math-shell-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .math-shell-identity {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .math-shell-brand h1 {
+    font-size: 1.9rem;
+  }
+
+  .math-shell-panel h2,
+  .math-shell-side-panel h2 {
+    font-size: 1.45rem;
+  }
+
+  .math-shell-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .math-shell-status-list {
+    grid-template-columns: 1fr;
+  }
+
+  .math-shell-status-list div + div {
+    border-left: 0;
+    border-top: 1px solid var(--line);
   }
 
   .portal-overview-benchmark-header,

--- a/docs/runtime-env-mode-checklists.md
+++ b/docs/runtime-env-mode-checklists.md
@@ -33,7 +33,7 @@ Use this mode for `bun run dev:web` and `bun run build:web`.
 
 ### Pages auth-entry runtime
 
-Use this mode for the Pages-managed auth provider-start handlers and the legacy finalize compatibility route.
+Use this mode for the Pages-managed auth provider-start handlers, the legacy finalize compatibility route, and the browser bundle that serves the public, portal, and math custom domains.
 
 - Checked-in example file: none by design
 - Required env:
@@ -45,6 +45,8 @@ Use this mode for the Pages-managed auth provider-start handlers and the legacy 
   - Cloudflare Pages runtime, not the browser bundle
 - Do not set here:
   - `VITE_API_BASE_URL` as a secret substitute
+- Notes:
+  - `math.paretoproof.com` uses the browser bundle and `/portal/me` access state; keep it authenticated and noindexed until dedicated math APIs and public discovery rules exist.
 
 ## API modes
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -15,12 +15,13 @@ This repo uses a small number of runtime rules.
 
 ## Deploy surfaces
 
-- Cloudflare Pages hosts the public site and auth-entry runtime.
+- Cloudflare Pages hosts the public site, auth-entry runtime, portal shell, and math shell.
 - Railway hosts the API.
 - Workers run locally or in hosted runtimes against the API control plane.
 - GHCR holds worker images.
 - Cloudflare R2 holds larger artifacts when the flow requires object storage.
 - Hosted Cloudflare Access split:
+  - `portal.paretoproof.com/*` and `math.paretoproof.com/*` are authenticated app surfaces and should stay `noindex` in Pages response headers.
   - `api.paretoproof.com/portal/*` must bypass Cloudflare Access so `portal.paretoproof.com` and `math.paretoproof.com` can make cross-origin JSON `fetch()` calls without an opaque Access redirect.
   - `api.paretoproof.com/internal/*` stays behind its own Cloudflare Access app for owner and service-token callers.
 


### PR DESCRIPTION
## Summary

Closes #891.

This PR turns the authenticated math surface into a real web shell instead of a thin portal-style placeholder. It keeps the implementation intentionally scoped to the web/auth routing slice: no math API endpoints, database schema, or admin math workflow are introduced here.

## What Changed

- Adds a dedicated `MathShell` layout with top-level math navigation for Home, Questions, Submissions, Reviews, and Launch.
- Keeps question-specific continuation on the math surface, including `/questions/:questionId`, while preserving explicit links back to portal-owned profile and run evidence.
- Makes portal bootstrap error/recovery copy surface-aware so localhost and hosted math failures say "math workspace" instead of generic portal wording.
- Adds math auth handoff and local-preview coverage for approved, unauthenticated, and pending states.
- Adds `math.paretoproof.com` noindex headers and runtime docs that document the authenticated Pages-hosted math shell boundary.

## Why

The shared route matrix and auth handoff already recognize `math.paretoproof.com`, but the web app still lacked a usable authenticated math destination. That made math deep links collapse back into portal-shaped UX and left the local auth-preview path under-tested for the math surface.

## Validation

- `bun run build:shared`
- `bun test src/routes/math-shell.test.js src/routes/auth-entry.test.js src/lib/approved-auth-handoff.test.js src/routes/portal-bootstrap.test.js`
- `bun --cwd apps/web typecheck`
- Bundled modern Node: `node --test src/routes/math-shell.browser.test.js`
- Bundled modern Node path: `bun --cwd apps/web build`
- `bun run check:bidi`
- `git diff --check`

## Notes

The full browser layout suite could not be used as a final local signal on this macOS sandbox because Chromium failed before app assertions with `MachPortRendezvousServer ... Permission denied`. The new math browser proof passes standalone.
